### PR TITLE
feat(core): add daff persistence API with localstorage implementation

### DIFF
--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -3,3 +3,5 @@ export { DaffAddress } from './address/address';
 export { DaffStoreFacade } from './store/facade';
 
 export { range } from './utils/range';
+
+export * from './storage/public_api';

--- a/libs/core/src/storage/localstorage/localstorage.service.spec.ts
+++ b/libs/core/src/storage/localstorage/localstorage.service.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DaffLocalStorageService } from './localstorage.service';
+import { PLATFORM_ID } from '@angular/core';
+import { ɵPLATFORM_SERVER_ID, ɵPLATFORM_BROWSER_ID } from '@angular/common';
+
+fdescribe('DaffLocalStorageService', () => {
+
+  describe('On the server', () => {
+    beforeEach(() => TestBed.configureTestingModule({
+      providers: [
+        { provide: PLATFORM_ID, useValue:  ɵPLATFORM_SERVER_ID }
+      ]
+    }));
+
+    it('should throw an error in a non-browser context', () => {
+      expect(() => TestBed.get(DaffLocalStorageService)).toThrowError()
+    });
+  })
+
+  describe('in the browser', () => {
+    let service: DaffLocalStorageService;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: PLATFORM_ID, useValue: ɵPLATFORM_BROWSER_ID }
+        ]
+      })
+
+      service = TestBed.get(DaffLocalStorageService);
+    });
+
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+  
+    it('should persist a key, value pair into localstorage', () => {
+      service.setItem("key", "value");
+      expect(localStorage.getItem("key")).toEqual("value");
+    });
+  
+    it('should remove a key from localstorage', () => {
+      service.setItem("key", "value");
+      service.removeItem("key");
+      expect(localStorage.getItem("key")).toBeNull();
+    });
+  
+    it('should update a key in localstorage', () => {
+      service.setItem("key", "value2");
+      expect(localStorage.getItem("key")).toEqual("value2");
+    });
+  
+    it('should retrieve a key from localstorage', () => {
+      service.setItem("key", "value");
+      expect(localStorage.getItem("key")).toEqual("value");
+    });
+  })
+});
+

--- a/libs/core/src/storage/localstorage/localstorage.service.spec.ts
+++ b/libs/core/src/storage/localstorage/localstorage.service.spec.ts
@@ -4,57 +4,53 @@ import { DaffLocalStorageService } from './localstorage.service';
 import { PLATFORM_ID } from '@angular/core';
 import { ɵPLATFORM_SERVER_ID, ɵPLATFORM_BROWSER_ID } from '@angular/common';
 
-fdescribe('DaffLocalStorageService', () => {
+describe('DaffLocalStorageService', () => {
+	describe('On the server', () => {
+		beforeEach(() =>
+			TestBed.configureTestingModule({
+				providers: [{ provide: PLATFORM_ID, useValue: ɵPLATFORM_SERVER_ID }],
+			}),
+		);
 
-  describe('On the server', () => {
-    beforeEach(() => TestBed.configureTestingModule({
-      providers: [
-        { provide: PLATFORM_ID, useValue:  ɵPLATFORM_SERVER_ID }
-      ]
-    }));
+		it('should throw an error in a non-browser context', () => {
+			expect(() => TestBed.get(DaffLocalStorageService)).toThrowError();
+		});
+	});
 
-    it('should throw an error in a non-browser context', () => {
-      expect(() => TestBed.get(DaffLocalStorageService)).toThrowError()
-    });
-  })
+	describe('in the browser', () => {
+		let service: DaffLocalStorageService;
 
-  describe('in the browser', () => {
-    let service: DaffLocalStorageService;
+		beforeEach(() => {
+			TestBed.configureTestingModule({
+				providers: [{ provide: PLATFORM_ID, useValue: ɵPLATFORM_BROWSER_ID }],
+			});
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          { provide: PLATFORM_ID, useValue: ɵPLATFORM_BROWSER_ID }
-        ]
-      })
+			service = TestBed.get(DaffLocalStorageService);
+		});
 
-      service = TestBed.get(DaffLocalStorageService);
-    });
+		it('should be created', () => {
+			expect(service).toBeTruthy();
+		});
 
-    it('should be created', () => {
-      expect(service).toBeTruthy();
-    });
-  
-    it('should persist a key, value pair into localstorage', () => {
-      service.setItem("key", "value");
-      expect(localStorage.getItem("key")).toEqual("value");
-    });
-  
-    it('should remove a key from localstorage', () => {
-      service.setItem("key", "value");
-      service.removeItem("key");
-      expect(localStorage.getItem("key")).toBeNull();
-    });
-  
-    it('should update a key in localstorage', () => {
-      service.setItem("key", "value2");
-      expect(localStorage.getItem("key")).toEqual("value2");
-    });
-  
-    it('should retrieve a key from localstorage', () => {
-      service.setItem("key", "value");
-      expect(localStorage.getItem("key")).toEqual("value");
-    });
-  })
+		it('should persist a key, value pair into localstorage', () => {
+			service.setItem('key', 'value');
+			expect(localStorage.getItem('key')).toEqual('value');
+		});
+
+		it('should remove a key from localstorage', () => {
+			service.setItem('key', 'value');
+			service.removeItem('key');
+			expect(localStorage.getItem('key')).toBeNull();
+		});
+
+		it('should update a key in localstorage', () => {
+			service.setItem('key', 'value2');
+			expect(localStorage.getItem('key')).toEqual('value2');
+		});
+
+		it('should retrieve a key from localstorage', () => {
+			service.setItem('key', 'value');
+			expect(localStorage.getItem('key')).toEqual('value');
+		});
+	});
 });
-

--- a/libs/core/src/storage/localstorage/localstorage.service.ts
+++ b/libs/core/src/storage/localstorage/localstorage.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { DaffPersistenceService } from '../persistence.interface';
+import { isPlatformBrowser } from '@angular/common';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DaffLocalStorageService implements DaffPersistenceService {
+  constructor(@Inject(PLATFORM_ID) platformId: string){
+    if(!isPlatformBrowser(platformId)){
+      throw new Error('The DaffLocalStorageService can only be instantiated in the browser.');
+    }
+  }
+
+  /**
+   * Persist the given item into local storage. 
+   */
+  setItem(key: string, value: any): void {
+    localStorage.setItem(key, value);
+  }
+
+  /**
+   * Retrieve the given item from localstorage.
+   */
+  getItem(key: string): any {
+    return localStorage.getItem(key);
+  }
+
+  /**
+   * Remove a given item from localstorage
+   */
+  removeItem(key: string): any {
+    localStorage.removeItem(key);
+  }
+
+  clear(){
+    localStorage.clear();
+  }
+}

--- a/libs/core/src/storage/persistence.interface.ts
+++ b/libs/core/src/storage/persistence.interface.ts
@@ -1,0 +1,6 @@
+export interface DaffPersistenceService {
+  setItem(key : string, value: any): void;
+  getItem(key: string): any;
+  clear(): void;
+  removeItem(key: string): void;
+}

--- a/libs/core/src/storage/public_api.ts
+++ b/libs/core/src/storage/public_api.ts
@@ -1,0 +1,2 @@
+export { DaffLocalStorageService } from './localstorage/localstorage.service';
+export { DaffPersistenceService } from './persistence.interface';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
We need a persistent storage mechanism for storing data between refreshes.

## What is the new behavior?
This adds a basic API and implements the API with a localstorage service.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information