### PR TITLE
feat(design): expand id type on qty-dropdown to allow for strings

### DIFF
--- a/libs/design/src/molecules/qty-dropdown/qty-dropdown.component.ts
+++ b/libs/design/src/molecules/qty-dropdown/qty-dropdown.component.ts
@@ -10,7 +10,7 @@ export class DaffQtyDropdownComponent implements OnInit {
   private readonly dropdownRange = 9;
 
   @Input() qty: number;
-  @Input() id: number;
+  @Input() id: number | string;
   @Output() qtyChanged: EventEmitter<number> = new EventEmitter<number>();
 
   dropdownItemCounter: number[];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, the `daff-qty-dropdown` 's `id` only allows for `number`. It can easily allow for `string` as well without issue.

## What is the new behavior?
This adds the string type as an allowed type.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```