### PR TITLE
bug(category): fix bug where effects layer canceled category calls wi…

### DIFF
--- a/libs/category/src/effects/category.effects.ts
+++ b/libs/category/src/effects/category.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { switchMap, catchError, withLatestFrom } from 'rxjs/operators';
+import { switchMap, catchError, withLatestFrom, mergeMap } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
 import { Store, select } from '@ngrx/store';
 
@@ -42,7 +42,7 @@ export class DaffCategoryEffects {
   @Effect()
   loadCategory$ : Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.CategoryLoadAction),
-    switchMap((action: DaffCategoryLoad) => this.processCategoryGetRequest(action.request))
+    mergeMap((action: DaffCategoryLoad) => this.processCategoryGetRequest(action.request))
   )
 
   @Effect()


### PR DESCRIPTION
…th a switchMap

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When a user makes multiple category calls (for a category previews for example), the switchMap in the effects layer cancels all but the most recent action stream.

## What is the new behavior?
SwitchMap was swapped with mergeMap, so all action streams are preserved. This is ok, because they are all read requests.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
I didn't add a test, because there was no change to business logic.