### PR TITLE
style(design): fix button-set flex issue on mobile

### DIFF
--- a/libs/design/src/molecules/button-set/button-set.component.scss
+++ b/libs/design/src/molecules/button-set/button-set.component.scss
@@ -1,14 +1,29 @@
+@import '../../scss/daff-util';
+
 .daff-button-set {
   display: flex;
   flex-wrap: wrap;
+  flex-direction: column;
+
+  @include breakpoint(mobile) {
+    flex-direction: row;
+  }
 
   > * {
-    margin-right: 5px;
+    margin: 0 0 5px 0;
 
     &:last-child {
-      margin-right: 0;
+      margin: 0;
     }
 
+    @include breakpoint(mobile) {
+      margin: 0 5px 0 0;
+  
+      &:last-child {
+        margin: 0;
+      }
+    }
+    
     &:focus {
       outline: none;
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Buttons inside button-set does not flex properly on small screens.

Issue Number: N/A


## What is the new behavior?
Allow small screens to` flex-direction: row;` and big screens to `flex-direction: column`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information