### PR TITLE
testing(core,demo): clean up path and usage of DaffMockCurrencyPipe

### DIFF
--- a/apps/demo/src/app/cart/components/cart-totals/cart-totals.component.spec.ts
+++ b/apps/demo/src/app/cart/components/cart-totals/cart-totals.component.spec.ts
@@ -13,7 +13,7 @@ class WrapperComponent {
   @Input() cartValue: Cart;
 }
 
-fdescribe('CartTotalsComponent', () => {
+describe('CartTotalsComponent', () => {
   let wrapper: WrapperComponent;
   let fixture: ComponentFixture<WrapperComponent>;
   let cartTotalsComponent: CartTotalsComponent;

--- a/apps/demo/src/app/cart/components/cart-totals/cart-totals.component.spec.ts
+++ b/apps/demo/src/app/cart/components/cart-totals/cart-totals.component.spec.ts
@@ -3,7 +3,7 @@ import { By } from '@angular/platform-browser';
 import { Component, Input } from '@angular/core';
 
 import { Cart } from '@daffodil/core';
-import { DaffCartItemFactory, DaffCartFactory, DaffMockPipes } from '@daffodil/core/testing';
+import { DaffCartItemFactory, DaffCartFactory, DaffMockCurrencyPipe } from '@daffodil/core/testing';
 
 import { CartTotalsComponent } from './cart-totals.component';
 import { CartTotalsItemModule } from '../cart-totals-item/cart-totals-item.module';
@@ -13,12 +13,12 @@ class WrapperComponent {
   @Input() cartValue: Cart;
 }
 
-describe('CartTotalsComponent', () => {
+fdescribe('CartTotalsComponent', () => {
   let wrapper: WrapperComponent;
   let fixture: ComponentFixture<WrapperComponent>;
   let cartTotalsComponent: CartTotalsComponent;
   let cartTotalsItemComponent: any;
-  let currencyPipeTransformSpy;
+  let currencyPipe;
   const cartFactory = new DaffCartFactory();
   const cartItemFactory = new DaffCartItemFactory();
 
@@ -33,9 +33,9 @@ describe('CartTotalsComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        CartTotalsComponent,
         WrapperComponent,
-        DaffMockPipes.DaffMockCurrencyPipe
+        CartTotalsComponent,
+        DaffMockCurrencyPipe
       ],
       imports: [
         CartTotalsItemModule
@@ -47,7 +47,7 @@ describe('CartTotalsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);
     wrapper = fixture.componentInstance;
-    currencyPipeTransformSpy = spyOn(DaffMockPipes.DaffMockCurrencyPipe.prototype, 'transform');
+    currencyPipe = spyOn(DaffMockCurrencyPipe.prototype, 'transform');
     
     wrapper.cartValue = mockCart;
 
@@ -98,7 +98,7 @@ describe('CartTotalsComponent', () => {
     });
   
     it('should call the angular CurrencyPipe.transform with cartTax', () => {
-      expect(currencyPipeTransformSpy).toHaveBeenCalledWith(cartTotalsComponent.cartTax);
+      expect(currencyPipe).toHaveBeenCalledWith(cartTotalsComponent.cartTax);
     });
   });
 
@@ -113,7 +113,7 @@ describe('CartTotalsComponent', () => {
     });
     
     it('should call the angular CurrencyPipe.transform with cart subtotal', () => {  
-      expect(currencyPipeTransformSpy).toHaveBeenCalledWith(mockCart.subtotal);
+      expect(currencyPipe).toHaveBeenCalledWith(mockCart.subtotal);
     });
   });
 
@@ -128,7 +128,7 @@ describe('CartTotalsComponent', () => {
     });
 
     it('should call the angular CurrencyPipe.transform with cart grand_total', () => {
-      expect(currencyPipeTransformSpy).toHaveBeenCalledWith(cartTotalsComponent.cart.grand_total);
+      expect(currencyPipe).toHaveBeenCalledWith(cartTotalsComponent.cart.grand_total);
     });
   });
 });

--- a/libs/core/testing/src/angular-mocks/mock-pipes.ts
+++ b/libs/core/testing/src/angular-mocks/mock-pipes.ts
@@ -1,6 +1,0 @@
-import { Pipe, PipeTransform } from '@angular/core';
-
-@Pipe({name: 'currency'})
-export class DaffMockCurrencyPipe implements PipeTransform {
-  transform(value: number) {};
-}

--- a/libs/core/testing/src/angular/mocks/pipes/currency.ts
+++ b/libs/core/testing/src/angular/mocks/pipes/currency.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * @docs
+ * A mock CurrencyPipe that does nothing to a given input.
+ * This pipe is useful for asserting that a CurrencyPipe is in use via a spy, 
+ * but ignoring the actual underlying implementation
+ */
+@Pipe({name: 'currency'})
+export class DaffMockCurrencyPipe implements PipeTransform {
+  transform(value: number) {};
+}

--- a/libs/core/testing/src/index.ts
+++ b/libs/core/testing/src/index.ts
@@ -21,9 +21,8 @@ export { productHelper };
 export { DaffShippingOptionFactory } from "./shipping/factories/shipping-option.factory";
 export { DaffShippingRateFactory } from "./shipping/factories/shipping-rate.factory";
 
-//Angular Mocks
-import * as DaffMockPipes from "./angular-mocks/mock-pipes";
-export { DaffMockPipes };
+//@angular/core
+export { DaffMockCurrencyPipe } from './angular/mocks/pipes/currency';
 
 //Core
 export { DaffCoreTestingModule } from "./testing.module";

--- a/libs/core/testing/src/testing.module.ts
+++ b/libs/core/testing/src/testing.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { DaffMockCurrencyPipe } from './angular-mocks/mock-pipes';
+import { DaffMockCurrencyPipe } from './angular/mocks/pipes/currency';
 
 @NgModule({
   declarations: [


### PR DESCRIPTION
@lderrickable I spent a bit of time clearing up the imports and paths of the `DaffMockCurrencyPipe`. Give it a look over.