### PR TITLE
feat(design): make sidebar viewport recalculate animation state on mode

### DIFF
--- a/libs/design/src/molecules/sidebar/sidebar-viewport/sidebar-viewport.component.spec.ts
+++ b/libs/design/src/molecules/sidebar/sidebar-viewport/sidebar-viewport.component.spec.ts
@@ -150,6 +150,17 @@ describe('DaffSidebarViewportComponent | Usage', () => {
       expect(component._animationState).toEqual("open");
     });
   });
+
+  it('should recalculate the animation state when the mode changes', () => {
+    wrapper.mode = "side";
+    wrapper.open = false;
+    fixture.detectChanges();
+    expect(component._animationState).toEqual("open");
+
+    wrapper.mode = "push";
+    fixture.detectChanges();
+    expect(component._animationState).toEqual("closed");
+  });
 });
 
 describe('DaffSidebarViewportComponent | Defaults', () => {

--- a/libs/design/src/molecules/sidebar/sidebar-viewport/sidebar-viewport.component.spec.ts
+++ b/libs/design/src/molecules/sidebar/sidebar-viewport/sidebar-viewport.component.spec.ts
@@ -8,7 +8,8 @@ import { DaffSidebarComponent } from '../sidebar/sidebar.component';
 import { DaffSidebarMode } from '../helper/sidebar-mode';
 import { DaffBackdropComponent, DaffBackdropModule } from '../../backdrop/public_api';
 
-@Component({template: `
+@Component({
+  template: `
   <div class="sidebar-content-wrapper">
     <daff-sidebar-viewport
       [backdropIsVisible]="backdropIsVisible"
@@ -23,7 +24,7 @@ class WrapperComponent {
   backdropIsVisible = false;
 
   mode: DaffSidebarMode = "side";
-  
+
   backdropClickedCounter = 0;
 
   incrementBackdropClicked() {
@@ -53,7 +54,7 @@ describe('DaffSidebarViewportComponent | Usage', () => {
         DaffSidebarComponent,
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -95,13 +96,13 @@ describe('DaffSidebarViewportComponent | Usage', () => {
 
       backdrop.backdropClicked.emit();
     });
-    
+
     it('should call component.backdropClicked.emit', () => {
       expect(component.backdropClicked.emit).toHaveBeenCalled();
     });
   });
 
-  describe('over mode' , () => {
+  describe('over mode', () => {
     beforeEach(() => {
       wrapper.mode = "over";
       fixture.detectChanges();
@@ -111,7 +112,7 @@ describe('DaffSidebarViewportComponent | Usage', () => {
       expect(backdrop).not.toBeNull();
     });
   });
-  
+
   describe('push mode', () => {
     beforeEach(() => {
       wrapper.mode = "push";
@@ -179,7 +180,7 @@ describe('DaffSidebarViewportComponent | Defaults', () => {
         DaffSidebarComponent,
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/libs/design/src/molecules/sidebar/sidebar-viewport/sidebar-viewport.component.ts
+++ b/libs/design/src/molecules/sidebar/sidebar-viewport/sidebar-viewport.component.ts
@@ -14,20 +14,28 @@ import { getAnimationState } from '../animation/sidebar-animation-state';
     daffSidebarAnimations.transformContent
   ]
 })
-export class DaffSidebarViewportComponent implements OnInit{
+export class DaffSidebarViewportComponent implements OnInit {
 
   _animationState: string;
-  
-  
+
+
   /**
    * Internal tracking variable for the state of sidebar viewport.
    */
   _opened = false;
-  
+
+  _mode: DaffSidebarMode = "side";
+
   /**
    * The mode to put the sidebar in
    */
-  @Input() mode: DaffSidebarMode = "side";
+  @Input()
+  get mode(): DaffSidebarMode { return this._mode; }
+  set mode(value: DaffSidebarMode) {
+    this._mode = value;
+    this._animationState = getAnimationState(this.opened, this.animationsEnabled);
+  }
+
   /**
    * Input state for whether or not the backdrop is 
    * "visible" to the human eye
@@ -39,31 +47,31 @@ export class DaffSidebarViewportComponent implements OnInit{
    * This is often used to close the sidebar
    */
   @Output() backdropClicked: EventEmitter<void> = new EventEmitter<void>();
-  
-  get animationsEnabled() : boolean {
-    return ( this.mode === "over" || this.mode === "push" ) ? true : false;
+
+  get animationsEnabled(): boolean {
+    return (this.mode === "over" || this.mode === "push") ? true : false;
   }
 
   ngOnInit() {
     this._animationState = getAnimationState(this.opened, this.animationsEnabled);
   }
-  
+
   /**
    * Property for the "opened" state of the sidebar
    */
   @Input()
   get opened(): boolean { return this._opened; }
-  set opened(value: boolean) { 
+  set opened(value: boolean) {
     this._opened = value;
     this._animationState = getAnimationState(value, this.animationsEnabled);
   }
-  
-  
-  _backdropClicked() : void {
+
+
+  _backdropClicked(): void {
     this.backdropClicked.emit();
   }
-  
-  get hasBackdrop() : boolean {
+
+  get hasBackdrop(): boolean {
     return (this.mode === "over" || this.mode === "push");
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
We don't recompute the animation when the mode changes, leading to the sidebar being visible when it shouldn't be.

Fixes: N/A


## What is the new behavior?
This appropriately hides/shows the sidebar on mode changes. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```