### PR TITLE
feat(category): make magento aggregation and sorting requests based o…

### DIFF
--- a/libs/category/src/drivers/magento/models/get-category-aggregations-response.ts
+++ b/libs/category/src/drivers/magento/models/get-category-aggregations-response.ts
@@ -1,0 +1,9 @@
+import { MagentoAggregation } from './aggregation';
+import { MagentoSortFields } from './sort-fields';
+
+export interface MagentoGetCategoryAggregationsResponse {
+	products: {
+		aggregations: MagentoAggregation[];
+		sort_fields: MagentoSortFields;
+	}
+}

--- a/libs/category/src/drivers/magento/models/get-products-response.ts
+++ b/libs/category/src/drivers/magento/models/get-products-response.ts
@@ -1,13 +1,9 @@
 import { ProductNode } from '@daffodil/product';
-import { MagentoAggregation } from './aggregation';
-import { MagentoSortFields } from './sort-fields';
 import { MagentoPageInfo } from './page-info';
 
 export interface MagentoGetProductsResponse {
 	products: {
-		aggregations: MagentoAggregation[];
 		items: ProductNode[];
-		sort_fields: MagentoSortFields;
 		page_info: MagentoPageInfo;
 		total_count: number;
 	}

--- a/libs/category/src/drivers/magento/queries/get-category-aggregations.ts
+++ b/libs/category/src/drivers/magento/queries/get-category-aggregations.ts
@@ -1,0 +1,30 @@
+import gql from 'graphql-tag';
+
+/**
+ * This query only exists because products and their associated aggregations/filter cannot
+ * be retrieved through a category call.
+ */
+export const MagentoGetCategoryAggregations = gql`
+query MagentoGetProducts($filter: ProductAttributeFilterInput!)
+{
+	products(filter: $filter)
+	{
+		aggregations {
+			label
+			count
+			attribute_code
+			options {
+					count
+					label
+					value
+			}
+		}
+		sort_fields {
+			default
+			options {
+				label
+				value
+			}
+		}
+	}
+}`

--- a/libs/category/src/drivers/magento/queries/get-products.ts
+++ b/libs/category/src/drivers/magento/queries/get-products.ts
@@ -28,27 +28,10 @@ query MagentoGetProducts($filter: ProductAttributeFilterInput!, $search: String,
 				}
 			}
 		}
-		aggregations {
-			label
-			count
-			attribute_code
-			options {
-					count
-					label
-					value
-			}
-		}
 		page_info {
 			page_size
 			current_page
 			total_pages
-		}
-		sort_fields {
-			default
-			options {
-				label
-				value
-			}
 		}
 	}
 }`


### PR DESCRIPTION
…n category Id only

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When magento returns available filters and sorts for a product call, it returns only filters and sorts available to the filtered products and not all products under the given category. We need all filters and sorts available to an entire category.

## What is the new behavior?
Retrieved aggregations and sorts are always only filtered by the given category ID.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```