### PR TITLE
feat(qty-dropdown): refactoring qty-dropdown

### DIFF
--- a/apps/foundation-demo/src/app/cart/cart.module.ts
+++ b/apps/foundation-demo/src/app/cart/cart.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
 import { CoreCartModule } from '@daffodil/core';
 
@@ -16,6 +17,7 @@ import { CartGrandTotalComponent } from './components/cart-grand-total/cart-gran
 @NgModule({
   imports: [
     CommonModule,
+    FormsModule,
     DesignModule,
     CoreCartModule,
   ],

--- a/apps/foundation-demo/src/app/cart/components/cart-item/cart-item.component.html
+++ b/apps/foundation-demo/src/app/cart/components/cart-item/cart-item.component.html
@@ -13,7 +13,7 @@
       <span class="cart-item__mobile-qty">Qty: </span>
       <span class="cart-item__mobile-qty">{{item.qty}}</span>
       <span class="cart-item__desktop-qty">
-        <qty-dropdown [qty]="item.qty" [id]="item.item_id"></qty-dropdown>
+        <qty-dropdown [(ngModel)]="item.qty"></qty-dropdown>
       </span>
     </div>
     <div class="cart-item__change">

--- a/apps/foundation-demo/src/app/cart/components/cart-item/cart-item.component.spec.ts
+++ b/apps/foundation-demo/src/app/cart/components/cart-item/cart-item.component.spec.ts
@@ -5,6 +5,7 @@ import { CartFactory, CartItem } from '@daffodil/core';
 
 import { CartItemComponent } from './cart-item.component';
 import { Component, Input } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 
 let cartFactory = new CartFactory();
 let mockCartItem = cartFactory.create().items[0];
@@ -29,6 +30,7 @@ describe('CartItemComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
+        FormsModule,
         CartItemComponent,
         TestCartItemWrapper,
         MockQtyDropdownComponent

--- a/apps/foundation-demo/src/app/design/molecules/molecules.module.ts
+++ b/apps/foundation-demo/src/app/design/molecules/molecules.module.ts
@@ -7,23 +7,23 @@ import { QtyDropdownComponent } from './qty-dropdown/qty-dropdown.component';
 import { ImageGalleryComponent } from './image-gallery/image-gallery.component';
 import { ImageListComponent } from './image-list/image-list.component';
 import { AccordionModule } from './accordion/accordion.module';
+import { QtyDropdownModule } from './qty-dropdown/qty-dropdown.module';
 
 @NgModule({
   imports: [
     CommonModule,
-    FormsModule,
-    AccordionModule
+    AccordionModule,
+    QtyDropdownModule
   ],
   declarations: [
-    QtyDropdownComponent,
     ImageGalleryComponent,
     ImageListComponent
   ],
   exports: [
-    QtyDropdownComponent,
     ImageGalleryComponent,
     ImageListComponent,
-    AccordionModule
+    AccordionModule,
+    QtyDropdownModule
   ]
 })
 export class MoleculesModule { }

--- a/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.component.html
+++ b/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.component.html
@@ -1,9 +1,15 @@
 <div class="qty-dropdown">
   <label class="qty-dropdown__label">
-    <select id="select_{{id}}" class="qty-dropdown__selector" [(ngModel)]="qty" (ngModelChange)="onChangedWrapper(qty)" (blur)="onTouched()" *ngIf="!showQtyInputField">
+    <select class="qty-dropdown__selector" 
+      #qtySelect
+      [formControl]="_qtyControl" 
+      *ngIf="!showQtyInputField" >
         <option *ngFor="let item of dropdownItemCounter" [value]="item+1">{{ item+1 }}</option>
         <option value="10">10+</option>
     </select>
-    <input id="input_{{id}}" class="qty-dropdown__input" [(ngModel)]="qty" (ngModelChange)="onChangedWrapper(qty)" (blur)="onTouched()" *ngIf="showQtyInputField">
-  </label>
+    <input class="qty-dropdown__input"
+        #qtyInput 
+        type="number" min="1" [formControl]="_qtyControl"
+        *ngIf="showQtyInputField">
+  </label> 
 </div>

--- a/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.component.scss
+++ b/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.component.scss
@@ -13,6 +13,7 @@
 
   &__input {
     padding-left: 10px;
+    margin: 0;
   }
 
   &__selector {

--- a/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.component.spec.ts
+++ b/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.component.spec.ts
@@ -1,27 +1,25 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 
 import { QtyDropdownComponent } from './qty-dropdown.component';
-import { Component } from '@angular/core';
+import { Component, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
-@Component({template: '<qty-dropdown [qty]="qtyValue" [id]="idValue"></qty-dropdown>'})
+@Component({template: '<qty-dropdown [ngModel]="qtyValue"></qty-dropdown>'})
 class TestQtyDropdownWrapper {
   qtyValue: string;
-  idValue: string;
 }
 
 describe('QtyDropdownComponent', () => {
   let component: TestQtyDropdownWrapper;
   let fixture: ComponentFixture<TestQtyDropdownWrapper>;
-  let mockQty = "3";
-  let mockId = "id";
-  let qtyDropdownComponent;
+  let qtyDropdownComponent: DebugElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        FormsModule
+        FormsModule,
+        ReactiveFormsModule
       ],
       declarations: [ 
         TestQtyDropdownWrapper,
@@ -34,9 +32,6 @@ describe('QtyDropdownComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TestQtyDropdownWrapper);
     component = fixture.componentInstance;
-    component.qtyValue = mockQty;
-    component.idValue = mockId;
-    
     qtyDropdownComponent = fixture.debugElement.query(By.css('qty-dropdown'));
     fixture.detectChanges();
   });
@@ -45,58 +40,36 @@ describe('QtyDropdownComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('can be passed a qty input', () => {
-    expect(qtyDropdownComponent.componentInstance.qty).toEqual(mockQty);
-  });
-
-  it('can be passed an id input', () => {
-    expect(qtyDropdownComponent.componentInstance.id).toEqual(mockId);
-  });
+  it('should have an array numbers of quantities defined on it by default', () => {
+    expect(qtyDropdownComponent.componentInstance.dropdownItemCounter).not.toBeNull();
+  })
 
   describe('ngOnInit', () => {
-    
-    it('should create the dropdownItemCounter array', () => {
-      expect(qtyDropdownComponent.componentInstance.dropdownItemCounter.length).toEqual(QtyDropdownComponent.dropdownRange);
-    });
+    xit('subscribe to the valueChanges of the formControl property', () => {
 
-    describe('when qty is not given as input', () => {
-      
-      beforeEach(() => {
-        fixture = TestBed.createComponent(TestQtyDropdownWrapper);
-        component = fixture.componentInstance;
-
-        fixture.detectChanges();
-        qtyDropdownComponent = fixture.debugElement.query(By.css('qty-dropdown'));        
-      });
-
-      it('should set qty to 1', () => {
-        expect(qtyDropdownComponent.componentInstance.qty).toEqual(1);
-      });
     });
   });
 
   describe('writeValue', () => {
 
-    let newQtyValue = 'newQtyValue';
+    let newQtyValue = 2;
 
     beforeEach(() => {
       spyOn(qtyDropdownComponent.componentInstance, 'onChange');
       qtyDropdownComponent.componentInstance.writeValue(newQtyValue);
     });
     
-    it('sets qty to argument', () => {
-      expect(qtyDropdownComponent.componentInstance.qty).toEqual(newQtyValue);
+    it('sets the qtyControl value to argument', () => {
+      expect(qtyDropdownComponent.componentInstance._qtyControl.value).toEqual(newQtyValue);
     });
 
     it('calls onChange with qty', () => {
-      expect(qtyDropdownComponent.componentInstance.onChange)
-        .toHaveBeenCalledWith(qtyDropdownComponent.componentInstance.qty);
+      expect(qtyDropdownComponent.componentInstance.onChange).toHaveBeenCalledWith(newQtyValue);
     });
   });
 
   describe('registerOnChange', () => {
-
-    let givenFunction: Function= () => {};
+    let givenFunction: Function = () => {};
 
     beforeEach(() => {
       qtyDropdownComponent.componentInstance.registerOnChange(givenFunction);
@@ -108,7 +81,6 @@ describe('QtyDropdownComponent', () => {
   });
 
   describe('registerOnTouched', () => {
-
     let givenFunction: Function= () => {};
 
     beforeEach(() => {
@@ -121,58 +93,40 @@ describe('QtyDropdownComponent', () => {
   });
 
   describe('setDisabledState', () => {
+    beforeEach(() => {
+      qtyDropdownComponent.componentInstance.inputHasBeenShown = false;
+      fixture.detectChanges();
+    });
 
-    describe('when inputHasBeenShown is false', () => {
-
+    describe('when not disabled', () => {
       beforeEach(() => {
-        qtyDropdownComponent.componentInstance.inputHasBeenShown = false;
+        qtyDropdownComponent.componentInstance.setDisabledState(false);
+      });
 
+      it('should not disable <input>', () => {
+        qtyDropdownComponent.componentInstance.inputHasBeenShown = true;
         fixture.detectChanges();
-      });
-      
-      describe('when argument is false', () => {
-        
-        it('should not disable <select>', () => {
-          qtyDropdownComponent.componentInstance.setDisabledState(false);
-
-          expect(fixture.debugElement.query(By.css('select')).properties.disabled).toBeFalsy();
-        });
+        expect(fixture.debugElement.query(By.css('input')).properties.disabled).toBeFalsy();
       });
 
-      describe('when argument is true', () => {
-        
-        it('should disable <select>', () => {
-          qtyDropdownComponent.componentInstance.setDisabledState(true);
-          
-          expect(fixture.debugElement.query(By.css('select')).properties.disabled).toBeTruthy();
-        });
+      it('should not disable <select>', () => {
+        expect(fixture.debugElement.query(By.css('select')).properties.disabled).toBeFalsy();
       });
     });
 
-    describe('when inputHasBeenShown is true', () => {
-
+    describe('when disabled', () => {
       beforeEach(() => {
-        qtyDropdownComponent.componentInstance.inputHasBeenShown = true;
+        qtyDropdownComponent.componentInstance.setDisabledState(true);
+      });
 
-        fixture.detectChanges();
+      it('should disable <input>', () => {
+        qtyDropdownComponent.componentInstance.inputHasBeenShown = true;
+        fixture.detectChanges();        
+        expect(fixture.debugElement.query(By.css('input')).properties.disabled).toBeTruthy();
       });
       
-      describe('when argument is false', () => {
-        
-        it('should not disable <input>', () => {
-          qtyDropdownComponent.componentInstance.setDisabledState(false);
-
-          expect(fixture.debugElement.query(By.css('input')).properties.disabled).toBeFalsy();
-        });
-      });
-
-      describe('when argument is true', () => {
-        
-        it('should disable <input>', () => {
-          qtyDropdownComponent.componentInstance.setDisabledState(true);
-          
-          expect(fixture.debugElement.query(By.css('input')).properties.disabled).toBeTruthy();
-        });
+      it('should disable <select>', () => {
+        expect(fixture.debugElement.query(By.css('select')).properties.disabled).toBeTruthy();
       });
     });
   });
@@ -209,7 +163,7 @@ describe('QtyDropdownComponent', () => {
     describe('when qty is greater than dropdownRange', () => {
 
       beforeEach(() => {
-        qtyDropdownComponent.componentInstance.qty = 10;
+        qtyDropdownComponent.componentInstance._qtyControl.patchValue(10);
         fixture.detectChanges();        
       });
 
@@ -223,28 +177,20 @@ describe('QtyDropdownComponent', () => {
     });
   });
 
-  describe('onChangedWrapper', () => {
+  describe('onQtyChanged', () => {
     
     let input;
 
     beforeEach(() => {
       input = "2";
-      spyOn(qtyDropdownComponent.componentInstance, 'selectInput').and.callThrough();      
+      spyOn(qtyDropdownComponent.componentInstance, 'focusInput').and.callThrough();      
     });
 
     it('calls onChange with argument', () => {
       spyOn(qtyDropdownComponent.componentInstance, "onChange");
-      qtyDropdownComponent.componentInstance.onChangedWrapper(input);
+      qtyDropdownComponent.componentInstance.onQtyChanged(input);
       
       expect(qtyDropdownComponent.componentInstance.onChange).toHaveBeenCalledWith(parseInt(input));
-    });
-
-    it('calls qtyChanged.emit', () => {
-      spyOn(qtyDropdownComponent.componentInstance.qtyChanged, 'emit');
-
-      qtyDropdownComponent.componentInstance.onChangedWrapper(input);
-      
-      expect(qtyDropdownComponent.componentInstance.qtyChanged.emit).toHaveBeenCalledWith(parseInt(input));
     });
     
     describe('when value is 10', () => {
@@ -252,22 +198,22 @@ describe('QtyDropdownComponent', () => {
       beforeEach(() => {
         qtyDropdownComponent.componentInstance.inputHasBeenShown = true;
         fixture.detectChanges();
-        qtyDropdownComponent.componentInstance.onChangedWrapper("10");
+        qtyDropdownComponent.componentInstance.onQtyChanged("10");
       });
       
-      it('should calls selectInput', () => {
-        expect(qtyDropdownComponent.componentInstance.selectInput).toHaveBeenCalled();
+      it('should call focusInput', () => {
+        expect(qtyDropdownComponent.componentInstance.focusInput).toHaveBeenCalled();
       });
     });
     
     describe('when value is not 10', () => {
 
       beforeEach(() => {
-        qtyDropdownComponent.componentInstance.onChangedWrapper("2");
+        qtyDropdownComponent.componentInstance.onQtyChanged("2");
       });
       
-      it('does not call selectInput', () => {
-        expect(qtyDropdownComponent.componentInstance.selectInput).not.toHaveBeenCalled();
+      it('does not call focusInput', () => {
+        expect(qtyDropdownComponent.componentInstance.focusInput).not.toHaveBeenCalled();
       });
     });
   });

--- a/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.component.ts
+++ b/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.component.ts
@@ -1,36 +1,57 @@
-import { Component, OnInit, Input, Renderer2, ElementRef, ViewChild, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Renderer2, forwardRef, ElementRef, ViewChild, ChangeDetectionStrategy, OnChanges } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR, FormControl, FormGroup } from '@angular/forms';
 
 @Component({
   selector: 'qty-dropdown',
   templateUrl: './qty-dropdown.component.html',
-  styleUrls: ['./qty-dropdown.component.scss']
-})
-export class QtyDropdownComponent implements OnInit {
-
-  @Input() qty: number;
-  @Input() id: number;
-
-  @Output() qtyChanged: EventEmitter<number> = new EventEmitter<number>();
-
-  static readonly dropdownRange = 9;
-  dropdownItemCounter: number[];
-  inputHasBeenShown: boolean;
-  onChange = (qty: number) => {};
-  onTouched = () => {};
-
-  constructor(private renderer: Renderer2) { }
-
-  ngOnInit() {
-    this.dropdownItemCounter = Array.from(Array(QtyDropdownComponent.dropdownRange),(x,i)=>i);
-
-    if (!this.qty) {
-      this.qty = 1;
+  styleUrls: ['./qty-dropdown.component.scss'],
+  providers: [
+    { 
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => QtyDropdownComponent),
+      multi: true
     }
+  ]
+})
+export class QtyDropdownComponent implements OnInit, ControlValueAccessor {
+  @ViewChild('qtySelect') selectEl: ElementRef;
+  @ViewChild('qtyInput') inputEl: ElementRef;
+
+  _qtyControl: FormControl = new FormControl(1);
+
+  //A filler array
+  static readonly dropdownItemCounter: number[] = [
+    1,2,3,4,5,6,7,8,9
+  ];
+
+  get dropdownRange() : number {
+    return QtyDropdownComponent.dropdownItemCounter.length;
   }
 
-  writeValue(qty: number): void {
-    this.qty = qty;
-    this.onChange(this.qty);
+  //A local state keeper for managing whether
+  //or not a user has been shown a textfield yet.
+  inputHasBeenShown: boolean = false;
+
+  //on-change handler
+  onChange = (qty: number) => {};
+
+  //on-touched handler
+  onTouched = () => {};
+
+  get showQtyInputField() : boolean {
+    return this._qtyControl.value >= this.dropdownRange || this.inputHasBeenShown;
+  }
+
+  ngOnInit() {
+    this._qtyControl.valueChanges.subscribe((val) => {
+      this.onQtyChanged(val);
+    })
+  }
+
+  writeValue(value: number): void {
+    if (value !== undefined && value !== null) {
+      this._qtyControl.patchValue(value);
+    }
   }
 
   registerOnChange(fn: (qty: number) => void): void {
@@ -41,41 +62,33 @@ export class QtyDropdownComponent implements OnInit {
     this.onTouched = fn;
   }
 
-  setDisabledState(isDisabled: boolean): void {
-    if (this.inputHasBeenShown) {
-      this.renderer.setProperty(document.getElementById('input_' + this.id), 'disabled', isDisabled);
-    } else {
-      this.renderer.setProperty(document.getElementById('select_' + this.id), 'disabled', isDisabled);
-    }
-  }
 
-  get showQtyInputField() : boolean {
-    if (!this.isQtyOutsideDropdownRange() && !this.inputHasBeenShown) {
-      return false
-    } else {
-      this.inputHasBeenShown = true;
-      return true;
-    }
-  }
-
-  onChangedWrapper(value: any) {
+  /**
+   * Trigger internal changes and push form values up.
+   * @param value : any
+   */
+  onQtyChanged(value: any) {
     value = parseInt(value);
-    if (value === 10) {
-      this.selectInput();
-    }
-    this.qtyChanged.emit(value);
     this.onChange(value);
+
+    if (value > this.dropdownRange) {
+      this.updateVisibility();
+      this.focusInput();
+    }
   }
 
-  private isQtyOutsideDropdownRange() {    
-    return this.qty > QtyDropdownComponent.dropdownRange;
+  //Todo
+  setDisabledState(isDisabled: boolean): void {
+    isDisabled ? this._qtyControl.disable() : this._qtyControl.enable();
   }
 
-  private selectInput() {
-    let that = this;
+  private updateVisibility() {
+    this.inputHasBeenShown = true;
+  }
+
+  private focusInput() {
     setTimeout(function() {
-      let input = document.getElementById("input_" + that.id) as HTMLInputElement;
-      input.select();
-    });
+      this.inputEl.nativeElement.focus();
+    }.bind(this),0);
   }
 }

--- a/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.md
+++ b/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.md
@@ -1,0 +1,9 @@
+# Quantity Dropdown Component
+
+## Purpose
+The quantity dropdown component is an opinionated UI component
+which allows a user to choose a quantity of an item to purchase. 
+
+### Notes
+Since generally, users only choose to `<= 10` items, we provide a `<select>`
+when the number is `<=10`, and a form input otherwise.

--- a/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.module.spec.ts
+++ b/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.module.spec.ts
@@ -1,0 +1,13 @@
+import { QtyDropdownModule } from './qty-dropdown.module';
+
+describe('QtyDropdownModule', () => {
+  let qtyDropdownModule: QtyDropdownModule;
+
+  beforeEach(() => {
+    qtyDropdownModule = new QtyDropdownModule();
+  });
+
+  it('should create an instance', () => {
+    expect(qtyDropdownModule).toBeTruthy();
+  });
+});

--- a/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.module.ts
+++ b/apps/foundation-demo/src/app/design/molecules/qty-dropdown/qty-dropdown.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { QtyDropdownComponent } from './qty-dropdown.component';
+import { ReactiveFormsModule } from '@angular/forms';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule
+  ],
+  declarations: [
+    QtyDropdownComponent
+  ],
+  exports: [
+    QtyDropdownComponent
+  ]
+})
+export class QtyDropdownModule { }

--- a/apps/foundation-demo/src/app/product/components/product/product.component.html
+++ b/apps/foundation-demo/src/app/product/components/product/product.component.html
@@ -9,7 +9,7 @@
   </div>
   <div class="product__qty">
     <div>Quantity</div>
-    <qty-dropdown id="{{product.id}}"></qty-dropdown>
+    <qty-dropdown [(ngModel)]="qty"></qty-dropdown>
   </div>
   <div class="product__buttons">
     <button type="button" class="button expanded uppercase embolden">add to cart</button>

--- a/apps/foundation-demo/src/app/product/components/product/product.component.spec.ts
+++ b/apps/foundation-demo/src/app/product/components/product/product.component.spec.ts
@@ -9,6 +9,7 @@ import { Component, Input } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 import { Image } from '../../../design/interfaces/image';
+import { FormsModule } from '@angular/forms';
 
 @Component({template: '<product [product]="productValue"></product>'})
 class ProductWrapperTest {
@@ -16,10 +17,7 @@ class ProductWrapperTest {
 }
 
 @Component({selector: 'qty-dropdown', template: ''})
-class MockQtyDropdownComponent {
-  @Input() qty: string;
-  @Input() id: string;
-}
+class MockQtyDropdownComponent {}
 
 @Component({selector: 'image-gallery', template: ''})
 class MockImageGalleryComponent { 
@@ -48,6 +46,7 @@ describe('ProductComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
+        FormsModule,
         RouterTestingModule
       ],
       declarations: [ 
@@ -107,10 +106,8 @@ describe('ProductComponent', () => {
 
   describe('on <qty-dropdown>', () => {
     
-    it('should set id', () => {
-      let qtyDropdownComponent = fixture.debugElement.query(By.css('qty-dropdown'));
+    xit('', () => {
 
-      expect(qtyDropdownComponent.componentInstance.id).toEqual(mockProduct.id);
     });
   });
 });

--- a/apps/foundation-demo/src/app/product/product.module.ts
+++ b/apps/foundation-demo/src/app/product/product.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
 import { CoreProductModule } from '@daffodil/core';
 import { ProductGridComponent } from './components/product-grid/product-grid.component';
@@ -13,6 +14,8 @@ import { DesignModule } from '../design/design.module';
 @NgModule({
   imports: [
     CommonModule,
+    FormsModule,
+
     DesignModule,
     CoreProductModule,
   ],


### PR DESCRIPTION
feat(qty-dropdown): refactoring qty-dropdown to not depend on external id for internal operations and migrating to proper ControlValueAccessor interface.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current qty-dropdown implements the interface for a ControlValueAccessor, but is missing the interface on it's class and additionally, has some odd quirks in it's internal workings. Additionally, the API (as described in the code) doesn't utilize ControlValueAccessor at all.

Issue Number: N/A


## What is the new behavior?
This refactors the component to utilize the ControlValueAccessor and removes the antiquated `@input` and `@output`.


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

The breaking change can be mitigated by changing the dependencies to rely upon `ngModel` or `formControl` as opposed to `qtyChanged` and `qty`.

## Other information