### PR TITLE
build(authorizenet): generate code coverage in correct folder

### DIFF
--- a/libs/authorizenet/karma.conf.js
+++ b/libs/authorizenet/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
         clearContext: false // leave Jasmine Spec Runner output visible in browser
       },
       coverageIstanbulReporter: {
-        dir: require('path').join(__dirname, '../../coverage'),
+        dir: require('path').join(__dirname, '../../coverage/libs/authorizenet'),
         reports: ['html', 'lcovonly'],
         fixWebpackSourcePaths: true
       },
@@ -29,4 +29,3 @@ module.exports = function (config) {
       singleRun: false
     });
   };
-  


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Code coverage is generated in the root coverage folder, `/coverage`.

Fixes: N/A


## What is the new behavior?
Code coverage is generated in a discrete folder, `/coverage/libs/authorizenet`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information