### PR TITLE
[WIP] feat(cart): add magento factories and mock helpers

### DIFF
--- a/libs/cart/src/drivers/magento/index.ts
+++ b/libs/cart/src/drivers/magento/index.ts
@@ -1,0 +1,3 @@
+
+export * from './models/outputs';
+

--- a/libs/cart/src/drivers/magento/models/outputs/cart-address.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/cart-address.ts
@@ -1,0 +1,17 @@
+export interface MagentoCartAddress {
+  region: {
+    code: string;
+    label: string;
+  };
+  country: {
+    code: string;
+    label: string;
+  };
+  street: string[];
+  company: string;
+  telephone: string;
+  postcode: string;
+  city: string;
+  firstname: string;
+  lastname: string;
+}

--- a/libs/cart/src/drivers/magento/models/outputs/cart-coupon.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/cart-coupon.ts
@@ -1,0 +1,3 @@
+export interface MagentoCartCoupon {
+  code: string;
+}

--- a/libs/cart/src/drivers/magento/models/outputs/cart-item.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/cart-item.ts
@@ -1,0 +1,18 @@
+import { MagentoMoney } from './money'
+import { MagentoProduct } from './product';
+
+/**
+ * An object for defining what the cart service requests and retrieves from a magento backend.
+ */
+export interface MagentoCartItem {
+  id: string;
+  prices: {
+    discounts: any[];
+    price: MagentoMoney;
+    row_total: MagentoMoney;
+    row_total_including_tax: MagentoMoney;
+    total_item_discount: MagentoMoney;
+  };
+  product: MagentoProduct;
+  quantity: number;
+}

--- a/libs/cart/src/drivers/magento/models/outputs/cart-payment-method.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/cart-payment-method.ts
@@ -1,0 +1,5 @@
+export interface MagentoCartPaymentMethod {
+  code: string;
+  purchase_order_number?: string;
+  title: string;
+}

--- a/libs/cart/src/drivers/magento/models/outputs/cart-shipping-method.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/cart-shipping-method.ts
@@ -1,0 +1,9 @@
+import { MagentoMoney } from './money';
+
+export interface MagentoCartShippingMethod {
+  carrier_code: string;
+  method_code: string;
+  carrier_title: string;
+  method_title: string;
+  amount: MagentoMoney;
+}

--- a/libs/cart/src/drivers/magento/models/outputs/cart.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/cart.ts
@@ -1,0 +1,25 @@
+import { MagentoCartItem } from './cart-item'
+import { MagentoCartPaymentMethod } from './cart-payment-method';
+import { MagentoCartAddress } from './cart-address';
+import { MagentoCartCoupon } from './cart-coupon';
+import { MagentoMoney } from './money';
+import { MagentoShippingAddress } from './shipping-address';
+
+/**
+ * An object for defining what the cart service requests and retrieves from a magento backend.
+ */
+export interface MagentoCart {
+  id: number;
+  billing_address: MagentoCartAddress;
+  shipping_addresses: MagentoShippingAddress[];
+  items: MagentoCartItem[];
+  available_payment_methods: MagentoCartPaymentMethod[];
+  selected_payment_method: MagentoCartPaymentMethod;
+  applied_coupons: MagentoCartCoupon[];
+  prices: {
+    grand_total: MagentoMoney,
+    subtotal_excluding_tax: MagentoMoney,
+    subtotal_including_tax: MagentoMoney,
+    subtotal_with_discount_excluding_tax: MagentoMoney,
+  }
+}

--- a/libs/cart/src/drivers/magento/models/outputs/index.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/index.ts
@@ -1,0 +1,11 @@
+
+export { MagentoCart } from './cart';
+export { MagentoCartItem } from './cart-item';
+export { MagentoCartAddress } from './cart-address';
+export { MagentoCartCoupon } from './cart-coupon';
+export { MagentoCartPaymentMethod } from './cart-payment-method';
+export { MagentoCartShippingMethod } from './cart-shipping-method';
+export { MagentoMoney } from './money';
+export { MagentoShippingAddress } from './shipping-address';
+export { MagentoProduct } from './product';
+

--- a/libs/cart/src/drivers/magento/models/outputs/money.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/money.ts
@@ -1,0 +1,4 @@
+export interface MagentoMoney {
+  value: number;
+  currency: string;
+}

--- a/libs/cart/src/drivers/magento/models/outputs/product.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/product.ts
@@ -1,0 +1,17 @@
+import { MagentoMoney } from './money';
+
+export interface MagentoProduct {
+  id: number;
+  image: {
+    label: string;
+    url: string;
+  };
+  manufacturer: number;
+  name: string;
+  description: string;
+  price_range: {
+    maximum_price: MagentoMoney;
+    minumum_price: MagentoMoney;
+  };
+  sku: string;
+}

--- a/libs/cart/src/drivers/magento/models/outputs/shipping-address.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/shipping-address.ts
@@ -1,0 +1,7 @@
+import { MagentoCartAddress } from './cart-address';
+import { MagentoCartShippingMethod } from './cart-shipping-method';
+
+export interface MagentoShippingAddress extends MagentoCartAddress {
+  available_shipping_methods: MagentoCartShippingMethod[];
+  selected_shipping_method: MagentoCartShippingMethod;
+}

--- a/libs/cart/src/drivers/public_api.ts
+++ b/libs/cart/src/drivers/public_api.ts
@@ -7,3 +7,5 @@ export { DaffCartPaymentServiceInterface, DaffCartPaymentDriver} from './interfa
 export { DaffCartShippingAddressServiceInterface, DaffCartShippingAddressDriver } from './interfaces/cart-shipping-address-service.interface';
 export { DaffCartShippingInformationServiceInterface, DaffCartShippingInformationDriver } from './interfaces/cart-shipping-information-service.interface';
 export { DaffCartShippingMethodsServiceInterface, DaffCartShippingMethodsDriver } from './interfaces/cart-shipping-methods-service.interface';
+
+export * from './magento';

--- a/libs/cart/testing/src/factories/cart-address.factory.ts
+++ b/libs/cart/testing/src/factories/cart-address.factory.ts
@@ -21,6 +21,7 @@ export class MockCartAddress implements DaffCartAddress {
   region = 'region';
   region_id = faker.random.number(1000);
   postcode = 'postcode';
+  country = faker.address.country();
   country_id = 'ISO';
   telephone = '+1 (123)-123-1234';
 }
@@ -29,7 +30,7 @@ export class MockCartAddress implements DaffCartAddress {
   providedIn: 'root'
 })
 export class DaffCartAddressFactory extends DaffModelFactory<DaffCartAddress> {
-  
+
   constructor(){
     super(MockCartAddress);
   }

--- a/libs/cart/testing/src/factories/cart-coupon.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart-coupon.factory.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DaffCartCouponFactory } from './cart-coupon.factory';
+import { DaffCartCoupon } from '@daffodil/cart';
+
+describe('Cart | Testing | Factories | CartCouponFactory', () => {
+  let cartItemFactory: DaffCartCouponFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffCartCouponFactory]
+    });
+
+    cartItemFactory = TestBed.get(DaffCartCouponFactory);
+  });
+
+  it('should be created', () => {
+    expect(cartItemFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+    let result: DaffCartCoupon;
+
+    beforeEach(() => {
+      result = cartItemFactory.create();
+    });
+
+    it('should return a CartCoupon with all required fields defined', () => {
+      expect(result.coupon_id).toBeDefined();
+      expect(result.code).toBeDefined();
+      expect(result.description).toBeDefined();
+    });
+  });
+
+  describe('createMany', () => {
+    let result: DaffCartCoupon[];
+
+    it('should create as many cart items as desired', () => {
+      const spy = spyOn(cartItemFactory, 'create');
+
+      result = cartItemFactory.createMany(2);
+      expect(result.length).toEqual(2);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(2);
+
+      spy.calls.reset();
+
+      result = cartItemFactory.createMany(3);
+      expect(result.length).toEqual(3);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(3);
+    });
+  })
+});

--- a/libs/cart/testing/src/factories/cart-coupon.factory.ts
+++ b/libs/cart/testing/src/factories/cart-coupon.factory.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { DaffCartCoupon } from '@daffodil/cart';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+export class MockDaffCartCoupon implements DaffCartCoupon {
+  coupon_id = faker.random.number(1000);
+  code = faker.random.alphaNumeric(20);
+  description = faker.random.words(5);
+};
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DaffCartCouponFactory extends DaffModelFactory<DaffCartCoupon> {
+  constructor() {
+    super(MockDaffCartCoupon);
+  }
+}

--- a/libs/cart/testing/src/factories/index.ts
+++ b/libs/cart/testing/src/factories/index.ts
@@ -1,0 +1,8 @@
+export { DaffCartFactory } from './cart.factory';
+export { DaffCartItemFactory } from './cart-item.factory';
+export { DaffCartAddressFactory } from './cart-address.factory';
+export { DaffCartPaymentFactory } from './cart-payment.factory';
+export { DaffCartShippingRateFactory } from './cart-shipping-rate.factory';
+export { DaffCartCouponFactory } from './cart-coupon.factory';
+
+export * from './magento';

--- a/libs/cart/testing/src/factories/magento/cart-address.factory.spec.ts
+++ b/libs/cart/testing/src/factories/magento/cart-address.factory.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoCartAddressFactory } from './cart-address.factory';
+import { MagentoCartAddress } from '@daffodil/cart';
+
+describe('Cart | Testing | Factories | CartAddressFactory', () => {
+  let cartItemFactory: MagentoCartAddressFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MagentoCartAddressFactory]
+    });
+
+    cartItemFactory = TestBed.get(MagentoCartAddressFactory);
+  });
+
+  it('should be created', () => {
+    expect(cartItemFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+    let result: MagentoCartAddress;
+
+    beforeEach(() => {
+      result = cartItemFactory.create();
+    });
+
+    it('should return a CartAddress with all required fields defined', () => {
+      expect(result.region.code).toBeDefined();
+      expect(result.region.label).toBeDefined();
+      expect(result.country.code).toBeDefined();
+      expect(result.country.label).toBeDefined();
+      expect(result.street[0]).toBeDefined();
+      expect(result.company).toBeDefined();
+      expect(result.telephone).toBeDefined();
+      expect(result.postcode).toBeDefined();
+      expect(result.city).toBeDefined();
+      expect(result.firstname).toBeDefined();
+      expect(result.lastname).toBeDefined();
+    });
+  });
+
+  describe('createMany', () => {
+    let result: MagentoCartAddress[];
+
+    it('should create as many cart items as desired', () => {
+      const spy = spyOn(cartItemFactory, 'create');
+
+      result = cartItemFactory.createMany(2);
+      expect(result.length).toEqual(2);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(2);
+
+      spy.calls.reset();
+
+      result = cartItemFactory.createMany(3);
+      expect(result.length).toEqual(3);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(3);
+    });
+  })
+});

--- a/libs/cart/testing/src/factories/magento/cart-address.factory.ts
+++ b/libs/cart/testing/src/factories/magento/cart-address.factory.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { MagentoCartAddress } from '@daffodil/cart';
+
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+export class MockMagentoCartAddress implements MagentoCartAddress {
+  region = {
+    code: faker.address.stateAbbr(),
+    label: faker.address.state()
+  };
+  country = {
+    code: faker.address.countryCode(),
+    label: faker.address.country()
+  };
+  street = [faker.address.streetAddress()];
+  company = faker.company.companyName();
+  telephone = faker.phone.phoneNumber();
+  postcode = faker.address.zipCode();
+  city = faker.address.city();
+  firstname = faker.name.firstName();
+  lastname = faker.name.lastName();
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MagentoCartAddressFactory extends DaffModelFactory<MagentoCartAddress> {
+  constructor() {
+    super(MockMagentoCartAddress);
+  }
+}

--- a/libs/cart/testing/src/factories/magento/cart-coupon.factory.spec.ts
+++ b/libs/cart/testing/src/factories/magento/cart-coupon.factory.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoCartCouponFactory } from './cart-coupon.factory';
+import { MagentoCartCoupon } from '@daffodil/cart';
+
+describe('Cart | Testing | Factories | CartCouponFactory', () => {
+  let cartItemFactory: MagentoCartCouponFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MagentoCartCouponFactory]
+    });
+
+    cartItemFactory = TestBed.get(MagentoCartCouponFactory);
+  });
+
+  it('should be created', () => {
+    expect(cartItemFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+    let result: MagentoCartCoupon;
+
+    beforeEach(() => {
+      result = cartItemFactory.create();
+    });
+
+    it('should return a CartCoupon with all required fields defined', () => {
+      expect(result.code).toBeDefined();
+    });
+  });
+
+  describe('createMany', () => {
+    let result: MagentoCartCoupon[];
+
+    it('should create as many cart items as desired', () => {
+      const spy = spyOn(cartItemFactory, 'create');
+
+      result = cartItemFactory.createMany(2);
+      expect(result.length).toEqual(2);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(2);
+
+      spy.calls.reset();
+
+      result = cartItemFactory.createMany(3);
+      expect(result.length).toEqual(3);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(3);
+    });
+  })
+});

--- a/libs/cart/testing/src/factories/magento/cart-coupon.factory.ts
+++ b/libs/cart/testing/src/factories/magento/cart-coupon.factory.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { MagentoCartCoupon } from '@daffodil/cart';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+export class MockMagentoCartCoupon implements MagentoCartCoupon {
+  code = faker.random.alphaNumeric(20);
+};
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MagentoCartCouponFactory extends DaffModelFactory<MagentoCartCoupon> {
+  constructor() {
+    super(MockMagentoCartCoupon);
+  }
+}

--- a/libs/cart/testing/src/factories/magento/cart-item.factory.spec.ts
+++ b/libs/cart/testing/src/factories/magento/cart-item.factory.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoCartItemFactory } from './cart-item.factory';
+import { MagentoCartItem } from '@daffodil/cart';
+
+describe('Cart | Testing | Factories | CartItemFactory', () => {
+  let cartItemFactory: MagentoCartItemFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MagentoCartItemFactory]
+    });
+
+    cartItemFactory = TestBed.get(MagentoCartItemFactory);
+  });
+
+  it('should be created', () => {
+    expect(cartItemFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+    let result: MagentoCartItem;
+
+    beforeEach(() => {
+      result = cartItemFactory.create();
+    });
+
+    it('should return a CartItem with all required fields defined', () => {
+      expect(result.id).toBeDefined();
+      expect(result.prices.discounts).toBeDefined();
+      expect(result.prices.price).toBeDefined();
+      expect(result.prices.row_total).toBeDefined();
+      expect(result.prices.row_total_including_tax).toBeDefined();
+      expect(result.prices.total_item_discount).toBeDefined();
+      expect(result.product).toBeDefined();
+      expect(result.quantity).toBeDefined();
+    });
+  });
+
+  describe('createMany', () => {
+    let result: MagentoCartItem[];
+
+    it('should create as many cart items as desired', () => {
+      const spy = spyOn(cartItemFactory, 'create');
+
+      result = cartItemFactory.createMany(2);
+      expect(result.length).toEqual(2);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(2);
+
+      spy.calls.reset();
+
+      result = cartItemFactory.createMany(3);
+      expect(result.length).toEqual(3);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(3);
+    });
+  })
+});

--- a/libs/cart/testing/src/factories/magento/cart-item.factory.ts
+++ b/libs/cart/testing/src/factories/magento/cart-item.factory.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import {
+  MagentoCartItem,
+  MagentoMoney,
+  MagentoProduct
+} from '@daffodil/cart';
+
+import { DaffModelFactory } from '@daffodil/core/testing';
+import { MagentoMoneyFactory } from './money.factory';
+import { MagentoProductFactory } from './product.factory';
+
+export class MockMagentoCartItem implements MagentoCartItem {
+  id = faker.random.number(1000);
+  prices = {
+    discounts: [],
+    price: this.money(),
+    row_total: this.money(),
+    row_total_including_tax: this.money(),
+    total_item_discount: this.money()
+  };
+  product = this.createProduct();
+  quantity = faker.random.number(20);
+
+  private createProduct(): MagentoProduct {
+    return (new MagentoProductFactory()).create()
+  }
+
+  private money(): MagentoMoney {
+    return (new MagentoMoneyFactory()).create()
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MagentoCartItemFactory extends DaffModelFactory<MagentoCartItem> {
+
+  constructor(){
+    super(MockMagentoCartItem);
+  }
+}

--- a/libs/cart/testing/src/factories/magento/cart-payment-method.factory.spec.ts
+++ b/libs/cart/testing/src/factories/magento/cart-payment-method.factory.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoCartPaymentMethodFactory } from './cart-payment-method.factory';
+import { MagentoCartPaymentMethod } from '@daffodil/cart';
+
+describe('Cart | Testing | Factories | CartPaymentMethodFactory', () => {
+  let cartItemFactory: MagentoCartPaymentMethodFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MagentoCartPaymentMethodFactory]
+    });
+
+    cartItemFactory = TestBed.get(MagentoCartPaymentMethodFactory);
+  });
+
+  it('should be created', () => {
+    expect(cartItemFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+    let result: MagentoCartPaymentMethod;
+
+    beforeEach(() => {
+      result = cartItemFactory.create();
+    });
+
+    it('should return a CartPaymentMethod with all required fields defined', () => {
+      expect(result.code).toBeDefined();
+      expect(result.title).toBeDefined();
+      expect(result.purchase_order_number).toBeDefined();
+    });
+  });
+
+  describe('createMany', () => {
+    let result: MagentoCartPaymentMethod[];
+
+    it('should create as many cart items as desired', () => {
+      const spy = spyOn(cartItemFactory, 'create');
+
+      result = cartItemFactory.createMany(2);
+      expect(result.length).toEqual(2);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(2);
+
+      spy.calls.reset();
+
+      result = cartItemFactory.createMany(3);
+      expect(result.length).toEqual(3);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(3);
+    });
+  })
+});

--- a/libs/cart/testing/src/factories/magento/cart-payment-method.factory.ts
+++ b/libs/cart/testing/src/factories/magento/cart-payment-method.factory.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { MagentoCartPaymentMethod } from '@daffodil/cart';
+
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+export class MockMagentoCartPaymentMethod implements MagentoCartPaymentMethod {
+	code = faker.random.word();
+	title = faker.random.word();
+	purchase_order_number = faker.random.word();
+}
+
+@Injectable({
+	providedIn: 'root',
+})
+export class MagentoCartPaymentMethodFactory extends DaffModelFactory<MagentoCartPaymentMethod> {
+	constructor() {
+		super(MockMagentoCartPaymentMethod);
+	}
+}

--- a/libs/cart/testing/src/factories/magento/cart-shipping-method.factory.spec.ts
+++ b/libs/cart/testing/src/factories/magento/cart-shipping-method.factory.spec.ts
@@ -1,0 +1,54 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoCartShippingMethodFactory } from './cart-shipping-method.factory';
+import { MagentoCartShippingMethod } from '@daffodil/cart';
+
+describe('Cart | Testing | Factories | CartShippingMethodFactory', () => {
+  let cartItemFactory: MagentoCartShippingMethodFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MagentoCartShippingMethodFactory]
+    });
+
+    cartItemFactory = TestBed.get(MagentoCartShippingMethodFactory);
+  });
+
+  it('should be created', () => {
+    expect(cartItemFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+    let result: MagentoCartShippingMethod;
+
+    beforeEach(() => {
+      result = cartItemFactory.create();
+    });
+
+    it('should return a CartShippingMethod with all required fields defined', () => {
+      expect(result.carrier_code).toBeDefined();
+      expect(result.carrier_title).toBeDefined();
+      expect(result.method_title).toBeDefined();
+      expect(result.method_code).toBeDefined();
+      expect(result.amount).toBeDefined();
+    });
+  });
+
+  describe('createMany', () => {
+    let result: MagentoCartShippingMethod[];
+
+    it('should create as many cart items as desired', () => {
+      const spy = spyOn(cartItemFactory, 'create');
+
+      result = cartItemFactory.createMany(2);
+      expect(result.length).toEqual(2);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(2);
+
+      spy.calls.reset();
+
+      result = cartItemFactory.createMany(3);
+      expect(result.length).toEqual(3);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(3);
+    });
+  })
+});

--- a/libs/cart/testing/src/factories/magento/cart-shipping-method.factory.ts
+++ b/libs/cart/testing/src/factories/magento/cart-shipping-method.factory.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { MagentoCartShippingMethod, MagentoMoney } from '@daffodil/cart';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+import { MagentoMoneyFactory } from './money.factory';
+
+export class MockCartShippingMethod implements MagentoCartShippingMethod {
+  carrier_code = faker.random.word();
+  carrier_title = faker.random.words(2);
+  method_title = faker.random.words(2);
+  method_code = faker.random.word();
+  amount = this.money();
+
+  private money(): MagentoMoney {
+    return (new MagentoMoneyFactory()).create()
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MagentoCartShippingMethodFactory extends DaffModelFactory<MagentoCartShippingMethod> {
+  constructor() {
+    super(MockCartShippingMethod);
+  }
+}

--- a/libs/cart/testing/src/factories/magento/cart.factory.spec.ts
+++ b/libs/cart/testing/src/factories/magento/cart.factory.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoCartFactory } from './cart.factory';
+import { MagentoCart } from '@daffodil/cart';
+
+describe('Cart | Testing | Factories | CartFactory', () => {
+  let cartItemFactory: MagentoCartFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MagentoCartFactory]
+    });
+
+    cartItemFactory = TestBed.get(MagentoCartFactory);
+  });
+
+  it('should be created', () => {
+    expect(cartItemFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+    let result: MagentoCart;
+
+    beforeEach(() => {
+      result = cartItemFactory.create();
+    });
+
+    it('should return a Cart with all required fields defined', () => {
+      expect(result.id).toBeDefined();
+      expect(result.applied_coupons).toBeDefined();
+      expect(result.items).toBeDefined();
+      expect(result.billing_address).toBeDefined();
+      expect(result.shipping_addresses).toBeDefined();
+      expect(result.available_payment_methods).toBeDefined();
+      expect(result.selected_payment_method).toBeDefined();
+      expect(result.prices.subtotal_excluding_tax).toBeDefined();
+      expect(result.prices.grand_total).toBeDefined();
+      expect(result.prices.subtotal_including_tax).toBeDefined();
+      expect(result.prices.subtotal_with_discount_excluding_tax).toBeDefined();
+    });
+  });
+
+  describe('createMany', () => {
+    let result: MagentoCart[];
+
+    it('should create as many cart items as desired', () => {
+      const spy = spyOn(cartItemFactory, 'create');
+
+      result = cartItemFactory.createMany(2);
+      expect(result.length).toEqual(2);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(2);
+
+      spy.calls.reset();
+
+      result = cartItemFactory.createMany(3);
+      expect(result.length).toEqual(3);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(3);
+    });
+  })
+});

--- a/libs/cart/testing/src/factories/magento/cart.factory.ts
+++ b/libs/cart/testing/src/factories/magento/cart.factory.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { MagentoCart, MagentoMoney } from '@daffodil/cart';
+import { DaffModelFactory } from '@daffodil/core/testing';
+import { MagentoMoneyFactory } from './money.factory';
+
+export class MockMagentoCart implements MagentoCart {
+  id = faker.random.number(1000);
+  prices = {
+    subtotal_excluding_tax: this.money(),
+    grand_total: this.money(),
+    subtotal_including_tax: this.money(),
+    subtotal_with_discount_excluding_tax: this.money(),
+  };
+  applied_coupons = [];
+  items = [];
+  billing_address = null;
+  shipping_addresses = [];
+  available_payment_methods = [];
+  selected_payment_method = null;
+
+  private money(): MagentoMoney {
+    return (new MagentoMoneyFactory()).create()
+  }
+};
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MagentoCartFactory extends DaffModelFactory<MagentoCart> {
+  constructor() {
+    super(MockMagentoCart);
+  }
+}

--- a/libs/cart/testing/src/factories/magento/index.ts
+++ b/libs/cart/testing/src/factories/magento/index.ts
@@ -1,0 +1,8 @@
+export { MagentoCartAddressFactory } from './cart-address.factory';
+export { MagentoCartCouponFactory } from './cart-coupon.factory';
+export { MagentoCartPaymentMethodFactory } from './cart-payment-method.factory';
+export { MagentoCartShippingMethodFactory } from './cart-shipping-method.factory';
+export { MagentoCartFactory } from './cart.factory';
+export { MagentoMoneyFactory } from './money.factory';
+export { MagentoProductFactory } from './product.factory';
+export { MagentoShippingAddressFactory } from './shipping-address.factory';

--- a/libs/cart/testing/src/factories/magento/money.factory.spec.ts
+++ b/libs/cart/testing/src/factories/magento/money.factory.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoMoneyFactory } from './money.factory';
+import { MagentoMoney } from '@daffodil/cart';
+
+describe('Cart | Testing | Factories | MoneyFactory', () => {
+  let cartItemFactory: MagentoMoneyFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MagentoMoneyFactory]
+    });
+
+    cartItemFactory = TestBed.get(MagentoMoneyFactory);
+  });
+
+  it('should be created', () => {
+    expect(cartItemFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+    let result: MagentoMoney;
+
+    beforeEach(() => {
+      result = cartItemFactory.create();
+    });
+
+    it('should return a Money with all required fields defined', () => {
+      expect(result.currency).toBeDefined();
+      expect(result.value).toBeDefined();
+    });
+  });
+
+  describe('createMany', () => {
+    let result: MagentoMoney[];
+
+    it('should create as many cart items as desired', () => {
+      const spy = spyOn(cartItemFactory, 'create');
+
+      result = cartItemFactory.createMany(2);
+      expect(result.length).toEqual(2);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(2);
+
+      spy.calls.reset();
+
+      result = cartItemFactory.createMany(3);
+      expect(result.length).toEqual(3);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(3);
+    });
+  })
+});

--- a/libs/cart/testing/src/factories/magento/money.factory.ts
+++ b/libs/cart/testing/src/factories/magento/money.factory.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { MagentoMoney } from '@daffodil/cart';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+export class MockMagentoMoney implements MagentoMoney {
+  value = faker.random.number(10000);
+  currency = faker.random.word();
+};
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MagentoMoneyFactory extends DaffModelFactory<MagentoMoney> {
+  constructor() {
+    super(MockMagentoMoney);
+  }
+}

--- a/libs/cart/testing/src/factories/magento/product.factory.spec.ts
+++ b/libs/cart/testing/src/factories/magento/product.factory.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoProductFactory } from './product.factory';
+import { MagentoProduct } from '@daffodil/cart';
+
+describe('Cart | Testing | Factories | ProductFactory', () => {
+  let cartItemFactory: MagentoProductFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MagentoProductFactory]
+    });
+
+    cartItemFactory = TestBed.get(MagentoProductFactory);
+  });
+
+  it('should be created', () => {
+    expect(cartItemFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+    let result: MagentoProduct;
+
+    beforeEach(() => {
+      result = cartItemFactory.create();
+    });
+
+    it('should return a Product with all required fields defined', () => {
+      expect(result.id).toBeDefined();
+      expect(result.image.label).toBeDefined();
+      expect(result.image.url).toBeDefined();
+      expect(result.manufacturer).toBeDefined();
+      expect(result.name).toBeDefined();
+      expect(result.description).toBeDefined();
+      expect(result.sku).toBeDefined();
+      expect(result.price_range.maximum_price).toBeDefined();
+      expect(result.price_range.minumum_price).toBeDefined();
+    });
+  });
+
+  describe('createMany', () => {
+    let result: MagentoProduct[];
+
+    it('should create as many cart items as desired', () => {
+      const spy = spyOn(cartItemFactory, 'create');
+
+      result = cartItemFactory.createMany(2);
+      expect(result.length).toEqual(2);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(2);
+
+      spy.calls.reset();
+
+      result = cartItemFactory.createMany(3);
+      expect(result.length).toEqual(3);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(3);
+    });
+  })
+});

--- a/libs/cart/testing/src/factories/magento/product.factory.ts
+++ b/libs/cart/testing/src/factories/magento/product.factory.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { MagentoProduct, MagentoMoney } from '@daffodil/cart';
+
+import { DaffModelFactory } from '@daffodil/core/testing';
+import { MagentoMoneyFactory } from './money.factory';
+
+export class MockMagentoProduct implements MagentoProduct {
+  id = faker.random.number(1000);
+  image = {
+    label: faker.random.words(3),
+    url: faker.image.imageUrl()
+  };
+  manufacturer = faker.random.number(1000);
+  name = faker.random.word();
+  description = faker.random.words(5);
+  price_range = {
+    maximum_price: this.money(),
+    minumum_price: this.money()
+  };
+  sku = faker.random.alphaNumeric(16);
+
+  private money(): MagentoMoney {
+    return (new MagentoMoneyFactory()).create()
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MagentoProductFactory extends DaffModelFactory<MagentoProduct> {
+
+  constructor(){
+    super(MockMagentoProduct);
+  }
+}

--- a/libs/cart/testing/src/factories/magento/shipping-address.factory.spec.ts
+++ b/libs/cart/testing/src/factories/magento/shipping-address.factory.spec.ts
@@ -1,0 +1,62 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoShippingAddressFactory } from './shipping-address.factory';
+import { MagentoShippingAddress } from '@daffodil/cart';
+
+describe('Cart | Testing | Factories | ShippingAddressFactory', () => {
+  let cartItemFactory: MagentoShippingAddressFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MagentoShippingAddressFactory]
+    });
+
+    cartItemFactory = TestBed.get(MagentoShippingAddressFactory);
+  });
+
+  it('should be created', () => {
+    expect(cartItemFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+    let result: MagentoShippingAddress;
+
+    beforeEach(() => {
+      result = cartItemFactory.create();
+    });
+
+    it('should return a ShippingAddress with all required fields defined', () => {
+      expect(result.region.code).toBeDefined();
+      expect(result.region.label).toBeDefined();
+      expect(result.country.code).toBeDefined();
+      expect(result.country.label).toBeDefined();
+      expect(result.street[0]).toBeDefined();
+      expect(result.company).toBeDefined();
+      expect(result.telephone).toBeDefined();
+      expect(result.postcode).toBeDefined();
+      expect(result.city).toBeDefined();
+      expect(result.firstname).toBeDefined();
+      expect(result.lastname).toBeDefined();
+      expect(result.available_shipping_methods).toBeDefined();
+      expect(result.selected_shipping_method).toBeDefined();
+    });
+  });
+
+  describe('createMany', () => {
+    let result: MagentoShippingAddress[];
+
+    it('should create as many cart items as desired', () => {
+      const spy = spyOn(cartItemFactory, 'create');
+
+      result = cartItemFactory.createMany(2);
+      expect(result.length).toEqual(2);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(2);
+
+      spy.calls.reset();
+
+      result = cartItemFactory.createMany(3);
+      expect(result.length).toEqual(3);
+      expect(cartItemFactory.create).toHaveBeenCalledTimes(3);
+    });
+  })
+});

--- a/libs/cart/testing/src/factories/magento/shipping-address.factory.ts
+++ b/libs/cart/testing/src/factories/magento/shipping-address.factory.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+
+import { MagentoShippingAddress } from '@daffodil/cart';
+
+import { DaffModelFactory } from '@daffodil/core/testing';
+import { MockMagentoCartAddress } from './cart-address.factory';
+
+export class MockMagentoShippingAddress extends MockMagentoCartAddress implements MagentoShippingAddress {
+  available_shipping_methods = [];
+  selected_shipping_method = null;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MagentoShippingAddressFactory extends DaffModelFactory<MagentoShippingAddress> {
+  constructor() {
+    super(MockMagentoShippingAddress);
+  }
+}

--- a/libs/cart/testing/src/helpers/magento/mocks/cart-address.ts
+++ b/libs/cart/testing/src/helpers/magento/mocks/cart-address.ts
@@ -1,0 +1,28 @@
+import { DaffCartAddress, MagentoCartAddress } from '@daffodil/cart';
+
+import { MagentoCartAddressFactory } from '../../../factories/magento/cart-address.factory';
+import { DaffCartAddressFactory } from '../../../factories/cart-address.factory';
+
+/**
+ * Creates mocked DaffCartAddress and MagentoCartAddress with matching fields.
+ */
+export function cartAddressMocks(): {
+  daff: DaffCartAddress;
+  magento: MagentoCartAddress;
+} {
+  const daff: DaffCartAddress = (new DaffCartAddressFactory()).create();
+  const magento: MagentoCartAddress = (new MagentoCartAddressFactory()).create();
+
+  magento.region.code = String(daff.region_id);
+  magento.region.label = daff.region;
+  magento.country.code = String(daff.country_id);
+  magento.country.label = daff.country;
+  magento.street = [daff.street];
+  magento.telephone = daff.telephone;
+  magento.postcode = daff.postcode;
+  magento.city = daff.city;
+  magento.firstname = daff.firstname;
+  magento.lastname = daff.lastname;
+
+  return {daff, magento}
+}

--- a/libs/cart/testing/src/helpers/magento/mocks/cart-coupon.ts
+++ b/libs/cart/testing/src/helpers/magento/mocks/cart-coupon.ts
@@ -1,0 +1,19 @@
+import { DaffCartCoupon, MagentoCartCoupon } from '@daffodil/cart';
+
+import { MagentoCartCouponFactory } from '../../../factories/magento/cart-coupon.factory';
+import { DaffCartCouponFactory } from '../../../factories/cart-coupon.factory';
+
+/**
+ * Creates mocked DaffCartCoupon and MagentoCartCoupon with matching fields.
+ */
+export function cartCouponMocks(): {
+  daff: DaffCartCoupon;
+  magento: MagentoCartCoupon;
+} {
+  const daff: DaffCartCoupon = (new DaffCartCouponFactory()).create();
+  const magento: MagentoCartCoupon = (new MagentoCartCouponFactory()).create();
+
+  magento.code = daff.code;
+
+  return {daff, magento}
+}

--- a/libs/cart/testing/src/helpers/magento/mocks/cart-item.ts
+++ b/libs/cart/testing/src/helpers/magento/mocks/cart-item.ts
@@ -1,0 +1,28 @@
+import { DaffCartItem, MagentoCartItem } from '@daffodil/cart';
+
+import { MagentoCartItemFactory } from '../../../factories/magento/cart-item.factory';
+import { DaffCartItemFactory } from '../../../factories/cart-item.factory';
+
+/**
+ * Creates mocked DaffCartItem and MagentoCartItem with matching fields.
+ */
+export function cartItemMocks(): {
+  daff: DaffCartItem;
+  magento: MagentoCartItem;
+} {
+  const daff: DaffCartItem = (new DaffCartItemFactory()).create();
+  const magento: MagentoCartItem = (new MagentoCartItemFactory()).create();
+
+  magento.id = String(daff.item_id);
+  // magento.product.image.label = daff.image.label;
+  // magento.product.image.url = daff.image.url;
+  magento.product.id = Number(daff.product_id);
+  magento.product.sku = daff.sku;
+  magento.product.name = daff.name;
+  magento.product.description = daff.description;
+  magento.quantity = daff.qty;
+  magento.prices.price.value = daff.price;
+  magento.prices.row_total.value = daff.row_total;
+
+  return {daff, magento}
+}

--- a/libs/cart/testing/src/helpers/magento/mocks/cart-payment-method.ts
+++ b/libs/cart/testing/src/helpers/magento/mocks/cart-payment-method.ts
@@ -1,0 +1,19 @@
+import { DaffCartPaymentMethod, MagentoCartPaymentMethod } from '@daffodil/cart';
+
+import { MagentoCartPaymentMethodFactory } from '../../../factories/magento/cart-payment-method.factory';
+import { DaffCartPaymentFactory } from '../../../factories/cart-payment.factory';
+
+/**
+ * Creates mocked DaffCartPaymentMethod and MagentoCartPaymentMethod with matching fields.
+ */
+export function cartPaymentMethodMocks(): {
+  daff: DaffCartPaymentMethod;
+  magento: MagentoCartPaymentMethod;
+} {
+  const daff: DaffCartPaymentMethod = (new DaffCartPaymentFactory()).create();
+  const magento: MagentoCartPaymentMethod = (new MagentoCartPaymentMethodFactory()).create();
+
+  magento.code = daff.method;
+
+  return {daff, magento}
+}

--- a/libs/cart/testing/src/helpers/magento/mocks/cart-shipping-method.ts
+++ b/libs/cart/testing/src/helpers/magento/mocks/cart-shipping-method.ts
@@ -1,0 +1,25 @@
+import { DaffCartShippingInformation, MagentoCartShippingMethod } from '@daffodil/cart';
+
+import { MagentoCartShippingMethodFactory } from '../../../factories/magento/cart-shipping-method.factory';
+import { DaffCartShippingRateFactory } from '../../../factories/cart-shipping-rate.factory';
+
+/**
+ * Creates mocked DaffCartShippingInformation and MagentoCartShippingMethod with matching fields.
+ */
+export function cartShippingMethodMocks(): {
+  daff: DaffCartShippingInformation;
+  magento: MagentoCartShippingMethod;
+} {
+  const daff: DaffCartShippingInformation = {
+    ...(new DaffCartShippingRateFactory()).create(),
+    address_id: 0
+  };
+  const magento: MagentoCartShippingMethod = (new MagentoCartShippingMethodFactory()).create();
+
+  magento.carrier_code = daff.carrier;
+  magento.carrier_title = daff.carrier_title;
+  magento.method_title = daff.method_title;
+  magento.amount.value = daff.price;
+
+  return {daff, magento}
+}

--- a/libs/cart/testing/src/helpers/magento/mocks/cart.ts
+++ b/libs/cart/testing/src/helpers/magento/mocks/cart.ts
@@ -1,0 +1,72 @@
+import { DaffCart, MagentoCart, MagentoShippingAddress } from '@daffodil/cart';
+
+import { MagentoCartFactory } from '../../../factories/magento/cart.factory';
+import { DaffCartFactory } from '../../../factories/cart.factory';
+import { cartItemMocks } from './cart-item';
+import { cartAddressMocks } from './cart-address';
+import { shippingAddressMocks } from './shipping-address';
+import { cartCouponMocks } from './cart-coupon';
+import { cartPaymentMethodMocks } from './cart-payment-method';
+import { cartShippingMethodMocks } from './cart-shipping-method';
+
+/**
+ * Creates mocked DaffCart and MagentoCart with matching fields.
+ */
+export function cartMocks(): {
+  daff: DaffCart;
+  magento: MagentoCart;
+} {
+  const daff: DaffCart = (new DaffCartFactory()).create();
+  const magento: MagentoCart = (new MagentoCartFactory()).create();
+
+  const {
+    daff: daffCartItem,
+    magento: magentoCartItem
+  } = cartItemMocks();
+  const {
+    daff: daffCartBillingAddress,
+    magento: magentoCartBillingAddress
+  } = cartAddressMocks();
+  const {
+    daff: daffCartShippingAddress,
+    magento: magentoCartShippingAddress
+  } = shippingAddressMocks();
+  const {
+    daff: daffCartCoupon,
+    magento: magentoCartCoupon
+  } = cartCouponMocks();
+  const {
+    daff: daffCartPaymentMethod,
+    magento: magentoCartPaymentMethod
+  } = cartPaymentMethodMocks();
+  const {
+    daff: daffCartShippingMethod,
+    magento: magentoCartShippingMethod
+  } = cartShippingMethodMocks();
+
+  magento.id = Number(daff.id);
+  magento.prices.subtotal_excluding_tax.value = daff.subtotal;
+  magento.prices.grand_total.value = daff.grand_total;
+
+  daff.items = [daffCartItem];
+  magento.items = [magentoCartItem];
+
+  daff.coupons = [daffCartCoupon];
+  magento.applied_coupons = [magentoCartCoupon];
+
+  daff.billing_address = daffCartBillingAddress;
+  magento.billing_address = magentoCartBillingAddress;
+
+  daff.shipping_address = daffCartShippingAddress;
+  magento.shipping_addresses = [magentoCartShippingAddress];
+
+  daff.payment = daffCartPaymentMethod;
+  magento.available_payment_methods = [magentoCartPaymentMethod];
+  magento.selected_payment_method = magentoCartPaymentMethod;
+
+  daff.shipping_information = daffCartShippingMethod;
+  magentoCartShippingAddress.available_shipping_methods = [magentoCartShippingMethod];
+  magentoCartShippingAddress.selected_shipping_method = magentoCartShippingMethod;
+
+  return {daff, magento}
+}

--- a/libs/cart/testing/src/helpers/magento/mocks/index.ts
+++ b/libs/cart/testing/src/helpers/magento/mocks/index.ts
@@ -1,0 +1,7 @@
+export { cartAddressMocks } from './cart-address';
+export { cartCouponMocks } from './cart-coupon';
+export { cartItemMocks } from './cart-item';
+export { cartPaymentMethodMocks } from './cart-payment-method';
+export { cartShippingMethodMocks } from './cart-shipping-method';
+export { cartMocks } from './cart';
+export { shippingAddressMocks } from './shipping-address';

--- a/libs/cart/testing/src/helpers/magento/mocks/shipping-address.ts
+++ b/libs/cart/testing/src/helpers/magento/mocks/shipping-address.ts
@@ -1,0 +1,30 @@
+import { DaffCartAddress, MagentoShippingAddress } from '@daffodil/cart';
+
+import { DaffCartAddressFactory } from '../../../factories/cart-address.factory';
+import { MagentoShippingAddressFactory } from '../../../factories/magento/shipping-address.factory';
+
+/**
+ * Creates mocked DaffCartAddress and MagentoShippingAddress with matching fields.
+ */
+export function shippingAddressMocks(): {
+  daff: DaffCartAddress;
+  magento: MagentoShippingAddress;
+} {
+  const daff: DaffCartAddress = (new DaffCartAddressFactory()).create();
+  const magento: MagentoShippingAddress = (new MagentoShippingAddressFactory()).create();
+
+  magento.region.code = String(daff.region_id);
+  magento.region.label = daff.region;
+  magento.country.code = String(daff.country_id);
+  magento.country.label = daff.country;
+  magento.street = [daff.street];
+  magento.telephone = daff.telephone;
+  magento.postcode = daff.postcode;
+  magento.city = daff.city;
+  magento.firstname = daff.firstname;
+  magento.lastname = daff.lastname;
+  magento.selected_shipping_method = null;
+  magento.available_shipping_methods = [];
+
+  return {daff, magento}
+}

--- a/libs/cart/testing/src/index.ts
+++ b/libs/cart/testing/src/index.ts
@@ -1,8 +1,5 @@
-export { DaffCartAddressFactory } from './factories/cart-address.factory';
-export { DaffCartItemFactory } from './factories/cart-item.factory';
-export { DaffCartPaymentFactory } from './factories/cart-payment.factory';
-export { DaffCartShippingRateFactory } from './factories/cart-shipping-rate.factory';
-export { DaffCartFactory } from './factories/cart.factory';
+export * from './factories';
+
 export { DaffTestingCartService } from './drivers/testing/cart.service';
 export { DaffInMemoryCartService } from './drivers/in-memory/cart.service';
 export { DaffInMemoryBackendCartService } from './in-memory-backend/cart.service';

--- a/libs/cart/testing/src/index.ts
+++ b/libs/cart/testing/src/index.ts
@@ -1,4 +1,5 @@
 export * from './factories';
+export * from './helpers/magento/mocks';
 
 export { DaffTestingCartService } from './drivers/testing/cart.service';
 export { DaffInMemoryCartService } from './drivers/in-memory/cart.service';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?
Adds Magento model factories. Also adds mock helpers that generate a pair of Magento and Daffodil models that have matching fields which is very useful for Magento driver testing.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Relies on #651 and #653.