### PR TITLE
feat(cart): add shipping address driver models

### DIFF
--- a/libs/cart/src/drivers/magento/index.ts
+++ b/libs/cart/src/drivers/magento/index.ts
@@ -6,3 +6,5 @@ export * from './models/outputs';
 export { DaffMagentoCartPaymentMethodsService } from './cart-payment-methods.service';
 export { DaffMagentoCartShippingMethodsService } from './cart-shipping-methods.service';
 
+export { MagentoCartAddressInput } from './models/inputs/cart-address';
+export { MagentoShippingAddressInput } from './models/inputs/shipping-address';

--- a/libs/cart/src/drivers/magento/models/inputs/cart-address.ts
+++ b/libs/cart/src/drivers/magento/models/inputs/cart-address.ts
@@ -1,0 +1,12 @@
+export interface MagentoCartAddressInput {
+  city:	string;
+  company?: string;
+  country_code: string;
+  firstname: string;
+  lastname: string;
+  postcode?: string;
+  region?: string;
+  save_in_address_book: boolean;
+  street: string[];
+  telephone?: string;
+}

--- a/libs/cart/src/drivers/magento/models/inputs/shipping-address.ts
+++ b/libs/cart/src/drivers/magento/models/inputs/shipping-address.ts
@@ -1,0 +1,7 @@
+import { MagentoCartAddressInput } from './cart-address';
+
+export interface MagentoShippingAddressInput {
+  address: MagentoCartAddressInput;
+  customer_address_id?: number;
+  customer_notes?: string;
+}

--- a/libs/cart/src/drivers/magento/models/outputs/cart-address.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/cart-address.ts
@@ -14,4 +14,5 @@ export interface MagentoCartAddress {
   city: string;
   firstname: string;
   lastname: string;
+  email: string;
 }

--- a/libs/cart/src/drivers/magento/models/outputs/cart.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/cart.ts
@@ -10,6 +10,7 @@ import { MagentoShippingAddress } from './shipping-address';
  */
 export interface MagentoCart {
   id: number;
+  email: string;
   billing_address: MagentoCartAddress;
   shipping_addresses: MagentoShippingAddress[];
   items: MagentoCartItem[];

--- a/libs/cart/src/drivers/magento/models/responses/get-cart.ts
+++ b/libs/cart/src/drivers/magento/models/responses/get-cart.ts
@@ -1,0 +1,5 @@
+import { MagentoCart } from '../outputs/cart';
+
+export interface MagentoGetCartResponse {
+  cart: MagentoCart;
+}

--- a/libs/cart/src/drivers/magento/models/responses/get-shipping-address.ts
+++ b/libs/cart/src/drivers/magento/models/responses/get-shipping-address.ts
@@ -1,0 +1,8 @@
+import { MagentoShippingAddress } from '../outputs/shipping-address';
+
+export interface MagentoGetShippingAddressResponse {
+  cart: {
+    shipping_addresses: MagentoShippingAddress[];
+    email: string;
+  };
+}

--- a/libs/cart/src/drivers/magento/models/responses/index.ts
+++ b/libs/cart/src/drivers/magento/models/responses/index.ts
@@ -1,2 +1,5 @@
 export { MagentoListPaymentMethodsResponse } from './list-payment-methods';
 export { MagentoListShippingMethodsResponse } from './list-shipping-methods';
+export { MagentoGetShippingAddressResponse } from './get-shipping-address';
+export { MagentoUpdateShippingAddressResponse } from './update-shipping-address';
+export { MagentoGetCartResponse } from './get-cart';

--- a/libs/cart/src/drivers/magento/models/responses/update-shipping-address.ts
+++ b/libs/cart/src/drivers/magento/models/responses/update-shipping-address.ts
@@ -1,0 +1,6 @@
+import { MagentoGetCartResponse } from './get-cart';
+
+export interface MagentoUpdateShippingAddressResponse {
+  setShippingAddressesOnCart: MagentoGetCartResponse;
+}
+

--- a/libs/cart/src/drivers/magento/queries/fragments/cart-address.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/cart-address.ts
@@ -1,0 +1,21 @@
+import gql from 'graphql-tag';
+
+export const cartAddressFragment = gql`
+  fragment cartAddress on CartAddressInterface {
+    city
+    country {
+      code
+      label
+    }
+    firstname
+    lastname
+    postcode
+    region {
+      code
+      label
+    }
+    street
+    telephone
+    company
+  }
+`;

--- a/libs/cart/src/drivers/magento/queries/fragments/cart-coupon.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/cart-coupon.ts
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export const cartCouponFragment = gql`
+  fragment cartCoupon on MagnetoCartCoupon {
+    code
+  }
+`;

--- a/libs/cart/src/drivers/magento/queries/fragments/cart-item.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/cart-item.ts
@@ -1,0 +1,31 @@
+import gql from 'graphql-tag';
+
+import { productFragment } from './product';
+import { moneyFragment } from './money';
+
+export const cartItemFragment = gql`
+  fragment cartItem on CartItemInterface {
+    id
+    product {
+      ...product
+    }
+    quantity
+    prices {
+      discounts
+      price {
+        ...money
+      }
+      row_total {
+        ...money
+      }
+      row_total_including_tax {
+        ...money
+      }
+      total_item_discount {
+        ...money
+      }
+    }
+  }
+  ${productFragment}
+  ${moneyFragment}
+`;

--- a/libs/cart/src/drivers/magento/queries/fragments/cart.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/cart.ts
@@ -1,0 +1,53 @@
+import gql from 'graphql-tag';
+
+import { moneyFragment } from './money';
+import { cartAddressFragment } from './cart-address';
+import { cartPaymentMethodFragment } from './cart-payment-method';
+import { cartItemFragment } from './cart-item';
+import { cartCouponFragment } from './cart-coupon';
+
+export const cartFragment = gql`
+  fragment cart on MagentoCart {
+    id
+    email
+    billing_address {
+      ...cartAddress
+    }
+    shipping_addresses {
+      ...cartAddress
+      available_shipping_methods
+      selected_shipping_method
+    }
+    items {
+      ...cartItem
+    }
+    available_payment_methods {
+      ...cartPaymentMethod
+    }
+    selected_payment_method {
+      ...cartPaymentMethod
+    }
+    applied_coupons {
+      ...cartCoupon
+    }
+    prices {
+      grand_total {
+        ...money
+      }
+      subtotal_excluding_tax {
+        ...money
+      }
+      subtotal_including_tax {
+        ...money
+      }
+      subtotal_with_discount_excluding_tax {
+        ...money
+      }
+    }
+  }
+  ${cartAddressFragment}
+  ${cartPaymentMethodFragment}
+  ${cartItemFragment}
+  ${moneyFragment}
+  ${cartCouponFragment}
+`;

--- a/libs/cart/src/drivers/magento/queries/fragments/index.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/index.ts
@@ -1,3 +1,7 @@
 export { moneyFragment } from './money';
+export { cartCouponFragment } from './cart-coupon';
+export { cartAddressFragment } from './cart-address';
+export { cartItemFragment } from './cart-item';
 export { cartPaymentMethodFragment } from './cart-payment-method';
 export { cartShippingMethodFragment } from './cart-shipping-method';
+export { cartFragment } from './cart';

--- a/libs/cart/src/drivers/magento/queries/fragments/product.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/product.ts
@@ -1,0 +1,26 @@
+import gql from 'graphql-tag';
+
+import { moneyFragment } from './money';
+
+export const productFragment = gql`
+  fragment product on MagnetoProduct {
+    id
+    image {
+      label,
+      url
+    }
+    manufacturer
+    name
+    description
+    price_range {
+      maximum_price {
+        ...money
+      }
+      minumum_price {
+        ...money
+      }
+    }
+    sku
+  }
+  ${moneyFragment}
+`;

--- a/libs/cart/src/drivers/magento/queries/get-shipping-address.ts
+++ b/libs/cart/src/drivers/magento/queries/get-shipping-address.ts
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag';
+
+import { cartAddressFragment } from './fragments';
+
+export const getShippingAddress = gql`
+  query GetShippingAddress($cartId: String!) {
+    cart(cart_id: $cartId) {
+      shipping_addresses {
+        ...cartAddress
+      }
+      email
+    }
+  }
+  ${cartAddressFragment}
+`;

--- a/libs/cart/src/drivers/magento/queries/index.ts
+++ b/libs/cart/src/drivers/magento/queries/index.ts
@@ -2,3 +2,5 @@ export * from './fragments';
 
 export { listPaymentMethods } from './list-payment-methods';
 export { listShippingMethods } from './list-shipping-methods';
+export { getShippingAddress } from './get-shipping-address';
+export { updateShippingAddress } from './update-shipping-address';

--- a/libs/cart/src/drivers/magento/queries/update-shipping-address.ts
+++ b/libs/cart/src/drivers/magento/queries/update-shipping-address.ts
@@ -1,0 +1,17 @@
+import gql from 'graphql-tag';
+
+import { cartFragment } from './fragments';
+
+export const updateShippingAddress = gql`
+  mutation UpdateShippingAddress($cartId: String!, $address: MagentoShippingAddressInput!) {
+    setShippingAddressesOnCart(input: {
+      cart_id: $cartId
+      shipping_addresses: [$address]
+    }) {
+      cart {
+        ...cart
+      }
+    }
+  }
+  ${cartFragment}
+`;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?
- Adds the email field to cart and cart-address
- Adds input models needed for shipping address driver
- Adds GraphQL fragments
- Adds shipping address driver queries
- Adds shipping address driver responses

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The shipping address driver can return the cart which introduces a lot of dependencies, like all of the fragments, transformers, and factories. This is the first a few PRs that will add these deps before adding the driver.

Relies on #657.