### PR TITLE
bug(cart): fix in memory api bug for adding the same product twice

### DIFF
--- a/libs/cart/testing/src/in-memory-backend/cart-items/cart-items.service.spec.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart-items/cart-items.service.spec.ts
@@ -105,13 +105,21 @@ describe('DaffInMemoryBackendCartItemsService', () => {
       reqInfoStub.url = cartUrl;
       reqInfoStub.req.body = mockCartItemInput;
       productId = mockCartItemInput.productId;
-
-      result = service.post(reqInfoStub);
     });
-
+		
     it('should return a cart with the added item', () => {
+			result = service.post(reqInfoStub);
       expect(result.body.items).toContain(jasmine.objectContaining({product_id: productId}));
-    });
+		});
+		
+		it('should add the given qty to an existing cart item qty', () => {
+			productId = reqInfoStub.collection[0].items[0].product_id;
+			const cart_item_qty = reqInfoStub.collection[0].items[0].qty;
+			reqInfoStub.req.body = { productId, qty: 2};
+			result = service.post(reqInfoStub);
+
+			expect(result.body.items[0].qty).toEqual(cart_item_qty + 2);
+		});
   });
 
   describe('processing an update request', () => {

--- a/libs/cart/testing/src/in-memory-backend/cart-items/cart-items.service.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart-items/cart-items.service.ts
@@ -102,9 +102,13 @@ export class DaffInMemoryBackendCartItemsService implements InMemoryDbService {
 
   private addItem(reqInfo: RequestInfo): DaffCart {
     const cart = this.getCart(reqInfo);
-    const itemInput = reqInfo.utils.getJsonBody(reqInfo.req);
-
-    cart.items.push(this.transformItemInput(itemInput));
+		const itemInput = reqInfo.utils.getJsonBody(reqInfo.req);
+		const existingCartItemIndex = cart.items.findIndex(item => item.product_id === itemInput.productId);
+		if(existingCartItemIndex > -1) {
+			cart.items[existingCartItemIndex].qty = cart.items[existingCartItemIndex].qty + itemInput.qty;
+		} else {
+			cart.items.push(this.transformItemInput(itemInput));
+		}
 
     return cart;
   }

--- a/libs/cart/testing/src/in-memory-backend/cart-root.service.integration.spec.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart-root.service.integration.spec.ts
@@ -134,16 +134,16 @@ describe('DaffInMemoryBackendCartRootService | Integration', () => {
 
   describe('processing an add item request', () => {
     let productId;
-    let qty;
+    let initialQty;
     let result;
 
     beforeEach(done => {
       productId = mockCartItem.product_id;
-      qty = mockCartItem.qty;
+      initialQty = mockCartItem.qty;
 
       httpClient.post<any>(`/api/cart-items/${cartId}/`, {
         productId,
-        qty
+        qty: 2
       }).subscribe(res => {
         result = res
         done();
@@ -152,7 +152,7 @@ describe('DaffInMemoryBackendCartRootService | Integration', () => {
 
     it('should return the updated cart with the added item', () => {
       expect(result.items[0].product_id).toEqual(productId);
-      expect(result.items[0].qty).toEqual(qty);
+      expect(result.items[0].qty).toEqual(initialQty + 2);
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Adding the same product twice while using the in memory api adds two different products, rather than updating the existing cart item.

Fixes: N/A


## What is the new behavior?
It updates the existing cart item qty instead of adding a new cart item.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```