### PR TITLE
fix(category): allow categories to be sorted based on platform response

### DIFF
--- a/libs/category/src/selectors/category.selector.spec.ts
+++ b/libs/category/src/selectors/category.selector.spec.ts
@@ -2,28 +2,35 @@ import { TestBed } from '@angular/core/testing';
 import { StoreModule, combineReducers, Store, select } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 
-import { fromProduct, DaffProductGridLoadSuccess, DaffProductUnion } from '@daffodil/product';
-import { DaffCategoryFactory, DaffCategoryPageConfigurationStateFactory } from '@daffodil/category/testing';
+import {
+	fromProduct,
+	DaffProductGridLoadSuccess,
+	DaffProductUnion,
+} from '@daffodil/product';
+import {
+	DaffCategoryFactory,
+	DaffCategoryPageConfigurationStateFactory,
+} from '@daffodil/category/testing';
 import { DaffProductFactory } from '@daffodil/product/testing';
 
 import { DaffCategoryLoadSuccess } from '../actions/category.actions';
-import { 
-  selectCategoryLoading, 
-  selectCategoryErrors, 
-  selectCategoryIds, 
-  selectCategoryEntities, 
-  selectAllCategories, 
-  selectCategoryTotal, 
-  selectCategoryPageConfigurationState,
-  selectCategoryState, 
-  selectSelectedCategoryId,
-  selectSelectedCategory,
-  selectCategoryPageProducts,
-  selectCategoryCurrentPage,
-  selectCategoryTotalPages,
-  selectCategoryPageSize,
-  selectCategoryFilters,
-  selectCategorySortOptions,
+import {
+	selectCategoryLoading,
+	selectCategoryErrors,
+	selectCategoryIds,
+	selectCategoryEntities,
+	selectAllCategories,
+	selectCategoryTotal,
+	selectCategoryPageConfigurationState,
+	selectCategoryState,
+	selectSelectedCategoryId,
+	selectSelectedCategory,
+	selectCategoryPageProducts,
+	selectCategoryCurrentPage,
+	selectCategoryTotalPages,
+	selectCategoryPageSize,
+	selectCategoryFilters,
+	selectCategorySortOptions,
 	selectCategory,
 	selectProductsByCategory,
 	selectCategoryPageProductIds,
@@ -33,7 +40,8 @@ import {
 	selectTotalProductsByCategory,
 	selectCategoryProductsLoading,
 	selectCategoryPageFilterRequests,
-	selectCategoryPageAppliedFilters
+	selectCategoryPageAppliedFilters,
+	selectCategoryFeatureState,
 } from './category.selector';
 import { CategoryReducersState } from '../reducers/category-reducers.interface';
 import { categoryReducers } from '../reducers/category-reducers';
@@ -45,319 +53,402 @@ import { DaffCategoryLoad } from '@daffodil/category';
 import { DaffCategoryFilterRequest } from '../models/requests/filter-request';
 
 describe('DaffCategorySelectors', () => {
-
-  let store: Store<CategoryReducersState>;
-  const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
-  const categoryPageConfigurationFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
-  const productFactory: DaffProductFactory = new DaffProductFactory();
+	let store: Store<CategoryReducersState>;
+	const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
+	const categoryPageConfigurationFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
+	const productFactory: DaffProductFactory = new DaffProductFactory();
 	let stubCategory: DaffCategory;
-  const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState = categoryPageConfigurationFactory.create();
+	let stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState;
 	let product: DaffProductUnion;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        StoreModule.forRoot({
-          category: combineReducers(categoryReducers),
-          product: combineReducers(fromProduct.reducers)
-        })
-      ]
-    });
-    
-    stubCategory = categoryFactory.create();
-    product = productFactory.create();
-    stubCategoryPageConfigurationState.id = stubCategory.id;
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [
+				StoreModule.forRoot({
+					category: combineReducers(categoryReducers),
+					product: combineReducers(fromProduct.reducers),
+				}),
+			],
+		});
+
+		stubCategory = categoryFactory.create();
+		stubCategoryPageConfigurationState = categoryPageConfigurationFactory.create();
+		product = productFactory.create();
+		stubCategoryPageConfigurationState.id = stubCategory.id;
 		stubCategoryPageConfigurationState.product_ids = [product.id];
 		stubCategory.product_ids = [product.id];
-		stubCategoryPageConfigurationState.filters = [
-			{
-				name: 'name',
-				type: DaffCategoryFilterType.Equal,
-				label: 'label',
-				options: [{
-					label: 'option_label',
-					value: 'value',
-					count: 2
-				}]
-			},
-			{
-				name: 'name2',
-				type: DaffCategoryFilterType.Equal,
-				label: 'label2',
-				options: [{
-					label: 'option_label2',
-					value: 'value2',
-					count: 2
-				}]
-			}
-		];
-    store = TestBed.get(Store);
+		store = TestBed.get(Store);
 
-    store.dispatch(new DaffCategoryLoadSuccess({ category: stubCategory, categoryPageConfigurationState: stubCategoryPageConfigurationState, products: null }));
-    store.dispatch(new DaffProductGridLoadSuccess([product]));
-  });
+		store.dispatch(
+			new DaffCategoryLoadSuccess({
+				category: stubCategory,
+				categoryPageConfigurationState: stubCategoryPageConfigurationState,
+				products: null,
+			}),
+		);
+		store.dispatch(new DaffProductGridLoadSuccess([product]));
+	});
 
-  describe('selectCategoryState', () => {
-    
-    it('selects CategoryReducerState for category', () => {
-      const expectedFeatureState = {
-        categoryPageConfigurationState: stubCategoryPageConfigurationState,
-        categoryLoading: false,
-        productsLoading: false,
-        errors: []
-      }
-      const selector = store.pipe(select(selectCategoryState));
-      const expected = cold('a', { a: expectedFeatureState });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectCategoryState', () => {
+		it('selects CategoryReducerState for category', () => {
+			const expectedFeatureState = {
+				categoryPageConfigurationState: stubCategoryPageConfigurationState,
+				categoryLoading: false,
+				productsLoading: false,
+				errors: [],
+			};
+			const selector = store.pipe(select(selectCategoryState));
+			const expected = cold('a', { a: expectedFeatureState });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategoryPageConfigurationState', () => {
+	describe('selectCategoryPageConfigurationState', () => {
+		it('selects the category page configuration state', () => {
+			const selector = store.pipe(select(selectCategoryPageConfigurationState));
+			const expected = cold('a', { a: stubCategoryPageConfigurationState });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the category page configuration state', () => {
-      const selector = store.pipe(select(selectCategoryPageConfigurationState));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectCategoryCurrentPage', () => {
+		it('selects the current page of the current category', () => {
+			const selector = store.pipe(select(selectCategoryCurrentPage));
+			const expected = cold('a', {
+				a: stubCategoryPageConfigurationState.current_page,
+			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategoryCurrentPage', () => {
+	describe('selectCategoryTotalPages', () => {
+		it('selects the total pages of products of the current category', () => {
+			const selector = store.pipe(select(selectCategoryTotalPages));
+			const expected = cold('a', {
+				a: stubCategoryPageConfigurationState.total_pages,
+			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the current page of the current category', () => {
-      const selector = store.pipe(select(selectCategoryCurrentPage));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.current_page });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectCategoryPageSize', () => {
+		it('selects the page size of the current category', () => {
+			const selector = store.pipe(select(selectCategoryPageSize));
+			const expected = cold('a', {
+				a: stubCategoryPageConfigurationState.page_size,
+			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategoryTotalPages', () => {
+	describe('selectCategoryFilters', () => {
+		it('selects filters of the current category', () => {
+			const selector = store.pipe(select(selectCategoryFilters));
+			const expected = cold('a', {
+				a: stubCategoryPageConfigurationState.filters,
+			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the total pages of products of the current category', () => {
-      const selector = store.pipe(select(selectCategoryTotalPages));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.total_pages });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectCategoryPageAppliedFilters', () => {
+		it('selects the applied filters of the current category', () => {
+			stubCategoryPageConfigurationState.filters = [
+				{
+					name: 'name',
+					type: DaffCategoryFilterType.Equal,
+					label: 'label',
+					options: [
+						{
+							label: 'option_label',
+							value: 'value',
+							count: 2,
+						},
+					],
+				},
+				{
+					name: 'name2',
+					type: DaffCategoryFilterType.Equal,
+					label: 'label2',
+					options: [
+						{
+							label: 'option_label2',
+							value: 'value2',
+							count: 2,
+						},
+					],
+				},
+			];
 
-  describe('selectCategoryPageSize', () => {
+			//Set initial state
+			store.dispatch(
+				new DaffCategoryLoadSuccess({
+					category: stubCategory,
+					categoryPageConfigurationState: stubCategoryPageConfigurationState,
+					products: null,
+				}),
+			);
 
-    it('selects the page size of the current category', () => {
-      const selector = store.pipe(select(selectCategoryPageSize));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.page_size });
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCategoryFilters', () => {
-
-    it('selects filters of the current category', () => {
-      const selector = store.pipe(select(selectCategoryFilters));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.filters });
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCategoryPageAppliedFilters', () => {
-
-    it('selects the applied filters of the current category', () => {
-			stubCategory.product_ids = [product.id];
 			const filterRequests: DaffCategoryFilterRequest[] = [
 				{
 					name: 'name',
 					type: DaffCategoryFilterType.Equal,
-					value: ['value']
-				}
+					value: ['value'],
+				},
 			];
-			const expectedAppliedFilters: DaffCategoryAppliedFilter[] = [{
-				name: 'name',
-				label: 'label',
-				type: DaffCategoryFilterType.Equal,
-				options: [{
-					label: 'option_label',
-					value: 'value'
-				}]
-			}]
-			store.dispatch(new DaffCategoryLoad({
-				id: stubCategoryPageConfigurationState.id,
-				filter_requests: filterRequests
-			}));
-      const selector = store.pipe(select(selectCategoryPageAppliedFilters));
-      const expected = cold('a', { a: expectedAppliedFilters });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+			const expectedAppliedFilters: DaffCategoryAppliedFilter[] = [
+				{
+					name: 'name',
+					label: 'label',
+					type: DaffCategoryFilterType.Equal,
+					options: [
+						{
+							label: 'option_label',
+							value: 'value',
+						},
+					],
+				},
+			];
+			store.dispatch(
+				new DaffCategoryLoad({
+					id: stubCategoryPageConfigurationState.id,
+					filter_requests: filterRequests,
+				}),
+			);
+			const selector = store.pipe(select(selectCategoryPageAppliedFilters));
+			const expected = cold('a', { a: expectedAppliedFilters });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategorySortOptions', () => {
+	describe('selectCategorySortOptions', () => {
+		it('selects the category sort options of the current category', () => {
+			const selector = store.pipe(select(selectCategorySortOptions));
+			const expected = cold('a', {
+				a: stubCategoryPageConfigurationState.sort_options,
+			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the category sort options of the current category', () => {
-      const selector = store.pipe(select(selectCategorySortOptions));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.sort_options });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectCategoryPageProductIds', () => {
+		it('selects the product_ids of the current category page', () => {
+			const selector = store.pipe(select(selectCategoryPageProductIds));
+			const expected = cold('a', {
+				a: stubCategoryPageConfigurationState.product_ids,
+			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategoryPageProductIds', () => {
+	describe('selectCategoryPageTotalProducts', () => {
+		it('selects the total number of products of the current category page', () => {
+			const selector = store.pipe(select(selectCategoryPageTotalProducts));
+			const expected = cold('a', {
+				a: stubCategoryPageConfigurationState.total_products,
+			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the product_ids of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageProductIds));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.product_ids });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectCategoryPageFilterRequests', () => {
+		it('selects the filter requests of the current category page', () => {
+			const selector = store.pipe(select(selectCategoryPageFilterRequests));
+			const expected = cold('a', {
+				a: stubCategoryPageConfigurationState.filter_requests,
+			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategoryPageTotalProducts', () => {
+	describe('selectCategoryPageAppliedSortOption', () => {
+		it('selects the applied sort option of the current category page', () => {
+			const selector = store.pipe(select(selectCategoryPageAppliedSortOption));
+			const expected = cold('a', {
+				a: stubCategoryPageConfigurationState.applied_sort_option,
+			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the total number of products of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageTotalProducts));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.total_products });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectCategoryPageAppliedSortDirection', () => {
+		it('selects the applied sort direction of the current category page', () => {
+			const selector = store.pipe(
+				select(selectCategoryPageAppliedSortDirection),
+			);
+			const expected = cold('a', {
+				a: stubCategoryPageConfigurationState.applied_sort_direction,
+			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategoryPageFilterRequests', () => {
+	describe('selectSelectedCategoryId', () => {
+		it('selects the id of the selected category', () => {
+			const selector = store.pipe(select(selectSelectedCategoryId));
+			const expected = cold('a', { a: stubCategory.id });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the filter requests of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageFilterRequests));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.filter_requests });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectCategoryLoading', () => {
+		it('selects the loading state of the category', () => {
+			const selector = store.pipe(select(selectCategoryLoading));
+			const expected = cold('a', { a: false });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategoryPageAppliedSortOption', () => {
+	describe('selectCategoryProductsLoading', () => {
+		it('selects the loading state of the category products', () => {
+			const selector = store.pipe(select(selectCategoryProductsLoading));
+			const expected = cold('a', { a: false });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the applied sort option of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageAppliedSortOption));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.applied_sort_option });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectCategoryErrors', () => {
+		it('returns the selected category id', () => {
+			const selector = store.pipe(select(selectCategoryErrors));
+			const expected = cold('a', { a: [] });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategoryPageAppliedSortDirection', () => {
+	describe('selectCategoryIds', () => {
+		it('returns all category ids', () => {
+			const selector = store.pipe(select(selectCategoryIds));
+			const expected = cold('a', { a: [stubCategory.id] });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the applied sort direction of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageAppliedSortDirection));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.applied_sort_direction });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectCategoryEntities', () => {
+		it('returns the categories as a dictionary object', () => {
+			const expectedDictionary = new Object();
+			expectedDictionary[stubCategory.id] = stubCategory;
 
-  describe('selectSelectedCategoryId', () => {
+			const selector = store.pipe(select(selectCategoryEntities));
+			const expected = cold('a', { a: expectedDictionary });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the id of the selected category', () => {
-      const selector = store.pipe(select(selectSelectedCategoryId));
-      const expected = cold('a', { a: stubCategory.id });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectAllCategories', () => {
+		it('returns all categories as an array', () => {
+			const selector = store.pipe(select(selectAllCategories));
+			const expected = cold('a', { a: [stubCategory] });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategoryLoading', () => {
+	describe('selectCategoryTotal', () => {
+		it('returns the total number of categories', () => {
+			const selector = store.pipe(select(selectCategoryTotal));
+			const expected = cold('a', { a: 1 });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('selects the loading state of the category', () => {
-      const selector = store.pipe(select(selectCategoryLoading));
-      const expected = cold('a', { a: false });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectSelectedCategory', () => {
+		it('selects the selected category', () => {
+			const selector = store.pipe(select(selectSelectedCategory));
+			const expected = cold('a', { a: stubCategory });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-  describe('selectCategoryProductsLoading', () => {
+	describe('selectCategoryPageProducts', () => {
+		it('selects the products of the selected category', () => {
+			const selector = store.pipe(select(selectCategoryPageProducts));
+			const expected = cold('a', { a: [product] });
+			expect(selector).toBeObservable(expected);
+		});
 
-    it('selects the loading state of the category products', () => {
-      const selector = store.pipe(select(selectCategoryProductsLoading));
-      const expected = cold('a', { a: false });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+		it('selects the products in the right order', () => {
+			const selector = store.pipe(select(selectCategoryPageProducts));
 
-  describe('selectCategoryErrors', () => {
+			const productA = productFactory.create();
+			const productB = productFactory.create();
 
-    it('returns the selected category id', () => {
-      const selector = store.pipe(select(selectCategoryErrors));
-      const expected = cold('a', { a: [] });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+			//Load a set of products
+			stubCategory.product_ids = [productA.id, productB.id];
+			stubCategoryPageConfigurationState.product_ids = [
+				productA.id,
+				productB.id,
+			];
+			const loadA = new DaffCategoryLoadSuccess({
+				category: {
+					...stubCategory,
+				},
+				categoryPageConfigurationState: {
+					...stubCategoryPageConfigurationState,
+				},
+				products: [productA, productB],
+			});
+			const loadAProducts = new DaffProductGridLoadSuccess([
+				productA,
+				productB,
+			]);
+			store.dispatch(loadAProducts);
+			store.dispatch(loadA);
+			const expectedA = cold('a', { a: [productA, productB] });
+			expect(selector).toBeObservable(expectedA);
 
-  describe('selectCategoryIds', () => {
+			//Load the same products in a different order
+			stubCategory.product_ids = [productB.id, productA.id];
+			stubCategoryPageConfigurationState.product_ids = [
+				productB.id,
+				productA.id,
+			];
+			const loadB = new DaffCategoryLoadSuccess({
+				category: {
+					...stubCategory,
+				},
+				categoryPageConfigurationState: {
+					...stubCategoryPageConfigurationState,
+				},
+				products: [productA, productB],
+			});
+			const loadBProducts = new DaffProductGridLoadSuccess([
+				productA,
+				productB,
+			]);
 
-    it('returns all category ids', () => {
-      const selector = store.pipe(select(selectCategoryIds));
-      const expected = cold('a', { a: [stubCategory.id] });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+			const expectedB = cold('b', { b: [productB, productA] });
+			store.dispatch(loadBProducts);
+			store.dispatch(loadB);
+			expect(selector).toBeObservable(expectedB);
+		});
+	});
 
-  describe('selectCategoryEntities', () => {
+	describe('selectCategory', () => {
+		it('selects the category by id', () => {
+			const selector = store.pipe(
+				select(selectCategory, { id: stubCategory.id }),
+			);
+			const expected = cold('a', { a: stubCategory });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-    it('returns the categories as a dictionary object', () => {
-      const expectedDictionary = new Object();
-      expectedDictionary[stubCategory.id] = stubCategory;
+	describe('selectProductsByCategory', () => {
+		it('selects products by category', () => {
+			const selector = store.pipe(
+				select(selectProductsByCategory, { id: stubCategory.id }),
+			);
+			const expected = cold('a', { a: [product] });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 
-      const selector = store.pipe(select(selectCategoryEntities));
-      const expected = cold('a', { a: expectedDictionary });
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectAllCategories', () => {
-
-    it('returns all categories as an array', () => {
-      const selector = store.pipe(select(selectAllCategories));
-      const expected = cold('a', { a: [stubCategory] });
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCategoryTotal', () => {
-
-    it('returns the total number of categories', () => {
-      const selector = store.pipe(select(selectCategoryTotal));
-      const expected = cold('a', { a: 1 });
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectSelectedCategory', () => {
-
-    it('selects the selected category', () => {
-      const selector = store.pipe(select(selectSelectedCategory));
-      const expected = cold('a', { a: stubCategory });
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCategoryPageProducts', () => {
-
-    it('selects the products of the selected category', () => {
-      const selector = store.pipe(select(selectCategoryPageProducts));
-      const expected = cold('a', { a: [product] });
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCategory', () => {
-
-    it('selects the category by id', () => {
-      const selector = store.pipe(select(selectCategory, { id: stubCategory.id }));
-      const expected = cold('a', { a: stubCategory });
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectProductsByCategory', () => {
-
-    it('selects products by category', () => {
-      const selector = store.pipe(select(selectProductsByCategory, { id: stubCategory.id }));
-      const expected = cold('a', { a: [product] });
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectTotalProductsByCategory', () => {
-
-    it('selects products by category', () => {
-      const selector = store.pipe(select(selectTotalProductsByCategory, { id: stubCategory.id }));
-      const expected = cold('a', { a: 1 });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+	describe('selectTotalProductsByCategory', () => {
+		it('selects products by category', () => {
+			const selector = store.pipe(
+				select(selectTotalProductsByCategory, { id: stubCategory.id }),
+			);
+			const expected = cold('a', { a: 1 });
+			expect(selector).toBeObservable(expected);
+		});
+	});
 });

--- a/libs/category/src/selectors/category.selector.ts
+++ b/libs/category/src/selectors/category.selector.ts
@@ -8,190 +8,207 @@ import { CategoryReducersState } from '../reducers/category-reducers.interface';
 import { categoryEntitiesAdapter } from '../reducers/category-entities/category-entities-adapter';
 import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
 import { DaffCategory } from '../models/category';
-import { DaffCategoryAppliedFilter, DaffCategoryAppliedFilterOption } from '../models/category-applied-filter';
-import { DaffCategoryFilterRequest, DaffCategoryFilterEqualRequest, DaffCategoryFilterRangeRequest, DaffCategoryFilterMatchRequest } from '../models/requests/filter-request';
-import { DaffCategoryFilter, DaffCategoryFilterOption } from '../models/category-filter';
-import { DaffCategoryFilterType } from '../models/category-filter-base';
+import { DaffCategoryAppliedFilter } from '../models/category-applied-filter';
+import { DaffCategoryFilterRequest } from '../models/requests/filter-request';
+import { DaffCategoryFilter } from '../models/category-filter';
 import { buildAppliedFilter } from './applied-filter/applied-filter-methods';
 
-const { selectIds, selectEntities, selectAll, selectTotal } = categoryEntitiesAdapter.getSelectors();
+const {
+	selectIds,
+	selectEntities,
+	selectAll,
+	selectTotal,
+} = categoryEntitiesAdapter.getSelectors();
 
 /**
  * Category Feature State
  */
-export const selectCategoryFeatureState = createFeatureSelector<CategoryReducersState>('category');
+export const selectCategoryFeatureState = createFeatureSelector<
+	CategoryReducersState
+>('category');
 
 /**
  * Category State
  */
 export const selectCategoryState = createSelector(
-  selectCategoryFeatureState,
-  (state: CategoryReducersState) => state.category
+	selectCategoryFeatureState,
+	(state: CategoryReducersState) => state.category,
 );
 
 /**
  * CategoryPageConfigurationState State
  */
 export const selectCategoryPageConfigurationState = createSelector(
-  selectCategoryState,
-  (state: CategoryReducerState) => state.categoryPageConfigurationState
+	selectCategoryState,
+	(state: CategoryReducerState) => state.categoryPageConfigurationState,
 );
 
 export const selectCategoryCurrentPage = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.current_page
+	selectCategoryPageConfigurationState,
+	(state: DaffCategoryPageConfigurationState) => state.current_page,
 );
 
 export const selectCategoryTotalPages = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.total_pages
+	selectCategoryPageConfigurationState,
+	(state: DaffCategoryPageConfigurationState) => state.total_pages,
 );
 
 export const selectCategoryPageSize = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.page_size
+	selectCategoryPageConfigurationState,
+	(state: DaffCategoryPageConfigurationState) => state.page_size,
 );
 
 export const selectCategoryFilters = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.filters
+	selectCategoryPageConfigurationState,
+	(state: DaffCategoryPageConfigurationState) => state.filters,
 );
 
 export const selectCategorySortOptions = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.sort_options
+	selectCategoryPageConfigurationState,
+	(state: DaffCategoryPageConfigurationState) => state.sort_options,
 );
 
 export const selectCategoryPageProductIds = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.product_ids
+	selectCategoryPageConfigurationState,
+	(state: DaffCategoryPageConfigurationState) => state.product_ids,
 );
 
 export const selectCategoryPageTotalProducts = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.total_products
+	selectCategoryPageConfigurationState,
+	(state: DaffCategoryPageConfigurationState) => state.total_products,
 );
 
 export const selectCategoryPageFilterRequests = createSelector(
 	selectCategoryPageConfigurationState,
-	(state: DaffCategoryPageConfigurationState) => state.filter_requests
+	(state: DaffCategoryPageConfigurationState) => state.filter_requests,
 );
 
 export const selectCategoryPageAppliedFilters = createSelector(
 	selectCategoryPageFilterRequests,
 	selectCategoryFilters,
-	(filterRequests: DaffCategoryFilterRequest[], availableFilters: DaffCategoryFilter[]): DaffCategoryAppliedFilter[] => {
-		if(!availableFilters || !availableFilters.length) return null;
-		return filterRequests.map(request => 
+	(
+		filterRequests: DaffCategoryFilterRequest[],
+		availableFilters: DaffCategoryFilter[],
+	): DaffCategoryAppliedFilter[] => {
+		if (!availableFilters || !availableFilters.length) return null;
+		return filterRequests.map(request =>
 			availableFilters
 				.filter(availableFilter => availableFilter.name === request.name)
-				.map(filter => buildAppliedFilter(filter, request)).shift()
+				.map(filter => buildAppliedFilter(filter, request))
+				.shift(),
 		);
-	}
+	},
 );
 
 export const selectCategoryPageAppliedSortOption = createSelector(
 	selectCategoryPageConfigurationState,
-	(state: DaffCategoryPageConfigurationState) => state.applied_sort_option
+	(state: DaffCategoryPageConfigurationState) => state.applied_sort_option,
 );
 
 export const selectCategoryPageAppliedSortDirection = createSelector(
 	selectCategoryPageConfigurationState,
-	(state: DaffCategoryPageConfigurationState) => state.applied_sort_direction
+	(state: DaffCategoryPageConfigurationState) => state.applied_sort_direction,
 );
 
 /**
  * Selected Category Id State
  */
 export const selectSelectedCategoryId = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.id
+	selectCategoryPageConfigurationState,
+	(state: DaffCategoryPageConfigurationState) => state.id,
 );
 
 /**
  * Category Loading State
  */
 export const selectCategoryLoading = createSelector(
-  selectCategoryState,
-  (state: CategoryReducerState) => state.categoryLoading
+	selectCategoryState,
+	(state: CategoryReducerState) => state.categoryLoading,
 );
 
 /**
  * Category Products Loading State
  */
 export const selectCategoryProductsLoading = createSelector(
-  selectCategoryState,
-  (state: CategoryReducerState) => state.productsLoading
+	selectCategoryState,
+	(state: CategoryReducerState) => state.productsLoading,
 );
 
 /**
  * Load Category Errors
  */
 export const selectCategoryErrors = createSelector(
-  selectCategoryState,
-  (state: CategoryReducerState) => state.errors
+	selectCategoryState,
+	(state: CategoryReducerState) => state.errors,
 );
 
 /**
  * Category Entities State
  */
 export const selectCategoryEntitiesState = createSelector(
-  selectCategoryFeatureState,
-  (state: CategoryReducersState) => state.categoryEntities
+	selectCategoryFeatureState,
+	(state: CategoryReducersState) => state.categoryEntities,
 );
 
 export const selectCategoryIds = createSelector(
-  selectCategoryEntitiesState,
-  selectIds
+	selectCategoryEntitiesState,
+	selectIds,
 );
 
 export const selectCategoryEntities = createSelector(
-  selectCategoryEntitiesState,
-  selectEntities
+	selectCategoryEntitiesState,
+	selectEntities,
 );
 
 export const selectAllCategories = createSelector(
-  selectCategoryEntitiesState,
-  selectAll
+	selectCategoryEntitiesState,
+	selectAll,
 );
 
 export const selectCategoryTotal = createSelector(
-  selectCategoryEntitiesState,
-  selectTotal
+	selectCategoryEntitiesState,
+	selectTotal,
 );
 
 /**
  * Combinatoric Category Selectors
  */
 export const selectSelectedCategory = createSelector(
-  selectCategoryEntities,
-  selectSelectedCategoryId,
-  (entities: Dictionary<DaffCategory>, selectedCategoryId: string) => entities[selectedCategoryId]
+	selectCategoryEntities,
+	selectSelectedCategoryId,
+	(entities: Dictionary<DaffCategory>, selectedCategoryId: string) =>
+		entities[selectedCategoryId],
 );
 
 export const selectCategoryPageProducts = createSelector(
-  selectCategoryPageProductIds,
-  fromProduct.selectAllProducts,
-  (ids, products: DaffProductUnion[]) => products.filter(product => ids.indexOf(product.id) >= 0)
+	selectCategoryPageProductIds,
+	fromProduct.selectProductEntities,
+	(ids, products: Dictionary<DaffProductUnion>) =>
+		ids.map(id => products[id]).filter(p => p != null),
 );
 
 export const selectCategory = createSelector(
 	selectCategoryEntities,
-	(entities, props) =>  entities[props.id]
+	(entities, props) => entities[props.id],
 );
 
 export const selectProductsByCategory = createSelector(
 	selectCategoryEntities,
 	fromProduct.selectAllProducts,
-	(entities, products, props) => entities[props.id] && entities[props.id].product_ids
-		? products.filter(product => entities[props.id].product_ids.indexOf(product.id) >= 0)
-		: null
+	(entities, products, props) =>
+		entities[props.id] && entities[props.id].product_ids
+			? products.filter(
+					product => entities[props.id].product_ids.indexOf(product.id) >= 0,
+			  )
+			: null,
 );
 
 export const selectTotalProductsByCategory = createSelector(
 	selectCategoryEntities,
 	fromProduct.selectAllProducts,
-	(entities, products, props) => selectProductsByCategory.projector(entities, products, { id: props.id })
-		? selectProductsByCategory.projector(entities, products, { id: props.id }).length
-		: null
+	(entities, products, props) =>
+		selectProductsByCategory.projector(entities, products, { id: props.id })
+			? selectProductsByCategory.projector(entities, products, { id: props.id })
+					.length
+			: null,
 );


### PR DESCRIPTION
When a category loads its products, they're in a certain order based on the platforms defined order. Previously we were filtering through an array, picking products as we found them in the array. This means that the order was determined client side instead of server-side.

I've changed this to map to the element in the entities dictionary to properly select the products in the appropriate order. I've also tacked on a filter to prevent undefined elements from being in the final array. This can be deleted once we have dependency injectable reducers.