### PR TITLE
Add `Colorable` and `daffColorableMixin` to support coloring components based on the palette.

### DIFF
--- a/apps/foundation-demo/src/app/cart/components/cart-wrapper/cart-wrapper.component.html
+++ b/apps/foundation-demo/src/app/cart/components/cart-wrapper/cart-wrapper.component.html
@@ -5,7 +5,7 @@
       <span class="cart-wrapper__item-count">{{cart.items.length}} {{itemText}}</span>
     </div>
     <cart [cart]="cart"></cart>
-    <button type="button" daff-button continue-shopping class="cart-wrapper__continue-shopping" *ngIf="isCartEmpty">
+    <button type="button" daff-button color="black" continue-shopping class="cart-wrapper__continue-shopping" *ngIf="isCartEmpty">
       Continue Shopping
     </button>
   </div>
@@ -15,10 +15,10 @@
       <promotion class="cart-wrapper__promotion"></promotion>
       <cart-totals class="cart-wrapper__cart-totals" [cart]="cart"></cart-totals>
       <div daff-button-set class="cart-wrapper__button-set">
-        <button type="button" daff-button proceed-to-checkout>
+        <button type="button" daff-button color="black" proceed-to-checkout>
           Proceed to Checkout
         </button>
-        <button type="button" daff-stroked-button continue-shopping>
+        <button type="button" daff-stroked-button color="black" continue-shopping>
           Continue Shopping
         </button>
       </div>

--- a/apps/foundation-demo/src/app/cart/components/promotion/promotion.component.html
+++ b/apps/foundation-demo/src/app/cart/components/promotion/promotion.component.html
@@ -3,6 +3,6 @@
   <span class="fas fa-chevron-down promotion__chevron"></span>
   <div class="promotion__form">
     <input daff-input class="promotion__input">
-    <button daff-button type="button" class="promotion__button">Apply</button>
+    <button daff-button color="black" type="button" class="promotion__button">Apply</button>
   </div>
 </div>

--- a/apps/foundation-demo/src/app/core/footer/footer.component.html
+++ b/apps/foundation-demo/src/app/core/footer/footer.component.html
@@ -22,9 +22,9 @@
       <li daff-list-item><a href="#">Accessories</a></li>
     </ul>
     <div daff-button-set>
-      <a daff-icon-button href="#" target="_blank" rel="noopener noreferrer"><i class="fab fa-twitter"></i></a>
-      <a daff-icon-button href="#" target="_blank" rel="noopener noreferrer"><i class="fab fa-facebook-f"></i></a>
-      <a daff-icon-button href="#" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+      <a daff-icon-button color="black" href="#" target="_blank" rel="noopener noreferrer"><i class="fab fa-twitter"></i></a>
+      <a daff-icon-button color="black" href="#" target="_blank" rel="noopener noreferrer"><i class="fab fa-facebook-f"></i></a>
+      <a daff-icon-button color="black" href="#" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
     </div>
   </div>
 </daff-container>

--- a/apps/foundation-demo/src/app/newsletter/newsletter.component.html
+++ b/apps/foundation-demo/src/app/newsletter/newsletter.component.html
@@ -10,7 +10,7 @@
     </div>
     <div class="newsletter__right">
       <input daff-input type="text" class="newsletter__input" placeholder="Email" name="email" />
-      <button type="submit" daff-button class="newsletter__button">Sign Up</button>
+      <button type="submit" daff-button color="accent" class="newsletter__button">Sign Up</button>
     </div>
   </div>
 </daff-container>

--- a/apps/foundation-demo/src/app/newsletter/newsletter.component.scss
+++ b/apps/foundation-demo/src/app/newsletter/newsletter.component.scss
@@ -40,7 +40,8 @@
 
   &__input {
     width: 60%;
-    display: inline;
+    display: inline-block;
+    border: 1px solid $white;
 
     @include breakpoint(tablet) {
       width: 70%;
@@ -48,8 +49,6 @@
   }
 
   &__button {
-    background-color: $accent;
-    border: 1px solid $accent;
     width: 40%;
     line-height: 1.5rem;
 

--- a/apps/foundation-demo/src/app/product/components/add-to-cart/add-to-cart.component.html
+++ b/apps/foundation-demo/src/app/product/components/add-to-cart/add-to-cart.component.html
@@ -1,1 +1,1 @@
-<button daff-button type="button" (click)="onAddToCart()">Add to Cart</button>
+<button daff-button color="black" type="button" (click)="onAddToCart()">Add to Cart</button>

--- a/libs/design/src/atoms/button/button.component.scss
+++ b/libs/design/src/atoms/button/button.component.scss
@@ -5,10 +5,7 @@
     display: inline-block;
     position: relative;
     overflow: hidden;
-    background-color: $black;
-    border: 1px solid $black;
     font-size: 1rem;
-    color: $white;
     margin: 0;
     padding: 15px 20px;
     text-align: center;
@@ -19,9 +16,48 @@
         outline: none;
     }
 
-    &:hover {
-        background-color: daff-color($daff-gray, 800);
-        border: 1px solid daff-color($daff-gray, 800);
+    &.daff-primary {
+        background-color: $primary;
+        border: 1px solid $primary;
+        color: $black;
+
+        &:hover {
+            background-color: daff-color($daff-primary, 700);
+            border: 1px solid daff-color($daff-primary, 700);
+        }
+    }
+
+    &.daff-accent {
+        background-color: $accent;
+        border: 1px solid $accent;
+        color: $white;
+
+        &:hover {
+            background-color: daff-color($daff-accent, 700);
+            border: 1px solid daff-color($daff-accent, 700);
+        }
+    }
+
+    &.daff-black {
+        background-color: $black;
+        border: 1px solid $black;
+        color: $white;
+
+        &:hover {
+            background-color: daff-color($daff-gray, 800);
+            border: 1px solid daff-color($daff-gray, 800);
+        }
+    }
+
+    &.daff-white {
+        background-color: $white;
+        border: 1px solid $white;
+        color: $black;
+
+        &:hover {
+            background-color: daff-color($daff-gray, 100);
+            border: 1px solid daff-color($daff-gray, 100);
+        }
     }
 }
 
@@ -43,8 +79,36 @@
         outline: none;
     }
 
-    &:hover {
-        color: daff-color($daff-gray, 800);
+    &.daff-primary {
+        color: $primary;
+
+        &:hover {
+            color: daff-color($daff-primary, 700);
+        }
+    }
+
+    &.daff-accent {
+        color: $accent;
+
+        &:hover {
+            color: daff-color($daff-accent, 700);
+        }
+    }
+
+    &.daff-black {
+        color: $black;
+
+        &:hover {
+            color: daff-color($daff-gray, 800);
+        }
+    }
+
+    &.daff-white {
+        color: $white;
+
+        &:hover {
+            color: daff-color($daff-gray, 100);
+        }
     }
 }
 
@@ -56,7 +120,6 @@
     background-color: transparent;
     border: 1px solid transparent;
     font-size: 1rem;
-    color: $black;
     margin: 0;
     padding: 15px 20px;
     text-align: center;
@@ -64,9 +127,36 @@
     transition: 0.2s ease-in;
 
 
-    &:hover {
-        border-color: daff-color($daff-gray, 400);
-        border: 1px solid daff-color($daff-gray, 400);
+    &.daff-primary {
+        color: $primary;
+
+        &:hover {
+            color: daff-color($daff-primary, 700);
+        }
+    }
+
+    &.daff-accent {
+        color: $accent;
+        
+        &:hover {
+            color: daff-color($daff-accent, 700);
+        }
+    }
+
+    &.daff-black {
+        color: $black;
+        
+        &:hover {
+            color: daff-color($daff-gray, 800);
+        }
+    }
+
+    &.daff-white {
+        color: $white;
+        
+        &:hover {
+            color: daff-color($daff-gray, 100);
+        }
     }
 
     &:focus {
@@ -79,19 +169,52 @@
     display: inline-block;
     position: relative;
     overflow: hidden;
-    background-color: transparent;
-    border: 1px solid $black;
     font-size: 1rem;
-    color: $black;
     margin: 0;
     padding: 15px 20px;
     text-align: center;
     cursor: pointer;
+    background-color: transparent;
     transition: 0.2s ease-in;
 
-    &:hover {
-        background-color: $black;
+    &.daff-primary {
+        border: 1px solid $primary;
+        color: $primary;
+
+        &:hover {
+            background-color: $primary;
+            color: $white;
+        }
+    }
+
+    &.daff-accent {
+        border: 1px solid $accent;
+        color: $accent;
+
+        &:hover {
+            background-color: $accent;
+            color: $white;
+        }
+    }
+
+    &.daff-black {
+        border: 1px solid $black;
+        color: $black;
+
+        &:hover {
+            background-color: $black;
+            color: $white;
+        }
+    }
+
+    &.daff-white {
+        border: 1px solid $white;
         color: $white;
+
+        &:hover {
+            background-color: $white;
+            color: $black;
+        }
     }
 
     &:focus {

--- a/libs/design/src/atoms/button/button.component.spec.ts
+++ b/libs/design/src/atoms/button/button.component.spec.ts
@@ -3,20 +3,23 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DaffButtonComponent } from './button.component';
 import { By } from '@angular/platform-browser';
+import { DaffPalette } from '../../core/colorable/colorable';
 
 @Component({
   template: `
-    <a daff-button>Link Daff Button</a>
-    <a daff-clear-button>Link Daff Clear Button</a>
-    <a daff-stroked-button>Link Daff Stroked Button</a>
-    <a daff-icon-button>Link Daff Icon Button</a>
-    <button daff-button>Button Daff Button</button>
-    <button daff-clear-button>Button Daff Clear Button</button>
-    <button daff-stroked-button>Button Daff Stroked Button</button>
-    <button daff-icon-button>Button Daff Icon Button</button>
+    <a daff-button [color]="color">Link Daff Button</a>
+    <a daff-clear-button [color]="color">Link Daff Clear Button</a>
+    <a daff-stroked-button [color]="color">Link Daff Stroked Button</a>
+    <a daff-icon-button [color]="color">Link Daff Icon Button</a>
+    <button daff-button [color]="color">Button Daff Button</button>
+    <button daff-clear-button [color]="color">Button Daff Clear Button</button>
+    <button daff-stroked-button [color]="color">Button Daff Stroked Button</button>
+    <button daff-icon-button [color]="color">Button Daff Icon Button</button>
   `
 })
-class TestButtonWrapper {}
+class TestButtonWrapper {
+  color: DaffPalette;
+}
 
 describe('DaffButtonComponent', () => {
   let component: TestButtonWrapper;
@@ -73,4 +76,14 @@ describe('DaffButtonComponent', () => {
       expect(fixture.debugElement.query(By.css('button[daff-icon-button]')).nativeElement.classList.contains('daff-icon-button')).toEqual(true);
     });
   }); 
+
+  describe('using a colored variant of a button',() => {
+    it('should set a color class on the button', () => {
+      component.color = "primary";
+      fixture.detectChanges();
+      
+      let buttonDE = fixture.debugElement.query(By.css('button[daff-button]'));
+      expect(buttonDE.nativeElement.classList.contains('daff-primary')).toEqual(true);
+    });
+  });
 });

--- a/libs/design/src/atoms/button/button.component.ts
+++ b/libs/design/src/atoms/button/button.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnInit, ViewEncapsulation, ChangeDetectionStrategy, ElementRef } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, ChangeDetectionStrategy, ElementRef, Input } from '@angular/core';
+
+import { daffColorMixin, DaffColorable, DaffPalette } from '../../core/colorable/colorable';
 
 /**
 * List of classes to add to Daff Button instances based on host attributes to style as different variants.
 */
-
 const BUTTON_HOST_ATTRIBUTES = [
   'daff-button',
   'daff-clear-button',
@@ -11,6 +12,14 @@ const BUTTON_HOST_ATTRIBUTES = [
   'daff-icon-button'
 ];
 
+/**
+ * An _elementRef is needed for the Colorable mixin
+ */
+export class DaffButtonBase{
+  constructor(public _elementRef: ElementRef) {}
+}
+
+const _daffButtonBase = daffColorMixin(DaffButtonBase) 
 
 @Component({
   selector: '' +
@@ -28,11 +37,14 @@ const BUTTON_HOST_ATTRIBUTES = [
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 
-export class DaffButtonComponent implements OnInit {
+export class DaffButtonComponent extends _daffButtonBase implements OnInit, DaffColorable {
+    @Input() color: DaffPalette;
 
     ngOnInit() {}
 
     constructor(private elementRef: ElementRef) {
+      super(elementRef);
+
       for (const attr of BUTTON_HOST_ATTRIBUTES) {
         if (this._hasHostAttributes(attr)) {
           (elementRef.nativeElement as HTMLElement).classList.add(attr);

--- a/libs/design/src/atoms/button/button.md
+++ b/libs/design/src/atoms/button/button.md
@@ -13,13 +13,19 @@ The button is used for making actions apparent to the end-user. It can be used t
 * `gc-stroked-button` — Rectangular outlined button with no background color
 * `gc-icon-button` — Icon button used with icon fonts
 
+## Colors
+
+To define a button color, add `color="[value]"` to the button tag.
+
+* Color values: `primary`, `accent`, `black`, and `white`
+
 ## Accessbility
 
 Icon buttons need to be given labels using `aria-label`.
 
 ## Usage
 ```
-<button daff-button>
+<button daff-button color="primary">
   button text
 </button>
 ```

--- a/libs/design/src/core/colorable/colorable.spec.ts
+++ b/libs/design/src/core/colorable/colorable.spec.ts
@@ -1,0 +1,138 @@
+import { daffColorMixin, colorInPalette } from "./colorable";
+import { ElementRef } from "@angular/core";
+
+/**
+ * Some of these tests are inspired by the @angular/material
+ * color common-behavior, as it is a really clean implementation.
+ */
+describe('daffColorMixin', () => {
+  let instance;
+  let classWithColor;
+
+  beforeEach(() => {
+    classWithColor = daffColorMixin(TestingClass);
+    instance = new classWithColor();
+  });
+
+  it('should add a color property to an existing class', () => {
+      expect("color" in instance).toBeTruthy();
+  });
+
+  it('should allow the consuming class to optionally define a default color', () => {
+    classWithColor = daffColorMixin(TestingClass, "primary");
+    instance = new classWithColor();
+
+    expect(instance.color).toEqual("primary");
+    expect(instance.element.classList).toContain('daff-primary');
+  });
+
+  describe('when a color is specified', () => {
+    
+    it('should set a namespaced color class', () => {
+      instance.color = "primary";
+
+      expect(instance.element.classList).toContain("daff-primary");
+    });
+  });
+
+  describe('when a color is not specified', () => {
+    
+    it('should default to no color class', () => {
+      instance.color = undefined;
+      expect(instance.element.classList.length).toEqual(0);
+    });
+  });
+
+  describe('when `color` changes', () => {
+
+    beforeEach(() => {
+      instance.color = "primary";
+      expect(instance.element.classList).toContain('daff-primary');
+
+      instance.color = "accent";
+    });
+    
+    it('should add the new color class', () => {
+      expect(instance.element.classList).toContain('daff-accent');
+    });
+
+    it('should remove the provious color class', () => {
+      expect(instance.element.classList).not.toContain('daff-primary');
+    });
+  });
+
+  describe('when one of the `DaffPalette` types is not used', () => {
+    it('should throw an error', () => {
+      expect(function(){
+        instance.color = "SOMEFAKEPALETTE"
+      }).toThrow(new TypeError("SOMEFAKEPALETTE is not a valid color for the DaffPalette"));
+    });
+  });
+
+  describe('when a default color is undefined', () => {
+    describe('and color is set to null or undefined', () => {
+      it('should do nothing', () => {
+        instance.color = null;
+        expect(instance.element.classList.value).toEqual("");
+
+        instance.color = undefined;
+        expect(instance.element.classList.value).toEqual("");
+      });
+    });
+  });
+
+  describe('when a default color is specified', () => {
+
+    beforeEach(() => {
+      classWithColor = daffColorMixin(TestingClass, "primary");
+      instance = new classWithColor();
+    });
+
+    describe('and color is set to null or undefined', () => {
+      it('should set color to the default color ', () => {
+        instance.color = null;
+
+        expect(instance.color).toEqual("primary");
+        expect(instance.element.classList).toContain('daff-primary');
+
+        instance.color = undefined;
+
+        expect(instance.color).toEqual("primary");
+        expect(instance.element.classList).toContain('daff-primary');
+      });
+    })
+  })
+});
+
+describe('colorInPalette', () => {
+  describe('when color is in the palette', () => {
+    it('should return true', () => {
+        expect(colorInPalette("black")).toEqual(true);
+        expect(colorInPalette("white")).toEqual(true);
+        expect(colorInPalette("primary")).toEqual(true);
+        expect(colorInPalette("accent")).toEqual(true);
+    });
+  });
+
+  describe('when color is NOT in the palette', () => {
+    it('should return false', () => {
+        expect(colorInPalette("purple")).toEqual(false);
+        expect(colorInPalette("green")).toEqual(false);
+        expect(colorInPalette("red")).toEqual(false);
+        expect(colorInPalette("blarck")).toEqual(false);
+    });
+  });
+
+  describe('when the color is undefined or null', () => {
+    it('should return false', () => {
+        expect(colorInPalette(undefined)).toEqual(false);
+        expect(colorInPalette(null)).toEqual(false);
+    });
+  });
+})
+
+class TestingClass {
+  element: HTMLElement = document.createElement('div');
+
+  _elementRef = new ElementRef<HTMLElement>(this.element);
+}

--- a/libs/design/src/core/colorable/colorable.ts
+++ b/libs/design/src/core/colorable/colorable.ts
@@ -1,0 +1,70 @@
+import { ElementRef, Type } from "@angular/core";
+import { Constructor } from '../constructor';
+
+/**
+ * In order to be colorable, our class must implement this property
+ */
+export interface DaffColorable {
+    color: DaffPalette;
+}
+
+/**
+ * These are the valid options that can be passed to a DaffColorable component
+ */
+export type DaffPalette = "primary" | "accent" | "black" | "white" | undefined;
+export enum DaffPaletteEnum {
+    PRIMARY = "primary",
+    ACCENT = "accent",
+    BLACK = "black",
+    WHITE = "white",
+}
+export interface HasElementRef {
+    _elementRef: ElementRef;
+  }
+
+/**
+ * This should be a trait, but typescript only supports mixins.
+ * See: https://github.com/Microsoft/TypeScript/issues/311
+ * 
+ * Turns out the material team followed the same path with the color mixin.
+ * https://github.com/angular/material2/blob/master/src/lib/core/common-behaviors/color.ts
+ */
+export function 
+    daffColorMixin<T extends Constructor<HasElementRef>>(Base: T, defaultColor? : DaffPalette) {
+    return class extends Base {
+        //TODO move this back to private in Typescript 3.1
+        _color: DaffPalette;
+
+        get color(): DaffPalette{return this._color;}
+        set color(value: DaffPalette) {
+            //Handle the default color
+            const incomingColor = value || defaultColor;
+
+            if(incomingColor !== undefined && !colorInPalette(incomingColor)){
+                throw new TypeError(incomingColor + " is not a valid color for the DaffPalette");   
+            }
+
+            if(incomingColor !== this._color){ //Only run the dom-render if a change occurs
+                //Remove the old color
+                if(this._color){
+                    this._elementRef.nativeElement.classList.remove(`daff-${this._color}`);
+                }
+
+                if(incomingColor){
+                    this._elementRef.nativeElement.classList.add(`daff-${incomingColor}`);
+                }
+
+                this._color = incomingColor;
+            }   
+        }
+
+        constructor(...args: any[]) {
+            super(...args);
+            this.color = defaultColor;
+        }
+    }
+}
+
+export function colorInPalette(color: string) : boolean{
+    return (<any>Object).values(DaffPaletteEnum).includes(color)
+}

--- a/libs/design/src/core/constructor.ts
+++ b/libs/design/src/core/constructor.ts
@@ -1,0 +1,7 @@
+/**
+ * A basic constructor type useful for mixins
+ * See https://blog.mariusschulz.com/2017/05/26/typescript-2-2-mixin-classes
+ * for a really good explanation of why mixins are useful.
+ */
+
+export type Constructor<T = {}> = new (...args: any[]) => T;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, you have to manually apply button colors.

Issue Number: #113 

## What is the new behavior?
You can now apply the mixin to the component class and get colors~
Fixes: #113 

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```