### PR TITLE
fix(category): fix bug where categoryPageConfigurationState was reset…

### DIFF
--- a/libs/category/src/reducers/category/category.reducer.ts
+++ b/libs/category/src/reducers/category/category.reducer.ts
@@ -28,7 +28,7 @@ export function categoryReducer(state = initialState, action: DaffCategoryAction
         ...state, 
         loading: true,
         categoryPageConfigurationState: {
-          ...initialState.categoryPageConfigurationState,
+          ...state.categoryPageConfigurationState,
           ...action.payload
         }
       };


### PR DESCRIPTION
… to initial state on every DaffCategoryLoad

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The CategoryPageConfigurationState was being reset in the reducer to the initialState on every DaffCategoryLoad call.

Fixes: N/A


## What is the new behavior?
The CategoryPageConfigurationState is set to the previous state and whatever DaffCategoryLoad is called with.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```