### PR TITLE
feat(design): force text-align: left on lists

### DIFF
--- a/libs/design/src/molecules/list/list/list.component.scss
+++ b/libs/design/src/molecules/list/list/list.component.scss
@@ -58,6 +58,7 @@
   $root: &;
   display: flex;
   padding: 8px 0;
+  text-align: left;
 
   &:first-of-type {
     padding: 0 0 8px 0;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, you can set "text-align:center" on lists and all the sub-elements center. I don't think this is ever desired.

Issue Number: N/A


## What is the new behavior?
The enforces the left-align behavior.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information