### PR TITLE
feat(product): enable get product magento call to get bundled products

### DIFF
--- a/libs/product/src/drivers/magento/models/bundled-product.ts
+++ b/libs/product/src/drivers/magento/models/bundled-product.ts
@@ -1,12 +1,12 @@
 import { ProductNode } from './product-node';
 import { MagentoSimpleProduct } from './simple-product';
 
-export enum MagentoPriceViewEnum {
+export enum MagentoBundledPriceViewEnum {
 	price_range = 'PRICE_RANGE',
 	as_low_as = 'AS_LOW_AS'
 }
 
-export enum MagentoBundleItemsEnum {
+export enum MagentoBundledItemsEnum {
 	together = 'TOGETHER',
 	separately = 'SEPARATELY'
 }
@@ -18,17 +18,17 @@ export enum MagentoPriceTypeEnum {
 }
 
 export interface MagentoBundledProduct extends ProductNode {
-	dynamic_price: boolean;
-	dynamic_sku: boolean;
-	dynamic_weight: boolean;
-	price_view: MagentoPriceViewEnum;
-	ship_bundle_items: MagentoBundleItemsEnum;
+	dynamic_price?: boolean;
+	dynamic_sku?: boolean;
+	dynamic_weight?: boolean;
+	price_view: MagentoBundledPriceViewEnum;
+	ship_bundle_items: MagentoBundledItemsEnum;
 	items: MagentoBundledProductItem[];
 }
 
 export interface MagentoBundledProductItem {
 	option_id: number;
-	position: number;
+	position?: number;
 	required: boolean;
 	sku: string;
 	title: string;
@@ -39,11 +39,11 @@ export interface MagentoBundledProductItem {
 export interface MagentoBundledProductItemOption {
 	can_change_quantity: boolean;
 	id: number;
-	is_default: boolean;
+	is_default?: boolean;
 	label: string;
-	position: number;
-	price_type: MagentoPriceTypeEnum;
-	price: number;
+	position?: number;
+	price_type?: MagentoPriceTypeEnum;
+	price?: number;
 	quantity: number;
-	product: MagentoSimpleProduct;
+	product?: MagentoSimpleProduct;
 }

--- a/libs/product/src/drivers/magento/models/get-product-response.ts
+++ b/libs/product/src/drivers/magento/models/get-product-response.ts
@@ -1,0 +1,14 @@
+import { ProductNode } from './product-node';
+
+export interface MagentoGetProductQueryResponse {
+	products: MagentoGetProductQueryProducts;
+	storeConfig: MagentoGetProductQueryStoreConfig;
+}
+
+export interface MagentoGetProductQueryProducts {
+	items: ProductNode[];
+}
+
+export interface MagentoGetProductQueryStoreConfig {
+	secure_base_media_url: string;
+}

--- a/libs/product/src/drivers/magento/models/product-node.ts
+++ b/libs/product/src/drivers/magento/models/product-node.ts
@@ -1,11 +1,18 @@
 import { ProductImageNode } from './product-image-node';
 import { ProductPriceNode } from './product-price-node';
 
+export enum MagentoProductTypeEnum {
+	BundledProduct = 'BundleProduct',
+	ConfigurableProduct = 'ConfigurableProduct',
+	SimpleProduct = 'SimpleProduct'
+}
+
 /**
  * An object for defining what the product service requests and retrieves from a magento backend.
  */
 export interface ProductNode {
-  id: number;
+	id: number;
+	__typename?: MagentoProductTypeEnum;
   name: string;
   sku: string;
   url_key: string;

--- a/libs/product/src/drivers/magento/public_api.ts
+++ b/libs/product/src/drivers/magento/public_api.ts
@@ -1,17 +1,6 @@
 export { ProductImageNode } from './models/product-image-node';
-export { ProductNode } from './models/product-node';
-export { 
-	MagentoBundledProduct, 
-	MagentoBundledProductItemOption,
-	MagentoBundledProductItem,
-	MagentoBundleItemsEnum,
-	MagentoPriceTypeEnum,
-	MagentoPriceViewEnum
-} from './models/bundled-product';
+export * from './models/product-node';
+export * from './models/bundled-product';
 export { ProductPriceNode } from './models/product-price-node';
 export { DaffMagentoProductTransformerService } from './transforms/product-transformer.service';
 export { DaffSortField } from './models/sort-field';
-export { GetProductQuery } from './queries/get-product';
-export { GetAllProductsQuery } from './queries/get-all-products';
-export { bundledProductFragment } from './queries/fragments/bundled-product';
-export { GetSortFieldsAndFiltersByCategory } from './queries/get-sort-fields-and-filters-by-category';

--- a/libs/product/src/index.ts
+++ b/libs/product/src/index.ts
@@ -1,12 +1,12 @@
-export { DaffProduct } from './models/product';
+export * from './models/product';
 export * from './actions/product.actions';
 export * from './actions/product-grid.actions';
 export * from './actions/best-sellers.actions';
 export { DaffProductUnion } from './models/product-union';
 export { DaffProductModification } from './models/product-modification';
 export { DaffProductImage } from './models/product-image';
-export { DaffBundledProduct } from './models/bundled-product';
-export { DaffBundledProductItem, DaffPriceTypeEnum, DaffBundledProductItemOption } from './models/bundled-product-item';
+export * from './models/bundled-product';
+export * from './models/bundled-product-item';
 
 import * as fromProduct from './reducers/index';
 export { fromProduct };

--- a/libs/product/src/models/bundled-product-item.ts
+++ b/libs/product/src/models/bundled-product-item.ts
@@ -6,18 +6,23 @@ export enum DaffPriceTypeEnum {
 	dynamic = 'DYNAMIC'
 }
 
+export enum DaffBundledProductItemType {
+	radio = 'RADIO',
+	checkbox = 'CHECKBOX',
+	select = 'SELECT'
+}
+
 export interface DaffBundledProductItem {
 	bundle_id: string;
 	bundle_option_id: number;
 	required: boolean;
 	title: string;
-	type: string;
+	type: DaffBundledProductItemType;
 	options: DaffBundledProductItemOption[];
 }
 
 export interface DaffBundledProductItemOption extends DaffProduct {
 	can_change_quantity: boolean;
-	id: string;
 	name?: string;
 	price?: string;
 	price_type?: DaffPriceTypeEnum;

--- a/libs/product/src/models/bundled-product.ts
+++ b/libs/product/src/models/bundled-product.ts
@@ -1,18 +1,12 @@
 import { DaffProduct } from './product';
 import { DaffBundledProductItem } from './bundled-product-item';
 
-export enum MagentoPriceViewEnum {
+export enum DaffBundledProductPriceViewEnum {
 	price_range = 'PRICE_RANGE',
 	as_low_as = 'AS_LOW_AS'
 }
 
-export enum MagentoBundleItemsEnum {
-	together = 'TOGETHER',
-	separately = 'SEPARATELY'
-}
-
 export interface DaffBundledProduct extends DaffProduct {
-	price_view: MagentoPriceViewEnum;
-	ship_bundle_items: MagentoBundleItemsEnum;
+	price_view: DaffBundledProductPriceViewEnum;
 	items: DaffBundledProductItem[];
 }

--- a/libs/product/src/models/product.ts
+++ b/libs/product/src/models/product.ts
@@ -1,11 +1,16 @@
 import { DaffProductImage } from './product-image';
 
+export enum DaffProductTypeEnum {
+	Simple = 'simple',
+	Composite = 'composite'
+}
+
 /**
  * An interface for a product usable by the @daffodil/product library.
  */
 export interface DaffProduct {
 	id: string;
-	__typename?: string;
+	__typename?: DaffProductTypeEnum;
   price?: string;
   name?: string;
   brand?: string;

--- a/libs/product/testing/src/factories/bundled-product.factory.spec.ts
+++ b/libs/product/testing/src/factories/bundled-product.factory.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DaffBundledProduct } from '@daffodil/product';
+
+import { DaffBundledProductFactory } from './bundled-product.factory';
+
+describe('Product | Testing | Factories | DaffBundledProductFactory', () => {
+  
+  let bundledProductFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffBundledProductFactory]
+    });
+
+    bundledProductFactory = TestBed.get(DaffBundledProductFactory);
+  });
+
+  it('should be created', () => {
+    expect(bundledProductFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+
+    let result: DaffBundledProduct;
+
+    beforeEach(() => {
+      result = bundledProductFactory.create();
+    });
+    
+    it('should return a BundledProduct with all required fields defined', () => {
+			expect(result.price_view).toBeDefined();
+      expect(result.items).toBeDefined();
+    });
+  });
+});

--- a/libs/product/testing/src/factories/bundled-product.factory.ts
+++ b/libs/product/testing/src/factories/bundled-product.factory.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import {
+	DaffBundledProduct, 
+	DaffBundledProductPriceViewEnum,
+	DaffPriceTypeEnum,
+	DaffBundledProductItemType,
+	DaffProductTypeEnum
+} from '@daffodil/product';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+import { MockProduct } from './product.factory';
+
+/**
+ * Mocked DaffBundledProduct object.
+ */
+export class MockBundledProduct extends MockProduct implements DaffBundledProduct {
+	__typename = DaffProductTypeEnum.Composite;
+	price_view = DaffBundledProductPriceViewEnum.as_low_as;
+	items = [{
+		bundle_id: faker.random.alphaNumeric(10),
+		bundle_option_id: faker.random.number(10),
+		required: faker.random.boolean(),
+		title: faker.random.words(2),
+		type: DaffBundledProductItemType.select,
+		options: [{
+			id: faker.random.alphaNumeric(10),
+			can_change_quantity: faker.random.boolean,
+			name: faker.random.words(2),
+			price: faker.random.number(1500).toString(),
+			price_type: DaffPriceTypeEnum.fixed,
+			quantity: faker.random.number(3)
+		}]
+	}]
+}
+
+/**
+ * Factory for creating DaffBundledProducts.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class DaffBundledProductFactory extends DaffModelFactory<DaffBundledProduct>{
+  constructor(){
+    super(MockBundledProduct);
+  }
+}

--- a/libs/product/testing/src/factories/magento/product.factory.spec.ts
+++ b/libs/product/testing/src/factories/magento/product.factory.spec.ts
@@ -27,7 +27,8 @@ describe('Product | Testing | Factories | MagentoProductFactory', () => {
     });
 
     it('should return a MagentoProduct with all required fields defined', () => {
-      expect(result.id).toBeDefined();
+			expect(result.id).toBeDefined();
+			expect(result.__typename).toBeDefined();
       expect(result.image.label).toBeDefined();
       expect(result.image.url).toBeDefined();
       expect(result.url_key).toBeDefined();

--- a/libs/product/testing/src/factories/magento/product.factory.ts
+++ b/libs/product/testing/src/factories/magento/product.factory.ts
@@ -1,13 +1,16 @@
 import { Injectable } from '@angular/core';
 import * as faker from 'faker/locale/en_US';
 
+import { MagentoProductTypeEnum } from '@daffodil/product';
+
 import {
   DaffModelFactory,
 } from '@daffodil/core/testing';
 import { MagentoProduct } from '@daffodil/product';
 
 export class MockMagentoProduct implements MagentoProduct {
-  id = faker.random.number(1000);
+	id = faker.random.number(1000);
+	__typename = MagentoProductTypeEnum.SimpleProduct;
   image = {
     label: faker.random.words(3),
     url: faker.image.imageUrl()

--- a/libs/product/testing/src/factories/product.factory.spec.ts
+++ b/libs/product/testing/src/factories/product.factory.spec.ts
@@ -29,7 +29,8 @@ describe('Product | Testing | Factories | DaffProductFactory', () => {
     
     it('should return a Product with all required fields defined', () => {
 
-      expect(result.id).toBeDefined();
+			expect(result.id).toBeDefined();
+			expect(result.__typename).toBeDefined();
       expect(result.price).toBeDefined();
       expect(result.name).toBeDefined();
       expect(result.brand).toBeDefined(); 

--- a/libs/product/testing/src/factories/product.factory.ts
+++ b/libs/product/testing/src/factories/product.factory.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@angular/core';
 import * as faker from 'faker/locale/en_US';
-import { DaffProduct } from '@daffodil/product';
+import { DaffProduct, DaffProductTypeEnum } from '@daffodil/product';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 /**
  * Mocked DaffProduct object.
  */
 export class MockProduct implements DaffProduct {
-  id = faker.random.number(10000).toString();
+	id = faker.random.number(10000).toString();
+	__typename = DaffProductTypeEnum.Simple;
   price = faker.random.number(1500).toString();
   name = faker.commerce.productName();
   brand = faker.company.companyName();

--- a/libs/product/testing/src/index.ts
+++ b/libs/product/testing/src/index.ts
@@ -1,4 +1,5 @@
 export { DaffProductFactory } from './factories/product.factory';
+export { DaffBundledProductFactory } from './factories/bundled-product.factory';
 export { DaffProductModificationFactory } from './factories/product-modification.factory';
 export { DaffProductImageFactory } from './factories/product-image.factory';
 export { DaffInMemoryBackendProductService } from './inmemory-backend/product.service';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
The get products call for magento can now retrieve bundled products.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```


## Other information
There is one particular thing I had a lot of trouble with. The fragment for the bundled product query doesn't seem to retrieve any fields in the first layer of the bundled product so:
```
fragment bundledProduct on BundleProduct {

----------------THESE FIELDS ARE NOT RETRIEVED AND RETURN AS NULL-----------------------
        dynamic_price
	dynamic_sku
	dynamic_weight
	price_view
	ship_bundle_items
-------------------------------------------------------------------------------------------------
	items {
		option_id
		position
		required
		sku
		title
		type
		options {
			can_change_quantity
			id
			is_default
			label
			position
			price_type
			price
			quantity
			product {
				id
				name
				sku
			}
		}
	}
}
```
But the rest of the fields come back just fine. I don't know why. Seems to have something to do with fragments, because if I don't use fragments and just paste the BundledProducts query into the GetProductQuery, it works fine.