### PR TITLE
feat(checkout): replace DaffCart type with Order type

### DIFF
--- a/libs/checkout/src/order/containers/order.component.spec.ts
+++ b/libs/checkout/src/order/containers/order.component.spec.ts
@@ -65,13 +65,4 @@ describe('OrderContainer', () => {
       });
     });
   });
-
-  describe('placeOrder', () => {
-    
-    it('should call store.dispatch with a DaffPlaceOrder action', () => {
-      component.placeOrder(stubOrder);
-
-      expect(store.dispatch).toHaveBeenCalledWith(new DaffPlaceOrder(stubOrder));
-    });
-  });
 });

--- a/libs/checkout/src/order/containers/order.component.ts
+++ b/libs/checkout/src/order/containers/order.component.ts
@@ -2,10 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Store, select } from '@ngrx/store';
 
-import { DaffPlaceOrder } from '../actions/order.actions';
-import { Order } from '../../models/order/order';
 import { DaffOrderReducersState } from '../reducers/order-reducers.interface';
 import { selectOrder, selectLoading } from '../selectors/order.selector';
+import { Order } from '../../models/order/order';
 
 @Component({
   selector: '[order-container]',
@@ -24,9 +23,5 @@ export class OrderContainer implements OnInit {
   ngOnInit() {
     this.order$ = this.store.pipe(select(selectOrder));
     this.loading$ = this.store.pipe(select(selectLoading));
-  }
-
-  placeOrder(cart: Order) {
-    this.store.dispatch(new DaffPlaceOrder(cart));
   }
 }

--- a/libs/checkout/src/order/effects/order.effects.spec.ts
+++ b/libs/checkout/src/order/effects/order.effects.spec.ts
@@ -4,19 +4,22 @@ import { Observable, of } from 'rxjs';
 import { hot, cold } from 'jasmine-marbles';
 
 import { DaffCart, DaffCartDriver, DaffCartServiceInterface } from '@daffodil/cart';
-import { DaffCartFactory, DaffTestingCartService } from '@daffodil/cart/testing';
-import { DaffTestingCheckoutService } from '@daffodil/checkout/testing';
+import { DaffTestingCartService, DaffCartFactory } from '@daffodil/cart/testing';
+import { DaffTestingCheckoutService, DaffOrderFactory } from '@daffodil/checkout/testing';
 
 import { OrderEffects } from './order.effects';
 import { DaffPlaceOrder, DaffPlaceOrderSuccess, DaffPlaceOrderFailure } from '../actions/order.actions';
 import { DaffCheckoutServiceInterface } from '../../drivers/interfaces/checkout-service.interface';
 import { DaffCheckoutDriver } from '../../drivers/injection-tokens/driver-checkout.token';
+import { Order } from '@daffodil/checkout';
 
 describe('Daffodil | State | Order | OrderEffects', () => {
   let actions$: Observable<any>;
   let effects: OrderEffects<DaffCart>;
   let daffCheckoutDriver: DaffCheckoutServiceInterface;
   let daffCartDriver: DaffCartServiceInterface<DaffCart>;
+  let stubOrder: Order;
+  let orderFactory: DaffOrderFactory;
   let stubCart: DaffCart;
   let cartFactory: DaffCartFactory;
 
@@ -37,11 +40,13 @@ describe('Daffodil | State | Order | OrderEffects', () => {
     });
 
     effects = TestBed.get(OrderEffects);
+    orderFactory = TestBed.get(DaffOrderFactory);
     cartFactory = TestBed.get(DaffCartFactory);
     daffCartDriver = TestBed.get(DaffCartDriver);
     daffCheckoutDriver = TestBed.get(DaffCheckoutDriver);
 
     stubCart = cartFactory.create();
+    stubOrder = orderFactory.create();
   });
 
   it('should be created', () => {
@@ -54,9 +59,9 @@ describe('Daffodil | State | Order | OrderEffects', () => {
     describe('and the call to CartService is successful', () => {
       
       beforeEach(() => {
-        spyOn(daffCheckoutDriver, 'placeOrder').and.returnValue(of(stubCart));
+        spyOn(daffCheckoutDriver, 'placeOrder').and.returnValue(of(stubOrder));
         const placeOrderAction = new DaffPlaceOrder(stubCart);
-        const placeOrderSuccessAction = new DaffPlaceOrderSuccess(stubCart);
+        const placeOrderSuccessAction = new DaffPlaceOrderSuccess(stubOrder);
         actions$ = hot('--a', { a: placeOrderAction });
         expected = cold('--b', { b: placeOrderSuccessAction });
       });
@@ -87,7 +92,7 @@ describe('Daffodil | State | Order | OrderEffects', () => {
   describe('when PlaceOrderSuccessAction is triggered', () => {
     
     let expected;
-    const placeOrderSuccessAction = new DaffPlaceOrderSuccess(stubCart);
+    const placeOrderSuccessAction = new DaffPlaceOrderSuccess(stubOrder);
 
     beforeEach(() => {
       spyOn(daffCartDriver, 'clear').and.returnValue(of());

--- a/libs/checkout/src/order/effects/order.effects.spec.ts
+++ b/libs/checkout/src/order/effects/order.effects.spec.ts
@@ -11,7 +11,7 @@ import { OrderEffects } from './order.effects';
 import { DaffPlaceOrder, DaffPlaceOrderSuccess, DaffPlaceOrderFailure } from '../actions/order.actions';
 import { DaffCheckoutServiceInterface } from '../../drivers/interfaces/checkout-service.interface';
 import { DaffCheckoutDriver } from '../../drivers/injection-tokens/driver-checkout.token';
-import { Order } from '@daffodil/checkout';
+import { Order } from '../../models/order/order';
 
 describe('Daffodil | State | Order | OrderEffects', () => {
   let actions$: Observable<any>;

--- a/libs/checkout/src/order/reducers/order/order.reducer.spec.ts
+++ b/libs/checkout/src/order/reducers/order/order.reducer.spec.ts
@@ -4,15 +4,18 @@ import { initialState, daffOrderReducer } from './order.reducer';
 import { DaffPlaceOrder, DaffPlaceOrderSuccess, DaffPlaceOrderFailure } from '../../actions/order.actions';
 import { Order } from '../../../models/order/order';
 import { DaffOrderReducerState } from './order-reducer.interface';
+import { DaffCartFactory } from '@daffodil/cart/testing';
+import { DaffCart } from '@daffodil/cart';
 
 describe('Order | Order Reducer', () => {
 
   let orderFactory: DaffOrderFactory;
   let stubOrder: Order;
+  let stubCart: DaffCart;
 
   beforeEach(() => {
     orderFactory = new DaffOrderFactory();
-
+    stubCart = new DaffCartFactory().create();
     stubOrder = orderFactory.create();
   });
 
@@ -30,7 +33,7 @@ describe('Order | Order Reducer', () => {
   describe('when PlaceOrderAction is triggered', () => {
 
     it('sets loading state to true', () => {
-      const placeOrderAction: DaffPlaceOrder = new DaffPlaceOrder(stubOrder);
+      const placeOrderAction: DaffPlaceOrder = new DaffPlaceOrder(stubCart);
       
       const result = daffOrderReducer(initialState, placeOrderAction);
 

--- a/libs/checkout/testing/src/drivers/in-memory/checkout.service.spec.ts
+++ b/libs/checkout/testing/src/drivers/in-memory/checkout.service.spec.ts
@@ -1,16 +1,16 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { DaffCart } from '@daffodil/cart';
-import { DaffCartFactory } from '@daffodil/cart/testing';
 
 import { DaffInMemoryCheckoutService } from './checkout.service';
+import { DaffOrderFactory } from '@daffodil/checkout/testing';
+import { Order } from '@daffodil/checkout';
 
 describe('Driver | In Memory | Checkout | CheckoutService', () => {
   let checkoutService: DaffInMemoryCheckoutService;
   let httpMock: HttpTestingController;
-  let cartFactory: DaffCartFactory;
-  let stubOrder: DaffCart;
+  let orderFactory: DaffOrderFactory;
+  let stubOrder: Order;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -23,7 +23,7 @@ describe('Driver | In Memory | Checkout | CheckoutService', () => {
     });
     
     httpMock = TestBed.get(HttpTestingController);
-    cartFactory = TestBed.get(DaffCartFactory);
+    orderFactory = TestBed.get(DaffOrderFactory);
     checkoutService = TestBed.get(DaffInMemoryCheckoutService);
   });
 
@@ -41,7 +41,7 @@ describe('Driver | In Memory | Checkout | CheckoutService', () => {
     beforeEach(() => {
       cartId = 'cartId';
 
-      stubOrder = cartFactory.create();
+      stubOrder = orderFactory.create();
     });
 
     describe('a successful placeOrder request', () => {

--- a/libs/checkout/testing/src/drivers/in-memory/checkout.service.ts
+++ b/libs/checkout/testing/src/drivers/in-memory/checkout.service.ts
@@ -2,8 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { DaffCart } from '@daffodil/cart';
-import { DaffCheckoutServiceInterface } from '@daffodil/checkout';
+import { DaffCheckoutServiceInterface, Order } from '@daffodil/checkout';
 
 @Injectable({
   providedIn: 'root'
@@ -13,7 +12,7 @@ export class DaffInMemoryCheckoutService implements DaffCheckoutServiceInterface
 
   constructor(private http: HttpClient) {}
 
-  placeOrder(cartId: string): Observable<DaffCart> {
-    return this.http.post<DaffCart>(this.url + '/placeOrder', { cartId });
+  placeOrder(cartId: string): Observable<Order> {
+    return this.http.post<Order>(this.url + '/placeOrder', { cartId });
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, the several types in `@daffodil/checkout` strictly return a hastily chosen type.

## What is the new behavior?
 This opts for a more sane choice. The `Order` type makes more sense for many types.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

Applications depending on the old type will need to shift to the new one.

## Other information