### PR TITLE
feat(category): make accessory actions dispatch DaffCategoryLoad

### DIFF
--- a/libs/category/src/effects/category.effects.spec.ts
+++ b/libs/category/src/effects/category.effects.spec.ts
@@ -159,20 +159,19 @@ describe('DaffCategoryEffects', () => {
 
     let expected;
     
-    it('should call get category with an id, page size, applied filters, and an applied sort option', () => {
+    it('should dispatch a category load with an id, page size, applied filters, and an applied sort option', () => {
       const changeCategoryPageSizeAction = new DaffChangeCategoryPageSize(3);
       actions$ = hot('--a', { a: changeCategoryPageSizeAction });
       
-      expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
-      expect(effects.changeCategoryPageSize$).toBeObservable(expected);
-
-      expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
+			const categoryLoadAction = new DaffCategoryLoad({ 
         id: categoryId,
 				page_size: 3,
 				applied_filters: stubCategoryPageConfigurationState.applied_filters,
 				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
 				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction
       });
+			expected = cold('--(a)', { a: categoryLoadAction });
+      expect(effects.changeCategoryPageSize$).toBeObservable(expected);
     });
   });
 
@@ -180,14 +179,11 @@ describe('DaffCategoryEffects', () => {
 
     let expected;
     
-    it('should call get category with every available parameter', () => {
+    it('should dispatch a category load with every available parameter', () => {
       const changeCategoryCurrentPageAction = new DaffChangeCategoryCurrentPage(3);
       actions$ = hot('--a', { a: changeCategoryCurrentPageAction });
-      
-      expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
-      expect(effects.changeCategoryCurrentPage$).toBeObservable(expected);
-
-      expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
+			
+			const categoryLoadAction = new DaffCategoryLoad({ 
         id: categoryId,
         page_size: stubCategoryPageConfigurationState.page_size,
 				current_page: 3,
@@ -195,6 +191,8 @@ describe('DaffCategoryEffects', () => {
 				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
 				applied_filters: stubCategoryPageConfigurationState.applied_filters
       });
+      expected = cold('--(a)', { a: categoryLoadAction });
+      expect(effects.changeCategoryCurrentPage$).toBeObservable(expected);
     });
   });
 
@@ -202,18 +200,15 @@ describe('DaffCategoryEffects', () => {
 
     let expected;
     
-    it('should call get category with an id, page size, applied filters, and an applied sorting option', () => {
+    it('should dispatch a category load with an id, page size, applied filters, and an applied sorting option', () => {
       const changeCategoryFiltersAction = new DaffChangeCategoryFilters([{
 				name: 'name',
 				action: 'action',
 				value: 'value'
 			}]);
       actions$ = hot('--a', { a: changeCategoryFiltersAction });
-      
-      expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
-      expect(effects.changeCategoryFilters$).toBeObservable(expected);
-
-      expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
+			
+			const categoryLoadAction = new DaffCategoryLoad({ 
 				id: categoryId,
         page_size: stubCategoryPageConfigurationState.page_size,
 				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
@@ -224,6 +219,8 @@ describe('DaffCategoryEffects', () => {
 					value: 'value'
 				}]
       });
+      expected = cold('--(a)', { a: categoryLoadAction });
+      expect(effects.changeCategoryFilters$).toBeObservable(expected);
     });
   });
 
@@ -246,20 +243,19 @@ describe('DaffCategoryEffects', () => {
 				store.overrideSelector(selectCategoryPageAppliedFilters, []);
 			});
 			
-			it('should call get category with the toggled filter', () => {
+			it('should dispatch a category load with the toggled filter', () => {
 				const toggleCategoryFilterAction = new DaffToggleCategoryFilter(toggledFilter);
 				actions$ = hot('--a', { a: toggleCategoryFilterAction });
 				
-				expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
-				expect(effects.toggleCategoryFilter$).toBeObservable(expected);
-	
-				expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
+				const categoryLoadAction = new DaffCategoryLoad({ 
 					id: categoryId,
 					page_size: stubCategoryPageConfigurationState.page_size,
 					applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
 					applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
 					applied_filters: [toggledFilter]
 				});
+				expected = cold('--(a)', { a: categoryLoadAction });
+				expect(effects.toggleCategoryFilter$).toBeObservable(expected);
 			});
 		});
 
@@ -269,20 +265,19 @@ describe('DaffCategoryEffects', () => {
 				store.overrideSelector(selectCategoryPageAppliedFilters, [toggledFilter]);
 			});
 			
-			it('should not call get category with the toggled filter', () => {
+			it('should not dispatch a category load with the toggled filter', () => {
 				const toggleCategoryFilterAction = new DaffToggleCategoryFilter(toggledFilter);
 				actions$ = hot('--a', { a: toggleCategoryFilterAction });
 				
-				expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
-				expect(effects.toggleCategoryFilter$).toBeObservable(expected);
-	
-				expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
+				const categoryLoadAction = new DaffCategoryLoad({ 
 					id: categoryId,
 					page_size: stubCategoryPageConfigurationState.page_size,
 					applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
 					applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
 					applied_filters: []
 				});
+				expected = cold('--(a)', { a: categoryLoadAction });
+				expect(effects.toggleCategoryFilter$).toBeObservable(expected);
 			});
 		});
   });
@@ -291,23 +286,22 @@ describe('DaffCategoryEffects', () => {
 
     let expected;
     
-    it('should call get category with an id, page size, applied filters, and an applied sorting option', () => {
+    it('should dispatch a category load with an id, page size, applied filters, and an applied sorting option', () => {
       const changeCategorySortingOption = new DaffChangeCategorySortingOption({
 				option: 'option',
 				direction: DaffSortDirectionEnum.Ascending
 			});
       actions$ = hot('--a', { a: changeCategorySortingOption });
-      
-      expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
-      expect(effects.changeCategorySort$).toBeObservable(expected);
-
-      expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
+			
+			const categoryLoadAction = new DaffCategoryLoad({ 
 				id: categoryId,
         page_size: stubCategoryPageConfigurationState.page_size,
 				applied_sort_direction: DaffSortDirectionEnum.Ascending,
 				applied_sort_option: 'option',
 				applied_filters: stubCategoryPageConfigurationState.applied_filters
       });
+      expected = cold('--(a)', { a: categoryLoadAction });
+      expect(effects.changeCategorySort$).toBeObservable(expected);
     });
   });
 });

--- a/libs/category/src/effects/category.effects.ts
+++ b/libs/category/src/effects/category.effects.ts
@@ -57,15 +57,13 @@ export class DaffCategoryEffects {
     switchMap((
 			[action, categoryId, appliedFilters, appliedSortOption, appliedSortDirection]: 
 			[DaffChangeCategoryPageSize, string, DaffCategoryFilterAction[], string, DaffSortDirectionEnum]
-		) =>
-      this.processCategoryGetRequest({
-        id: categoryId,
-        page_size: action.pageSize,
-				applied_filters: appliedFilters,
-				applied_sort_option: appliedSortOption,
-				applied_sort_direction: appliedSortDirection
-      })
-    )
+		) => of(new DaffCategoryLoad({
+      id: categoryId,
+			page_size: action.pageSize,
+			applied_filters: appliedFilters,
+			applied_sort_option: appliedSortOption,
+			applied_sort_direction: appliedSortDirection
+		})))
   )
 
   @Effect()
@@ -81,16 +79,14 @@ export class DaffCategoryEffects {
     switchMap((
 			[action, categoryId, pageSize, appliedFilters, appliedSortOption, appliedSortDirection]: 
 			[DaffChangeCategoryCurrentPage, string, number, DaffCategoryFilterAction[], string, DaffSortDirectionEnum]
-		) =>
-      this.processCategoryGetRequest({
-        id: categoryId,
-        page_size: pageSize,
-				current_page: action.currentPage,
-				applied_filters: appliedFilters,
-				applied_sort_option: appliedSortOption,
-				applied_sort_direction: appliedSortDirection
-      })
-    )
+		) => of(new DaffCategoryLoad({
+			id: categoryId,
+			page_size: pageSize,
+			current_page: action.currentPage,
+			applied_filters: appliedFilters,
+			applied_sort_option: appliedSortOption,
+			applied_sort_direction: appliedSortDirection
+		})))
   )
 
   @Effect()
@@ -105,15 +101,13 @@ export class DaffCategoryEffects {
     switchMap((
 			[action, categoryId, pageSize, appliedSortOption, appliedSortDirection]: 
 			[DaffChangeCategoryFilters, string, number, string, DaffSortDirectionEnum]
-		) =>
-      this.processCategoryGetRequest({
-        id: categoryId,
-        page_size: pageSize,
-				applied_filters: action.filters,
-				applied_sort_option: appliedSortOption,
-				applied_sort_direction: appliedSortDirection
-      })
-    )
+		) => of(new DaffCategoryLoad({
+			id: categoryId,
+			page_size: pageSize,
+			applied_filters: action.filters,
+			applied_sort_option: appliedSortOption,
+			applied_sort_direction: appliedSortDirection
+		})))
   )
 
   @Effect()
@@ -129,15 +123,13 @@ export class DaffCategoryEffects {
     switchMap((
 			[action, categoryId, pageSize, appliedFilters, appliedSortOption, appliedSortDirection]: 
 			[DaffToggleCategoryFilter, string, number, DaffCategoryFilterAction[], string, DaffSortDirectionEnum]
-		) => {
-			return this.processCategoryGetRequest({
-        id: categoryId,
-        page_size: pageSize,
-				applied_filters: this.toggleCategoryFilter(action.filter, appliedFilters),
-				applied_sort_option: appliedSortOption,
-				applied_sort_direction: appliedSortDirection
-      })
-		})
+		) => of(new DaffCategoryLoad({
+			id: categoryId,
+			page_size: pageSize,
+			applied_filters: this.toggleCategoryFilter(action.filter, appliedFilters),
+			applied_sort_option: appliedSortOption,
+			applied_sort_direction: appliedSortDirection
+		})))
   )
 
   @Effect()
@@ -151,15 +143,13 @@ export class DaffCategoryEffects {
     switchMap((
 			[action, categoryId, pageSize, appliedFilters]: 
 			[DaffChangeCategorySortingOption, string, number, DaffCategoryFilterAction[]]
-		) =>
-      this.processCategoryGetRequest({
-        id: categoryId,
-        page_size: pageSize,
-				applied_filters: appliedFilters,
-				applied_sort_option: action.sort.option,
-				applied_sort_direction: action.sort.direction
-      })
-    )
+		) => of(new DaffCategoryLoad({
+			id: categoryId,
+			page_size: pageSize,
+			applied_filters: appliedFilters,
+			applied_sort_option: action.sort.option,
+			applied_sort_direction: action.sort.direction
+		})))
 	)
 	
 	private toggleCategoryFilter(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
 Because the reducer only gets the applied filters and sorts off of the `DaffCategoryLoad` action, bypassing that action with a `DaffChangeFilters` action will also bypass setting that state in the reduceers. This is currently because magento does not return applied filters or sorts on a category call. Maybe we can find a way to force magento to return applied filters and sorts in the future. 

Fixes: N/A


## What is the new behavior?
The accessory category actions, such as `DaffChangeFilters`, now call `DaffCategoryLoad` instead of directly calling the category driver.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```