### PR TITLE
fix(cart, product): magento cart item has bad image URL

### DIFF
--- a/libs/cart/src/drivers/magento/queries/fragments/cart-item.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/cart-item.ts
@@ -9,6 +9,10 @@ export const cartItemFragment = gql`
     id
     product {
       ...product
+      thumbnail {
+        url
+        label
+      }
     }
     quantity
     prices {

--- a/libs/cart/src/drivers/magento/queries/fragments/cart-item.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/cart-item.ts
@@ -9,10 +9,6 @@ export const cartItemFragment = gql`
     id
     product {
       ...product
-      thumbnail {
-        url
-        label
-      }
     }
     quantity
     prices {

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-item.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-item.service.spec.ts
@@ -57,7 +57,7 @@ describe('Driver | Magento | Cart | Transformer | MagentoCartItem', () => {
       mockMagentoCartItem.quantity = qty;
       mockMagentoCartItem.prices.price.value = price;
 			mockMagentoCartItem.prices.total_item_discount.value = discount;
-			mockMagentoCartItem.product.image = {
+			mockMagentoCartItem.product.thumbnail = {
 				url: url,
 				label: label
 			}

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-item.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-item.service.ts
@@ -28,9 +28,9 @@ export class DaffMagentoCartItemTransformer {
       row_total: cartItem.prices.row_total.value,
       product_id: String(cartItem.product.id),
 			image: {
-				id: cartItem.product.image.label,
-				url: cartItem.product.image.url,
-				label: cartItem.product.image.label
+				id: cartItem.product.thumbnail.label,
+				url: cartItem.product.thumbnail.url,
+				label: cartItem.product.thumbnail.label
       },
       total_discount: cartItem.prices.total_item_discount.value,
 

--- a/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.spec.ts
@@ -26,7 +26,7 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
   delete stubCategoryPageConfigurationState.applied_sort_direction;
   delete stubCategoryPageConfigurationState.applied_sort_option;
 	stubCategoryPageConfigurationState.id = stubCategory.id;
-  
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -60,7 +60,7 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
         }],
         children_count: stubCategory.children_count
 			}
-			
+
 			aggregates = [{
 				attribute_code: stubCategoryPageConfigurationState.filters[0].name,
 				label: stubCategoryPageConfigurationState.filters[0].label,
@@ -77,7 +77,7 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 					}
 				]
 			}];
-			
+
 			page_info = {
 				page_size: stubCategoryPageConfigurationState.page_size,
 				current_page: stubCategoryPageConfigurationState.current_page,
@@ -107,6 +107,10 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 					image: {
 						url: 'url',
 						label: 'label'
+          },
+          thumbnail: {
+						url: 'url',
+						label: 'label'
 					}
 				}
 			];
@@ -120,9 +124,9 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 				total_count: stubCategoryPageConfigurationState.total_products
 			}
 		});
-		
+
 		describe('when the filter type is select', () => {
-			
+
 			it('should return a DaffCategoryPageConfigurationState with an equal filter type', () => {
 				aggregates[0].type = 'select';
 				stubCategoryPageConfigurationState.filters[0].type = DaffCategoryFilterType.Equal;
@@ -130,9 +134,9 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 				expect(service.transform(completeCategoryResponse)).toEqual(stubCategoryPageConfigurationState);
 			});
 		});
-		
+
 		describe('when the filter type is boolean', () => {
-			
+
 			it('should return a DaffCategoryPageConfigurationState with a equal filter type', () => {
 				aggregates[0].type = 'boolean';
 				stubCategoryPageConfigurationState.filters[0].type = DaffCategoryFilterType.Equal;
@@ -140,9 +144,9 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 				expect(service.transform(completeCategoryResponse)).toEqual(stubCategoryPageConfigurationState);
 			});
 		});
-		
+
 		describe('when the filter type is multiselect', () => {
-			
+
 			it('should return a DaffCategoryPageConfigurationState with a equal filter type', () => {
 				aggregates[0].type = 'multiselect';
 				stubCategoryPageConfigurationState.filters[0].type = DaffCategoryFilterType.Equal;
@@ -150,9 +154,9 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 				expect(service.transform(completeCategoryResponse)).toEqual(stubCategoryPageConfigurationState);
 			});
 		});
-		
+
 		describe('when the filter type is price', () => {
-			
+
 			it('should return a DaffCategoryPageConfigurationState with a range filter type', () => {
 				aggregates[0].type = 'price';
 				stubCategoryPageConfigurationState.filters[0].type = DaffCategoryFilterType.Range;
@@ -169,9 +173,9 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 				expect(service.transform(completeCategoryResponse)).toEqual(stubCategoryPageConfigurationState);
 			});
 		});
-		
+
 		describe('when the filter type is anything else', () => {
-			
+
 			it('should return a DaffCategoryPageConfigurationState with a match filter type', () => {
 				aggregates[0].type = 'textfield';
 				stubCategoryPageConfigurationState.filters[0].type = DaffCategoryFilterType.Match;

--- a/libs/category/src/drivers/magento/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-response-transform.service.spec.ts
@@ -53,7 +53,7 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
       magentoCategoryTransformerServiceSpy.transform.and.returnValue(stubCategory);
       magentoCategoryPageConfigurationTransformerServiceSpy.transform.and.returnValue(stubCategoryPageConfigurationState);
       magentoProductTransformerServiceSpy.transformMany.and.returnValue(stubProducts);
-  
+
       const category: MagentoCategory = {
         id: stubCategory.id,
         name: stubCategory.name,
@@ -69,7 +69,7 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
 				attribute_code: stubCategoryPageConfigurationState.filters[0].name,
 				label: stubCategoryPageConfigurationState.filters[0].label
 			}];
-			
+
 			const page_info: MagentoPageInfo = {
 				page_size: stubCategoryPageConfigurationState.page_size,
 				current_page: stubCategoryPageConfigurationState.current_page,
@@ -99,6 +99,10 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
 					image: {
 						url: 'url',
 						label: 'label'
+					},
+          thumbnail: {
+						url: 'url',
+						label: 'label'
 					}
 				}
 			];
@@ -121,16 +125,16 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
 
     it('should call transform on the magentoCategoryPageConfigurationService', () => {
       service.transform(completeCategory);
-      
+
       expect(magentoCategoryPageConfigurationTransformerServiceSpy.transform).toHaveBeenCalledWith(completeCategory);
     });
 
     it('should call transformMany on the magentoCategoryTransformerService', () => {
       service.transform(completeCategory);
-      
+
       expect(magentoProductTransformerServiceSpy.transformMany).toHaveBeenCalledWith(completeCategory.products);
     });
-    
+
     it('should return a DaffGetCategoryResponse compiled from the other injected transformers', () => {
       expect(service.transform(completeCategory)).toEqual(
         {
@@ -141,7 +145,7 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
         }
       );
 		});
-		
+
 		it('should return the magento MagentoCompleteCategoryResponse on the daffodil reponse', () => {
 			expect((<any>service.transform(completeCategory)).magentoCompleteCategoryResponse).toEqual(completeCategory);
 		});

--- a/libs/category/src/drivers/magento/transformers/category-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-transformer.service.spec.ts
@@ -11,7 +11,7 @@ describe('DaffMagentoCategoryTransformerService', () => {
   let service: DaffMagentoCategoryTransformerService;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
 	const stubCategory: DaffCategory = categoryFactory.create();
-  
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -26,7 +26,7 @@ describe('DaffMagentoCategoryTransformerService', () => {
   });
 
   describe('transform', () => {
-    
+
     it('should return a DaffCategory', () => {
       const magentoCategory: MagentoCategory = {
         id: stubCategory.id,
@@ -46,7 +46,11 @@ describe('DaffMagentoCategoryTransformerService', () => {
 						sku: stubCategory.product_ids[0],
 						url_key: 'url_key',
 						image: null,
-						price_range: null
+						price_range: null,
+            thumbnail: {
+              url: 'url',
+              label: 'label'
+            }
 					}]
 				},
         children_count: stubCategory.children_count

--- a/libs/product/src/drivers/magento/models/product-node.ts
+++ b/libs/product/src/drivers/magento/models/product-node.ts
@@ -16,6 +16,10 @@ export interface ProductNode {
   image: {
 		url: string,
 		label: string
+  };
+  thumbnail: {
+		url: string,
+		label: string
 	};
   price_range: {
 		maximum_price: {

--- a/libs/product/src/drivers/magento/queries/fragments/product.ts
+++ b/libs/product/src/drivers/magento/queries/fragments/product.ts
@@ -19,6 +19,10 @@ export const magentoProductFragment = gql`
 			url
 			label
 		}
+    thumbnail {
+			url
+			label
+		}
 		media_gallery_entries {
 			label
 			file

--- a/libs/product/testing/src/factories/magento/product.factory.spec.ts
+++ b/libs/product/testing/src/factories/magento/product.factory.spec.ts
@@ -31,6 +31,8 @@ describe('Product | Testing | Factories | MagentoProductFactory', () => {
       expect(result.id).toBeDefined();
       expect(result.image.label).toBeDefined();
       expect(result.image.url).toBeDefined();
+      expect(result.thumbnail.label).toBeDefined();
+      expect(result.thumbnail.url).toBeDefined();
       expect(result.url_key).toBeDefined();
       expect(result.name).toBeDefined();
       expect(result.description).toBeDefined();

--- a/libs/product/testing/src/factories/magento/product.factory.ts
+++ b/libs/product/testing/src/factories/magento/product.factory.ts
@@ -13,6 +13,10 @@ export class MockMagentoProduct implements MagentoProduct {
     label: faker.random.words(3),
     url: faker.image.imageUrl()
   };
+  thumbnail = {
+    label: faker.random.words(3),
+    url: faker.image.imageUrl()
+  };
   name = faker.random.word();
   description = {
 		html: faker.random.words(5)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Magento cart item product responses return a placeholder image URL (that 404s) which is different from the one in the actual product query.

## What is the new behavior?
The product query includes a thumbnail image URL which is used for the cart item image.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information