### PR TITLE
feat(category): add a productsLoading state to category for when a fu…

### DIFF
--- a/libs/category/src/actions/category.actions.ts
+++ b/libs/category/src/actions/category.actions.ts
@@ -112,7 +112,8 @@ export type DaffCategoryActions =
   | DaffCategoryLoad
   | DaffCategoryLoadSuccess
   | DaffCategoryLoadFailure
-  | DaffChangeCategoryPageSize
+	| DaffChangeCategoryPageSize
+	| DaffChangeCategoryCurrentPage
   | DaffChangeCategorySortingOption
   | DaffChangeCategoryFilters
   | DaffToggleCategoryFilter;

--- a/libs/category/src/effects/category.effects.spec.ts
+++ b/libs/category/src/effects/category.effects.spec.ts
@@ -108,7 +108,7 @@ describe('DaffCategoryEffects', () => {
   describe('processCategoryGetRequest', () => {
     
     let expected;
-    const categoryLoadAction = new DaffCategoryLoad(categoryId);
+    const categoryLoadAction = new DaffCategoryLoad({id: categoryId});
     
     describe('when the call to CategoryService is successful', () => {
 
@@ -153,25 +153,25 @@ describe('DaffCategoryEffects', () => {
 
       expect(daffCategoryDriver.get).toHaveBeenCalledWith({ id: categoryId });
     });
-  });
+	});
 
   describe('when ChangeCategoryPageSize action is triggered', () => {
 
     let expected;
     
-    it('should dispatch a category load with an id, page size, applied filters, and an applied sort option', () => {
+    it('should call get category with an id, page size, applied filters, and an applied sort option', () => {
       const changeCategoryPageSizeAction = new DaffChangeCategoryPageSize(3);
       actions$ = hot('--a', { a: changeCategoryPageSizeAction });
       
-			const categoryLoadAction = new DaffCategoryLoad({ 
+      expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
+			expect(effects.changeCategoryPageSize$).toBeObservable(expected);
+      expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
         id: categoryId,
 				page_size: 3,
 				applied_filters: stubCategoryPageConfigurationState.applied_filters,
 				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
 				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction
       });
-			expected = cold('--(a)', { a: categoryLoadAction });
-      expect(effects.changeCategoryPageSize$).toBeObservable(expected);
     });
   });
 
@@ -179,11 +179,13 @@ describe('DaffCategoryEffects', () => {
 
     let expected;
     
-    it('should dispatch a category load with every available parameter', () => {
+    it('should call get category with every available parameter', () => {
       const changeCategoryCurrentPageAction = new DaffChangeCategoryCurrentPage(3);
       actions$ = hot('--a', { a: changeCategoryCurrentPageAction });
 			
-			const categoryLoadAction = new DaffCategoryLoad({ 
+			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
+			expect(effects.changeCategoryCurrentPage$).toBeObservable(expected);
+			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
         id: categoryId,
         page_size: stubCategoryPageConfigurationState.page_size,
 				current_page: 3,
@@ -191,8 +193,6 @@ describe('DaffCategoryEffects', () => {
 				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
 				applied_filters: stubCategoryPageConfigurationState.applied_filters
       });
-      expected = cold('--(a)', { a: categoryLoadAction });
-      expect(effects.changeCategoryCurrentPage$).toBeObservable(expected);
     });
   });
 
@@ -200,7 +200,7 @@ describe('DaffCategoryEffects', () => {
 
     let expected;
     
-    it('should dispatch a category load with an id, page size, applied filters, and an applied sorting option', () => {
+    it('should call get category with an id, page size, applied filters, and an applied sorting option', () => {
       const changeCategoryFiltersAction = new DaffChangeCategoryFilters([{
 				name: 'name',
 				action: DaffCategoryFilterActionEnum.Equal,
@@ -208,7 +208,9 @@ describe('DaffCategoryEffects', () => {
 			}]);
       actions$ = hot('--a', { a: changeCategoryFiltersAction });
 			
-			const categoryLoadAction = new DaffCategoryLoad({ 
+			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
+			expect(effects.changeCategoryFilters$).toBeObservable(expected);
+			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
 				id: categoryId,
         page_size: stubCategoryPageConfigurationState.page_size,
 				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
@@ -219,8 +221,6 @@ describe('DaffCategoryEffects', () => {
 					value: 'value'
 				}]
       });
-      expected = cold('--(a)', { a: categoryLoadAction });
-      expect(effects.changeCategoryFilters$).toBeObservable(expected);
     });
   });
 
@@ -250,18 +250,12 @@ describe('DaffCategoryEffects', () => {
 				store.overrideSelector(selectCategoryPageAppliedFilters, []);
 			});
 			
-			it('should dispatch a category load with the toggled filter', () => {
+			it('should dispatch a DaffChangeCategoryFilters action with the toggled filter', () => {
 				const toggleCategoryFilterAction = new DaffToggleCategoryFilter(newFilter);
 				actions$ = hot('--a', { a: toggleCategoryFilterAction });
 				
-				const categoryLoadAction = new DaffCategoryLoad({ 
-					id: categoryId,
-					page_size: stubCategoryPageConfigurationState.page_size,
-					applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
-					applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
-					applied_filters: [newFilter]
-				});
-				expected = cold('--(a)', { a: categoryLoadAction });
+				const changeCategoryFilters = new DaffChangeCategoryFilters([newFilter]);
+				expected = cold('--(a)', { a: changeCategoryFilters });
 				expect(effects.toggleCategoryFilter$).toBeObservable(expected);
 			});
 		});
@@ -272,18 +266,12 @@ describe('DaffCategoryEffects', () => {
 				store.overrideSelector(selectCategoryPageAppliedFilters, [existingFilter]);
 			});
 			
-			it('should not dispatch a category load with the toggled filter', () => {
+			it('should dispatch a DaffChangeCategoryFilters action without the toggled filter', () => {
 				const toggleCategoryFilterAction = new DaffToggleCategoryFilter(newFilter);
 				actions$ = hot('--a', { a: toggleCategoryFilterAction });
 				
-				const categoryLoadAction = new DaffCategoryLoad({ 
-					id: categoryId,
-					page_size: stubCategoryPageConfigurationState.page_size,
-					applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
-					applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
-					applied_filters: []
-				});
-				expected = cold('--(a)', { a: categoryLoadAction });
+				const changeCategoryFilters = new DaffChangeCategoryFilters([]);
+				expected = cold('--(a)', { a: changeCategoryFilters });
 				expect(effects.toggleCategoryFilter$).toBeObservable(expected);
 			});
 		});
@@ -293,22 +281,22 @@ describe('DaffCategoryEffects', () => {
 
     let expected;
     
-    it('should dispatch a category load with an id, page size, applied filters, and an applied sorting option', () => {
+    it('should call get category with an id, page size, applied filters, and an applied sorting option', () => {
       const changeCategorySortingOption = new DaffChangeCategorySortingOption({
 				option: 'option',
 				direction: DaffSortDirectionEnum.Ascending
 			});
       actions$ = hot('--a', { a: changeCategorySortingOption });
 			
-			const categoryLoadAction = new DaffCategoryLoad({ 
+			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
+			expect(effects.changeCategorySort$).toBeObservable(expected);
+			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
 				id: categoryId,
         page_size: stubCategoryPageConfigurationState.page_size,
 				applied_sort_direction: DaffSortDirectionEnum.Ascending,
 				applied_sort_option: 'option',
 				applied_filters: stubCategoryPageConfigurationState.applied_filters
       });
-      expected = cold('--(a)', { a: categoryLoadAction });
-      expect(effects.changeCategorySort$).toBeObservable(expected);
     });
   });
 });

--- a/libs/category/src/effects/category.effects.ts
+++ b/libs/category/src/effects/category.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { switchMap, catchError, withLatestFrom, mergeMap, concatMap } from 'rxjs/operators';
+import { switchMap, catchError, withLatestFrom } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
 import { Store, select } from '@ngrx/store';
 
@@ -42,7 +42,7 @@ export class DaffCategoryEffects {
   @Effect()
   loadCategory$ : Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.CategoryLoadAction),
-    mergeMap((action: DaffCategoryLoad) => this.processCategoryGetRequest(action.request))
+    switchMap((action: DaffCategoryLoad) => this.processCategoryGetRequest(action.request))
   )
 
   @Effect()
@@ -54,7 +54,7 @@ export class DaffCategoryEffects {
       this.store.pipe(select(selectCategoryPageAppliedSortOption)),
       this.store.pipe(select(selectCategoryPageAppliedSortDirection))
 		),
-    mergeMap((
+    switchMap((
 			[action, categoryId, appliedFilters, appliedSortOption, appliedSortDirection]: 
 			[DaffChangeCategoryPageSize, string, DaffCategoryFilterAction[], string, DaffSortDirectionEnum]
 		) => this.processCategoryGetRequest({
@@ -76,7 +76,7 @@ export class DaffCategoryEffects {
       this.store.pipe(select(selectCategoryPageAppliedSortOption)),
       this.store.pipe(select(selectCategoryPageAppliedSortDirection))
     ),
-    mergeMap((
+    switchMap((
 			[action, categoryId, pageSize, appliedFilters, appliedSortOption, appliedSortDirection]: 
 			[DaffChangeCategoryCurrentPage, string, number, DaffCategoryFilterAction[], string, DaffSortDirectionEnum]
 		) => this.processCategoryGetRequest({
@@ -98,7 +98,7 @@ export class DaffCategoryEffects {
       this.store.pipe(select(selectCategoryPageAppliedSortOption)),
       this.store.pipe(select(selectCategoryPageAppliedSortDirection))
     ),
-    mergeMap((
+    switchMap((
 			[action, categoryId, pageSize, appliedSortOption, appliedSortDirection]: 
 			[DaffChangeCategoryFilters, string, number, string, DaffSortDirectionEnum]
 		) => this.processCategoryGetRequest({
@@ -116,7 +116,7 @@ export class DaffCategoryEffects {
     withLatestFrom(
       this.store.pipe(select(selectCategoryPageAppliedFilters))
     ),
-    mergeMap((
+    switchMap((
 			[action, appliedFilters]: 
 			[DaffToggleCategoryFilter, DaffCategoryFilterAction[]]
 		) => of(new DaffChangeCategoryFilters(this.toggleCategoryFilter(action.filter, appliedFilters))))
@@ -130,7 +130,7 @@ export class DaffCategoryEffects {
 			this.store.pipe(select(selectCategoryPageSize)),
       this.store.pipe(select(selectCategoryPageAppliedFilters))
     ),
-    mergeMap((
+    switchMap((
 			[action, categoryId, pageSize, appliedFilters]: 
 			[DaffChangeCategorySortingOption, string, number, DaffCategoryFilterAction[]]
 		) => this.processCategoryGetRequest({
@@ -159,7 +159,7 @@ export class DaffCategoryEffects {
 
   private processCategoryGetRequest(payload: DaffCategoryRequest) {
     return this.driver.get(payload).pipe(
-      concatMap((resp: DaffGetCategoryResponse) => [
+      switchMap((resp: DaffGetCategoryResponse) => [
         new DaffProductGridLoadSuccess(resp.products),
         new DaffCategoryLoadSuccess(resp)
       ]),

--- a/libs/category/src/facades/category.facade.spec.ts
+++ b/libs/category/src/facades/category.facade.spec.ts
@@ -212,16 +212,29 @@ describe('DaffCategoryFacade', () => {
     });
   });
 
-  describe('loading$', () => {
+  describe('categoryLoading$', () => {
     it('should be false if the category state is not loading', () => {
       const expected = cold('a', { a: false });
-      expect(facade.loading$).toBeObservable(expected);
+      expect(facade.categoryLoading$).toBeObservable(expected);
     });
   
     it('should be true if the category state is loading', () => {
       const expected = cold('a', { a: true });
       store.dispatch(new DaffCategoryLoad({ id: '1' }));
-      expect(facade.loading$).toBeObservable(expected);
+      expect(facade.categoryLoading$).toBeObservable(expected);
+    });
+  });
+
+  describe('productsLoading$', () => {
+    it('should be false if the category products are not loading', () => {
+      const expected = cold('a', { a: false });
+      expect(facade.productsLoading$).toBeObservable(expected);
+    });
+  
+    it('should be true if the category products are loading', () => {
+      const expected = cold('a', { a: true });
+      store.dispatch(new DaffCategoryLoad({ id: '1' }));
+      expect(facade.productsLoading$).toBeObservable(expected);
     });
   });
 

--- a/libs/category/src/facades/category.facade.ts
+++ b/libs/category/src/facades/category.facade.ts
@@ -24,7 +24,8 @@ import {
 	selectCategoryPageAppliedFilters,
 	selectCategoryPageAppliedSortOption,
 	selectCategoryPageAppliedSortDirection,
-	selectTotalProductsByCategory
+	selectTotalProductsByCategory,
+	selectCategoryProductsLoading
 } from '../selectors/category.selector';
 import { CategoryReducersState } from '../reducers/category-reducers.interface';
 import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
@@ -91,7 +92,11 @@ export class DaffCategoryFacade implements DaffStoreFacade<Action> {
   /**
    * The loading state for retrieving a single category.
    */
-  loading$: Observable<boolean>;
+  categoryLoading$: Observable<boolean>;
+  /**
+   * The loading state for retrieving only the products of the category.
+   */
+  productsLoading$: Observable<boolean>;
   /**
    * Errors associated with retrieving a single category.
    */
@@ -134,7 +139,8 @@ export class DaffCategoryFacade implements DaffStoreFacade<Action> {
     this.appliedFilters$ = this.store.pipe(select(selectCategoryPageAppliedFilters));
     this.appliedSortOption$ = this.store.pipe(select(selectCategoryPageAppliedSortOption));
     this.appliedSortDirection$ = this.store.pipe(select(selectCategoryPageAppliedSortDirection));
-    this.loading$ = this.store.pipe(select(selectCategoryLoading));
+    this.categoryLoading$ = this.store.pipe(select(selectCategoryLoading));
+    this.productsLoading$ = this.store.pipe(select(selectCategoryProductsLoading));
 		this.errors$ = this.store.pipe(select(selectCategoryErrors));
 	}
 

--- a/libs/category/src/reducers/category/category-reducer-state.interface.ts
+++ b/libs/category/src/reducers/category/category-reducer-state.interface.ts
@@ -2,6 +2,7 @@ import { DaffCategoryPageConfigurationState } from '../../models/category-page-c
 
 export interface CategoryReducerState {
   categoryPageConfigurationState: DaffCategoryPageConfigurationState,
-  loading: boolean,
+  categoryLoading: boolean,
+  productsLoading: boolean,
   errors: string[]
 }

--- a/libs/category/src/reducers/category/category.reducer.spec.ts
+++ b/libs/category/src/reducers/category/category.reducer.spec.ts
@@ -1,11 +1,12 @@
 import { DaffCategoryFactory, DaffCategoryPageConfigurationStateFactory } from '@daffodil/category/testing';
 
 import { CategoryReducerState } from './category-reducer-state.interface';
-import { DaffCategoryLoad, DaffCategoryLoadSuccess, DaffCategoryLoadFailure } from '../../actions/category.actions';
+import { DaffCategoryLoad, DaffCategoryLoadSuccess, DaffCategoryLoadFailure, DaffChangeCategoryPageSize, DaffChangeCategoryCurrentPage, DaffChangeCategorySortingOption, DaffChangeCategoryFilters, DaffToggleCategoryFilter } from '../../actions/category.actions';
 import { categoryReducer } from './category.reducer';
 import { DaffCategory } from '../../models/category';
 import { DaffCategoryPageConfigurationState } from '../../models/category-page-configuration-state';
-import { DaffCategoryRequest } from '../../models/requests/category-request';
+import { DaffCategoryRequest, DaffSortDirectionEnum } from '../../models/requests/category-request';
+import { DaffCategoryFilterActionEnum, DaffCategoryFilterAction } from '../../models/requests/filter-action';
 
 describe('Category | Category Reducer', () => {
 
@@ -28,7 +29,8 @@ describe('Category | Category Reducer', () => {
 			total_products: null,
 			product_ids: []
     },
-    loading: false,
+		categoryLoading: false,
+		productsLoading: false,
     errors: []
   };
 
@@ -70,8 +72,12 @@ describe('Category | Category Reducer', () => {
       result = categoryReducer(initialState, categoryLoadAction);
     });
 
-    it('sets loading state to true', () => {
-      expect(result.loading).toEqual(true);
+    it('sets categoryLoading state to true', () => {
+      expect(result.categoryLoading).toEqual(true);
+    });
+
+    it('sets productsLoading state to true', () => {
+      expect(result.productsLoading).toEqual(true);
     });
 
     it('sets the included parameters on categoryPageConfigurationState', () => {
@@ -99,6 +105,107 @@ describe('Category | Category Reducer', () => {
 		});
   });
 
+  describe('when ChangeCategoryPageSizeAction is triggered', () => {
+    let result;
+
+    beforeEach(() => {
+      const changeCategoryPageSize: DaffChangeCategoryPageSize = new DaffChangeCategoryPageSize(3);
+
+      result = categoryReducer(initialState, changeCategoryPageSize);
+    });
+
+    it('does not change the categoryLoading state', () => {
+      expect(result.categoryLoading).toEqual(false);
+    });
+
+    it('sets productsLoading state to true', () => {
+      expect(result.productsLoading).toEqual(true);
+		});
+		
+		it('should set the categoryPageConfigurationState page size', () => {
+			expect(result.categoryPageConfigurationState.page_size).toEqual(3);
+		});
+  });
+
+  describe('when ChangeCategoryCurrentPageAction is triggered', () => {
+    let result;
+
+    beforeEach(() => {
+      const changeCategoryCurrentPage: DaffChangeCategoryCurrentPage = new DaffChangeCategoryCurrentPage(3);
+
+      result = categoryReducer(initialState, changeCategoryCurrentPage);
+    });
+
+    it('does not change the categoryLoading state', () => {
+      expect(result.categoryLoading).toEqual(false);
+    });
+
+    it('sets productsLoading state to true', () => {
+      expect(result.productsLoading).toEqual(true);
+		});
+		
+		it('should set the categoryPageConfigurationState current page', () => {
+			expect(result.categoryPageConfigurationState.current_page).toEqual(3);
+		});
+  });
+
+  describe('when ChangeCategorySortingOptionAction is triggered', () => {
+    let result;
+
+    beforeEach(() => {
+      const changeCategorySortingOption: DaffChangeCategorySortingOption = new DaffChangeCategorySortingOption({
+				option: 'option',
+				direction: DaffSortDirectionEnum.Ascending
+			});
+
+      result = categoryReducer(initialState, changeCategorySortingOption);
+    });
+
+    it('does not change the categoryLoading state', () => {
+      expect(result.categoryLoading).toEqual(false);
+    });
+
+    it('sets productsLoading state to true', () => {
+      expect(result.productsLoading).toEqual(true);
+		});
+		
+		it('should set the categoryPageConfigurationState applied sort option', () => {
+			expect(result.categoryPageConfigurationState.applied_sort_option).toEqual('option');
+		});
+		
+		it('should set the categoryPageConfigurationState applied sort direction', () => {
+			expect(result.categoryPageConfigurationState.applied_sort_direction).toEqual(DaffSortDirectionEnum.Ascending);
+		});
+  });
+
+  describe('when ChangeCategoryFiltersAction is triggered', () => {
+    let result;
+		let expectedFilters: DaffCategoryFilterAction[];
+
+    beforeEach(() => {
+			expectedFilters = [{
+				action: DaffCategoryFilterActionEnum.Equal,
+				name: 'name',
+				value: 'value'
+			}];
+      const changeCategoryFilters: DaffChangeCategoryFilters = new DaffChangeCategoryFilters(expectedFilters);
+
+      result = categoryReducer(initialState, changeCategoryFilters);
+    });
+
+    it('does not change the categoryLoading state', () => {
+      expect(result.categoryLoading).toEqual(false);
+    });
+
+    it('sets productsLoading state to true', () => {
+      expect(result.productsLoading).toEqual(true);
+		});
+		
+		it('should set the categoryPageConfigurationState applied filters', () => {
+			expect(result.categoryPageConfigurationState.applied_filters).toEqual(expectedFilters);
+		});
+  });
+
   describe('when CategoryLoadSuccessAction is triggered', () => {
 
     let result: CategoryReducerState;
@@ -107,15 +214,20 @@ describe('Category | Category Reducer', () => {
     beforeEach(() => {
       state = {
         ...initialState,
-        loading: true
+        categoryLoading: true,
+        productsLoading: true,
       }
 
       const categoryLoadSuccess = new DaffCategoryLoadSuccess({ category: category, categoryPageConfigurationState: categoryPageConfigurationState, products: null });
       result = categoryReducer(state, categoryLoadSuccess);
     });
 
-    it('sets loading to false', () => {
-      expect(result.loading).toEqual(false);
+    it('sets categoryLoading to false', () => {
+      expect(result.categoryLoading).toEqual(false);
+    });
+
+    it('sets productsLoading to false', () => {
+      expect(result.productsLoading).toEqual(false);
     });
 
     it('sets categoryPageConfigurationState from the payload', () => {
@@ -132,7 +244,8 @@ describe('Category | Category Reducer', () => {
     beforeEach(() => {
       state = {
         ...initialState,
-        loading: true,
+        categoryLoading: true,
+        productsLoading: true,
         errors: new Array('firstError')
       }
 
@@ -141,8 +254,12 @@ describe('Category | Category Reducer', () => {
       result = categoryReducer(state, categoryLoadFailure);
     });
 
-    it('sets loading to false', () => {
-      expect(result.loading).toEqual(false);
+    it('sets categoryLoading to false', () => {
+      expect(result.categoryLoading).toEqual(false);
+    });
+
+    it('sets productsLoading to false', () => {
+      expect(result.productsLoading).toEqual(false);
     });
 
     it('adds an error to state.errors', () => {

--- a/libs/category/src/reducers/category/category.reducer.ts
+++ b/libs/category/src/reducers/category/category.reducer.ts
@@ -15,7 +15,8 @@ const initialState: CategoryReducerState = {
 		total_products: null,
 		product_ids: []
   },
-  loading: false,
+	categoryLoading: false,
+	productsLoading: false,
   errors: []
 };
 
@@ -29,18 +30,57 @@ export function categoryReducer(state = initialState, action: DaffCategoryAction
 			if(!action.request.applied_filters) action.request.applied_filters = [];
       return { 
         ...state, 
-        loading: true,
+				categoryLoading: true,
+				productsLoading: true,
         categoryPageConfigurationState: {
           ...state.categoryPageConfigurationState,
           ...action.request
         }
-      };
+			};
+		case DaffCategoryActionTypes.ChangeCategoryPageSizeAction:
+			return { 
+				...state, 
+				productsLoading: true,
+				categoryPageConfigurationState: {
+					...state.categoryPageConfigurationState,
+					page_size: action.pageSize
+				}
+			};
+		case DaffCategoryActionTypes.ChangeCategoryCurrentPageAction:
+			return { 
+				...state, 
+				productsLoading: true,
+				categoryPageConfigurationState: {
+					...state.categoryPageConfigurationState,
+					current_page: action.currentPage
+				}
+			};
+		case DaffCategoryActionTypes.ChangeCategorySortingOptionAction:
+			return { 
+				...state, 
+				productsLoading: true,
+				categoryPageConfigurationState: {
+					...state.categoryPageConfigurationState,
+					applied_sort_option: action.sort.option,
+					applied_sort_direction: action.sort.direction
+				}
+			};
+		case DaffCategoryActionTypes.ChangeCategoryFiltersAction:
+			return { 
+				...state, 
+				productsLoading: true,
+				categoryPageConfigurationState: {
+					...state.categoryPageConfigurationState,
+					applied_filters: action.filters
+				}
+			};
     // This reducer cannot spread over state, because this would wipe out the applied filters on state. Applied filters are not
     // set here for reasons stated above.
     case DaffCategoryActionTypes.CategoryLoadSuccessAction:
       return { 
         ...state, 
-        loading: false,
+				categoryLoading: false,
+				productsLoading: false,
         categoryPageConfigurationState: {
           ...state.categoryPageConfigurationState,
           id: action.response.categoryPageConfigurationState.id,
@@ -56,7 +96,8 @@ export function categoryReducer(state = initialState, action: DaffCategoryAction
     case DaffCategoryActionTypes.CategoryLoadFailureAction:
       return {
         ...state,
-        loading: false,
+				categoryLoading: false,
+				productsLoading: false,
         errors: [action.errorMessage]
       };
     default:

--- a/libs/category/src/selectors/category.selector.spec.ts
+++ b/libs/category/src/selectors/category.selector.spec.ts
@@ -31,7 +31,8 @@ import {
 	selectCategoryPageAppliedFilters,
 	selectCategoryPageAppliedSortOption,
 	selectCategoryPageAppliedSortDirection,
-	selectTotalProductsByCategory
+	selectTotalProductsByCategory,
+	selectCategoryProductsLoading
 } from './category.selector';
 import { CategoryReducersState } from '../reducers/category-reducers.interface';
 import { categoryReducers } from '../reducers/category-reducers';
@@ -74,7 +75,8 @@ describe('DaffCategorySelectors', () => {
     it('selects CategoryReducerState for category', () => {
       const expectedFeatureState = {
         categoryPageConfigurationState: stubCategoryPageConfigurationState,
-        loading: false,
+        categoryLoading: false,
+        productsLoading: false,
         errors: []
       }
       const selector = store.pipe(select(selectCategoryState));
@@ -195,6 +197,15 @@ describe('DaffCategorySelectors', () => {
 
     it('selects the loading state of the category', () => {
       const selector = store.pipe(select(selectCategoryLoading));
+      const expected = cold('a', { a: false });
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCategoryProductsLoading', () => {
+
+    it('selects the loading state of the category products', () => {
+      const selector = store.pipe(select(selectCategoryProductsLoading));
       const expected = cold('a', { a: false });
       expect(selector).toBeObservable(expected);
     });

--- a/libs/category/src/selectors/category.selector.ts
+++ b/libs/category/src/selectors/category.selector.ts
@@ -95,7 +95,15 @@ export const selectSelectedCategoryId = createSelector(
  */
 export const selectCategoryLoading = createSelector(
   selectCategoryState,
-  (state: CategoryReducerState) => state.loading
+  (state: CategoryReducerState) => state.categoryLoading
+);
+
+/**
+ * Category Products Loading State
+ */
+export const selectCategoryProductsLoading = createSelector(
+  selectCategoryState,
+  (state: CategoryReducerState) => state.productsLoading
 );
 
 /**


### PR DESCRIPTION
…ll category refresh is not needed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The entire category reloads for any category action.

## What is the new behavior?
The entire category only reloads when necessary. Otherwise there is now a state for when only the category products will change.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
I think I made the right call on the usage of mergeMap vs concatMap in the effects but take a look at that in particular. Another thing that wasn't quite as straightforward as I thought it would be is the `DaffToggleCategoryFilterAction`. It needs to dispatch the `DaffChangeCategoryFilters` action because the logic that actually toggles the filter would need to be done in both the reducer and the effects otherwise.