### PR TITLE
feat(design): create chevron mixin to remove fontawesome dependency in design library

### DIFF
--- a/libs/design/src/molecules/accordion/accordion-item/accordion-item.component.html
+++ b/libs/design/src/molecules/accordion/accordion-item/accordion-item.component.html
@@ -1,7 +1,9 @@
 <div class="daff-accordion-item__header" (click)="toggleActive()">
   <ng-content select="[daffAccordionItemTitle]"></ng-content>
-  <span [hidden]="_open"><i class="fas fa-chevron-down daff-accordion-item__icon"></i></span>
-  <span [hidden]="!_open"><i class="fas fa-chevron-up daff-accordion-item__icon"></i></span>
+  <span [hidden]="_open" class="daff-accordion-item__open-icon">
+  </span>
+  <span [hidden]="!_open" class="daff-accordion-item__close-icon">
+  </span>
 </div>
 <div [@openAccordion]="_animationState">
   <ng-content></ng-content>

--- a/libs/design/src/molecules/accordion/accordion-item/accordion-item.component.scss
+++ b/libs/design/src/molecules/accordion/accordion-item/accordion-item.component.scss
@@ -32,4 +32,16 @@
       padding-top: 30px;
     }
   }
+
+  &__open-icon {
+    &:after {
+      @include chevron($direction: "down");
+  }
+  }
+
+  &__close-icon {
+    &:after {
+      @include chevron($direction: "up");
+    }
+  }
 }

--- a/libs/design/src/scss/daff-util.scss
+++ b/libs/design/src/scss/daff-util.scss
@@ -12,3 +12,4 @@
 //TODO Remove these from @daffodil/design
 @import 'mixins/cart-total';
 @import 'mixins/dividers';
+@import 'mixins/chevron';

--- a/libs/design/src/scss/mixins/_chevron.scss
+++ b/libs/design/src/scss/mixins/_chevron.scss
@@ -1,0 +1,44 @@
+/**
+* @docs
+* 
+* The chevron mixin sets directional chevron icons to elements
+* 
+* @usage
+* ```
+* @include chevron($direction: "down");
+* ```
+*/
+
+@mixin chevron($direction) {
+  content: '';
+  display: inline-block;
+  position: relative;
+  border-style: solid;
+	border-width: 0.15em 0.15em 0 0;
+  height: 0.5em;
+  width: 0.5em;
+  left: -0.15em;
+  top: 0.15em;
+  vertical-align: middle;
+  backface-visibility: initial;
+
+  @if $direction == "down" {
+    top: -0.15em;
+	  transform: rotate(135deg);
+  }
+
+  @else if $direction == "up" {
+    transform: rotate(-45deg);
+  }
+
+  @else if $direction == "left" {
+    left: 0.15em;
+    top: -0.075em;
+	  transform: rotate(-135deg);
+  }
+
+  @else if $direction == "right" {
+    top: -0.075em;
+	  transform: rotate(45deg);
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
FontAwesome is only used in one instance in the design library (up/down chevron for accordion). We don't need to load the whole FontAwesome library if it's only used in one instance.

Fixes: #264 


## What is the new behavior?
Create chevron mixin to handle icons for accordion.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information