### PR TITLE
fix(cart): importing magento driver module breaks app builds

### DIFF
--- a/apps/demo/src/app/app.module.ts
+++ b/apps/demo/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { ThankYouModule } from './thank-you/thank-you.module';
 import { DemoRoutingComponentModule } from './routing/routing-component.module';
 import { InMemoryModule } from './in-memory.module';
 import { DemoCartRootModule } from './cart/cart-root.module';
+import { MagentoModule } from './magento.module';
 
 @NgModule({
   declarations: [
@@ -38,8 +39,9 @@ import { DemoCartRootModule } from './cart/cart-root.module';
 
     HttpClientModule,
 
-    InMemoryModule,
-    
+    // InMemoryModule,
+    MagentoModule,
+
     StoreModule.forRoot({}),
     EffectsModule.forRoot([]),
 
@@ -47,7 +49,7 @@ import { DemoCartRootModule } from './cart/cart-root.module';
       maxAge: 25, // Retains last 25 states
       logOnly: environment.production, // Restrict extension to log-only mode
     }),
-    
+
     AppRoutingModule,
     DemoRoutingComponentModule,
     DemoCartRootModule,

--- a/apps/demo/src/app/app.module.ts
+++ b/apps/demo/src/app/app.module.ts
@@ -27,7 +27,6 @@ import { ThankYouModule } from './thank-you/thank-you.module';
 import { DemoRoutingComponentModule } from './routing/routing-component.module';
 import { InMemoryModule } from './in-memory.module';
 import { DemoCartRootModule } from './cart/cart-root.module';
-import { MagentoModule } from './magento.module';
 
 @NgModule({
   declarations: [
@@ -39,8 +38,7 @@ import { MagentoModule } from './magento.module';
 
     HttpClientModule,
 
-    // InMemoryModule,
-    MagentoModule,
+    InMemoryModule,
 
     StoreModule.forRoot({}),
     EffectsModule.forRoot([]),

--- a/apps/demo/src/app/magento.module.ts
+++ b/apps/demo/src/app/magento.module.ts
@@ -2,21 +2,20 @@ import { NgModule } from '@angular/core';
 
 import { ApolloBoostModule, ApolloBoost } from 'apollo-angular-boost';
 import { DaffProductMagentoDriverModule } from '@daffodil/product';
-import { DaffCartInMemoryDriverModule } from '@daffodil/cart/testing';
 import { DaffCheckoutInMemoryDriverModule } from '@daffodil/checkout/testing';
 import { DaffNavigationMagentoDriverModule } from '@daffodil/navigation';
 import { DaffNewsletterInMemoryDriverModule } from '@daffodil/newsletter/testing';
+import { DaffCartMagentoDriverModule } from '@daffodil/cart';
 
 @NgModule({
   imports: [
     //Magento
     ApolloBoostModule,
     DaffProductMagentoDriverModule.forRoot(),
-    DaffCartInMemoryDriverModule.forRoot(),
+    DaffCartMagentoDriverModule.forRoot(),
     DaffCheckoutInMemoryDriverModule.forRoot(),
     DaffNavigationMagentoDriverModule.forRoot(),
     DaffNewsletterInMemoryDriverModule.forRoot()
-
   ]
 })
 export class MagentoModule {

--- a/libs/cart/src/drivers/public_api.ts
+++ b/libs/cart/src/drivers/public_api.ts
@@ -8,4 +8,4 @@ export { DaffCartShippingAddressServiceInterface, DaffCartShippingAddressDriver 
 export { DaffCartShippingInformationServiceInterface, DaffCartShippingInformationDriver } from './interfaces/cart-shipping-information-service.interface';
 export { DaffCartShippingMethodsServiceInterface, DaffCartShippingMethodsDriver } from './interfaces/cart-shipping-methods-service.interface';
 
-export * from './magento';
+export * from './magento/index';

--- a/libs/cart/src/drivers/public_api.ts
+++ b/libs/cart/src/drivers/public_api.ts
@@ -8,4 +8,6 @@ export { DaffCartShippingAddressServiceInterface, DaffCartShippingAddressDriver 
 export { DaffCartShippingInformationServiceInterface, DaffCartShippingInformationDriver } from './interfaces/cart-shipping-information-service.interface';
 export { DaffCartShippingMethodsServiceInterface, DaffCartShippingMethodsDriver } from './interfaces/cart-shipping-methods-service.interface';
 
+// this needs to be pointing at index
+// see https://github.com/ng-packagr/ng-packagr/issues/195
 export * from './magento/index';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Importing `DaffCartMagentoDriverModule` and using it in an app will break the build with error:
```
Error during template compile of 'MagentoModule'
  Function calls are not supported in decorators but 'DaffCartMagentoDriverModule' was called.
```


## What is the new behavior?
The app using the module will correctly build.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information