### PR TITLE
feat(navigation): add a testing module to mock out the DaffNavigation…

### DIFF
--- a/libs/navigation/src/facades/navigation.facade.ts
+++ b/libs/navigation/src/facades/navigation.facade.ts
@@ -2,17 +2,16 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Store, select, Action } from '@ngrx/store';
 
-import { DaffStoreFacade } from '@daffodil/core';
-
 import { DaffNavigationModule } from '../navigation.module';
 import { selectNavigationTree, selectNavigationLoading, selectNavigationErrors } from '../selectors/navigation.selector';
 import { NavigationReducersState } from '../reducers/navigation-reducers.interface';
 import { DaffNavigationTreeUnion } from '../models/navigation-tree-union';
+import { DaffNavigationFacadeInterface } from '../interfaces/navigation-facade.interface';
 
 @Injectable({
   providedIn: DaffNavigationModule
 })
-export class DaffNavigationFacade implements DaffStoreFacade<Action> {
+export class DaffNavigationFacade implements DaffNavigationFacadeInterface {
   /**
    * The navigation retrieved in a single navigation call.
    */

--- a/libs/navigation/src/index.ts
+++ b/libs/navigation/src/index.ts
@@ -16,3 +16,4 @@ export {
   selectNavigationErrors
 } from './selectors/navigation.selector';
 export { DaffNavigationMagentoDriverModule } from './drivers/magento/navigation-driver.module';
+export { DaffNavigationFacadeInterface } from './interfaces/navigation-facade.interface';

--- a/libs/navigation/src/interfaces/navigation-facade.interface.ts
+++ b/libs/navigation/src/interfaces/navigation-facade.interface.ts
@@ -1,0 +1,13 @@
+import { Observable } from "rxjs";
+import { Action } from "@ngrx/store";
+
+import { DaffStoreFacade } from "@daffodil/core";
+
+import { DaffNavigationTree } from "../models/navigation-tree";
+
+export interface DaffNavigationFacadeInterface extends DaffStoreFacade<Action> {
+  loading$: Observable<boolean>;
+  tree$: Observable<DaffNavigationTree>;
+  errors$: Observable<string[]>;
+  dispatch(action: Action): void;
+}

--- a/libs/navigation/src/interfaces/navigation-facade.interface.ts
+++ b/libs/navigation/src/interfaces/navigation-facade.interface.ts
@@ -1,9 +1,9 @@
-import { Observable } from "rxjs";
-import { Action } from "@ngrx/store";
+import { Observable } from 'rxjs';
+import { Action } from '@ngrx/store';
 
-import { DaffStoreFacade } from "@daffodil/core";
+import { DaffStoreFacade } from '@daffodil/core';
 
-import { DaffNavigationTree } from "../models/navigation-tree";
+import { DaffNavigationTree } from '../models/navigation-tree';
 
 export interface DaffNavigationFacadeInterface extends DaffStoreFacade<Action> {
   loading$: Observable<boolean>;

--- a/libs/navigation/testing/src/helpers/mocks/mock-navigation.facade.ts
+++ b/libs/navigation/testing/src/helpers/mocks/mock-navigation.facade.ts
@@ -1,11 +1,12 @@
-import { DaffNavigationFacade, DaffNavigationTree } from "@daffodil/navigation";
 import { Observable, BehaviorSubject } from "rxjs";
+
+import { DaffNavigationTree, DaffNavigationFacadeInterface } from "@daffodil/navigation";
 
 /**
  * A mock of the DaffNavigationFacade used to remove any interaction with the ngrx store.
  * This mock should be imported into tests using the DaffNavigationTestingModule.
  */
-export class MockDaffNavigationFacade extends DaffNavigationFacade {
+export class MockDaffNavigationFacade implements DaffNavigationFacadeInterface {
   loading$: Observable<boolean> = new BehaviorSubject(false);
   tree$: Observable<DaffNavigationTree> = new BehaviorSubject(null);
   errors$: Observable<string[]> = new BehaviorSubject([]);

--- a/libs/navigation/testing/src/helpers/mocks/mock-navigation.facade.ts
+++ b/libs/navigation/testing/src/helpers/mocks/mock-navigation.facade.ts
@@ -1,0 +1,13 @@
+import { DaffNavigationFacade, DaffNavigationTree } from "@daffodil/navigation";
+import { Observable, BehaviorSubject } from "rxjs";
+
+/**
+ * A mock of the DaffNavigationFacade used to remove any interaction with the ngrx store.
+ * This mock should be imported into tests using the DaffNavigationTestingModule.
+ */
+export class MockDaffNavigationFacade extends DaffNavigationFacade {
+  loading$: Observable<boolean> = new BehaviorSubject(false);
+  tree$: Observable<DaffNavigationTree> = new BehaviorSubject(null);
+  errors$: Observable<string[]> = new BehaviorSubject([]);
+  dispatch() { }
+}

--- a/libs/navigation/testing/src/helpers/mocks/mock-navigation.facade.ts
+++ b/libs/navigation/testing/src/helpers/mocks/mock-navigation.facade.ts
@@ -1,6 +1,6 @@
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject } from 'rxjs';
 
-import { DaffNavigationTree, DaffNavigationFacadeInterface } from "@daffodil/navigation";
+import { DaffNavigationTree, DaffNavigationFacadeInterface } from '@daffodil/navigation';
 
 /**
  * A mock of the DaffNavigationFacade used to remove any interaction with the ngrx store.

--- a/libs/navigation/testing/src/helpers/mocks/mock-navigation.facade.ts
+++ b/libs/navigation/testing/src/helpers/mocks/mock-navigation.facade.ts
@@ -1,4 +1,4 @@
-import { Observable, BehaviorSubject } from "rxjs";
+import { BehaviorSubject } from "rxjs";
 
 import { DaffNavigationTree, DaffNavigationFacadeInterface } from "@daffodil/navigation";
 
@@ -7,8 +7,8 @@ import { DaffNavigationTree, DaffNavigationFacadeInterface } from "@daffodil/nav
  * This mock should be imported into tests using the DaffNavigationTestingModule.
  */
 export class MockDaffNavigationFacade implements DaffNavigationFacadeInterface {
-  loading$: Observable<boolean> = new BehaviorSubject(false);
-  tree$: Observable<DaffNavigationTree> = new BehaviorSubject(null);
-  errors$: Observable<string[]> = new BehaviorSubject([]);
+  loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  tree$: BehaviorSubject<DaffNavigationTree> = new BehaviorSubject(null);
+  errors$: BehaviorSubject<string[]> = new BehaviorSubject([]);
   dispatch() { }
 }

--- a/libs/navigation/testing/src/helpers/navigation-testing.module.ts
+++ b/libs/navigation/testing/src/helpers/navigation-testing.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MockDaffNavigationFacade } from './mocks/mock-navigation.facade';
+import { DaffNavigationFacade } from '@daffodil/navigation';
+
+/**
+ * The DaffNavigationTestingModule provides a mock for the DaffNavigationFacade. This makes testing much simpler
+ * by removing any interaction with the ngrx store.
+ */
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  providers: [
+    { provide: DaffNavigationFacade, useClass: MockDaffNavigationFacade }
+  ]
+})
+export class DaffNavigationTestingModule { }

--- a/libs/navigation/testing/src/index.ts
+++ b/libs/navigation/testing/src/index.ts
@@ -4,3 +4,4 @@ export { DaffTestingNavigationService } from './drivers/testing/navigation.servi
 export { DaffInMemoryNavigationService } from './drivers/in-memory/navigation.service';
 export { DaffNavigationInMemoryDriverModule } from './drivers/in-memory/navigation-driver.module';
 export { DaffNavigationTestingDriverModule } from './drivers/testing/navigation-driver.module';
+export { DaffNavigationTestingModule } from './helpers/navigation-testing.module';

--- a/libs/navigation/testing/src/index.ts
+++ b/libs/navigation/testing/src/index.ts
@@ -5,3 +5,4 @@ export { DaffInMemoryNavigationService } from './drivers/in-memory/navigation.se
 export { DaffNavigationInMemoryDriverModule } from './drivers/in-memory/navigation-driver.module';
 export { DaffNavigationTestingDriverModule } from './drivers/testing/navigation-driver.module';
 export { DaffNavigationTestingModule } from './helpers/navigation-testing.module';
+export { MockDaffNavigationFacade } from './helpers/mocks/mock-navigation.facade';


### PR DESCRIPTION
…Facade in tests

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently the end user needs to provide his/her own mock of the `DaffNavigationFacade` whenever it comes up in testing to avoid any interaction with ngrx store.

Fixes: N/A


## What is the new behavior?
`@daffodil/navigation/testing` now has a `DaffNavigationTestingModule` that provides a mocked version of the `DaffNavigationFacade` for you.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```