### PR TITLE
fix(product): make DaffProduct.id actually be the productId instead o…

### DIFF
--- a/libs/product/src/drivers/magento/transforms/product-transformer.service.ts
+++ b/libs/product/src/drivers/magento/transforms/product-transformer.service.ts
@@ -19,7 +19,8 @@ export class DaffMagentoProductTransformerService implements DaffProductTransfor
   transform(response: any): DaffProductUnion {
     const product: ProductNode = response.products.items[0];
     return {
-      id: product.sku,
+      id: product.id.toString(),
+      sku: product.sku,
       url: product.url_key,
       name: product.name,
       images: [
@@ -45,7 +46,8 @@ export class DaffMagentoProductTransformerService implements DaffProductTransfor
 
   private transformList(product: ProductNode): DaffProductUnion {
     return {
-      id: product.sku,
+      id: product.id.toString(),
+      sku: product.sku,
       url: product.url_key,
       name: product.name,
       images: [

--- a/libs/product/src/models/product.ts
+++ b/libs/product/src/models/product.ts
@@ -5,6 +5,7 @@ import { DaffProductImage } from './product-image';
  */
 export interface DaffProduct {
   id: string;
+  sku?: string;
   price?: string;
   name?: string;
   brand?: string;

--- a/libs/product/testing/src/factories/product.factory.spec.ts
+++ b/libs/product/testing/src/factories/product.factory.spec.ts
@@ -30,6 +30,7 @@ describe('Product | Testing | Factories | DaffProductFactory', () => {
     it('should return a Product with all required fields defined', () => {
 
       expect(result.id).toBeDefined();
+      expect(result.sku).toBeDefined();
       expect(result.price).toBeDefined();
       expect(result.name).toBeDefined();
       expect(result.brand).toBeDefined(); 

--- a/libs/product/testing/src/factories/product.factory.ts
+++ b/libs/product/testing/src/factories/product.factory.ts
@@ -8,6 +8,7 @@ import { DaffModelFactory } from '@daffodil/core/testing';
  */
 export class MockProduct implements DaffProduct {
   id = faker.random.number(10000).toString();
+  sku = faker.random.number(10000).toString();
   price = faker.random.number(1500).toString();
   name = faker.commerce.productName();
   brand = faker.company.companyName();


### PR DESCRIPTION
…f sku

Right now the ID on DaffProduct is actually the product sku. This PR makes the DaffProduct.id come from the id property, and adds the sku property to the DaffProduct.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```


## Other information
Probably nothing will break, because none of the apps really knew that the "DaffProduct.id" was actually the sku.