### PR TITLE
feat(design): add supported design size breakpoints as typescript enum

### DIFF
--- a/libs/design/src/core/breakpoints/breakpoints.ts
+++ b/libs/design/src/core/breakpoints/breakpoints.ts
@@ -1,0 +1,8 @@
+export enum DaffBreakpoints {
+  DESKTOP = "(min-width: 1920px)",
+	LAPTOP = "(min-width: 1440px)",
+	SMALL_LAPTOP = "(min-width: 1200px)",
+	BIG_TABLET = "(min-width: 1024px)",
+	TABLET = "(min-width: 768px)",
+	MOBILE = "(min-width: 480px)",
+}

--- a/libs/design/src/public_api.ts
+++ b/libs/design/src/public_api.ts
@@ -31,3 +31,4 @@ export * from './molecules/card/public_api';
 
 // Core
 export * from './core/colorable/colorable';
+export * from './core/breakpoints/breakpoints';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, we don't have a clear way to match the current breakpoints in Typescript.

Fixes: N/A


## What is the new behavior?
This gives us the ability to reference Daffodil CSS breakpoints in Typescript when necessary.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information