### PR TITLE
bug(cart): fix bug where cart mutation was not detected because the o…

### DIFF
--- a/libs/cart/testing/src/in-memory-backend/cart-items/cart-items.service.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart-items/cart-items.service.ts
@@ -96,6 +96,7 @@ export class DaffInMemoryBackendCartItemsService implements InMemoryDbService {
       ...cart.items[itemIndex],
       ...item
     };
+		cart.items = Object.assign([], cart.items);
 
     return cart
   }
@@ -109,6 +110,7 @@ export class DaffInMemoryBackendCartItemsService implements InMemoryDbService {
 		} else {
 			cart.items.push(this.transformItemInput(itemInput));
 		}
+		cart.items = Object.assign([], cart.items);
 
     return cart;
   }
@@ -117,7 +119,8 @@ export class DaffInMemoryBackendCartItemsService implements InMemoryDbService {
     const cart = this.getCart(reqInfo);
     const itemIndex = cart.items.findIndex(({item_id}) => String(itemId) === String(item_id));
 
-    cart.items.splice(itemIndex, 1);
+		cart.items.splice(itemIndex, 1);
+		cart.items = Object.assign([], cart.items);
 
     return cart;
   }

--- a/libs/cart/testing/src/in-memory-backend/cart/cart.service.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart/cart.service.ts
@@ -56,6 +56,7 @@ export class DaffInMemoryBackendCartService implements InMemoryDbService {
     const cart = this.getCart(reqInfo);
 
     cart.items = [];
+		cart.items = Object.assign([], cart.items);
 
     return cart
   }

--- a/libs/cart/testing/src/in-memory-backend/cart/cart.service.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart/cart.service.ts
@@ -56,7 +56,6 @@ export class DaffInMemoryBackendCartService implements InMemoryDbService {
     const cart = this.getCart(reqInfo);
 
     cart.items = [];
-		cart.items = Object.assign([], cart.items);
 
     return cart
   }


### PR DESCRIPTION
…bject reference point did not change

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When using the in memory api, redux doesn't detect a change to the cart items, because the reference point to the cart does not change in memory. In other words, when we do a `cart.items.push(newCartItem)`, the `cart.items` property does not change in memory, and the memoized selectors don't register that a change in the items array has occurred. A reproduction of this bug can be done by adding and removing items to and from the cart and watching the DaffCartFacade.items$ property. The selector behind that property will not detect a change, so it will not notify its Observables. 

Fixes: N/A


## What is the new behavior?
Every time a mutation to the cart occurs in memory, a brand new object is generated and set to the mutated part of the cart.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
This fix is impossible to test without a kind of integration test of the whole cart package, so no tests were added.