### PR TITLE
feat(branding): make logo pull text color from environment

### DIFF
--- a/libs/branding/src/lib/logo/logo-theme.scss
+++ b/libs/branding/src/lib/logo/logo-theme.scss
@@ -1,16 +1,10 @@
-@mixin daff-logo-theme($theme){
-    $base: daff-map-deep-get($theme, "core.base");
-    $base-contrast: daff-map-deep-get($theme, "core.base-contrast");
+@mixin daff-logo-theme($theme) {
+	$base: daff-map-deep-get($theme, 'core.base');
+	$base-contrast: daff-map-deep-get($theme, 'core.base-contrast');
 
-    .daff-logo {
-        &--full {
-            @if(daff-luminance($base) >= 0.5) {
-                fill: daff-color($daff-blue, 60);
-            }
-
-            @if(daff-luminance($base) < 0.5) {
-                fill: $white;
-            }
-        }
-    }
+	.daff-logo {
+		&--full {
+			fill: currentColor;
+		}
+	}
 }

--- a/libs/branding/src/lib/logo/logo.component.scss
+++ b/libs/branding/src/lib/logo/logo.component.scss
@@ -6,36 +6,37 @@ $logo-dil-width: 30%;
 $logo-spacer-width: 3.5%;
 
 :host {
-    display: block;
-    width: 100%;
+	display: block;
+	width: 100%;
 }
 
 .daff-logo {
-    &--full {
-        display: flex;
-        align-items: center;
-    
-        .spacer {
-            flex: 1 0 $logo-spacer-width; 
-        }
-    
-        .daff {
-            flex: 1 0 $logo-daff-width;
-        }
-    
-        .flower {
-            display: block;
-            max-width: 100%;
-            min-width: 0;
-            flex: 1 0 $logo-flower-width;
-        }
-    
-        .dil {
-            flex: 1 0 $logo-dil-width;
-        }
-    
-        .daff, .dil {
-            width: 100%;
-        }
-    }
+	&--full {
+		display: flex;
+		align-items: center;
+
+		.spacer {
+			flex: 1 0 $logo-spacer-width;
+		}
+
+		.daff {
+			flex: 1 0 $logo-daff-width;
+		}
+
+		.flower {
+			display: block;
+			max-width: 100%;
+			min-width: 0;
+			flex: 1 0 $logo-flower-width;
+		}
+
+		.dil {
+			flex: 1 0 $logo-dil-width;
+		}
+
+		.daff,
+		.dil {
+			width: 100%;
+		}
+	}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, we can't render a `daff-logo` on a dark background in a light theme. This corrects that.

Touches #227 


## What is the new behavior?
This makes the navbar pull its color from the environment.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information