### PR TITLE
feat(geography, core): add DaffAddress types and deprecate core Types

### DIFF
--- a/libs/core/src/address/address.ts
+++ b/libs/core/src/address/address.ts
@@ -1,6 +1,6 @@
 /**
  * @deprecated
- * Prefer the `DaffAddress` of `@daffodil/geography`
+ * Prefer the `DaffAddress` of `daffodil/geography`
  */
 export interface DaffAddress {
   firstname: string;

--- a/libs/core/src/address/address.ts
+++ b/libs/core/src/address/address.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated
+ * Prefer the `DaffAddress` of `@daffodil/geography`
+ */
 export interface DaffAddress {
   firstname: string;
   lastname: string;

--- a/libs/core/testing/src/address/factories/address.factory.ts
+++ b/libs/core/testing/src/address/factories/address.factory.ts
@@ -6,7 +6,7 @@ import { DaffModelFactory } from '../../factories/factory';
 
 /**
  * @deprecated
- * Prefer the `MockDaffAddress` of `@daffodil/geography/testing`
+ * Prefer the `MockDaffAddress` of daffodil/geography/testing`
  */
 export class MockDaffAddress implements DaffAddress {
   firstname = faker.name.firstName();
@@ -21,7 +21,7 @@ export class MockDaffAddress implements DaffAddress {
 
 /**
  * @deprecated
- * Prefer the `DaffAddressFactory` of `@daffodil/geography/testing`
+ * Prefer the `DaffAddressFactory` of `daffodil/geography/testing`
  */
 @Injectable({
   providedIn: 'root'

--- a/libs/geography/src/address/address.ts
+++ b/libs/geography/src/address/address.ts
@@ -1,0 +1,12 @@
+/**
+ * A basic model of an address
+ */
+export interface DaffAddress {
+  street: string;
+  city: string;
+  region: string;
+  region_id?: string | number;
+  country?: string;
+  country_id?: string | number;
+  postcode: string;
+}

--- a/libs/geography/src/address/personal-address.ts
+++ b/libs/geography/src/address/personal-address.ts
@@ -1,0 +1,15 @@
+import { DaffAddress } from "./address";
+
+/**
+ * A specialized type of address useful for associating a physical address 
+ * with a particular individual.
+ */
+export interface DaffPersonalAddress extends DaffAddress {
+	prefix?: string;
+	suffix?: string;
+	firstname: string;
+	middlename?: string;
+	lastname: string;
+	telephone: string;
+	email?: string;
+}

--- a/libs/geography/src/address/personal-address.ts
+++ b/libs/geography/src/address/personal-address.ts
@@ -1,7 +1,7 @@
-import { DaffAddress } from "./address";
+import { DaffAddress } from './address';
 
 /**
- * A specialized type of address useful for associating a physical address 
+ * A specialized type of address useful for associating a physical address
  * with a particular individual.
  */
 export interface DaffPersonalAddress extends DaffAddress {

--- a/libs/geography/src/index.ts
+++ b/libs/geography/src/index.ts
@@ -1,4 +1,5 @@
 /*
  * Public API Surface of @daffodil/geography
  */
-export const holder = 'GEO';
+export { DaffAddress } from './address/address';
+export { DaffPersonalAddress } from './address/personal-address';

--- a/libs/geography/testing/ng-package.json
+++ b/libs/geography/testing/ng-package.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/geography/testing",
+  "deleteDestPath": false,
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/geography/testing/package.json
+++ b/libs/geography/testing/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@daffodil/geography/testing"
+}

--- a/libs/geography/testing/src/address/factories/address.factory.spec.ts
+++ b/libs/geography/testing/src/address/factories/address.factory.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed, async } from '@angular/core/testing';
+
+import { DaffAddressFactory, MockDaffAddress } from './address.factory';
+import { DaffAddress } from '@daffodil/core';
+
+describe('Core | Interfaces | Factories | DaffAddressFactory', () => {
+  
+  let daffodilAddressFactory;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffAddressFactory]
+    });
+
+    daffodilAddressFactory = TestBed.get(DaffAddressFactory);
+  }));
+
+  it('should be created', () => {
+    expect(daffodilAddressFactory).toBeTruthy();
+  });
+
+  describe('creating an address', () => {
+
+    let result: MockDaffAddress;
+
+    beforeEach(() => {
+      result = daffodilAddressFactory.create();
+    });
+
+    it('should return an Address with firstname', () => {
+      expect(result.firstname).toBeDefined();
+    });
+
+    it('should return an Address with lastname', () => {
+      expect(result.lastname).toBeDefined();
+    });
+
+    it('should return an Address with street', () => {
+      expect(result.street).toBeDefined();
+    });
+
+    it('should return an Address with city', () => {
+      expect(result.city).toBeDefined();
+    });
+
+    it('should return an Address with region', () => {
+      expect(result.region).toBeDefined();
+    });
+
+    it('should return an Address with an email', () => {
+      expect(result.email).toBeDefined();
+    });
+
+    it('should return an Address with postcode', () => {
+      expect(result.postcode).toBeDefined();
+    });
+
+    it('should return an Address with telephone', () => {
+      expect(result.telephone).toBeDefined();
+    });
+  });
+  
+  describe('creating many addresses', () => {
+    let result: DaffAddress[];
+
+    it('should create as many cart addresses as desired', () => {
+      result = daffodilAddressFactory.createMany(2);
+      expect(result.length).toEqual(2);
+
+      result = daffodilAddressFactory.createMany(3);
+      expect(result.length).toEqual(3);
+    })
+  });
+});

--- a/libs/geography/testing/src/address/factories/address.factory.spec.ts
+++ b/libs/geography/testing/src/address/factories/address.factory.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, async } from '@angular/core/testing';
 
 import { DaffAddressFactory, MockDaffAddress } from './address.factory';
-import { DaffAddress } from '@daffodil/core';
+import { DaffAddress } from '@daffodil/geography';
 
 describe('Core | Interfaces | Factories | DaffAddressFactory', () => {
   

--- a/libs/geography/testing/src/address/factories/address.factory.ts
+++ b/libs/geography/testing/src/address/factories/address.factory.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
-import { DaffAddress } from '@daffodil/core';
+
+import { DaffModelFactory } from '@daffodil/core/testing';
+import { DaffAddress } from '@daffodil/geography';
 
 import * as faker from 'faker/locale/en_US';
-import { DaffModelFactory } from '../../factories/factory';
 
 export class MockDaffAddress implements DaffAddress {
   firstname = faker.name.firstName();

--- a/libs/geography/testing/src/address/factories/address.factory.ts
+++ b/libs/geography/testing/src/address/factories/address.factory.ts
@@ -4,25 +4,17 @@ import { DaffAddress } from '@daffodil/core';
 import * as faker from 'faker/locale/en_US';
 import { DaffModelFactory } from '../../factories/factory';
 
-/**
- * @deprecated
- * Prefer the `MockDaffAddress` of `@daffodil/geography/testing`
- */
 export class MockDaffAddress implements DaffAddress {
   firstname = faker.name.firstName();
   lastname = faker.name.lastName();
   street = faker.address.streetName();
   city = faker.address.city();
-  state = faker.address.stateAbbr();
+  region = faker.address.stateAbbr();
   email = faker.internet.email();
   postcode = faker.address.zipCode();
   telephone = faker.phone.phoneNumber();
 }
 
-/**
- * @deprecated
- * Prefer the `DaffAddressFactory` of `@daffodil/geography/testing`
- */
 @Injectable({
   providedIn: 'root'
 })

--- a/libs/geography/testing/src/index.ts
+++ b/libs/geography/testing/src/index.ts
@@ -1,0 +1,2 @@
+// Address
+export { DaffAddressFactory } from './address/factories/address.factory';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -82,6 +82,9 @@
       "@daffodil/geography": [
         "dist/geography"
       ],
+      "@daffodil/geography/testing": [
+        "dist/geography/testing"
+      ],
     }
   },
   "exclude": [


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
N/A

Fixes: N/A

## What is the new behavior?
This adds the DaffAddress types to the `@daffodil/geography` package.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information