### PR TITLE
fix(category): allow categories to be sorted based on platform response

### DIFF
--- a/libs/category/src/selectors/category.selector.spec.ts
+++ b/libs/category/src/selectors/category.selector.spec.ts
@@ -326,13 +326,68 @@ describe('DaffCategorySelectors', () => {
   });
 
   describe('selectCategoryPageProducts', () => {
+		it('selects the products of the selected category', () => {
+			const selector = store.pipe(select(selectCategoryPageProducts));
+			const expected = cold('a', { a: [product] });
+			expect(selector).toBeObservable(expected);
+		});
 
-    it('selects the products of the selected category', () => {
-      const selector = store.pipe(select(selectCategoryPageProducts));
-      const expected = cold('a', { a: [product] });
-      expect(selector).toBeObservable(expected);
-    });
-  });
+		it('selects the products in the right order', () => {
+			const selector = store.pipe(select(selectCategoryPageProducts));
+
+			const productA = productFactory.create();
+			const productB = productFactory.create();
+
+			//Load a set of products
+			stubCategory.product_ids = [productA.id, productB.id];
+			stubCategoryPageConfigurationState.product_ids = [
+				productA.id,
+				productB.id,
+			];
+			const loadA = new DaffCategoryLoadSuccess({
+				category: {
+					...stubCategory,
+				},
+				categoryPageConfigurationState: {
+					...stubCategoryPageConfigurationState,
+				},
+				products: [productA, productB],
+			});
+			const loadAProducts = new DaffProductGridLoadSuccess([
+				productA,
+				productB,
+			]);
+			store.dispatch(loadAProducts);
+			store.dispatch(loadA);
+			const expectedA = cold('a', { a: [productA, productB] });
+			expect(selector).toBeObservable(expectedA);
+
+			//Load the same products in a different order
+			stubCategory.product_ids = [productB.id, productA.id];
+			stubCategoryPageConfigurationState.product_ids = [
+				productB.id,
+				productA.id,
+			];
+			const loadB = new DaffCategoryLoadSuccess({
+				category: {
+					...stubCategory,
+				},
+				categoryPageConfigurationState: {
+					...stubCategoryPageConfigurationState,
+				},
+				products: [productA, productB],
+			});
+			const loadBProducts = new DaffProductGridLoadSuccess([
+				productA,
+				productB,
+			]);
+
+			const expectedB = cold('b', { b: [productB, productA] });
+			store.dispatch(loadBProducts);
+			store.dispatch(loadB);
+			expect(selector).toBeObservable(expectedB);
+		});
+	});
 
   describe('selectCategory', () => {
 

--- a/libs/category/src/selectors/category.selector.ts
+++ b/libs/category/src/selectors/category.selector.ts
@@ -170,9 +170,10 @@ export const selectSelectedCategory = createSelector(
 );
 
 export const selectCategoryPageProducts = createSelector(
-  selectCategoryPageProductIds,
-  fromProduct.selectAllProducts,
-  (ids, products: DaffProductUnion[]) => products.filter(product => ids.indexOf(product.id) >= 0)
+	selectCategoryPageProductIds,
+	fromProduct.selectProductEntities,
+	(ids, products: Dictionary<DaffProductUnion>) =>
+		ids.map(id => products[id]).filter(p => p != null),
 );
 
 export const selectCategory = createSelector(


### PR DESCRIPTION
When a category loads its products, they're in a certain order based on the platforms defined order. Previously we were filtering through an array, picking products as we found them in the array. This means that the order was determined client side instead of server-side.

I've changed this to map to the element in the entities dictionary to properly select the products in the appropriate order. I've also tacked on a filter to prevent undefined elements from being in the final array. This can be deleted once we have dependency injectable reducers.