### PR TITLE
feat(auth): change register interface to return DaffLoginInfo

### DIFF
--- a/libs/auth/src/drivers/interfaces/register-service.interface.ts
+++ b/libs/auth/src/drivers/interfaces/register-service.interface.ts
@@ -1,17 +1,17 @@
 import { Observable } from 'rxjs';
 import { DaffAccountRegistration } from '../../models/account-registration';
-import { DaffAuthToken } from '../../models/auth-token';
+import { DaffLoginInfo } from '../../models/login-info';
 
 export interface DaffRegisterServiceInterface<
-TRequest extends DaffAccountRegistration,
-TResponse extends DaffAuthToken
+  TRequest extends DaffAccountRegistration,
+  TResponse extends DaffLoginInfo
 > {
 
   /**
    * Registers an account for the specified customer.
    *
-   * @param {T} registration
-   * @returns {Observable<string>} An access token.
+   * @param registration The account registration info.
+   * @returns Login info.
    */
   register(registration: TRequest): Observable<TResponse>;
 }

--- a/libs/auth/testing/src/drivers/in-memory/register/register.service.spec.ts
+++ b/libs/auth/testing/src/drivers/in-memory/register/register.service.spec.ts
@@ -6,6 +6,7 @@ import {
   DaffAuthToken,
   DaffAccountRegistration,
   DaffLoginDriver,
+  DaffLoginInfo
 } from '@daffodil/auth';
 
 import { DaffInMemoryRegisterService } from './register.service';
@@ -16,18 +17,14 @@ describe('Driver | InMemory | Auth | RegisterService', () => {
   let registerService;
   let httpMock: HttpTestingController;
 
-  const loginServiceSpy = jasmine.createSpyObj('DaffInMemoryLoginService', ['login'])
-
   const registrationFactory: DaffAccountRegistrationFactory = new DaffAccountRegistrationFactory();
-  const authFactory: DaffAuthTokenFactory = new DaffAuthTokenFactory();
 
-  let token: string;
   let email: string;
   let password: string;
   let firstName: string;
   let lastName: string;
   let mockRegistration: DaffAccountRegistration;
-  let mockAuth: DaffAuthToken;
+  let mockLoginInfo: DaffLoginInfo;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -35,11 +32,7 @@ describe('Driver | InMemory | Auth | RegisterService', () => {
         HttpClientTestingModule
       ],
       providers: [
-        DaffInMemoryRegisterService,
-        {
-          provide: DaffLoginDriver,
-          useValue: loginServiceSpy
-        }
+        DaffInMemoryRegisterService
       ]
     });
 
@@ -47,15 +40,16 @@ describe('Driver | InMemory | Auth | RegisterService', () => {
     registerService = TestBed.get(DaffInMemoryRegisterService);
 
     mockRegistration = registrationFactory.create();
-    mockAuth = authFactory.create();
 
-    token = mockAuth.token;
     firstName = mockRegistration.customer.firstName;
     lastName = mockRegistration.customer.lastName;
     email = mockRegistration.customer.email;
     password = mockRegistration.password;
 
-    loginServiceSpy.login.withArgs({email, password}).and.returnValue(of(mockAuth));
+    mockLoginInfo = {
+      email,
+      password
+    };
   });
 
   it('should be created', () => {
@@ -78,9 +72,9 @@ describe('Driver | InMemory | Auth | RegisterService', () => {
       req.flush(mockRegistration.customer);
     });
 
-    it('should return an AuthToken', () => {
-      registerService.register(mockRegistration).subscribe(auth => {
-        expect(auth).toEqual(mockAuth);
+    it('should return a DaffLoginInfo', () => {
+      registerService.register(mockRegistration).subscribe(loginInfo => {
+        expect(loginInfo).toEqual(mockLoginInfo);
       });
 
       const req = httpMock.expectOne(`${registerService.url}register`);

--- a/libs/auth/testing/src/drivers/in-memory/register/register.service.ts
+++ b/libs/auth/testing/src/drivers/in-memory/register/register.service.ts
@@ -1,15 +1,12 @@
 import { Injectable, Inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { mergeMapTo } from 'rxjs/operators';
+import { mapTo } from 'rxjs/operators';
 
 import {
-  DaffLoginDriver,
   DaffRegisterServiceInterface,
-  DaffLoginServiceInterface,
   DaffCustomerRegistration,
   DaffAccountRegistration,
-  DaffAuthToken,
   DaffLoginInfo
 } from '@daffodil/auth';
 
@@ -18,23 +15,20 @@ import {
 })
 export class DaffInMemoryRegisterService implements DaffRegisterServiceInterface<
   DaffAccountRegistration,
-  DaffAuthToken
+  DaffLoginInfo
 > {
   url = '/api/auth/';
 
   constructor(
     private http: HttpClient,
-    @Inject(DaffLoginDriver) private loginDriver: DaffLoginServiceInterface<DaffLoginInfo, DaffAuthToken>
   ) {}
 
-  register(registration: DaffAccountRegistration): Observable<DaffAuthToken> {
+  register(registration: DaffAccountRegistration): Observable<DaffLoginInfo> {
     return this.http.post<DaffCustomerRegistration>(`${this.url}register`, registration).pipe(
-      mergeMapTo(
-        this.loginDriver.login({
-          email: registration.customer.email,
-          password: registration.password
-        })
-      )
+      mapTo({
+        email: registration.customer.email,
+        password: registration.password
+      })
     );
   }
 }

--- a/libs/auth/testing/src/drivers/testing/register/register.service.spec.ts
+++ b/libs/auth/testing/src/drivers/testing/register/register.service.spec.ts
@@ -1,23 +1,24 @@
 import { TestBed } from '@angular/core/testing';
 
 import {
-  DaffAuthToken,
+  DaffLoginInfo,
   DaffRegisterServiceInterface,
   DaffAccountRegistration,
   DaffCustomerRegistration
-} from '../../../../../src';
+} from '@daffodil/auth';
 import { DaffTestingRegisterService } from './register.service';
 import { DaffAccountRegistrationFactory } from '../../../factories/account-registration.factory';
 
 describe('Driver | Testing | Auth | RegisterService', () => {
   let registerService: DaffRegisterServiceInterface<
     DaffAccountRegistration,
-    DaffAuthToken
+    DaffLoginInfo
   >;
 
   const registrationFactory: DaffAccountRegistrationFactory = new DaffAccountRegistrationFactory();
 
   let mockRegistration: DaffAccountRegistration;
+  let mockLoginInfo: DaffLoginInfo;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -29,16 +30,21 @@ describe('Driver | Testing | Auth | RegisterService', () => {
     registerService = TestBed.get(DaffTestingRegisterService);
 
     mockRegistration = registrationFactory.create();
+
+    mockLoginInfo = {
+      email: mockRegistration.customer.email,
+      password: mockRegistration.password
+    };
   });
 
   it('should be created', () => {
     expect(registerService).toBeTruthy();
   });
 
-  describe('register | obtaining a token', () => {
-    it('should return a token', () => {
-      registerService.register(mockRegistration).subscribe(auth => {
-        expect(auth.token).toBeTruthy();
+  describe('register | obtaining login info', () => {
+    it('should return login info', () => {
+      registerService.register(mockRegistration).subscribe(loginInfo => {
+        expect(loginInfo).toEqual(mockLoginInfo);
       });
     });
   });

--- a/libs/auth/testing/src/drivers/testing/register/register.service.ts
+++ b/libs/auth/testing/src/drivers/testing/register/register.service.ts
@@ -3,22 +3,21 @@ import { Observable, of } from 'rxjs';
 
 import {
   DaffAccountRegistration,
-  DaffAuthToken,
+  DaffLoginInfo,
   DaffRegisterServiceInterface,
 } from '@daffodil/auth';
-
-import { DaffAuthTokenFactory } from '../../../factories/auth-token.factory';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DaffTestingRegisterService implements DaffRegisterServiceInterface<
   DaffAccountRegistration,
-  DaffAuthToken
+  DaffLoginInfo
 > {
-  constructor (private factory: DaffAuthTokenFactory) {}
-
-  register(registration: DaffAccountRegistration): Observable<DaffAuthToken> {
-    return of(this.factory.create());
+  register(registration: DaffAccountRegistration): Observable<DaffLoginInfo> {
+    return of({
+      email: registration.customer.email,
+      password: registration.password
+    });
   }
 }

--- a/libs/auth/testing/src/inmemory-backend/auth.service.integration.spec.ts
+++ b/libs/auth/testing/src/inmemory-backend/auth.service.integration.spec.ts
@@ -1,11 +1,19 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { HttpClientInMemoryWebApiModule, STATUS } from 'angular-in-memory-web-api';
+import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
+
+import { DaffAccountRegistrationFactory } from '@daffodil/auth/testing';
+import { DaffAccountRegistration, DaffLoginInfo } from '@daffodil/auth';
 
 import { DaffInMemoryBackendAuthService } from './auth.service';
 
 describe('DaffAuthInMemoryBackend | Integration', () => {
   let httpClient;
+
+  const registrationFactory = new DaffAccountRegistrationFactory();
+
+  let mockRegistration: DaffAccountRegistration;
+  let mockLoginInfo: DaffLoginInfo;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -16,21 +24,27 @@ describe('DaffAuthInMemoryBackend | Integration', () => {
     });
 
     httpClient = TestBed.get(HttpClient);
+
+    mockRegistration = registrationFactory.create();
+    mockLoginInfo = {
+      email: mockRegistration.customer.email,
+      password: mockRegistration.password
+    };
   });
 
   describe('processing a login request', () => {
     it('should process post requests of the form `/api/auth/login` and return a token', done => {
       httpClient.post('/api/auth/login', {}).subscribe(result => {
-        expect(result).toBeDefined();
+        expect(result.token).toBeDefined();
         done();
       });
     });
   });
 
   describe('processing a register request', () => {
-    it('should process post requests of the form `/api/auth/register` and return the customer info', done => {
-      httpClient.post('/api/auth/register', {}).subscribe(result => {
-        expect(result).toBeDefined();
+    it('should process post requests of the form `/api/auth/register` and return the login info', done => {
+      httpClient.post('/api/auth/register', mockRegistration).subscribe(result => {
+        expect(result).toEqual(mockLoginInfo);
         done();
       });
     });

--- a/libs/auth/testing/src/inmemory-backend/auth.service.ts
+++ b/libs/auth/testing/src/inmemory-backend/auth.service.ts
@@ -47,11 +47,13 @@ export class DaffInMemoryBackendAuthService implements InMemoryDbService {
   private register(reqInfo) {
     const {
       customer,
+      password
     } = reqInfo.utils.getJsonBody(reqInfo.req);
 
     return reqInfo.utils.createResponse$(() => ({
       body: {
-        id: this.generateId()
+        email: customer.email,
+        password
       },
       status: STATUS.CREATED
     }))

--- a/libs/auth/testing/src/inmemory-backend/auth.service.unit.spec.ts
+++ b/libs/auth/testing/src/inmemory-backend/auth.service.unit.spec.ts
@@ -55,12 +55,17 @@ describe('DaffAuthInMemoryBackend | Unit', () => {
   });
 
   describe('processing a register request', () => {
-    it('should process post requests of the form `/api/auth/register` and return the customer info with a CREATED status', () => {
+    it('should process post requests of the form `/api/auth/register` and return the login info with a CREATED status', () => {
+      const mockRegistration = registrationFactory.create();
+      const mockLoginInfo = {
+        email: mockRegistration.customer.email,
+        password: mockRegistration.password
+      };
       reqInfoStub.id = 'register';
-      reqInfoStub.req.body = registrationFactory.create();
+      reqInfoStub.req.body = mockRegistration;
       const result = authTestingService.post(reqInfoStub);
 
-      expect(result.body.id).toBeDefined();
+      expect(result.body).toEqual(mockLoginInfo);
       expect(result.status).toEqual(STATUS.CREATED);
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`DaffRegisterServiceInterface#register` returns `DaffAuthToken`.

Fixes: N/A


## What is the new behavior?
`DaffRegisterServiceInterface#register` returns `DaffLoginInfo`.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Extracted from #623 regarding [this comment](https://github.com/graycoreio/daffodil/pull/623#discussion_r378471020).