### PR TITLE
bug(category): fix some bugs with the get category query

### DIFF
--- a/libs/category/src/drivers/magento/category.service.ts
+++ b/libs/category/src/drivers/magento/category.service.ts
@@ -49,7 +49,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
 	}
 	
 	private getProductsQueryVariables(request: DaffCategoryRequest) {
-		let queryVariables = {
+		const queryVariables = {
 			filter: this.magentoAppliedFiltersTransformer.transform(request.id, request.applied_filters)
 		};
 		if(request.page_size) queryVariables['pageSize'] = request.page_size;

--- a/libs/category/src/drivers/magento/category.service.ts
+++ b/libs/category/src/drivers/magento/category.service.ts
@@ -14,7 +14,6 @@ import { MagentoGetProductsQuery } from './queries/get-products';
 import { DaffMagentoAppliedFiltersTransformService } from './transformers/applied-filter-transformer.service';
 import { DaffMagentoAppliedSortOptionTransformService } from './transformers/applied-sort-option-transformer.service';
 import { DaffMagentoCategoryResponseTransformService } from './transformers/category-response-transform.service';
-import { CompleteCategoryResponse } from './models/outputs/complete-category-response';
 
 @Injectable({
   providedIn: 'root'
@@ -51,16 +50,13 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
 	
 	private getProductsQueryVariables(request: DaffCategoryRequest) {
 		const queryVariables = {
-			filter: this.magentoAppliedFiltersTransformer.transform(request.id, request.applied_filters),
-			search: null,
-			pageSize: request.page_size,
-			currentPage: request.current_page,
-			sort: this.magentoAppliedSortTransformer.transform(request.applied_sort_option, request.applied_sort_direction)
+			filter: this.magentoAppliedFiltersTransformer.transform(request.id, request.applied_filters)
+		};
+		if(request.page_size) queryVariables['pageSize'] = request.page_size;
+		if(request.current_page) queryVariables['currentPage'] = request.current_page;
+		if(request.applied_sort_option && request.applied_sort_direction) {
+			queryVariables['sort'] = this.magentoAppliedSortTransformer.transform(request.applied_sort_option, request.applied_sort_direction);
 		}
-
-		if(!queryVariables.pageSize) delete queryVariables.pageSize;
-		if(!queryVariables.currentPage) delete queryVariables.currentPage;
-		if(!queryVariables.sort) delete queryVariables.sort;
 
 		return queryVariables;
 	}

--- a/libs/category/src/drivers/magento/category.service.ts
+++ b/libs/category/src/drivers/magento/category.service.ts
@@ -14,6 +14,7 @@ import { MagentoGetProductsQuery } from './queries/get-products';
 import { DaffMagentoAppliedFiltersTransformService } from './transformers/applied-filter-transformer.service';
 import { DaffMagentoAppliedSortOptionTransformService } from './transformers/applied-sort-option-transformer.service';
 import { DaffMagentoCategoryResponseTransformService } from './transformers/category-response-transform.service';
+import { CompleteCategoryResponse } from './models/outputs/complete-category-response';
 
 @Injectable({
   providedIn: 'root'
@@ -49,23 +50,32 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
 	}
 	
 	private getProductsQueryVariables(request: DaffCategoryRequest) {
-		return {
-			filter: this.magentoAppliedFiltersTransformer.transform(request.applied_filters),
+		const queryVariables = {
+			filter: this.magentoAppliedFiltersTransformer.transform(request.id, request.applied_filters),
 			search: null,
 			pageSize: request.page_size,
 			currentPage: request.current_page,
 			sort: this.magentoAppliedSortTransformer.transform(request.applied_sort_option, request.applied_sort_direction)
 		}
+
+		if(!queryVariables.pageSize) delete queryVariables.pageSize;
+		if(!queryVariables.currentPage) delete queryVariables.currentPage;
+		if(!queryVariables.sort) delete queryVariables.sort;
+
+		return queryVariables;
 	}
 
-	private buildCompleteCategoryResponse(categoryReponse: MagentoGetACategoryResponse, productsResponse: MagentoGetProductsResponse) {
+	private buildCompleteCategoryResponse(
+		categoryResponse: MagentoGetACategoryResponse, 
+		productsResponse: MagentoGetProductsResponse
+	): MagentoCompleteCategoryResponse {
 		return {
-			category: categoryReponse.category,
-			products: productsResponse.products,
-			aggregates: productsResponse.aggregates,
-			sort_fields: productsResponse.sort_fields,
-			total_count: productsResponse.total_count,
-			page_info: productsResponse.page_info
+			category: categoryResponse.categoryList[0],
+			products: productsResponse.products.items,
+			aggregates: productsResponse.products.aggregations,
+			sort_fields: productsResponse.products.sort_fields,
+			total_count: productsResponse.products.total_count,
+			page_info: productsResponse.products.page_info
 		};
 	}
 }

--- a/libs/category/src/drivers/magento/category.service.ts
+++ b/libs/category/src/drivers/magento/category.service.ts
@@ -14,6 +14,7 @@ import { MagentoGetProductsQuery } from './queries/get-products';
 import { DaffMagentoAppliedFiltersTransformService } from './transformers/applied-filter-transformer.service';
 import { DaffMagentoAppliedSortOptionTransformService } from './transformers/applied-sort-option-transformer.service';
 import { DaffMagentoCategoryResponseTransformService } from './transformers/category-response-transform.service';
+import { MagentoGetProductsByCategoriesRequest } from './models/requests/get-products-by-categories-request';
 
 @Injectable({
   providedIn: 'root'
@@ -48,7 +49,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
     );
 	}
 	
-	private getProductsQueryVariables(request: DaffCategoryRequest) {
+	private getProductsQueryVariables(request: DaffCategoryRequest): MagentoGetProductsByCategoriesRequest {
 		const queryVariables = {
 			filter: this.magentoAppliedFiltersTransformer.transform(request.id, request.applied_filters)
 		};

--- a/libs/category/src/drivers/magento/category.service.ts
+++ b/libs/category/src/drivers/magento/category.service.ts
@@ -49,7 +49,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
 	}
 	
 	private getProductsQueryVariables(request: DaffCategoryRequest) {
-		const queryVariables = {
+		let queryVariables = {
 			filter: this.magentoAppliedFiltersTransformer.transform(request.id, request.applied_filters)
 		};
 		if(request.page_size) queryVariables['pageSize'] = request.page_size;

--- a/libs/category/src/drivers/magento/models/get-category-response.ts
+++ b/libs/category/src/drivers/magento/models/get-category-response.ts
@@ -1,5 +1,5 @@
 import { MagentoCategory } from './category';
 
 export interface MagentoGetACategoryResponse {
-  category: MagentoCategory;
+  categoryList: MagentoCategory[];
 }

--- a/libs/category/src/drivers/magento/models/get-products-response.ts
+++ b/libs/category/src/drivers/magento/models/get-products-response.ts
@@ -4,9 +4,11 @@ import { MagentoSortFields } from './sort-fields';
 import { MagentoPageInfo } from './page-info';
 
 export interface MagentoGetProductsResponse {
-	aggregates: MagentoAggregation[];
-	products: ProductNode[];
-	sort_fields: MagentoSortFields;
-	page_info: MagentoPageInfo;
-	total_count: number;
+	products: {
+		aggregations: MagentoAggregation[];
+		items: ProductNode[];
+		sort_fields: MagentoSortFields;
+		page_info: MagentoPageInfo;
+		total_count: number;
+	}
 }

--- a/libs/category/src/drivers/magento/models/requests/get-products-by-categories-request.ts
+++ b/libs/category/src/drivers/magento/models/requests/get-products-by-categories-request.ts
@@ -2,9 +2,9 @@ import { MagentoCategoryFilters } from './filters';
 import { MagentoSortFieldAction } from './sort';
 
 export interface MagentoGetProductsByCategoriesRequest {
-	filters: MagentoCategoryFilters;
+	filter: MagentoCategoryFilters;
 	search?: string;
-	page_size?: number;
-	current_page?: number;
+	pageSize?: number;
+	currentPage?: number;
 	sort?: MagentoSortFieldAction;
 }

--- a/libs/category/src/drivers/magento/models/requests/sort.ts
+++ b/libs/category/src/drivers/magento/models/requests/sort.ts
@@ -1,3 +1,8 @@
+export enum MagentoSortDirectionEnum {
+	Ascending = 'ASC',
+	Decending = 'DESC'
+}
+
 export interface MagentoSortFieldAction {
-	[x: string]: string;
+	[x: string]: MagentoSortDirectionEnum;
 }

--- a/libs/category/src/drivers/magento/queries/get-category.ts
+++ b/libs/category/src/drivers/magento/queries/get-category.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const MagentoGetCategoryQuery = gql`
-query MagentoGetCategoryQuery($filters: MagentoCategoryFilters){
+query MagentoGetCategoryQuery($filters: CategoryFilterInput){
 	categoryList(filters: $filters) {
 		id
 		name

--- a/libs/category/src/drivers/magento/transformers/applied-filter-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/applied-filter-transformer.service.spec.ts
@@ -7,6 +7,7 @@ import { DaffCategoryFilterAction } from '../../../models/requests/filter-action
 describe('DaffMagentoAppliedFiltersTransformService', () => {
 
 	let service: DaffMagentoAppliedFiltersTransformService;
+	const categoryId = 'id';
 	const categoryFilterActions: DaffCategoryFilterAction[] = [
 		{
 			action: 'action',
@@ -37,6 +38,9 @@ describe('DaffMagentoAppliedFiltersTransformService', () => {
     
     it('should transform an array of DafFCategoryFilterAction into a MagentoCategoryFilters', () => {
 			const expectedReturn: MagentoCategoryFilters = {
+				category_id: {
+					eq: 'id'
+				},
 				code: {
 					action: 'value'
 				},
@@ -44,7 +48,7 @@ describe('DaffMagentoAppliedFiltersTransformService', () => {
 					action2: 'value2'
 				}
 			}
-      expect(service.transform(categoryFilterActions)).toEqual(expectedReturn);
+      expect(service.transform(categoryId, categoryFilterActions)).toEqual(expectedReturn);
     });
   });
 });

--- a/libs/category/src/drivers/magento/transformers/applied-filter-transformer.service.ts
+++ b/libs/category/src/drivers/magento/transformers/applied-filter-transformer.service.ts
@@ -8,11 +8,16 @@ import { DaffCategoryFilterAction } from '../../../models/requests/filter-action
 })
 export class DaffMagentoAppliedFiltersTransformService {
 
-  transform(daffFilters: DaffCategoryFilterAction[]): MagentoCategoryFilters {
-		const magentoFilters: MagentoCategoryFilters = {};
+  transform(categoryId: string, daffFilters: DaffCategoryFilterAction[] = []): MagentoCategoryFilters {
+		const magentoFilters: MagentoCategoryFilters = {
+			category_id: {
+				eq: categoryId
+			}
+		};
 
 		daffFilters.forEach(filter => {
 			magentoFilters[filter.code] = {
+				...magentoFilters[filter.code],
 				[filter.action]: filter.value
 			}
 		});

--- a/libs/category/src/drivers/magento/transformers/applied-sort-option-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/applied-sort-option-transformer.service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 
 import { DaffMagentoAppliedSortOptionTransformService } from './applied-sort-option-transformer.service';
-import { MagentoSortFieldAction } from '../models/requests/sort';
+import { MagentoSortFieldAction, MagentoSortDirectionEnum } from '../models/requests/sort';
+import { DaffSortDirectionEnum } from '../../../models/requests/category-request';
 
 describe('DaffMagentoAppliedSortOptionTransformService', () => {
 
@@ -24,9 +25,9 @@ describe('DaffMagentoAppliedSortOptionTransformService', () => {
     
     it('should return a MagentoSortOptionAction', () => {
 			const expectedReturn: MagentoSortFieldAction = {
-				sortOption: 'ASCE'
+				sortOption: MagentoSortDirectionEnum.Ascending
 			}
-      expect(service.transform('sortOption', 'ASCE')).toEqual(expectedReturn);
+      expect(service.transform('sortOption', DaffSortDirectionEnum.Ascending)).toEqual(expectedReturn);
     });
   });
 });

--- a/libs/category/src/drivers/magento/transformers/applied-sort-option-transformer.service.ts
+++ b/libs/category/src/drivers/magento/transformers/applied-sort-option-transformer.service.ts
@@ -9,7 +9,6 @@ import { DaffSortDirectionEnum } from '../../../models/requests/category-request
 export class DaffMagentoAppliedSortOptionTransformService {
 
   transform(appliedOption: string, appliedDirection: DaffSortDirectionEnum): MagentoSortFieldAction {
-		if(!appliedOption) return null;
 		return {
 			[appliedOption]: this.transformDirection(appliedDirection)
 		}

--- a/libs/category/src/drivers/magento/transformers/applied-sort-option-transformer.service.ts
+++ b/libs/category/src/drivers/magento/transformers/applied-sort-option-transformer.service.ts
@@ -1,15 +1,25 @@
 import { Injectable } from '@angular/core';
 
-import { MagentoSortFieldAction } from '../models/requests/sort';
+import { MagentoSortFieldAction, MagentoSortDirectionEnum } from '../models/requests/sort';
+import { DaffSortDirectionEnum } from '../../../models/requests/category-request';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DaffMagentoAppliedSortOptionTransformService {
 
-  transform(appliedOption: string, appliedDirection: string): MagentoSortFieldAction {
+  transform(appliedOption: string, appliedDirection: DaffSortDirectionEnum): MagentoSortFieldAction {
+		if(!appliedOption) return null;
 		return {
-			[appliedOption]: appliedDirection
+			[appliedOption]: this.transformDirection(appliedDirection)
 		}
-  }
+	}
+	
+	private transformDirection(direction: DaffSortDirectionEnum): MagentoSortDirectionEnum {
+		if(direction === DaffSortDirectionEnum.Ascending) {
+			return MagentoSortDirectionEnum.Ascending;
+		} else if(direction === DaffSortDirectionEnum.Decending) {
+			return MagentoSortDirectionEnum.Decending;
+		}
+	}
 }

--- a/libs/category/src/drivers/magento/transformers/category-response-transform.service.ts
+++ b/libs/category/src/drivers/magento/transformers/category-response-transform.service.ts
@@ -19,6 +19,7 @@ export class DaffMagentoCategoryResponseTransformService {
   ) {}
 
   transform(completeCategory: MagentoCompleteCategoryResponse): DaffGetCategoryResponse {
+		console.log(completeCategory);
     return {
 			...{ magentoCompleteCategoryResponse: completeCategory },
       category: this.magentoCategoryTransformerService.transform(completeCategory.category),

--- a/libs/category/src/drivers/magento/transformers/category-response-transform.service.ts
+++ b/libs/category/src/drivers/magento/transformers/category-response-transform.service.ts
@@ -19,7 +19,6 @@ export class DaffMagentoCategoryResponseTransformService {
   ) {}
 
   transform(completeCategory: MagentoCompleteCategoryResponse): DaffGetCategoryResponse {
-		console.log(completeCategory);
     return {
 			...{ magentoCompleteCategoryResponse: completeCategory },
       category: this.magentoCategoryTransformerService.transform(completeCategory.category),

--- a/libs/category/src/index.ts
+++ b/libs/category/src/index.ts
@@ -39,7 +39,10 @@ export { DaffCategoryFilter, DaffCategoryFilterTypes, DaffCategoryFilterOption }
 export { DaffCategoryPageConfigurationState } from './models/category-page-configuration-state';
 export { DaffCategoryBreadcrumb } from './models/category-breadcrumb'
 export { DaffCategory } from './models/category'
-export { DaffCategoryRequest } from './models/requests/category-request';
+export { 
+	DaffCategoryRequest,
+	DaffSortDirectionEnum
+} from './models/requests/category-request';
 export { DaffCategorySortOption } from './models/category-sort-option';
 export { DaffCategoryFilterAction } from './models/requests/filter-action';
 

--- a/libs/category/src/models/requests/category-request.ts
+++ b/libs/category/src/models/requests/category-request.ts
@@ -1,10 +1,15 @@
 import { DaffCategoryFilterAction } from './filter-action';
 
+export enum DaffSortDirectionEnum {
+	Ascending = 'ASC',
+	Decending = 'DSC'
+}
+
 export interface DaffCategoryRequest {
   id: string;
   applied_filters?: DaffCategoryFilterAction[];
   applied_sort_option?: string;
-  applied_sort_direction?: string;
+  applied_sort_direction?: DaffSortDirectionEnum;
   current_page?: number;
   page_size?: number;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
There were a lot of little things I did wrong when setting up the category get request. I tested all these changes in demo and everything is working perfectly now.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

What was fixed:
1. Some of the query variables for the magento GetProducts call can't be null. They need not to exist.
2. The expected object for the magento category response just wasn't correct.
3. The sort input of the category call for both the daffodil and magento models needed to be defined as enums instead of strings.
4. Misnaming of a magento query argument type.
5. The category id needed to be added to the `filters` argument of the get products call.