### PR TITLE
feat(cart): handle empty and null responses in Magento driver

### DIFF
--- a/libs/cart/src/drivers/magento/cart-billing-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-billing-address.service.spec.ts
@@ -145,6 +145,25 @@ describe('Driver | Magento | Cart | CartBillingAddressService', () => {
       });
     });
 
+    describe('when the response is null', () => {
+      beforeEach(() => {
+        mockGetBillingAddressResponse.cart.billing_address = null;
+      });
+
+      it('should return null and not throw', done => {
+        service.get(cartId).subscribe(result => {
+          expect(result).toBeNull();
+          done();
+        });
+
+        const op = controller.expectOne(getBillingAddress);
+
+        op.flush({
+          data: mockGetBillingAddressResponse
+        });
+      });
+    });
+
     afterEach(() => {
       controller.verify();
     });

--- a/libs/cart/src/drivers/magento/cart-billing-address.service.ts
+++ b/libs/cart/src/drivers/magento/cart-billing-address.service.ts
@@ -39,10 +39,13 @@ export class DaffMagentoCartBillingAddressService implements DaffCartBillingAddr
       query: getBillingAddress,
       variables: {cartId}
     }).pipe(
-      map(result => this.billingAddressTransformer.transform({
-        ...result.data.cart.billing_address,
-        email: result.data.cart.email
-      }))
+      map(result => result.data.cart.billing_address
+        ? this.billingAddressTransformer.transform({
+          ...result.data.cart.billing_address,
+          email: result.data.cart.email
+        })
+        : null
+      )
     )
   }
 

--- a/libs/cart/src/drivers/magento/cart-payment-methods.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-payment-methods.service.spec.ts
@@ -66,7 +66,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodsService', () => {
       }
     };
 
-    magentoCartPaymentTransformerSpy.transform.withArgs(mockMagentoPaymentMethod).and.returnValue(mockDaffCartPayment);
+    magentoCartPaymentTransformerSpy.transform.withArgs(jasmine.objectContaining(mockMagentoPaymentMethod)).and.returnValue(mockDaffCartPayment);
   });
 
   it('should be created', () => {

--- a/libs/cart/src/drivers/magento/cart-payment-methods.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-payment-methods.service.spec.ts
@@ -66,7 +66,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodsService', () => {
       }
     };
 
-    magentoCartPaymentTransformerSpy.transform.withArgs(jasmine.objectContaining(mockMagentoPaymentMethod)).and.returnValue(mockDaffCartPayment);
+    magentoCartPaymentTransformerSpy.transform.withArgs(mockMagentoPaymentMethod).and.returnValue(mockDaffCartPayment);
   });
 
   it('should be created', () => {

--- a/libs/cart/src/drivers/magento/cart-shipping-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-address.service.spec.ts
@@ -149,6 +149,25 @@ describe('Driver | Magento | Cart | CartShippingAddressService', () => {
       });
     });
 
+    describe('when the response is an empty array', () => {
+      beforeEach(() => {
+        mockGetShippingAddressResponse.cart.shipping_addresses = [];
+      });
+
+      it('should return null and not throw', done => {
+        service.get(cartId).subscribe(result => {
+          expect(result).toBeNull();
+          done();
+        });
+
+        const op = controller.expectOne(getShippingAddress);
+
+        op.flush({
+          data: mockGetShippingAddressResponse
+        });
+      });
+    });
+
     afterEach(() => {
       controller.verify();
     });

--- a/libs/cart/src/drivers/magento/cart-shipping-address.service.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-address.service.ts
@@ -31,10 +31,13 @@ export class DaffMagentoCartShippingAddressService implements DaffCartShippingAd
       query: getShippingAddress,
       variables: {cartId}
     }).pipe(
-      map(result => this.shippingAddressTransformer.transform({
-        ...result.data.cart.shipping_addresses[0],
-        email: result.data.cart.email
-      }))
+      map(result => result.data.cart.shipping_addresses.length > 0
+        ? this.shippingAddressTransformer.transform({
+          ...result.data.cart.shipping_addresses[0],
+          email: result.data.cart.email
+        })
+        : null
+      )
     )
   }
 

--- a/libs/cart/src/drivers/magento/cart-shipping-address.service.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-address.service.ts
@@ -31,7 +31,7 @@ export class DaffMagentoCartShippingAddressService implements DaffCartShippingAd
       query: getShippingAddress,
       variables: {cartId}
     }).pipe(
-      map(result => result.data.cart.shipping_addresses.length > 0
+      map(result => result.data.cart.shipping_addresses[0]
         ? this.shippingAddressTransformer.transform({
           ...result.data.cart.shipping_addresses[0],
           email: result.data.cart.email

--- a/libs/cart/src/drivers/magento/cart-shipping-information.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-information.service.spec.ts
@@ -97,7 +97,9 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
     mockMagentoCart.shipping_addresses = [mockMagentoShippingAddress];
     mockGetSelectedShippingMethodResponse = {
       cart: {
-        selected_shipping_method: mockMagentoShippingMethod
+        shipping_addresses: [{
+          selected_shipping_method: mockMagentoShippingMethod
+        }]
       }
     };
     mockSetSelectedShippingMethodResponse = {
@@ -138,6 +140,25 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
 
       op.flush({
         data: mockGetSelectedShippingMethodResponse
+      });
+    });
+
+    describe('when the response is an empty array', () => {
+      beforeEach(() => {
+        mockGetSelectedShippingMethodResponse.cart.shipping_addresses = [];
+      });
+
+      it('should return null and not throw', done => {
+        service.get(cartId).subscribe(result => {
+          expect(result).toBeNull();
+          done();
+        });
+
+        const op = controller.expectOne(getSelectedShippingMethod);
+
+        op.flush({
+          data: mockGetSelectedShippingMethodResponse
+        });
       });
     });
 

--- a/libs/cart/src/drivers/magento/cart-shipping-information.service.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-information.service.ts
@@ -35,7 +35,10 @@ export class DaffMagentoCartShippingInformationService implements DaffCartShippi
       query: getSelectedShippingMethod,
       variables: {cartId}
     }).pipe(
-      map(result => this.shippingRateTransformer.transform(result.data.cart.selected_shipping_method))
+      map(result => result.data.cart.shipping_addresses.length > 0 && result.data.cart.shipping_addresses[0].selected_shipping_method
+        ? this.shippingRateTransformer.transform(result.data.cart.shipping_addresses[0].selected_shipping_method)
+        : null
+      )
     );
   }
 

--- a/libs/cart/src/drivers/magento/cart-shipping-information.service.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-information.service.ts
@@ -35,7 +35,7 @@ export class DaffMagentoCartShippingInformationService implements DaffCartShippi
       query: getSelectedShippingMethod,
       variables: {cartId}
     }).pipe(
-      map(result => result.data.cart.shipping_addresses.length > 0 && result.data.cart.shipping_addresses[0].selected_shipping_method
+      map(result => result.data.cart.shipping_addresses[0]
         ? this.shippingRateTransformer.transform(result.data.cart.shipping_addresses[0].selected_shipping_method)
         : null
       )

--- a/libs/cart/src/drivers/magento/models/responses/get-selected-shipping-method.ts
+++ b/libs/cart/src/drivers/magento/models/responses/get-selected-shipping-method.ts
@@ -2,6 +2,8 @@ import { MagentoCartShippingMethod } from '../outputs/cart-shipping-method';
 
 export interface MagentoGetSelectedShippingMethodResponse {
   cart: {
-    selected_shipping_method: MagentoCartShippingMethod;
+    shipping_addresses: {
+      selected_shipping_method: MagentoCartShippingMethod;
+    }[];
   };
 }

--- a/libs/cart/src/drivers/magento/queries/add-cart-item.ts
+++ b/libs/cart/src/drivers/magento/queries/add-cart-item.ts
@@ -3,13 +3,13 @@ import gql from 'graphql-tag';
 import { cartFragment } from './fragments';
 
 export const addCartItem = gql`
-  mutation AddCartItem($cartId: String!, $input: MagentoCartItemInput!) {
-    addSimpleProductsToCart(
+  mutation AddCartItem($cartId: String!, $input: CartItemInput!) {
+    addSimpleProductsToCart(input: {
       cart_id: $cartId,
       cart_items: [{
         data: $input
       }]
-    ) {
+    }) {
       cart {
         ...cart
       }

--- a/libs/cart/src/drivers/magento/queries/get-selected-shipping-method.ts
+++ b/libs/cart/src/drivers/magento/queries/get-selected-shipping-method.ts
@@ -5,8 +5,10 @@ import { selectedShippingMethodFragment } from './fragments';
 export const getSelectedShippingMethod = gql`
   query GetSelectedShippingMethod($cartId: String!) {
     cart(cart_id: $cartId) {
-      selected_shipping_method {
-        ...selectedShippingMethod
+      shipping_addresses {
+        selected_shipping_method {
+          ...selectedShippingMethod
+        }
       }
     }
   }

--- a/libs/cart/src/drivers/magento/queries/remove-cart-item.ts
+++ b/libs/cart/src/drivers/magento/queries/remove-cart-item.ts
@@ -3,11 +3,11 @@ import gql from 'graphql-tag';
 import { cartFragment } from './fragments';
 
 export const removeCartItem = gql`
-  mutation RemoveCartItem($cartId: String!, $itemId: MagentoCartItemInput!) {
-    removeItemFromCart(
+  mutation RemoveCartItem($cartId: String!, $itemId: Int!) {
+    removeItemFromCart(input: {
       cart_id: $cartId,
       cart_item_id: $itemId
-    ) {
+    }) {
       cart {
         ...cart
       }

--- a/libs/cart/src/drivers/magento/queries/set-guest-email.ts
+++ b/libs/cart/src/drivers/magento/queries/set-guest-email.ts
@@ -1,17 +1,14 @@
 import gql from 'graphql-tag';
 
-import { cartFragment } from './fragments';
-
 export const setGuestEmail = gql`
   mutation SetGuestEmail($cartId: String!, $email: String!) {
-    setGuestEmailOnCart(
+    setGuestEmailOnCart(input: {
       cart_id: $cartId,
       email: $email
-    ) {
+    }) {
       cart {
         email
       }
     }
   }
-  ${cartFragment}
 `;

--- a/libs/cart/src/drivers/magento/queries/set-selected-payment-method.ts
+++ b/libs/cart/src/drivers/magento/queries/set-selected-payment-method.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { cartFragment } from './fragments';
 
 export const setSelectedPaymentMethod = gql`
-  mutation SetSelectedPaymentMethod($cartId: String!, $payment: MagentoPaymentMethodInput!) {
+  mutation SetSelectedPaymentMethod($cartId: String!, $payment: PaymentMethodInput!) {
     setPaymentMethodOnCart(input: {
       cart_id: $cartId
       payment_method: $payment

--- a/libs/cart/src/drivers/magento/queries/set-selected-shipping-method.ts
+++ b/libs/cart/src/drivers/magento/queries/set-selected-shipping-method.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { cartFragment } from './fragments';
 
 export const setSelectedShippingMethod = gql`
-  mutation SetSelectedShippingMethod($cartId: String!, $method: MagentoShippingMethodInput!) {
+  mutation SetSelectedShippingMethod($cartId: String!, $method: ShippingMethodInput!) {
     setShippingMethodsOnCart(input: {
       cart_id: $cartId
       shipping_methods: [$method]

--- a/libs/cart/src/drivers/magento/queries/update-billing-address.ts
+++ b/libs/cart/src/drivers/magento/queries/update-billing-address.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { cartFragment } from './fragments';
 
 export const updateBillingAddress = gql`
-  mutation UpdateBillingAddress($cartId: String!, $address: MagentoBillingAddressInput!) {
+  mutation UpdateBillingAddress($cartId: String!, $address: BillingAddressInput!) {
     setBillingAddressOnCart(input: {
       cart_id: $cartId
       billing_address: $address

--- a/libs/cart/src/drivers/magento/queries/update-cart-item.ts
+++ b/libs/cart/src/drivers/magento/queries/update-cart-item.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { cartFragment } from './fragments';
 
 export const updateCartItem = gql`
-  mutation UpdateCartItem($cartId: String!, $input: MagentoCartItemInput!) {
+  mutation UpdateCartItem($cartId: String!, $input: CartItemUpdateInput!) {
     updateCartItems(input: {
       cart_id: $cartId
       cart_items: [$input]

--- a/libs/cart/src/drivers/magento/queries/update-shipping-address.ts
+++ b/libs/cart/src/drivers/magento/queries/update-shipping-address.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { cartFragment } from './fragments';
 
 export const updateShippingAddress = gql`
-  mutation UpdateShippingAddress($cartId: String!, $address: MagentoShippingAddressInput!) {
+  mutation UpdateShippingAddress($cartId: String!, $address: ShippingAddressInput!) {
     setShippingAddressesOnCart(input: {
       cart_id: $cartId
       shipping_addresses: [$address]

--- a/libs/cart/src/drivers/magento/transforms/outputs/billing-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/billing-address.service.spec.ts
@@ -61,5 +61,15 @@ describe('Driver | Magento | Cart | Transformer | MagentoBillingAddress', () => 
     it('should call the cart address transformer with the address', () => {
       expect(cartAddressTransformerSpy.transform).toHaveBeenCalledWith(mockMagentoBillingAddress);
     });
+
+    describe('when the argument is null', () => {
+      beforeEach(() => {
+        transformedBillingAddress = service.transform(null);
+      });
+
+      it('should return null and not throw an error', () => {
+        expect(transformedBillingAddress).toBeNull();
+      });
+    });
   });
 });

--- a/libs/cart/src/drivers/magento/transforms/outputs/billing-address.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/billing-address.service.ts
@@ -20,9 +20,9 @@ export class DaffMagentoBillingAddressTransformer {
    * @param address the address from a magento cart query.
    */
   transform(address: MagentoCartAddress): DaffCartAddress {
-    return {
+    return address ? {
       ...this.addressTransformer.transform(address),
       address_type: 'billing',
-    }
+    } : null
   }
 }

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-address.service.spec.ts
@@ -58,5 +58,15 @@ describe('Driver | Magento | Cart | Transformer | MagentoCartAddress', () => {
     it('should set magento_address', () => {
       expect(transformedCartAddress.magento_address).toEqual(mockMagentoCartAddress);
     });
+
+    describe('when the argument is null', () => {
+      beforeEach(() => {
+        transformedCartAddress = service.transform(null);
+      });
+
+      it('should return null and not throw an error', () => {
+        expect(transformedCartAddress).toBeNull();
+      });
+    });
   });
 });

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-address.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-address.service.ts
@@ -15,7 +15,7 @@ export class DaffMagentoCartAddressTransformer {
    * @param address the address from a magento cart query.
    */
   transform(address: MagentoCartAddress): DaffCartAddress {
-    return {
+    return address ? {
       ...{magento_address: address},
 
       // address
@@ -39,6 +39,6 @@ export class DaffMagentoCartAddressTransformer {
       middlename: null,
       prefix: null,
       address_type: null,
-    }
+    } : null
   }
 }

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-item.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-item.service.spec.ts
@@ -63,5 +63,15 @@ describe('Driver | Magento | Cart | Transformer | MagentoCartItem', () => {
     it('should set magento_cart_item', () => {
       expect(transformedCartItem.magento_cart_item).toEqual(mockMagentoCartItem);
     });
-  })
+
+    describe('when the argument is null', () => {
+      beforeEach(() => {
+        transformedCartItem = service.transform(null);
+      });
+
+      it('should return null and not throw an error', () => {
+        expect(transformedCartItem).toBeNull();
+      });
+    });
+  });
 });

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-item.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-item.service.ts
@@ -16,7 +16,7 @@ export class DaffMagentoCartItemTransformer {
    * @param response the response from a magento cart query.
    */
   transform(cartItem: MagentoCartItem): DaffCartItem {
-    return {
+    return cartItem ? {
       ...{magento_cart_item: cartItem},
 
       // base
@@ -31,6 +31,6 @@ export class DaffMagentoCartItemTransformer {
 
       // TODO: implement
       parent_item_id: 0
-    }
+    } : null
   }
 }

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-payment.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-payment.service.spec.ts
@@ -49,6 +49,16 @@ describe('Driver | Magento | Cart | Transformer | MagentoCartPayment', () => {
 
     it('should set magento_payment_method', () => {
       expect(transformedCartPayment.magento_payment_method).toEqual(mockMagentoPaymentMethod);
-    })
+    });
+
+    describe('when the argument is null', () => {
+      beforeEach(() => {
+        transformedCartPayment = service.transform(null);
+      });
+
+      it('should return null and not throw an error', () => {
+        expect(transformedCartPayment).toBeNull();
+      });
+    });
   });
 });

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-payment.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-payment.service.ts
@@ -16,10 +16,10 @@ export class DaffMagentoCartPaymentTransformer {
    * @param response the response from a magento cart query.
    */
   transform(responsePayment: MagentoCartPaymentMethod): DaffCartPaymentMethod {
-    return {
+    return responsePayment ? {
       ...{magento_payment_method: responsePayment},
 
       method: responsePayment.code
-    }
+    } : null
   }
 }

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-shipping-information.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-shipping-information.service.spec.ts
@@ -65,5 +65,15 @@ describe('Driver | Magento | Cart | Transformer | MagentoShippingInformation', (
     it('should call the cart shipping rate transformer with the address', () => {
       expect(cartShippingRateTransformerSpy.transform).toHaveBeenCalledWith(mockMagentoShippingMethod);
     });
+
+    describe('when the argument is null', () => {
+      beforeEach(() => {
+        transformedShippingInformation = service.transform(null);
+      });
+
+      it('should return null and not throw an error', () => {
+        expect(transformedShippingInformation).toBeNull();
+      });
+    });
   })
 });

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-shipping-information.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-shipping-information.service.ts
@@ -17,10 +17,10 @@ export class DaffMagentoCartShippingInformationTransformer {
    * @param shippingMethod the shippingMethod from a magento cart query.
    */
   transform(shippingMethod: MagentoCartShippingMethod): DaffCartShippingInformation {
-    return {
+    return shippingMethod ? {
       ...this.shippingRateTransformer.transform(shippingMethod),
       // TODO: implement
       address_id: 0
-    }
+    } : null
   }
 }

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-shipping-rate.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-shipping-rate.service.spec.ts
@@ -54,5 +54,15 @@ describe('Driver | Magento | Cart | Transformer | MagentoCartShippingRate', () =
     it('should set magento_shipping_method', () => {
       expect(transformedCartShippingRate.magento_shipping_method).toEqual(mockMagentoShippingMethod);
     });
+
+    describe('when the argument is null', () => {
+      beforeEach(() => {
+        transformedCartShippingRate = service.transform(null);
+      });
+
+      it('should return null and not throw an error', () => {
+        expect(transformedCartShippingRate).toBeNull();
+      });
+    });
   });
 });

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-shipping-rate.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-shipping-rate.service.ts
@@ -15,7 +15,7 @@ export class DaffMagentoCartShippingRateTransformer {
    * @param shippingMethod the shippingMethod from a magento cart query.
    */
   transform(shippingMethod: MagentoCartShippingMethod): DaffCartShippingRate {
-    return {
+    return shippingMethod ? {
       ...{magento_shipping_method: shippingMethod},
 
       carrier: shippingMethod.carrier_code,
@@ -27,6 +27,6 @@ export class DaffMagentoCartShippingRateTransformer {
       // TODO: implement
       id: null,
       method_description: null
-    }
+    } : null
   }
 }

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart.service.spec.ts
@@ -9,7 +9,8 @@ import {
   DaffCartFactory,
   MagentoShippingAddressFactory,
   MagentoCartItemFactory,
-  MagentoCartAddressFactory
+  MagentoCartAddressFactory,
+  MagentoCartShippingMethodFactory
 } from '@daffodil/cart/testing';
 
 import { DaffMagentoCartTransformer } from './cart.service';
@@ -32,6 +33,7 @@ describe('Driver | Magento | Cart | Transformer | MagentoCart', () => {
   let magentoShippingAddressFactory: MagentoShippingAddressFactory;
   let magentoCartAddressFactory: MagentoCartAddressFactory;
   let magentoCartItemFactory: MagentoCartItemFactory;
+  let magentoShippingMethodFactory: MagentoCartShippingMethodFactory;
 
   let mockDaffCart: DaffCart;
   let mockMagentoCart;
@@ -86,6 +88,7 @@ describe('Driver | Magento | Cart | Transformer | MagentoCart', () => {
     magentoShippingAddressFactory = TestBed.get(MagentoShippingAddressFactory);
     magentoCartAddressFactory = TestBed.get(MagentoCartAddressFactory);
     magentoCartItemFactory = TestBed.get(MagentoCartItemFactory);
+    magentoShippingMethodFactory = TestBed.get(MagentoCartShippingMethodFactory);
 
     cartItemTransformerSpy = TestBed.get(DaffMagentoCartItemTransformer);
     cartAddressTransformerSpy = TestBed.get(DaffMagentoCartAddressTransformer);
@@ -105,11 +108,13 @@ describe('Driver | Magento | Cart | Transformer | MagentoCart', () => {
       email: mockMagentoCart.email
     };
     mockCartItem = magentoCartItemFactory.create();
+    mockShippingMethod = magentoShippingMethodFactory.create();
     mockMagentoCart.shipping_addresses = [mockShippingAddress];
     mockMagentoCart.billing_address = mockBillingAddress;
     mockMagentoCart.items = [mockCartItem];
     mockPaymentMethod = mockMagentoCart.selected_payment_method;
-    mockShippingMethod = mockShippingAddress.selected_shipping_method;
+    mockShippingAddress.selected_shipping_method = mockShippingMethod;
+    mockShippingAddress.available_shipping_methods = [mockShippingMethod];
 
     cartItemTransformerSpy.transform.withArgs(mockCartItem).and.returnValue(mockDaffCart.items[0]);
     cartAddressTransformerSpy.transform.withArgs(mockBillingAddress).and.returnValue(mockDaffCart.billing_address);
@@ -125,62 +130,96 @@ describe('Driver | Magento | Cart | Transformer | MagentoCart', () => {
 
   describe('transform | transforming a cart', () => {
     let transformedCart;
-    let id;
-    let subtotal;
-    let grand_total;
 
-    beforeEach(() => {
-      id = 5;
-      subtotal = 20;
-      grand_total = 20.20;
+    describe('when the cart has all its fields defined', () => {
+      let id;
+      let subtotal;
+      let grand_total;
 
-      mockMagentoCart.id = id;
-      mockMagentoCart.prices.subtotal_excluding_tax.value = subtotal;
-      mockMagentoCart.prices.grand_total.value = grand_total;
+      beforeEach(() => {
+        id = 5;
+        subtotal = 20;
+        grand_total = 20.20;
 
-      transformedCart = service.transform(mockMagentoCart);
+        mockMagentoCart.id = id;
+        mockMagentoCart.prices.subtotal_excluding_tax.value = subtotal;
+        mockMagentoCart.prices.grand_total.value = grand_total;
+
+        transformedCart = service.transform(mockMagentoCart);
+      });
+
+      it('should return an object with the correct values', () => {
+        expect(String(transformedCart.id)).toEqual(String(id));
+        expect(transformedCart.subtotal).toEqual(subtotal);
+        expect(transformedCart.grand_total).toEqual(grand_total);
+      });
+
+      it('should call the cart address transformer with the billing address', () => {
+        expect(cartAddressTransformerSpy.transform).toHaveBeenCalledWith(mockBillingAddress);
+      });
+
+      it('should call the shipping address transformer with the shipping address', () => {
+        expect(shippingAddressTransformerSpy.transform).toHaveBeenCalledWith(jasmine.objectContaining({
+          email: mockShippingAddress.email,
+          street: mockShippingAddress.street,
+          region: mockShippingAddress.region,
+        }));
+      });
+
+      it('should call the cart item transformer with the cart item', () => {
+        expect(cartItemTransformerSpy.transform).toHaveBeenCalledWith(mockCartItem);
+      });
+
+      it('should call the shipping information transformer with the shipping method', () => {
+        expect(cartShippingInformationTransformerSpy.transform).toHaveBeenCalledWith(mockShippingMethod);
+      });
+
+      it('should call the shipping rate transformer with each of the available shipping methods', () => {
+        mockShippingAddress.available_shipping_methods.forEach(method => {
+          expect(cartShippingRateTransformerSpy.transform).toHaveBeenCalledWith(method);
+        });
+      });
+
+      it('should call the cart payment transformer with the payment method', () => {
+        expect(cartPaymentTransformerSpy.transform).toHaveBeenCalledWith(mockPaymentMethod);
+      });
+
+      it('should call the cart address transformer with the billing address', () => {
+        expect(cartAddressTransformerSpy.transform).toHaveBeenCalledWith(mockBillingAddress);
+      });
+
+      it('should call the shipping address transformer with the shipping address', () => {
+        expect(shippingAddressTransformerSpy.transform).toHaveBeenCalledWith(mockShippingAddress);
+      });
+
+      it('should set the magento_cart field', () => {
+        expect(transformedCart.magento_cart).toEqual(mockMagentoCart);
+      });
     });
 
-    it('should return an object with the correct values', () => {
-      expect(String(transformedCart.id)).toEqual(String(id));
-      expect(transformedCart.subtotal).toEqual(subtotal);
-      expect(transformedCart.grand_total).toEqual(grand_total);
-    });
+    describe('when the cart has empty and uninitialized fields', () => {
+      beforeEach(() => {
+        mockMagentoCart.shipping_addresses = [];
+        mockMagentoCart.billing_address = null;
 
-    it('should call the cart address transformer with the billing address', () => {
-      expect(cartAddressTransformerSpy.transform).toHaveBeenCalledWith(mockBillingAddress);
-    });
+        transformedCart = service.transform(mockMagentoCart);
+      });
 
-    it('should call the shipping address transformer with the shipping address', () => {
-      expect(shippingAddressTransformerSpy.transform).toHaveBeenCalledWith(jasmine.objectContaining({
-        email: mockShippingAddress.email,
-        street: mockShippingAddress.street,
-        region: mockShippingAddress.region,
-      }));
-    });
+      it('should not call the cart address transformer', () => {
+        expect(cartAddressTransformerSpy.transform).not.toHaveBeenCalled();
+      });
 
-    it('should call the cart item transformer with the cart item', () => {
-      expect(cartItemTransformerSpy.transform).toHaveBeenCalledWith(mockCartItem);
-    });
+      it('should not call the shipping address transformer', () => {
+        expect(shippingAddressTransformerSpy.transform).not.toHaveBeenCalled();
+      });
 
-    it('should call the shipping information transformer with the shipping method', () => {
-      expect(cartShippingInformationTransformerSpy.transform).toHaveBeenCalledWith(mockShippingMethod);
-    });
+      it('should not call the shipping information transformer', () => {
+        expect(cartShippingInformationTransformerSpy.transform).not.toHaveBeenCalled();
+      });
 
-    it('should call the cart payment transformer with the payment method', () => {
-      expect(cartPaymentTransformerSpy.transform).toHaveBeenCalledWith(mockPaymentMethod);
-    });
-
-    it('should call the cart address transformer with the billing address', () => {
-      expect(cartAddressTransformerSpy.transform).toHaveBeenCalledWith(mockBillingAddress);
-    });
-
-    it('should call the shipping address transformer with the shipping address', () => {
-      expect(shippingAddressTransformerSpy.transform).toHaveBeenCalledWith(mockShippingAddress);
-    });
-
-    it('should set the magento_cart field', () => {
-      expect(transformedCart.magento_cart).toEqual(mockMagentoCart);
+      it('should not call the shipping rate transformer', () => {
+        expect(cartShippingRateTransformerSpy.transform).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart.service.spec.ts
@@ -197,28 +197,13 @@ describe('Driver | Magento | Cart | Transformer | MagentoCart', () => {
       });
     });
 
-    describe('when the cart has empty and uninitialized fields', () => {
+    describe('when the argument is null', () => {
       beforeEach(() => {
-        mockMagentoCart.shipping_addresses = [];
-        mockMagentoCart.billing_address = null;
-
-        transformedCart = service.transform(mockMagentoCart);
+        transformedCart = service.transform(null);
       });
 
-      it('should not call the cart address transformer', () => {
-        expect(cartAddressTransformerSpy.transform).not.toHaveBeenCalled();
-      });
-
-      it('should not call the shipping address transformer', () => {
-        expect(shippingAddressTransformerSpy.transform).not.toHaveBeenCalled();
-      });
-
-      it('should not call the shipping information transformer', () => {
-        expect(cartShippingInformationTransformerSpy.transform).not.toHaveBeenCalled();
-      });
-
-      it('should not call the shipping rate transformer', () => {
-        expect(cartShippingRateTransformerSpy.transform).not.toHaveBeenCalled();
+      it('should return null and not throw an error', () => {
+        expect(transformedCart).toBeNull();
       });
     });
   });

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart.service.ts
@@ -27,19 +27,23 @@ export class DaffMagentoCartTransformer {
 
   private transformShippingAddress(cart: MagentoCart): {shipping_address: DaffCart['shipping_address']} {
     return {
-      shipping_address: this.shippingAddressTransformer.transform({
-        ...cart.shipping_addresses[0],
-        email: cart.email
-      })
+      shipping_address: cart.shipping_addresses.length > 0
+        ? this.shippingAddressTransformer.transform({
+          ...cart.shipping_addresses[0],
+          email: cart.email
+        })
+        : null
     }
   }
 
   private transformBillingAddress(cart: MagentoCart): {billing_address: DaffCart['billing_address']} {
     return {
-      billing_address: this.billingAddressTransformer.transform({
-        ...cart.billing_address,
-        email: cart.email
-      }),
+      billing_address: cart.billing_address
+        ? this.billingAddressTransformer.transform({
+          ...cart.billing_address,
+          email: cart.email
+        })
+        : null
     }
   }
 
@@ -89,11 +93,13 @@ export class DaffMagentoCartTransformer {
   private transformCoupons(cart: MagentoCart): {coupons: DaffCart['coupons']} {
     return {
       // TODO: extract into separate transformer
-      coupons: cart.applied_coupons.map(({code}) => ({
-        coupon_id: 0,
-        code,
-        description: ''
-      })),
+      coupons: cart.applied_coupons
+        ? cart.applied_coupons.map(({code}) => ({
+          coupon_id: 0,
+          code,
+          description: ''
+        }))
+        : []
     }
   }
 
@@ -105,15 +111,19 @@ export class DaffMagentoCartTransformer {
 
   private transformShippingInformation(cart: MagentoCart): {shipping_information: DaffCart['shipping_information']} {
     return {
-      shipping_information: this.shippingInformationTransformer.transform(cart.shipping_addresses[0].selected_shipping_method),
+      shipping_information: cart.shipping_addresses.length > 0 && cart.shipping_addresses[0].selected_shipping_method
+        ? this.shippingInformationTransformer.transform(cart.shipping_addresses[0].selected_shipping_method)
+        : null
     }
   }
 
   private transformShippingMethods(cart: MagentoCart): {available_shipping_methods: DaffCart['available_shipping_methods']} {
     return {
-      available_shipping_methods: cart.shipping_addresses[0].available_shipping_methods.map(method =>
-        this.shippingRateTransformer.transform(method)
-      )
+      available_shipping_methods: cart.shipping_addresses.length > 0
+        ? cart.shipping_addresses[0].available_shipping_methods.map(method =>
+          this.shippingRateTransformer.transform(method)
+        )
+        : []
     }
   }
 

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart.service.ts
@@ -27,23 +27,19 @@ export class DaffMagentoCartTransformer {
 
   private transformShippingAddress(cart: MagentoCart): {shipping_address: DaffCart['shipping_address']} {
     return {
-      shipping_address: cart.shipping_addresses.length > 0
-        ? this.shippingAddressTransformer.transform({
-          ...cart.shipping_addresses[0],
-          email: cart.email
-        })
-        : null
+      shipping_address: this.shippingAddressTransformer.transform({
+        ...cart.shipping_addresses[0],
+        email: cart.email
+      })
     }
   }
 
   private transformBillingAddress(cart: MagentoCart): {billing_address: DaffCart['billing_address']} {
     return {
-      billing_address: cart.billing_address
-        ? this.billingAddressTransformer.transform({
-          ...cart.billing_address,
-          email: cart.email
-        })
-        : null
+      billing_address: this.billingAddressTransformer.transform({
+        ...cart.billing_address,
+        email: cart.email
+      })
     }
   }
 
@@ -111,19 +107,15 @@ export class DaffMagentoCartTransformer {
 
   private transformShippingInformation(cart: MagentoCart): {shipping_information: DaffCart['shipping_information']} {
     return {
-      shipping_information: cart.shipping_addresses.length > 0 && cart.shipping_addresses[0].selected_shipping_method
-        ? this.shippingInformationTransformer.transform(cart.shipping_addresses[0].selected_shipping_method)
-        : null
+      shipping_information: this.shippingInformationTransformer.transform(cart.shipping_addresses[0].selected_shipping_method)
     }
   }
 
   private transformShippingMethods(cart: MagentoCart): {available_shipping_methods: DaffCart['available_shipping_methods']} {
     return {
-      available_shipping_methods: cart.shipping_addresses.length > 0
-        ? cart.shipping_addresses[0].available_shipping_methods.map(method =>
-          this.shippingRateTransformer.transform(method)
-        )
-        : []
+      available_shipping_methods: cart.shipping_addresses[0].available_shipping_methods.map(method =>
+        this.shippingRateTransformer.transform(method)
+      )
     }
   }
 
@@ -140,7 +132,7 @@ export class DaffMagentoCartTransformer {
    * @param cart the cart from a magento cart query.
    */
   transform(cart: MagentoCart): DaffCart {
-    return {
+    return cart ? {
       // add the magento cart in this way to avoid 'object literal may only specify known proerties'
       ...{magento_cart: cart},
 
@@ -156,6 +148,6 @@ export class DaffMagentoCartTransformer {
       ...this.transformPaymentMethods(cart),
 
       id: cart.id
-    }
+    } : null
   }
 }

--- a/libs/cart/src/drivers/magento/transforms/outputs/shipping-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/shipping-address.service.spec.ts
@@ -61,5 +61,15 @@ describe('Driver | Magento | Cart | Transformer | MagentoShippingAddress', () =>
     it('should call the cart address transformer with the address', () => {
       expect(cartAddressTransformerSpy.transform).toHaveBeenCalledWith(mockMagentoShippingAddress);
     });
+
+    describe('when the argument is null', () => {
+      beforeEach(() => {
+        transformedShippingAddress = service.transform(null);
+      });
+
+      it('should return null and not throw an error', () => {
+        expect(transformedShippingAddress).toBeNull();
+      });
+    });
   });
 });

--- a/libs/cart/src/drivers/magento/transforms/outputs/shipping-address.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/shipping-address.service.ts
@@ -18,9 +18,9 @@ export class DaffMagentoShippingAddressTransformer {
    * @param address the address from a magento cart query.
    */
   transform(address: MagentoShippingAddress): DaffCartAddress {
-    return {
+    return address ? {
       ...this.addressTransformer.transform(address),
       address_type: 'shipping',
-    }
+    } : null
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Magento responses that contain null or empty fields will cause the transformers to throw when passed
- Queries use incorrect parameters

## What is the new behavior?
- The drivers and cart transformer will check for `null` and `[]` responses and return `null` without invoking the transformer
- Queries now use the correct parameters

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information