### PR TITLE
Make all randomly generated prices under 1000

### DIFF
--- a/libs/core/testing/src/cart/factories/cart-item.factory.ts
+++ b/libs/core/testing/src/cart/factories/cart-item.factory.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import * as faker from 'faker/locale/en_US';
 
-import { CartItem, range } from '@daffodil/core';
+import { CartItem } from '@daffodil/core';
 
 import { ModelFactory } from "../../factories/factory";
 
@@ -18,13 +18,13 @@ export class MockCartItem implements CartItem {
   description = 'description';
   weight = faker.random.number(1000);
   qty = faker.random.number({min:1, max:100});
-  price = faker.random.number(1000);
+  price = faker.random.number(999);
   discount_percent = faker.random.number(10);
   discount_amount = faker.random.number(100);
   tax_percent = faker.random.number(10);
   tax_amount = faker.random.number(10);
-  row_total = faker.random.number(1000);
-  row_total_with_discount = faker.random.number(1000);
+  row_total = faker.random.number(999);
+  row_total_with_discount = faker.random.number(999);
   row_weight = faker.random.number(100);
   tax_before_discount = faker.random.number(100);
 }

--- a/libs/core/testing/src/cart/factories/cart-shipping-rate.factory.spec.ts
+++ b/libs/core/testing/src/cart/factories/cart-shipping-rate.factory.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { DaffCartItemFactory } from './cart-item.factory';
-import { CartItem, CartShippingRate } from '@daffodil/core';
+import { CartShippingRate } from '@daffodil/core';
 import { DaffCartShippingRateFactory } from './cart-shipping-rate.factory';
 
 describe('Core | Testing | Cart | Factories | CartShippingRateFactory', () => {

--- a/libs/core/testing/src/cart/factories/cart-shipping-rate.factory.ts
+++ b/libs/core/testing/src/cart/factories/cart-shipping-rate.factory.ts
@@ -14,7 +14,7 @@ export class MockCartShippingRate implements CartShippingRate {
     code = 'code';
     method = 'swallow';
     method_description = 'efficient';
-    price = faker.random.number(1000);
+    price = faker.random.number(999);
     error_message = 'error message';
     method_title = 'laden';
 }

--- a/libs/core/testing/src/cart/factories/cart.factory.ts
+++ b/libs/core/testing/src/cart/factories/cart.factory.ts
@@ -1,20 +1,20 @@
 import { Injectable } from '@angular/core';
 import * as faker from 'faker/locale/en_US';
 
-import { Cart, CartItem, CartAddress} from '@daffodil/core';
+import { Cart } from '@daffodil/core';
 import { ModelFactory } from '../../factories/factory';
 
 export class MockCart implements Cart {
   id = faker.random.number(1000);
   created_at = new Date();
   updated_at = new Date();
-  store_to_base_rate = faker.random.number(1000);
-  grand_total = faker.random.number(1000);
+  store_to_base_rate = faker.random.number(999);
+  grand_total = faker.random.number(999);
   checkout_method = 'card';
   customer_id = faker.random.number(1000);
   coupon_code = faker.random.number(100000).toString();
-  subtotal = faker.random.number(1000);
-  subtotal_with_discount = faker.random.number(1000);
+  subtotal = faker.random.number(999);
+  subtotal_with_discount = faker.random.number(999);
   items = [];
   addresses = [];
   payment = null;

--- a/libs/core/testing/src/product/factories/product.factory.ts
+++ b/libs/core/testing/src/product/factories/product.factory.ts
@@ -5,7 +5,7 @@ import { ModelFactory } from "../../factories/factory";
 
 export class MockProduct implements Product {
   id = faker.random.number(10000).toString();
-  price = faker.random.number(1000).toString();
+  price = faker.random.number(999).toString();
   name = faker.commerce.productName();
   brand = faker.company.companyName();
   description = "Lorem ipsum dolor sit amet, accumsan ullamcorper ei eam. Sint appetere ocurreret no per, et cum lorem disputationi. Sit ut magna delenit, assum vidisse vocibus sed ut. In aperiri malorum accusamus sea, novum mediocritatem ius at. Duo agam probo honestatis ut. Nec regione splendide cu, unum graeco vivendum in duo."


### PR DESCRIPTION
make all randomly generated prices under 1000 to make formatted prices easier to test

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently randomly generated prices can range from 1-1000. A build failed because a formatted price in the DOM was `$1,000` instead of $1000`. 

Issue Number: N/A


## What is the new behavior?
Instead of making the tests formatted too, I just decreased the price range from 1-1000 to 1-999.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```