### PR TITLE
feat(design): update sidebar animation and positioning

### DIFF
--- a/apps/design-land/src/app/app-routing.module.ts
+++ b/apps/design-land/src/app/app-routing.module.ts
@@ -22,7 +22,8 @@ export const appRoutes: Routes = [
   {path: 'modal', loadChildren: './modal/modal.module#ModalModule'},
   {path: 'paginator', loadChildren: './paginator/paginator.module#PaginatorModule'},
   {path: 'progress-indicator', loadChildren: './progress-indicator/progress-indicator.module#ProgressIndicatorModule'},
-  {path: 'qty-dropdown', loadChildren: './qty-dropdown/qty-dropdown.module#QtyDropdownModule'}
+  {path: 'qty-dropdown', loadChildren: './qty-dropdown/qty-dropdown.module#QtyDropdownModule'},
+  {path: 'sidebar', loadChildren: './sidebar/sidebar.module#SidebarModule'}
 ]
 
 @NgModule({

--- a/apps/design-land/src/app/app.component.html
+++ b/apps/design-land/src/app/app.component.html
@@ -1,25 +1,28 @@
 <daff-sidebar-viewport>
-    <daff-sidebar>
-        Atoms
-        <a daff-sidebar-item routerLink="button">Button</a>
-        <a daff-sidebar-item routerLink="link">Link</a>
-        <a daff-sidebar-item routerLink="loading-icon">Loading Icon</a>
-        <a daff-sidebar-item routerLink="progress-indicator">Progress Indicator</a>
-        Molecules
-        <a daff-sidebar-item routerLink="accordion">Accordion</a>
-        <a daff-sidebar-item routerLink="callout">Callout</a>
-        <a daff-sidebar-item routerLink="card">Card</a>
-        <a daff-sidebar-item routerLink="feature">Feature</a>
-        <a daff-sidebar-item routerLink="form">Form</a>
-        <a daff-sidebar-item routerLink="hero">Hero</a>
-        <a daff-sidebar-item routerLink="image-gallery">Image Gallery</a>
-        <a daff-sidebar-item routerLink="list">List</a>
-        <a daff-sidebar-item routerLink="navbar">Navigation Bar</a>
-        <a daff-sidebar-item routerLink="modal">Modal</a>
-        <a daff-sidebar-item routerLink="paginator">Paginator</a>
-        <a daff-sidebar-item routerLink="qty-dropdown">Quantity Dropdown</a>
-    </daff-sidebar>
-    <div class="design-land__content">
-        <router-outlet></router-outlet>
-    </div>
+  <daff-sidebar>
+    <daff-list type="link">
+      <h3 daffListSubheader>Atoms</h3>
+      <a daff-sidebar-item routerLink="button">Button</a>
+      <a daff-sidebar-item routerLink="link">Link</a>
+      <a daff-sidebar-item routerLink="loading-icon">Loading Icon</a>
+      <a daff-sidebar-item routerLink="progress-indicator">Progress Indicator</a>
+      <h3 daffListSubheader>Molecules</h3>
+      <a daff-sidebar-item routerLink="accordion">Accordion</a>
+      <a daff-sidebar-item routerLink="callout">Callout</a>
+      <a daff-sidebar-item routerLink="card">Card</a>
+      <a daff-sidebar-item routerLink="feature">Feature</a>
+      <a daff-sidebar-item routerLink="form">Form</a>
+      <a daff-sidebar-item routerLink="hero">Hero</a>
+      <a daff-sidebar-item routerLink="image-gallery">Image Gallery</a>
+      <a daff-sidebar-item routerLink="list">List</a>
+      <a daff-sidebar-item routerLink="navbar">Navigation Bar</a>
+      <a daff-sidebar-item routerLink="modal">Modal</a>
+      <a daff-sidebar-item routerLink="sidebar">Sidebar</a>
+      <a daff-sidebar-item routerLink="paginator">Paginator</a>
+      <a daff-sidebar-item routerLink="qty-dropdown">Quantity Dropdown</a>
+    </daff-list>
+  </daff-sidebar>
+  <div class="design-land__content">
+    <router-outlet></router-outlet>
+  </div>
 </daff-sidebar-viewport>

--- a/apps/design-land/src/app/app.module.ts
+++ b/apps/design-land/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { NgModule } from '@angular/core';
 import { DesignLandAppRoutingModule } from './app-routing.module';
 
 import { DesignLandAppComponent } from './app.component';
-import { DaffSidebarModule } from '@daffodil/design';
+import { DaffSidebarModule, DaffListModule } from '@daffodil/design';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NavbarComponent } from './navbar/navbar.component';
 
@@ -15,7 +15,8 @@ import { NavbarComponent } from './navbar/navbar.component';
     BrowserAnimationsModule,
     
     DaffSidebarModule,
-    DesignLandAppRoutingModule
+    DaffListModule,
+    DesignLandAppRoutingModule,
   ],
   declarations: [
     DesignLandAppComponent,

--- a/apps/design-land/src/app/sidebar/sidebar-routing.module.ts
+++ b/apps/design-land/src/app/sidebar/sidebar-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { SidebarComponent } from './sidebar.component';
+
+const routes: Routes = [
+  {path: '', component: SidebarComponent}
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class SidebarRoutingModule { }

--- a/apps/design-land/src/app/sidebar/sidebar.component.html
+++ b/apps/design-land/src/app/sidebar/sidebar.component.html
@@ -1,10 +1,12 @@
-<ul>
-  <li><button (click)="mode='push'">Push Mode</button></li>
-  <li><button (click)="mode='side'">Side Mode</button></li>
-  <li><button (click)="mode='over'">Over Mode</button></li>
-</ul>
+<daff-form-field>
+  <select daff-native-select [(ngModel)]="mode">
+    <option value="push">Push (push)</option>
+    <option value="side">Side (side)</option>
+    <option value="over">Over (over)</option>
+  </select>
+</daff-form-field>
 
-<button (click)="open = !open">Toggle Visibility</button>
+<button daff-button (click)="open = !open">{{ open ? "Close" : "Open" }}</button>
 
 <daff-sidebar-viewport [mode]="mode" [opened]="open">
     <daff-sidebar>

--- a/apps/design-land/src/app/sidebar/sidebar.component.html
+++ b/apps/design-land/src/app/sidebar/sidebar.component.html
@@ -1,0 +1,14 @@
+<ul>
+  <li><button (click)="mode='push'">Push Mode</button></li>
+  <li><button (click)="mode='side'">Side Mode</button></li>
+  <li><button (click)="mode='over'">Over Mode</button></li>
+</ul>
+
+<button (click)="open = !open">Toggle Visibility</button>
+
+<daff-sidebar-viewport [mode]="mode" [opened]="open">
+    <daff-sidebar>
+      sidebar
+    </daff-sidebar>
+    <p>Some Content</p>
+</daff-sidebar-viewport>

--- a/apps/design-land/src/app/sidebar/sidebar.component.spec.ts
+++ b/apps/design-land/src/app/sidebar/sidebar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SidebarComponent } from './sidebar.component';
+
+describe('SidebarComponent', () => {
+  let component: SidebarComponent;
+  let fixture: ComponentFixture<SidebarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SidebarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SidebarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/design-land/src/app/sidebar/sidebar.component.ts
+++ b/apps/design-land/src/app/sidebar/sidebar.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+import { DaffSidebarMode } from '@daffodil/design';
+
+@Component({
+  selector: 'design-land-sidebar',
+  templateUrl: './sidebar.component.html',
+  styleUrls: ['./sidebar.component.scss']
+})
+export class SidebarComponent {
+  mode: DaffSidebarMode = "push";
+  open: boolean = false;
+ }

--- a/apps/design-land/src/app/sidebar/sidebar.module.ts
+++ b/apps/design-land/src/app/sidebar/sidebar.module.ts
@@ -3,12 +3,17 @@ import { CommonModule } from '@angular/common';
 
 import { SidebarRoutingModule } from './sidebar-routing.module';
 import { SidebarComponent } from './sidebar.component';
-import { DaffSidebarModule } from '@daffodil/design';
+import { DaffSidebarModule, DaffButtonModule, DaffNativeSelectModule, DaffFormFieldModule } from '@daffodil/design';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [SidebarComponent],
   imports: [
     CommonModule,
+    FormsModule,
+    DaffNativeSelectModule,
+    DaffFormFieldModule,
+    DaffButtonModule,
     DaffSidebarModule,
     SidebarRoutingModule
   ]

--- a/apps/design-land/src/app/sidebar/sidebar.module.ts
+++ b/apps/design-land/src/app/sidebar/sidebar.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { SidebarRoutingModule } from './sidebar-routing.module';
+import { SidebarComponent } from './sidebar.component';
+import { DaffSidebarModule } from '@daffodil/design';
+
+@NgModule({
+  declarations: [SidebarComponent],
+  imports: [
+    CommonModule,
+    DaffSidebarModule,
+    SidebarRoutingModule
+  ]
+})
+export class SidebarModule { }

--- a/libs/design/src/molecules/sidebar/animation/sidebar-animation-state.spec.ts
+++ b/libs/design/src/molecules/sidebar/animation/sidebar-animation-state.spec.ts
@@ -11,7 +11,7 @@ describe('SidebarAnimationState Calculation', () => {
         expect(getAnimationState(true, false)).toEqual(DaffSidebarAnimationStates.OPEN);
     });
 
-    it('should return `void` if it is not open', () => {
-        expect(getAnimationState(false, true)).toEqual(DaffSidebarAnimationStates.VOID);
+    it('should return `closed` if it is not open', () => {
+        expect(getAnimationState(false, true)).toEqual(DaffSidebarAnimationStates.CLOSED);
     })
 })

--- a/libs/design/src/molecules/sidebar/animation/sidebar-animation-state.ts
+++ b/libs/design/src/molecules/sidebar/animation/sidebar-animation-state.ts
@@ -4,6 +4,6 @@ export const getAnimationState = (open : boolean, enabled: boolean = true) => {
         return "open";
     }
     else {
-        return "void";
+        return "closed";
     }
 }

--- a/libs/design/src/molecules/sidebar/animation/sidebar-animation.ts
+++ b/libs/design/src/molecules/sidebar/animation/sidebar-animation.ts
@@ -6,6 +6,11 @@ import {
     trigger,
     AnimationTriggerMetadata,
   } from '@angular/animations';
+
+const duration = "350ms";
+const sidebarAnimateRemainTransition = "cubic-bezier(0.4, 0.0, 0.2, 1)";
+const sidebarAnimateInTransition = "cubic-bezier(0.0, 0.0, 0.2, 1)";
+const sidebarAnimateOutTransition = "cubic-bezier(0.4, 0.0, 1, 1)";
   
 export const daffSidebarAnimations: {
     readonly transformSidebar: AnimationTriggerMetadata,
@@ -18,19 +23,19 @@ export const daffSidebarAnimations: {
         'transform': 'none',
         'visibility': 'visible',
       })),
-      transition('void <=> open',
-          animate('350ms cubic-bezier(0.25, 0.8, 0.25, 1)'))
+      transition('open => closed', animate(duration + ' ' + sidebarAnimateOutTransition)),
+      transition('closed => open', animate(duration + ' ' + sidebarAnimateInTransition))
     ]),
     transformContent: trigger('transformContent', [
-      state('void', style({
+      state('closed', style({
         'transform': 'none',
       })),
-      transition('void <=> open',
-          animate('350ms cubic-bezier(0.25, 0.8, 0.25, 1)'))
+      transition('open => closed', animate(duration + ' ' + sidebarAnimateOutTransition)),
+      transition('closed => open', animate(duration + ' ' + sidebarAnimateInTransition))
     ])
   };
 
 export enum DaffSidebarAnimationStates {
     OPEN =  'open',
-    VOID = 'void'
+    CLOSED = 'closed'
 }

--- a/libs/design/src/molecules/sidebar/sidebar-viewport/sidebar-viewport.component.scss
+++ b/libs/design/src/molecules/sidebar/sidebar-viewport/sidebar-viewport.component.scss
@@ -11,19 +11,21 @@ $daff-sidebar-viewport-z-index: 1;
 	// fixes a bug where certain elements show in front of backdrop for a second.
 	display: flex;
 	min-height: 100%;
-	overflow: hidden;
-	position: absolute;
+	position: relative;
 	width: 100%;
 	z-index: $daff-sidebar-viewport-z-index;
 
 	&__content {
 		flex: 0 1 auto;
 		width: 100%;
+		will-change: transform;
 		z-index: $daff-sidebar-content-z-index;
 	}
 
 	&__sidebar {
+		flex-shrink: 0;
 		width: $sidebar-width;
+		will-change: transform, visibility;
 		z-index: $daff-sidebar-z-index;
 	}
 
@@ -36,28 +38,30 @@ $daff-sidebar-viewport-z-index: 1;
 	}
 
 	&.push {
-		#{$root}__sidebar {
+		> #{$root}__sidebar {
 			bottom: 0;
 			height: 100%;
 			left: 0;
 			position: absolute;
 			top: 0;
 			transform: translate3d(-$sidebar-width, 0, 0);
+			visibility: hidden;
 		}
 
-		#{$root}__content {
+		> #{$root}__content {
 			transform: translate3d($sidebar-width, 0, 0);
 		}
 	}
 
 	&.over {
-		#{$root}__sidebar {
+		> #{$root}__sidebar {
 			bottom: 0;
 			height: 100%;
 			left: 0;
-			position: fixed;
+			position: absolute;
 			top: 0;
 			transform: translate3d(-$sidebar-width, 0, 0);
+			visibility: hidden;
 		}
 	}
 }

--- a/libs/design/src/molecules/sidebar/sidebar/sidebar-theme.scss
+++ b/libs/design/src/molecules/sidebar/sidebar/sidebar-theme.scss
@@ -10,9 +10,5 @@
 		background: $base;
 		box-shadow: 6px 1px 9px 0 $shadow-color;
 		color: $font-color;
-
-		&__item {
-			color: $font-color;
-		}
 	}
 }

--- a/libs/design/src/molecules/sidebar/sidebar/sidebar.component.ts
+++ b/libs/design/src/molecules/sidebar/sidebar/sidebar.component.ts
@@ -36,9 +36,7 @@ export class DaffSidebarComponent {
      */
     this._ngZone.runOutsideAngular(() => {
       fromEvent<KeyboardEvent>(this._elementRef.nativeElement, 'keydown').pipe(
-          filter(event => {
-            return event.key === "Escape"
-          })
+          filter(event => event.key === "Escape")
       ).subscribe(event => this._ngZone.run(() => {
           this.escapePressed.emit();
           event.stopPropagation();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, the sidebar doesn't really support switching modes and the animations are janky if there's an `*ngIf` on the sidebar.


## What is the new behavior?
This cleans up the animations, adds an example to design-land, and cleans up some of the positioning of the sidebar.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

This does change the `over` mode from `position: fixed` to `position: absolute` so there's potentially some breakage if someone is expecting the sidebar to leave its viewport.

## Other information