### PR TITLE
fix(cart): throw error when in memory cart does not exist

### DIFF
--- a/libs/cart/testing/src/drivers/in-memory/cart/cart.service.spec.ts
+++ b/libs/cart/testing/src/drivers/in-memory/cart/cart.service.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { DaffCart } from '@daffodil/cart';
+import { DaffCart, DaffCartNotFoundError } from '@daffodil/cart';
 
 import { DaffCartFactory } from '../../../factories/cart.factory';
 import { DaffInMemoryCartService } from './cart.service';
+import { catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 describe('Driver | In Memory | Cart | CartService', () => {
   let cartService: DaffInMemoryCartService;
@@ -51,6 +53,21 @@ describe('Driver | In Memory | Cart | CartService', () => {
 
       expect(req.request.method).toBe('GET');
       req.flush(mockCart);
+		});
+
+    it('should throw a daffodil error when it receives an error', (done) => {
+			cartService.get(cartId).pipe(
+				catchError((error) => {
+					expect(error).toEqual(DaffCartNotFoundError);
+					done();
+					return of(null);
+				})
+			).subscribe();
+					
+			const req = httpMock.expectOne(`${cartService.url}/${cartId}`);
+
+			expect(req.request.method).toBe('GET');
+			req.error(new ErrorEvent('404'));
     });
   });
 

--- a/libs/cart/testing/src/drivers/in-memory/cart/cart.service.ts
+++ b/libs/cart/testing/src/drivers/in-memory/cart/cart.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 
-import { DaffCart, DaffCartServiceInterface } from '@daffodil/cart';
+import { DaffCart, DaffCartServiceInterface, DaffCartNotFoundError } from '@daffodil/cart';
+import { catchError, map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -13,7 +14,10 @@ export class DaffInMemoryCartService implements DaffCartServiceInterface<DaffCar
   constructor(private http: HttpClient) {}
 
   get(cartId: DaffCart['id']): Observable<DaffCart> {
-    return this.http.get<DaffCart>(`${this.url}/${cartId}`);
+    return this.http.get<DaffCart>(`${this.url}/${cartId}`).pipe(
+			catchError((error: Error) => throwError(DaffCartNotFoundError)),
+			map(result => result)
+		);
   }
 
   addToCart(productId: string, qty: number): Observable<DaffCart> {

--- a/libs/cart/testing/src/in-memory-backend/cart/cart.service.spec.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart/cart.service.spec.ts
@@ -73,12 +73,20 @@ describe('DaffInMemoryBackendCartService', () => {
     beforeEach(() => {
       reqInfoStub.url = baseUrl;
 
-      result = service.get(reqInfoStub);
     });
-
+		
     it('should return the cart', () => {
+			result = service.get(reqInfoStub);
       expect(result.body).toEqual(mockCart);
-    });
+      expect(result.status).toEqual(STATUS.OK);
+		});
+		
+		it('should return an error response when the cart does not exist', () => {
+			reqInfoStub.id = null;
+			result = service.get(reqInfoStub);
+
+			expect(result.status).toEqual(STATUS.NOT_FOUND);
+		});
   });
 
   describe('processing a create request', () => {

--- a/libs/cart/testing/src/in-memory-backend/cart/cart.service.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart/cart.service.ts
@@ -18,10 +18,11 @@ export class DaffInMemoryBackendCartService implements InMemoryDbService {
   }
 
   get(reqInfo: RequestInfo) {
-    return reqInfo.utils.createResponse$(() => ({
-      body: this.getCart(reqInfo),
-      status: STATUS.OK
-    }))
+		const cart = this.getCart(reqInfo)
+		return reqInfo.utils.createResponse$(() => ({
+			body: cart,
+			status: cart ? STATUS.OK : STATUS.NOT_FOUND
+		}));
   }
 
   post(reqInfo: RequestInfo) {
@@ -71,6 +72,6 @@ export class DaffInMemoryBackendCartService implements InMemoryDbService {
   }
 
   private getCart(reqInfo: RequestInfo): DaffCart {
-    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id)
+		return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Every time the app is refreshed while using the in memory cart driver, the cart Id in local storage no longer matches the one in the in memory api and it fails all cart calls silently.

## What is the new behavior?
A daffodil 404 error is thrown when the cart is not found, ensuring that the app can deal with it in the same way it deals with a platform 404 error.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```