### PR TITLE
feat(cart): catch storage errors

### DIFF
--- a/libs/cart/src/actions/cart.actions.ts
+++ b/libs/cart/src/actions/cart.actions.ts
@@ -3,6 +3,7 @@ import { Action } from '@ngrx/store';
 import { DaffCart } from '../models/cart';
 
 export enum DaffCartActionTypes {
+  CartStorageFailureAction = '[DaffCart] Cart Storage Failure Action',
   CartLoadAction = '[DaffCart] Cart Load Action',
   CartLoadSuccessAction = '[DaffCart] Cart Load Success Action',
   CartLoadFailureAction = '[DaffCart] Cart Load Failure Action',
@@ -15,6 +16,10 @@ export enum DaffCartActionTypes {
   CartClearAction = '[DaffCart] Cart Reset Action',
   CartClearSuccessAction = '[DaffCart] Cart Reset Success Action',
   CartClearFailureAction = '[DaffCart] Cart Reset Failure Action'
+}
+
+export class DaffCartStorageFailure implements Action {
+  readonly type = DaffCartActionTypes.CartStorageFailureAction;
 }
 
 export class DaffCartLoad implements Action {
@@ -84,6 +89,7 @@ export class DaffCartClearFailure implements Action {
 }
 
 export type DaffCartActions<T extends DaffCart> =
+  | DaffCartStorageFailure
   | DaffCartLoad
   | DaffCartLoadSuccess<T>
   | DaffCartLoadFailure

--- a/libs/cart/src/storage/cart-storage.service.ts
+++ b/libs/cart/src/storage/cart-storage.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 
-import { DaffLocalStorageService } from '@daffodil/core';
+import { DaffPersistenceService, DaffPersistenceServiceToken } from '@daffodil/core';
 
 @Injectable({
   providedIn: 'root'
@@ -8,7 +8,7 @@ import { DaffLocalStorageService } from '@daffodil/core';
 export class DaffCartStorageService {
   private readonly CART_STORAGE_ID = 'DAFF_CART_ID';
 
-  constructor(private storageService: DaffLocalStorageService){}
+  constructor(@Inject(DaffPersistenceServiceToken) private storageService: DaffPersistenceService){}
 
   getCartId(): string {
     return this.storageService.getItem(this.CART_STORAGE_ID);

--- a/libs/core/src/storage/error/error.service.spec.ts
+++ b/libs/core/src/storage/error/error.service.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DaffErrorStorageService } from './error.service';
+
+describe('DaffErrorStorageService', () => {
+  let service: DaffErrorStorageService;
+
+  beforeEach(() => {
+    service = TestBed.get(DaffErrorStorageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('setItem | throwing an error', () => {
+    it('should throw an error', () => {
+      expect(service.setItem.bind(service)).toThrowError('The DaffErrorStorageService always throws an error.')
+    });
+  });
+
+  describe('getItem | throwing an error', () => {
+    it('should throw an error', () => {
+      expect(service.getItem.bind(service)).toThrowError('The DaffErrorStorageService always throws an error.')
+    });
+  });
+
+  describe('removeItem | throwing an error', () => {
+    it('should throw an error', () => {
+      expect(service.removeItem.bind(service)).toThrowError('The DaffErrorStorageService always throws an error.')
+    });
+  });
+
+  describe('clear | throwing an error', () => {
+    it('should throw an error', () => {
+      expect(service.clear.bind(service)).toThrowError('The DaffErrorStorageService always throws an error.')
+    });
+  });
+});

--- a/libs/core/src/storage/error/error.service.ts
+++ b/libs/core/src/storage/error/error.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 
 import { DaffPersistenceService } from '../persistence.interface';
+import { DaffStorageServiceError } from './error';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DaffErrorStorageService implements DaffPersistenceService {
-  static ERROR_MESSAGE = 'The DaffErrorStorageService always throws an error.';
+  static readonly ERROR_MESSAGE = 'The DaffErrorStorageService always throws an error.';
 
   setItem(key: string, value: any): void {
     this.throwError();
@@ -25,6 +26,6 @@ export class DaffErrorStorageService implements DaffPersistenceService {
   }
 
   private throwError() {
-    throw new Error(DaffErrorStorageService.ERROR_MESSAGE);
+    throw new DaffStorageServiceError(DaffErrorStorageService.ERROR_MESSAGE);
   }
 }

--- a/libs/core/src/storage/error/error.service.ts
+++ b/libs/core/src/storage/error/error.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+
+import { DaffPersistenceService } from '../persistence.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DaffErrorStorageService implements DaffPersistenceService {
+  static ERROR_MESSAGE = 'The DaffErrorStorageService always throws an error.';
+
+  setItem(key: string, value: any): void {
+    this.throwError();
+  }
+
+  getItem(key: string): any {
+    this.throwError();
+  }
+
+  removeItem(key: string): any {
+    this.throwError();
+  }
+
+  clear(){
+    this.throwError();
+  }
+
+  private throwError() {
+    throw new Error(DaffErrorStorageService.ERROR_MESSAGE);
+  }
+}

--- a/libs/core/src/storage/error/error.ts
+++ b/libs/core/src/storage/error/error.ts
@@ -1,0 +1,3 @@
+export class DaffStorageServiceError extends Error {
+  readonly name = 'DaffStorageServiceError';
+}

--- a/libs/core/src/storage/persistence.interface.spec.ts
+++ b/libs/core/src/storage/persistence.interface.spec.ts
@@ -1,0 +1,27 @@
+import { Inject } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { DaffPersistenceServiceToken as Token, DaffPersistenceService } from './persistence.interface'
+import { DaffLocalStorageService } from './localstorage/localstorage.service';
+
+class MockService {
+  constructor(@Inject(Token) public service: DaffPersistenceService) {}
+}
+
+describe('DaffPersistenceServiceToken', () => {
+  let mockService: MockService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MockService
+      ]
+    });
+
+    mockService = TestBed.get(MockService);
+  });
+
+  it('should inject a DaffLocalStorageService', () => {
+    expect(mockService.service instanceof DaffLocalStorageService).toBeTruthy()
+  });
+});

--- a/libs/core/src/storage/persistence.interface.ts
+++ b/libs/core/src/storage/persistence.interface.ts
@@ -1,6 +1,15 @@
+import { InjectionToken, inject, PLATFORM_ID } from '@angular/core';
+
+import { DaffLocalStorageService } from './localstorage/localstorage.service';
+
 export interface DaffPersistenceService {
   setItem(key : string, value: any): void;
   getItem(key: string): any;
   clear(): void;
   removeItem(key: string): void;
 }
+
+export const DaffPersistenceServiceToken = new InjectionToken<DaffPersistenceService>('DaffPersistenceService', {
+  providedIn: 'root',
+  factory: () => new DaffLocalStorageService(inject<string>(PLATFORM_ID)),
+});

--- a/libs/core/src/storage/public_api.ts
+++ b/libs/core/src/storage/public_api.ts
@@ -1,3 +1,4 @@
+export { DaffStorageServiceError } from './error/error';
 export { DaffErrorStorageService } from './error/error.service';
 export { DaffLocalStorageService } from './localstorage/localstorage.service';
 export { DaffPersistenceService } from './persistence.interface';

--- a/libs/core/src/storage/public_api.ts
+++ b/libs/core/src/storage/public_api.ts
@@ -1,4 +1,4 @@
 export { DaffStorageServiceError } from './error/error';
 export { DaffErrorStorageService } from './error/error.service';
 export { DaffLocalStorageService } from './localstorage/localstorage.service';
-export { DaffPersistenceService } from './persistence.interface';
+export { DaffPersistenceService, DaffPersistenceServiceToken } from './persistence.interface';

--- a/libs/core/src/storage/public_api.ts
+++ b/libs/core/src/storage/public_api.ts
@@ -1,2 +1,3 @@
+export { DaffErrorStorageService } from './error/error.service';
 export { DaffLocalStorageService } from './localstorage/localstorage.service';
 export { DaffPersistenceService } from './persistence.interface';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
SSR will not work due to cart effects using `DaffCartStorageService`.
Fixes: N/A


## What is the new behavior?
The cart effects will catch storage errors and dispatch a specific action.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Still needs a way to provide the error storage service when not on the browser platform.