### PR TITLE
Get products by category

### DIFF
--- a/apps/demo/src/app/magento.module.ts
+++ b/apps/demo/src/app/magento.module.ts
@@ -4,6 +4,7 @@ import { ApolloBoostModule, ApolloBoost } from 'apollo-angular-boost';
 import { DaffProductMagentoDriverModule } from '@daffodil/product';
 import { DaffCartInMemoryDriverModule } from '@daffodil/cart/testing';
 import { DaffCheckoutInMemoryDriverModule } from '@daffodil/checkout/testing';
+import { DaffCategoryMagentoDriverModule } from '@daffodil/category';
 
 @NgModule({
   imports: [
@@ -11,7 +12,8 @@ import { DaffCheckoutInMemoryDriverModule } from '@daffodil/checkout/testing';
     ApolloBoostModule,
     DaffProductMagentoDriverModule.forRoot(),
     DaffCartInMemoryDriverModule.forRoot(),
-    DaffCheckoutInMemoryDriverModule.forRoot()
+    DaffCheckoutInMemoryDriverModule.forRoot(),
+    DaffCategoryMagentoDriverModule.forRoot()
   ]
 })
 export class MagentoModule {

--- a/apps/demo/src/app/product/pages/product-grid-view/product-grid-view.component.spec.ts
+++ b/apps/demo/src/app/product/pages/product-grid-view/product-grid-view.component.spec.ts
@@ -11,6 +11,7 @@ import { DaffProductGridFacade, DaffProduct } from '@daffodil/product';
 import { ProductGridViewComponent } from './product-grid-view.component';
 import { ProductGridComponent } from '../../components/product-grid/product-grid.component';
 import { ProductGridModule } from '../../components/product-grid/product-grid.module';
+import { DaffCategoryLoad } from '@daffodil/category';
 
 class MockDaffProductGridFacade {
   loading$: Observable<boolean> = new BehaviorSubject(false);
@@ -72,10 +73,10 @@ describe('ProductGridViewComponent', () => {
       expect(component.loading$).toBeObservable(expected);
     });
 
-    it('should dispatch a DaffProductLoad', () => {
+    it('should dispatch a DaffCategoryLoad', () => {
       spyOn(facade, 'dispatch');
       component.ngOnInit();
-      expect(facade.dispatch).toHaveBeenCalled();
+      expect(facade.dispatch).toHaveBeenCalledWith(new DaffCategoryLoad("2"));
     });
   });
 

--- a/apps/demo/src/app/product/pages/product-grid-view/product-grid-view.component.ts
+++ b/apps/demo/src/app/product/pages/product-grid-view/product-grid-view.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { DaffProductGridFacade, DaffProductUnion, DaffProductGridLoad } from '@daffodil/product';
+import { DaffProductGridFacade, DaffProductUnion } from '@daffodil/product';
 import { Observable } from 'rxjs';
+import { DaffCategoryLoad } from '@daffodil/category';
 
 @Component({
   selector: 'demo-product-grid-view',
@@ -16,6 +17,6 @@ export class ProductGridViewComponent implements OnInit {
   ngOnInit() {
     this.products$ = this.facade.products$;
     this.loading$ = this.facade.loading$;
-    this.facade.dispatch(new DaffProductGridLoad());
+    this.facade.dispatch(new DaffCategoryLoad("2"));
   }
 }

--- a/apps/demo/src/app/product/pages/product-grid-view/product-grid-view.module.ts
+++ b/apps/demo/src/app/product/pages/product-grid-view/product-grid-view.module.ts
@@ -7,6 +7,7 @@ import { DaffProductModule } from '@daffodil/product';
 import { DaffLoadingIconModule } from '@daffodil/design';
 import { ProductGridModule } from '../../components/product-grid/product-grid.module';
 import { ProductGridViewComponent } from './product-grid-view.component';
+import { DaffCategoryModule } from '@daffodil/category';
 
 @NgModule({
   imports: [
@@ -14,7 +15,8 @@ import { ProductGridViewComponent } from './product-grid-view.component';
     DaffLoadingIconModule,
     ProductGridModule,
     DaffContainerModule,
-    DaffProductModule
+    DaffProductModule,
+    DaffCategoryModule
   ],
   declarations: [
     ProductGridViewComponent

--- a/apps/demo/tsconfig.dev.json
+++ b/apps/demo/tsconfig.dev.json
@@ -10,7 +10,9 @@
       "@daffodil/product": ["libs/product/src"],
       "@daffodil/product/testing": ["libs/product/testing/src"],
       "@daffodil/cart/testing": ["libs/cart/testing/src"],
-      "@daffodil/checkout/testing": ["libs/checkout/testing/src"]
+      "@daffodil/checkout/testing": ["libs/checkout/testing/src"],
+      "@daffodil/category": ["libs/category/src"],
+      "@daffodil/category/testing": ["libs/category/testing/src"]
     }
   }
 }

--- a/libs/category/src/category.module.ts
+++ b/libs/category/src/category.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { DaffCategoryStateModule } from './category-state.module';
+import { DaffProductModule } from '@daffodil/product';
 
 @NgModule({
   imports: [
@@ -11,6 +12,7 @@ import { DaffCategoryStateModule } from './category-state.module';
      * Ngrx/store
      */
     DaffCategoryStateModule,
+    DaffProductModule
   ]
 })
 export class DaffCategoryModule { }

--- a/libs/category/src/drivers/interfaces/category-query-manager.interface.ts
+++ b/libs/category/src/drivers/interfaces/category-query-manager.interface.ts
@@ -1,5 +1,5 @@
 import { QueryOptions } from "apollo-client";
 
 export interface DaffCategoryQueryManagerInterface {
-  getACategoryQuery(identifier: string): QueryOptions;
+  getACategoryQuery(identifier: any): QueryOptions;
 }

--- a/libs/category/src/drivers/magento/category.service.spec.ts
+++ b/libs/category/src/drivers/magento/category.service.spec.ts
@@ -68,8 +68,7 @@ describe('Driver | Magento | Category | CategoryService', () => {
             total_count: stubCategory.total_products,
             items: []
           },
-          children_count: stubCategory.children_count,
-          children: []
+          children_count: stubCategory.children_count
         }
       };
     });
@@ -80,8 +79,8 @@ describe('Driver | Magento | Category | CategoryService', () => {
         expect(category.products).toEqual(transformedProducts);
       });
       
-      const op = controller.expectOne(categoryGraphQlQueryManagerService.getACategoryQuery(stubCategory.id).query);
-      expect(op.operation.variables.id).toEqual(stubCategory.id);
+      const op = controller.expectOne(categoryGraphQlQueryManagerService.getACategoryQuery(parseInt(stubCategory.id, 10)).query);
+      expect(op.operation.variables.id).toEqual(parseInt(stubCategory.id, 10));
 
       op.flush({
         data: response
@@ -93,8 +92,8 @@ describe('Driver | Magento | Category | CategoryService', () => {
         expect(categoryTransformService.transform).toHaveBeenCalledWith(response.category);
       });
       
-      const op = controller.expectOne(categoryGraphQlQueryManagerService.getACategoryQuery(stubCategory.id).query);
-      expect(op.operation.variables.id).toEqual(stubCategory.id);
+      const op = controller.expectOne(categoryGraphQlQueryManagerService.getACategoryQuery(parseInt(stubCategory.id, 10)).query);
+      expect(op.operation.variables.id).toEqual(parseInt(stubCategory.id, 10));
 
       op.flush({
         data: response
@@ -106,8 +105,8 @@ describe('Driver | Magento | Category | CategoryService', () => {
         expect(productTransformService.transformMany).toHaveBeenCalledWith([]);
       });
       
-      const op = controller.expectOne(categoryGraphQlQueryManagerService.getACategoryQuery(stubCategory.id).query);
-      expect(op.operation.variables.id).toEqual(stubCategory.id);
+      const op = controller.expectOne(categoryGraphQlQueryManagerService.getACategoryQuery(parseInt(stubCategory.id, 10)).query);
+      expect(op.operation.variables.id).toEqual(parseInt(stubCategory.id, 10));
 
       op.flush({
         data: response

--- a/libs/category/src/drivers/magento/category.service.ts
+++ b/libs/category/src/drivers/magento/category.service.ts
@@ -28,8 +28,9 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
   ) {}
 
   get(categoryId: string): Observable<DaffGetCategoryResponse> {
-    return this.apollo.query<GetACategoryResponse>(this.queryManager.getACategoryQuery(categoryId)).pipe(
+    return this.apollo.query<GetACategoryResponse>(this.queryManager.getACategoryQuery(parseInt(categoryId, 10))).pipe(
       map(result => {
+        console.log(this.magentoProductTransformerService);
         return {
           category: this.magentoCategoryTransformerService.transform(result.data.category),
           products: this.magentoProductTransformerService.transformMany(result.data.category.products.items)

--- a/libs/category/src/drivers/magento/queries/category-query-manager.service.ts
+++ b/libs/category/src/drivers/magento/queries/category-query-manager.service.ts
@@ -9,10 +9,10 @@ import { DaffCategoryQueryManagerInterface } from '../../interfaces/category-que
 })
 export class DaffMagentoCategoryGraphQlQueryManagerService implements DaffCategoryQueryManagerInterface {
 
-  getACategoryQuery(identifier: string) : QueryOptions {
+  getACategoryQuery(identifier: number) : QueryOptions {
     return {
       query:  gql`
-      query GetACategory($id: ID!){
+      query GetACategory($id: Int){
         category(id: $id) {
           id
           name
@@ -38,12 +38,6 @@ export class DaffMagentoCategoryGraphQlQueryManagerService implements DaffCatego
             }
           }
           children_count
-          children {
-            id
-            level
-            name
-            path
-          }
         }
       }`,
       variables: {

--- a/libs/category/src/drivers/magento/transformers/category-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-transformer.service.spec.ts
@@ -43,26 +43,7 @@ describe('DaffMagentoCategoryTransformerService', () => {
             }
           ]
         },
-        children_count: mockCategory.children_count,
-        children: [{
-          id: mockCategory.children[0].id,
-          name: mockCategory.children[0].name,
-          products: {
-            total_count: mockCategory.children[0].total_products,
-            items: [
-              {
-                id: parseInt(mockCategory.children[0].productIds[0], 10),
-                name: 'name',
-                sku: 'sku',
-                url_key: 'url_key',
-                image: null,
-                price: null
-              }
-            ]
-          },
-          children: [],
-          children_count: mockCategory.children[0].children_count
-        }]
+        children_count: mockCategory.children_count
       }
 
       expect(service.transform(categoryNodeInput)).toEqual(mockCategory);

--- a/libs/category/src/drivers/magento/transformers/category-transformer.service.ts
+++ b/libs/category/src/drivers/magento/transformers/category-transformer.service.ts
@@ -15,9 +15,6 @@ export class DaffMagentoCategoryTransformerService implements DaffCategoryTransf
       name: categoryNode.name,
       total_products: categoryNode.products.total_count,
       children_count: categoryNode.children_count,
-      children: categoryNode.children.map((child) => {
-        return this.transform(child)
-      }),
       productIds: categoryNode.products.items.map(product => product.id.toString())
     }
   }

--- a/libs/category/src/effects/category.effects.ts
+++ b/libs/category/src/effects/category.effects.ts
@@ -31,9 +31,7 @@ export class DaffCategoryEffects {
             new DaffProductGridLoadSuccess(resp.products),
             new DaffCategoryLoadSuccess(resp.category)
           ]),
-          catchError(error => {
-            return of(new DaffCategoryLoadFailure('Failed to load the category'));
-          })
+          catchError(error => of(new DaffCategoryLoadFailure('Failed to load the category')))
         )
     )
   )

--- a/libs/category/src/index.ts
+++ b/libs/category/src/index.ts
@@ -7,6 +7,7 @@ export { DaffCategoryFacade } from './facades/category.facade';
 export { DaffCategoryModule } from './category.module';
 export { DaffCategoryDriver } from './drivers/injection-tokens/category-driver.token';
 export { DaffCategoryServiceInterface } from './drivers/interfaces/category-service.interface';
+export { DaffCategoryMagentoDriverModule } from './drivers/magento/category-driver.module';
 
 export {
   selectCategoryFeatureState,

--- a/libs/category/testing/src/factories/category.factory.ts
+++ b/libs/category/testing/src/factories/category.factory.ts
@@ -10,16 +10,6 @@ export class MockCategory implements DaffCategory {
   children_count = faker.random.number(10);
   total_products = faker.random.number(10);
   productIds = [faker.random.number(100).toString()];
-  children = [
-    {
-      id: faker.random.number(10000).toString(),
-      name: faker.commerce.productMaterial(),
-      children_count: faker.random.number(10),
-      total_products: faker.random.number(10),
-      productIds: [faker.random.number(100).toString()],
-      children: []
-    }
-  ];
 }
 
 @Injectable({


### PR DESCRIPTION
…egory call to demo

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The category magento graphQL call takes a string when it should take a number, which make the call fail. The product-grid in demo uses a `DaffProductGridLoad` action to load products, when they should be loaded by category. 

Fixes: N/A


## What is the new behavior?
The magento graphQL call works as expected now, and the product-grid in the demo app loads products based on category. The demo implementation will be better once https://github.com/graycoreio/daffodil/pull/433 gets into develop, but I think this can be reviewed as is now.

You'll notice I removed the `children` field from the DaffCategory. I did this because I didn't think it was really needed, since this would probably be handled by the navigation module, and it made the transformation layer a little extra complicated. If you think it should be there, let me know and I can put it back.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```