### PR TITLE
bug(category): fix bug where applied filters were being set to null i…

### DIFF
--- a/libs/category/src/selectors/category.selector.spec.ts
+++ b/libs/category/src/selectors/category.selector.spec.ts
@@ -159,6 +159,27 @@ describe('DaffCategorySelectors', () => {
 
   describe('selectCategoryPageAppliedFilters', () => {
 
+    it('sets applied filters to [] if the available filters is []', () => {
+			stubCategory.product_ids = [product.id];
+			stubCategoryPageConfigurationState.filters = [];
+			store.dispatch(new DaffCategoryLoadSuccess({ category: stubCategory, categoryPageConfigurationState: stubCategoryPageConfigurationState, products: null }));
+			const filterRequests: DaffCategoryFilterRequest[] = [
+				{
+					name: 'name',
+					type: DaffCategoryFilterType.Equal,
+					value: ['value']
+				}
+			];
+			const expectedAppliedFilters: DaffCategoryAppliedFilter[] = [];
+			store.dispatch(new DaffCategoryLoad({
+				id: stubCategoryPageConfigurationState.id,
+				filter_requests: filterRequests
+			}));
+      const selector = store.pipe(select(selectCategoryPageAppliedFilters));
+      const expected = cold('a', { a: expectedAppliedFilters });
+      expect(selector).toBeObservable(expected);
+    });
+
     it('selects the applied filters of the current category', () => {
 			stubCategory.product_ids = [product.id];
 			const filterRequests: DaffCategoryFilterRequest[] = [

--- a/libs/category/src/selectors/category.selector.ts
+++ b/libs/category/src/selectors/category.selector.ts
@@ -81,7 +81,7 @@ export const selectCategoryPageAppliedFilters = createSelector(
 	selectCategoryPageFilterRequests,
 	selectCategoryFilters,
 	(filterRequests: DaffCategoryFilterRequest[], availableFilters: DaffCategoryFilter[]): DaffCategoryAppliedFilter[] => {
-		if(!availableFilters || !availableFilters.length) return null;
+		if(!availableFilters.length) return [];
 		return filterRequests.map(request => 
 			availableFilters
 				.filter(availableFilter => availableFilter.name === request.name)


### PR DESCRIPTION
…nstead of an empty array

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
We still need the availableFilters.length check, because when the category is loading and the filter requests are already in state, this selector has no available filters to match with the filter requests and the selector will return an array of undefined values. There might be a better way to do the `.map`s and `.filter`s, but I'm not seeing it.