### PR TITLE
fix(category): make category in-memory api work with a sensible curre…

### DIFF
--- a/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
+++ b/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
@@ -4,10 +4,12 @@ import * as faker from 'faker/locale/en_US';
 import { DaffCategoryPageConfigurationState } from '@daffodil/category';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
+export const DEFAULT_PAGE_SIZE = 20;
+
 export class MockCategoryPageConfigurationState implements DaffCategoryPageConfigurationState {
   id = faker.random.number(100);
-  page_size = faker.random.number(10, 20);
-  current_page = faker.random.number(10);
+  page_size = DEFAULT_PAGE_SIZE;
+  current_page = 1;
   filters = [{
     name: 'Category',
     items_count: 2,

--- a/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
+++ b/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
@@ -4,11 +4,9 @@ import * as faker from 'faker/locale/en_US';
 import { DaffCategoryPageConfigurationState } from '@daffodil/category';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
-export const DEFAULT_PAGE_SIZE = 20;
-
 export class MockCategoryPageConfigurationState implements DaffCategoryPageConfigurationState {
   id = faker.random.number(100);
-  page_size = DEFAULT_PAGE_SIZE;
+  page_size = 20;
   current_page = 1;
   filters = [{
     name: 'Category',

--- a/libs/category/testing/src/inmemory-backend/category.service.spec.ts
+++ b/libs/category/testing/src/inmemory-backend/category.service.spec.ts
@@ -24,14 +24,18 @@ describe('Driver | InMemory | Category | DaffInMemoryBackendCategoryService', ()
     expect(categoryTestingService).toBeTruthy();
   });
 
-  describe('get - with any parameter', () => {
+  describe('get', () => {
       
     let reqInfoStub;
     let result;
+    const stubPageSize = 5;
+    const stubCurrentPage = 2;
 
     beforeEach(() => {
       reqInfoStub = {
         id: 'any parameter',
+        page_size: stubPageSize,
+        current_page: stubCurrentPage,
         utils: {
           createResponse$: (func) => {
             return func();
@@ -48,6 +52,14 @@ describe('Driver | InMemory | Category | DaffInMemoryBackendCategoryService', ()
         categoryPageConfigurationState: categoryTestingService.categoryPageConfigurationState,
         products: inMemoryBackendProductService.products
       });
+    });
+
+    it('should set page_size when the page_size is provided', () => {
+      expect(result.body.categoryPageConfigurationState.page_size).toEqual(stubPageSize);
+    });
+
+    it('should set current_page when the current_page is provided', () => {
+      expect(result.body.categoryPageConfigurationState.current_page).toEqual(stubCurrentPage);
     });
   });
 });

--- a/libs/category/testing/src/inmemory-backend/category.service.ts
+++ b/libs/category/testing/src/inmemory-backend/category.service.ts
@@ -10,7 +10,7 @@ import { DaffCategory, DaffCategoryPageConfigurationState } from '@daffodil/cate
 import { DaffInMemoryBackendProductService } from '@daffodil/product/testing';
 
 import { DaffCategoryFactory } from '../factories/category.factory';
-import { DaffCategoryPageConfigurationStateFactory, DEFAULT_PAGE_SIZE } from '../factories/category-page-configuration-state.factory';
+import { DaffCategoryPageConfigurationStateFactory } from '../factories/category-page-configuration-state.factory';
 
 @Injectable({
   providedIn: 'root'
@@ -44,7 +44,7 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
     this.category.id = reqInfo.id;
     this.categoryPageConfigurationState.id = reqInfo.id;
     this.categoryPageConfigurationState.current_page = reqInfo.current_page ? reqInfo.current_page : 1;
-    this.categoryPageConfigurationState.page_size = reqInfo.page_size ? reqInfo.page_size : DEFAULT_PAGE_SIZE;
+    this.categoryPageConfigurationState.page_size = reqInfo.page_size ? reqInfo.page_size : this.categoryPageConfigurationState.page_size;
     return reqInfo.utils.createResponse$(() => {
       return {
         body: {

--- a/libs/category/testing/src/inmemory-backend/category.service.ts
+++ b/libs/category/testing/src/inmemory-backend/category.service.ts
@@ -10,7 +10,7 @@ import { DaffCategory, DaffCategoryPageConfigurationState } from '@daffodil/cate
 import { DaffInMemoryBackendProductService } from '@daffodil/product/testing';
 
 import { DaffCategoryFactory } from '../factories/category.factory';
-import { DaffCategoryPageConfigurationStateFactory } from '../factories/category-page-configuration-state.factory';
+import { DaffCategoryPageConfigurationStateFactory, DEFAULT_PAGE_SIZE } from '../factories/category-page-configuration-state.factory';
 
 @Injectable({
   providedIn: 'root'
@@ -43,6 +43,8 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
   get(reqInfo: any) {
     this.category.id = reqInfo.id;
     this.categoryPageConfigurationState.id = reqInfo.id;
+    this.categoryPageConfigurationState.current_page = reqInfo.current_page ? reqInfo.current_page : 1;
+    this.categoryPageConfigurationState.page_size = reqInfo.page_size ? reqInfo.page_size : DEFAULT_PAGE_SIZE;
     return reqInfo.utils.createResponse$(() => {
       return {
         body: {


### PR DESCRIPTION
…nt_page, and actually update provided categoryPageConfiguration parameters

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Category in memory api defines CategoryPageConfigurationStates with currentPages that are greater than the total pages available, which doesn't make sense.

Fixes: N/A


## What is the new behavior?
Current page and total page values make sense now. Also, the in-memory call for getting a category can now simulate a call for a different current_page and a different page_size.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```