### PR TITLE
feat(design): update image template to fix padding top calculation

### DIFF
--- a/libs/design/src/atoms/image/image.component.html
+++ b/libs/design/src/atoms/image/image.component.html
@@ -1,1 +1,3 @@
-<img [src]="src" [alt]="alt" (load)="load" />
+<div class="daff-image__wrapper" [style.paddingTop]="paddingTop">
+	<img [src]="src" [alt]="alt" (load)="load()" />
+</div>

--- a/libs/design/src/atoms/image/image.component.html
+++ b/libs/design/src/atoms/image/image.component.html
@@ -1,3 +1,3 @@
 <div class="daff-image__wrapper" [style.paddingTop]="paddingTop">
-	<img [src]="src" [alt]="alt" (load)="load()" />
+	<img [src]="src" [alt]="alt" (load)="load.emit" />
 </div>

--- a/libs/design/src/atoms/image/image.component.scss
+++ b/libs/design/src/atoms/image/image.component.scss
@@ -1,9 +1,8 @@
 @import '../../scss/daff-util';
 
 :host {
-	display: block;
-	position: relative;
-	height: 0;
+	display: inline-block;
+	width: 100%;
 
 	img {
 		position: absolute;
@@ -11,5 +10,12 @@
 		top: 0;
 		height: auto;
 		max-width: 100%;
+	}
+}
+
+.daff-image {
+	&__wrapper {
+		position: relative;
+		height: 0;
 	}
 }

--- a/libs/design/src/atoms/image/image.component.spec.ts
+++ b/libs/design/src/atoms/image/image.component.spec.ts
@@ -20,6 +20,7 @@ describe('DaffImageComponent', () => {
   let component: DaffImageComponent;
   let de: DebugElement;
   let fixture: ComponentFixture<WrapperComponent>;
+  let wrapperDE: DebugElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -35,6 +36,7 @@ describe('DaffImageComponent', () => {
     fixture = TestBed.createComponent(WrapperComponent);
     wrapper = fixture.componentInstance;
     de = fixture.debugElement.query(By.css('daff-image'));
+    wrapperDE = fixture.debugElement.query(By.css('.daff-image__wrapper'));
     component = de.componentInstance;
 
     fixture.detectChanges();
@@ -92,21 +94,29 @@ describe('DaffImageComponent', () => {
     expect(() => fixture.detectChanges()).toThrowError(/height/);
   });
 
-  it('sets padding-top to an empty string on the host element if width is `0`', () => {
+  it('sets padding-top to an empty string on `.daff-image__wrapper` if width is `0`', () => {
     wrapper.height = 100;
     wrapper.width = 0;
 
     fixture.detectChanges();
 
-    expect(de.styles['padding-top']).toEqual(null);
+    expect(wrapperDE.styles['paddingTop']).toEqual(null);
   });
 
-  it('calculates and sets `padding-top` on the host element based on height and width', () => {
+  it('calculates and sets `padding-top` on `.daff-image__wrapper` based on height and width', () => {
     wrapper.height = 100;
     wrapper.width = 300;
 
     fixture.detectChanges();
 
-    expect(de.styles['padding-top']).toEqual('calc(' + wrapper.height + ' / ' + wrapper.width + ' * 100%)');
+    expect(wrapperDE.styles['paddingTop']).toEqual('calc(' + wrapper.height + ' / ' + wrapper.width + ' * 100%)');
+  });
+
+  it('sets `max-width` on the host element based on the dwidth', () => {
+    wrapper.width = 300;
+
+    fixture.detectChanges();
+
+    expect(de.styles['max-width']).toEqual(wrapper.width + 'px');
   });
 });

--- a/libs/design/src/atoms/image/image.component.ts
+++ b/libs/design/src/atoms/image/image.component.ts
@@ -75,11 +75,15 @@ export class DaffImageComponent implements OnInit {
 
   constructor(private sanitizer: DomSanitizer) {}
 
-  @HostBinding('style.padding-top') get paddingTop() {
+  get paddingTop(): any {
     if (!this.height || !this.width ) {
       return undefined;
     }
     
     return this.sanitizer.bypassSecurityTrustStyle('calc(' + this.height + ' / ' + this.width + ' * 100%)');
+  }
+
+  @HostBinding('style.max-width') get maxWidth(): string {
+    return this.width + 'px';
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Padding-top was not getting calculated correctly because it was taking the width/height of the parent div.

Fixes: N/A


## What is the new behavior?
Add a wrapper div to handle the correct width/height calculation.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information