### PR TITLE
fix(daffio): fix display type on host element in footer

### DIFF
--- a/apps/daffio/src/app/core/footer/footer.component.scss
+++ b/apps/daffio/src/app/core/footer/footer.component.scss
@@ -1,6 +1,7 @@
 @import 'daff-util';
 
 :host {
+  display: block;
   padding: 50px 25px;
   border-top: 1px solid daff-color($daff-gray, 200);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The footer on the daffio site is off in Firefox and Safari.

Issue Number: N/A


## What is the new behavior?
This changes the `display` property on the `host` footer element to `block` to make it act correctly in both Firefox and Safari.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```