### PR TITLE
fix(cart): fix bug where clearing a cart with more than one item failed

### DIFF
--- a/libs/cart/src/drivers/magento/cart.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart.service.spec.ts
@@ -132,6 +132,7 @@ describe('Driver | Magento | Cart | CartService', () => {
 
   describe('clear | remove all items from the cart', () => {
     it('should make a delete cart item request for every item in the cart', done => {
+			spyOn(service, 'get').and.returnValue(of(mockDaffCart));
       service.clear(cartId).subscribe(() => {
         mockDaffCart.items.forEach(item => {
           expect(magentoCartItemSpy.delete).toHaveBeenCalledWith(cartId, item.item_id)
@@ -140,24 +141,12 @@ describe('Driver | Magento | Cart | CartService', () => {
       });
     });
 
-    it('should return an cart observable with no items', done => {
+    it('should return the cart from the get cart call', done => {
+			spyOn(service, 'get').and.returnValue(of(mockDaffCart));
       service.clear(cartId).subscribe(result => {
-        expect(result.items.length).toEqual(0);
+        expect(result).toEqual(mockDaffCart);
         done();
       });
-		});
-		
-		describe('when there are no items in the cart', () => {
-			
-			it('should return the cart', done => {
-				mockDaffCart.items = [];
-				magentoCartItemSpy.list.and.returnValue(of(mockDaffCart.items));
-
-				service.clear(cartId).subscribe((result) => {
-					expect(result).toEqual(mockDaffCart);
-					done();
-				})
-			});
 		});
   });
 

--- a/libs/cart/src/drivers/magento/cart.service.ts
+++ b/libs/cart/src/drivers/magento/cart.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject } from '@angular/core';
 import { Apollo } from 'apollo-angular';
 
-import { Observable, zip, of, throwError, forkJoin } from 'rxjs';
+import { Observable, throwError, forkJoin } from 'rxjs';
 import { map, switchMap, catchError } from 'rxjs/operators';
 
 import { DaffCartServiceInterface } from '../interfaces/cart-service.interface';
@@ -55,28 +55,11 @@ export class DaffMagentoCartService implements DaffCartServiceInterface<DaffCart
   clear(cartId: string): Observable<Partial<DaffCart>> {
     return this.cartItemDriver.list(cartId).pipe(
       switchMap(items =>
-				// make the delete requests in parallel and collect them into a single observable
-				// return null if there are no items in the cart
-        items.length ? forkJoin(...items.map(item =>
+        forkJoin(...items.map(item =>
           this.cartItemDriver.delete(cartId, item.item_id)
-        )) : of(null)
+        ))
       ),
-			// make a get request if there were no items in the cart
-			// todo: find a better way to do this. Because all of the remove item requests are made
-			// asynchronously, there is no guarantee that any cart response will be the "last" one, i.e.
-			// the one with no more items.
-			switchMap(updatedCarts => updatedCarts ? 
-				of(this.removeLeftoverItems(updatedCarts)) : 
-				this.get(cartId))
+			switchMap(() => this.get(cartId))
     )
-	}
-	
-	/**
-	 * This assumes that the remove requests all succeed, and manually sets the cart items to an empty array.
-	 */
-	private removeLeftoverItems(carts: DaffCart[]): DaffCart {
-		carts[0].items = [];
-
-		return carts[0];
 	}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The cartDriver.clear() method tries to remove all the cart items at the same time but through different cart item requests. The logic in cartDriver.clear() assumes that there will be a "final" cart item remove request, and that the payload of that request will have no cart items. Because these cart item requests are asynchronous, there is rarely a case where any cart item remove responses have no items when the original cart has more than one item.

Fixes: N/A


## What is the new behavior?
A bit of a hacky patch that will be readdressed in the future. It is assumed that the cart item requests are successful (though individual cart item remove errors will still bubble through), and just returns an otherwise updated cart with no items.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```