### PR TITLE
feat(design): make daff-link pull font-size from their surroundings

### DIFF
--- a/libs/design/src/atoms/link/link.component.scss
+++ b/libs/design/src/atoms/link/link.component.scss
@@ -3,8 +3,8 @@
 .daff-link {
 	@include clickable();
 	display: inline-block;
-	font-size: 1rem;
-	line-height: 1.5rem;
+	font-size: 1em;
+	line-height: 1.5em;
 	text-decoration: none;
 
 	&[disabled] {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, the `[daff-link]` has a fixed font-size.


## What is the new behavior?
[daff-link] should its size from the surrounding fonts.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information