### PR TITLE
bug(category): set the product ids on the categoryPageConfigState ins…

### DIFF
--- a/libs/category/testing/src/inmemory-backend/category.service.spec.ts
+++ b/libs/category/testing/src/inmemory-backend/category.service.spec.ts
@@ -67,7 +67,7 @@ describe('Driver | InMemory | Category | DaffInMemoryBackendCategoryService', ()
 		});
 		
 		it('should set no more products on the category than the page_size', () => {
-			expect(result.body.category.productIds.length).toBeLessThanOrEqual(result.body.categoryPageConfigurationState.page_size);
+			expect(result.body.categoryPageConfigurationState.product_ids.length).toBeLessThanOrEqual(result.body.categoryPageConfigurationState.page_size);
 		});
 
     it('should set page_size when the page_size is provided', () => {

--- a/libs/category/testing/src/inmemory-backend/category.service.ts
+++ b/libs/category/testing/src/inmemory-backend/category.service.ts
@@ -42,14 +42,14 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
 			id: reqInfo.id,
 			page_size: this.generatePageSize(reqInfo),
 			current_page: this.getCurrentPageParam(reqInfo),
-			total_pages: this.getTotalPages(allCategoryProductIds, this.generatePageSize(reqInfo))
+			total_pages: this.getTotalPages(allCategoryProductIds, this.generatePageSize(reqInfo)),
+			product_ids: this.trimProductIdsToSinglePage(allCategoryProductIds, this.getCurrentPageParam(reqInfo), this.generatePageSize(reqInfo))
 		});
 
 		this.category = this.categoryFactory.create({
 			id: reqInfo.id,
 			total_products: allCategoryProductIds.length,
 			page_size: this.generatePageSize(reqInfo),
-			productIds: this.trimProductIdsToSinglePage(allCategoryProductIds, this.getCurrentPageParam(reqInfo), this.generatePageSize(reqInfo))
 		});
 
     return reqInfo.utils.createResponse$(() => {


### PR DESCRIPTION
…tead of the category in the in memory api

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The product Ids in the category in memory api are being set on the category object instead of the category page configuration state object.

## What is the new behavior?
The product Ids are now set on the category page configuration state object.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```