### PR TITLE
feat(cart): add get to in-memory backend

### DIFF
--- a/libs/cart/testing/src/in-memory-backend/cart.service.spec.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart.service.spec.ts
@@ -14,7 +14,7 @@ describe('Driver | Cart | In Memory | CartService', () => {
   let stubProductImage: DaffProductImage;
   let daffCartFactory: jasmine.SpyObj<DaffCartFactory>;
   let daffProductImageFactory: jasmine.SpyObj<DaffProductImageFactory>;
-  
+
   beforeEach(() => {
     const daffCartFactorySpy = jasmine.createSpyObj('DaffCartFactory', ['create']);
     const daffProductImageFactorySpy = jasmine.createSpyObj('DaffProductImageFactory', ['create']);
@@ -28,7 +28,7 @@ describe('Driver | Cart | In Memory | CartService', () => {
         { provide: DaffProductImageFactory, useValue: daffProductImageFactorySpy}
       ]
     });
-    
+
     daffCartFactory = TestBed.get(DaffCartFactory);
     daffProductImageFactory = TestBed.get(DaffProductImageFactory);
     daffProductImageFactory.create.and.returnValue(stubProductImage);
@@ -47,10 +47,36 @@ describe('Driver | Cart | In Memory | CartService', () => {
     beforeEach(() => {
       result = cartTestingService.createDb();
     });
-    
+
     it('should return a cart', () => {
       result = cartTestingService.createDb();
       expect(result.cart).toEqual(stubCart);
+    });
+  });
+
+  describe('get', () => {
+    let reqInfoStub;
+    let result;
+
+    beforeEach(() => {
+      reqInfoStub = {
+        req: {
+          body: 'body'
+        },
+        utils: {
+          createResponse$: func => {
+            return func();
+          }
+        }
+      };
+      result = cartTestingService.get(reqInfoStub);
+    });
+
+    it('should return the returned value from createResponse$', () => {
+      expect(result).toEqual({
+        body: stubCart,
+        status: STATUS.OK
+      });
     });
   });
 
@@ -187,7 +213,7 @@ describe('Driver | Cart | In Memory | CartService', () => {
 
       it('should remove the items in the cart', () => {
         result = cartTestingService.post(reqInfoStub);
-        
+
         expect(result.body.items.length).toEqual(0);
       });
     });

--- a/libs/cart/testing/src/in-memory-backend/cart.service.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart.service.ts
@@ -21,6 +21,15 @@ export class DaffInMemoryBackendCartService implements InMemoryDbService {
     this.cart = this.cartFactory.create();
   }
 
+  get(reqInfo: any) {
+    return reqInfo.utils.createResponse$(() => {
+      return {
+        body: this.cart,
+        status: STATUS.OK
+      };
+    })
+  }
+
   post(reqInfo: any) {
     return reqInfo.utils.createResponse$(() => {
       if (reqInfo.id === 'addToCart') {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The in-memory backend has no `get` method.
Fixes: N/A


## What is the new behavior?
The in-memory backend has a `get` method which can be referenced in apps' own `InMemoryDbService`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information