### PR TITLE
refactor(product): move reducer state interfaces into their own files

### DIFF
--- a/libs/product/src/reducers/best-sellers/best-sellers-reducer-state.interface.ts
+++ b/libs/product/src/reducers/best-sellers/best-sellers-reducer-state.interface.ts
@@ -1,0 +1,5 @@
+export interface DaffBestSellersReducerState {
+  productIds: string[],
+  loading: boolean,
+  errors: string[]
+}

--- a/libs/product/src/reducers/best-sellers/best-sellers.reducer.spec.ts
+++ b/libs/product/src/reducers/best-sellers/best-sellers.reducer.spec.ts
@@ -1,8 +1,9 @@
-import { DaffBestSellersLoad, DaffBestSellersLoadSuccess, DaffBestSellersLoadFailure, DaffBestSellersReset } from '../actions/best-sellers.actions';
-import { initialState, reducer, getBestSellersLoading, getBestSellersIds, State } from '../reducers/best-sellers.reducer';
-import { DaffProduct } from '../models/product';
+import { DaffBestSellersLoad, DaffBestSellersLoadSuccess, DaffBestSellersLoadFailure, DaffBestSellersReset } from '../../actions/best-sellers.actions';
+import { initialState, reducer, getBestSellersLoading, getBestSellersIds } from './best-sellers.reducer';
+import { DaffProduct } from '../../models/product';
 
 import { DaffProductFactory } from '@daffodil/product/testing';
+import { DaffBestSellersReducerState } from './best-sellers-reducer-state.interface';
 
 describe('Product | Best Sellers Reducer', () => {
 
@@ -41,7 +42,7 @@ describe('Product | Best Sellers Reducer', () => {
 
     let products: DaffProduct[];
     let result;
-    let state: State;
+    let state: DaffBestSellersReducerState;
 
     beforeEach(() => {
       state = {
@@ -68,7 +69,7 @@ describe('Product | Best Sellers Reducer', () => {
 
     let error: string;
     let result;
-    let state: State;
+    let state: DaffBestSellersReducerState;
 
     beforeEach(() => {
       state = {

--- a/libs/product/src/reducers/best-sellers/best-sellers.reducer.ts
+++ b/libs/product/src/reducers/best-sellers/best-sellers.reducer.ts
@@ -1,21 +1,16 @@
-import { DaffBestSellersActionTypes, DaffBestSellersActions } from '../actions/best-sellers.actions';
-import { DaffProduct } from '../models/product';
+import { DaffBestSellersActionTypes, DaffBestSellersActions } from '../../actions/best-sellers.actions';
+import { DaffProduct } from '../../models/product';
+import { DaffBestSellersReducerState } from './best-sellers-reducer-state.interface';
 
-export interface State {
-  productIds: string[],
-  loading: boolean,
-  errors: string[]
-}
-
-export const initialState: State = {
+export const initialState: DaffBestSellersReducerState = {
   productIds: [],
   loading: false,
   errors: []
 };
 
-export const resetState: State = Object.assign({}, initialState);
+export const resetState: DaffBestSellersReducerState = Object.assign({}, initialState);
 
-export function reducer(state = initialState, action: DaffBestSellersActions): State {
+export function reducer(state = initialState, action: DaffBestSellersActions): DaffBestSellersReducerState {
   switch (action.type) {
     case DaffBestSellersActionTypes.BestSellersLoadAction:
       return {...state, loading: true};
@@ -35,9 +30,9 @@ export function reducer(state = initialState, action: DaffBestSellersActions): S
   }
 }
 
-export const getBestSellersIds = (state: State) => state.productIds;
+export const getBestSellersIds = (state: DaffBestSellersReducerState) => state.productIds;
 
-export const getBestSellersLoading = (state: State) => state.loading;
+export const getBestSellersLoading = (state: DaffBestSellersReducerState) => state.loading;
 
 function getIds(products: DaffProduct[]): string[] {
   const ids: string[] = new Array();

--- a/libs/product/src/reducers/index.ts
+++ b/libs/product/src/reducers/index.ts
@@ -1,19 +1,24 @@
 import { ActionReducerMap, createSelector, createFeatureSelector,MemoizedSelector } from '@ngrx/store';
+import { EntityState } from '@ngrx/entity';
 
-import * as fromProductEntities from './product-entities.reducer';
-import * as fromProductGrid from './product-grid.reducer';
-import * as fromProduct from './product.reducer';
-import * as fromBestSellers from './best-sellers.reducer';
+import * as fromProductEntities from './product-entities/product-entities.reducer';
+import * as fromProductGrid from './product-grid/product-grid.reducer';
+import * as fromProduct from './product/product.reducer';
+import * as fromBestSellers from './best-sellers/best-sellers.reducer';
 import { DaffProductUnion } from '../models/product-union';
+import { DaffProduct } from '../models/product';
+import { DaffProductGridReducerState } from './product-grid/product-grid-reducer-state.interface';
+import { DaffProductReducerState } from './product/product-reducer-state.interface';
+import { DaffBestSellersReducerState } from './best-sellers/best-sellers-reducer-state.interface';
 
 /**
  * Interface for product redux store.
  */
 export interface State {
-  products : fromProductEntities.State;
-  productGrid: fromProductGrid.State;
-  product: fromProduct.State;
-  bestSellers: fromBestSellers.State;
+  products : EntityState<DaffProduct>;
+  productGrid: DaffProductGridReducerState;
+  product: DaffProductReducerState;
+  bestSellers: DaffBestSellersReducerState;
 }
 
 /**

--- a/libs/product/src/reducers/product-entities/product-entities-reducer-adapter.ts
+++ b/libs/product/src/reducers/product-entities/product-entities-reducer-adapter.ts
@@ -1,0 +1,7 @@
+import { EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { DaffProductUnion } from '../../models/product-union';
+
+/**
+ * Product Adapter for changing/overwriting entity state.
+ */
+export const productEntitiesAdapter : EntityAdapter<DaffProductUnion> = createEntityAdapter<DaffProductUnion>();

--- a/libs/product/src/reducers/product-entities/product-entities.reducer.spec.ts
+++ b/libs/product/src/reducers/product-entities/product-entities.reducer.spec.ts
@@ -1,11 +1,11 @@
 import { DaffProductFactory, DaffProductModificationFactory } from '@daffodil/product/testing';
 
-import { DaffProductLoadSuccess, DaffProductModify } from '../actions/product.actions';
-import { DaffProductGridLoadSuccess, DaffProductGridReset } from '../actions/product-grid.actions';
-import { initialState, reducer } from '../reducers/product-entities.reducer';
-import { DaffBestSellersLoadSuccess } from '../actions/best-sellers.actions';
-import { DaffProduct } from '../models/product';
-import { DaffProductModification } from '../models/product-modification';
+import { DaffProductLoadSuccess, DaffProductModify } from '../../actions/product.actions';
+import { DaffProductGridLoadSuccess, DaffProductGridReset } from '../../actions/product-grid.actions';
+import { initialState, reducer } from './product-entities.reducer';
+import { DaffBestSellersLoadSuccess } from '../../actions/best-sellers.actions';
+import { DaffProduct } from '../../models/product';
+import { DaffProductModification } from '../../models/product-modification';
 
 describe('Product | Product Entities Reducer', () => {
 

--- a/libs/product/src/reducers/product-entities/product-entities.reducer.ts
+++ b/libs/product/src/reducers/product-entities/product-entities.reducer.ts
@@ -1,24 +1,15 @@
-import { createEntityAdapter, EntityState, EntityAdapter, Dictionary } from '@ngrx/entity';
+import { EntityState, Dictionary } from '@ngrx/entity';
 
-import { DaffProductGridActionTypes, DaffProductGridActions } from '../actions/product-grid.actions';
-import { DaffProductActionTypes, DaffProductActions } from '../actions/product.actions';
-import { DaffBestSellersActionTypes, DaffBestSellersActions } from '../actions/best-sellers.actions';
-import { DaffProductUnion } from '../models/product-union';
-
-/**
- * Interface for product entity state.
- */
-export interface State extends EntityState<DaffProductUnion> {}
-
-/**
- * Product Adapter for changing/overwriting entity state.
- */
-export const productAdapter : EntityAdapter<DaffProductUnion> = createEntityAdapter<DaffProductUnion>();
+import { DaffProductGridActionTypes, DaffProductGridActions } from '../../actions/product-grid.actions';
+import { DaffProductActionTypes, DaffProductActions } from '../../actions/product.actions';
+import { DaffBestSellersActionTypes, DaffBestSellersActions } from '../../actions/best-sellers.actions';
+import { DaffProductUnion } from '../../models/product-union';
+import { productEntitiesAdapter } from './product-entities-reducer-adapter';
 
 /**
  * Initial state for product entity state.
  */
-export const initialState: State = productAdapter.getInitialState();
+export const initialState: EntityState<DaffProductUnion> = productEntitiesAdapter.getInitialState();
 
 /**
  * Reducer function that catches actions and changes/overwrites product entities state.
@@ -29,14 +20,14 @@ export const initialState: State = productAdapter.getInitialState();
  */
 export function reducer(
   state = initialState, 
-  action: DaffProductGridActions | DaffBestSellersActions | DaffProductActions): State {
+  action: DaffProductGridActions | DaffBestSellersActions | DaffProductActions): EntityState<DaffProductUnion> {
   switch (action.type) {
     case DaffProductGridActionTypes.ProductGridLoadSuccessAction:
-      return productAdapter.upsertMany(action.payload, state);
+      return productEntitiesAdapter.upsertMany(action.payload, state);
     case DaffBestSellersActionTypes.BestSellersLoadSuccessAction:
-      return productAdapter.upsertMany(action.payload, state);
+      return productEntitiesAdapter.upsertMany(action.payload, state);
     case DaffProductActionTypes.ProductLoadSuccessAction:
-      return productAdapter.upsertOne(
+      return productEntitiesAdapter.upsertOne(
         { 
           id: action.payload.id, 
           ...action.payload
@@ -44,7 +35,7 @@ export function reducer(
         state
       );
     case DaffProductActionTypes.ProductModifyAction:
-      return productAdapter.updateOne(
+      return productEntitiesAdapter.updateOne(
         {
           id: action.payload.id,
           changes: action.payload.modification
@@ -52,13 +43,13 @@ export function reducer(
         state
       );
     case DaffProductGridActionTypes.ProductGridResetAction:
-      return productAdapter.removeAll(state);
+      return productEntitiesAdapter.removeAll(state);
     default:
       return state;
   }
 }
 
-const { selectIds, selectEntities, selectAll, selectTotal } = productAdapter.getSelectors();
+const { selectIds, selectEntities, selectAll, selectTotal } = productEntitiesAdapter.getSelectors();
 /**
  * Selector for product IDs.
  */

--- a/libs/product/src/reducers/product-grid/product-grid-reducer-state.interface.ts
+++ b/libs/product/src/reducers/product-grid/product-grid-reducer-state.interface.ts
@@ -1,0 +1,10 @@
+import { DaffProduct } from '../../models/product';
+
+/**
+ * Interface for product grid state.
+ */
+export interface DaffProductGridReducerState {
+  products: DaffProduct[],
+  loading: boolean,
+  errors: string[]
+}

--- a/libs/product/src/reducers/product-grid/product-grid.reducer.spec.ts
+++ b/libs/product/src/reducers/product-grid/product-grid.reducer.spec.ts
@@ -1,8 +1,9 @@
 import { DaffProductFactory } from '@daffodil/product/testing';
 
-import { DaffProductGridLoad, DaffProductGridLoadSuccess, DaffProductGridLoadFailure } from '../actions/product-grid.actions';
-import { initialState, reducer, getProductGridLoading, State } from '../reducers/product-grid.reducer';
-import { DaffProduct } from '../models/product';
+import { DaffProductGridLoad, DaffProductGridLoadSuccess, DaffProductGridLoadFailure } from '../../actions/product-grid.actions';
+import { initialState, reducer, getProductGridLoading } from './product-grid.reducer';
+import { DaffProduct } from '../../models/product';
+import { DaffProductGridReducerState } from './product-grid-reducer-state.interface';
 
 describe('Product | Product Grid Reducer', () => {
 
@@ -41,7 +42,7 @@ describe('Product | Product Grid Reducer', () => {
 
     let products: DaffProduct[];
     let result;
-    let state: State;
+    let state: DaffProductGridReducerState;
 
     beforeEach(() => {
       state = {
@@ -63,7 +64,7 @@ describe('Product | Product Grid Reducer', () => {
 
     let error: string;
     let result;
-    let state: State;
+    let state: DaffProductGridReducerState;
 
     beforeEach(() => {
       state = {

--- a/libs/product/src/reducers/product-grid/product-grid.reducer.ts
+++ b/libs/product/src/reducers/product-grid/product-grid.reducer.ts
@@ -1,19 +1,10 @@
-import { DaffProductGridActionTypes, DaffProductGridActions } from '../actions/product-grid.actions';
-import { DaffProduct } from '../models/product';
-
-/**
- * Interface for product grid state.
- */
-export interface State {
-  products: DaffProduct[],
-  loading: boolean,
-  errors: string[]
-}
+import { DaffProductGridActionTypes, DaffProductGridActions } from '../../actions/product-grid.actions';
+import { DaffProductGridReducerState } from './product-grid-reducer-state.interface';
 
 /**
  * Initial values of the product grid state.
  */
-export const initialState: State = {
+export const initialState: DaffProductGridReducerState = {
   products: [],
   loading: false,
   errors: []
@@ -26,7 +17,7 @@ export const initialState: State = {
  * @param action a product grid action
  * @returns Product grid state
  */
-export function reducer(state = initialState, action: DaffProductGridActions): State {
+export function reducer(state = initialState, action: DaffProductGridActions): DaffProductGridReducerState {
   switch (action.type) {
     case DaffProductGridActionTypes.ProductGridLoadAction:
       return {...state, loading: true};
@@ -47,4 +38,4 @@ export function reducer(state = initialState, action: DaffProductGridActions): S
  * 
  * @param state current redux state object
  */
-export const getProductGridLoading = (state: State) => state.loading;
+export const getProductGridLoading = (state: DaffProductGridReducerState) => state.loading;

--- a/libs/product/src/reducers/product/product-reducer-state.interface.ts
+++ b/libs/product/src/reducers/product/product-reducer-state.interface.ts
@@ -1,0 +1,9 @@
+/**
+ * Interface for product state.
+ */
+export interface DaffProductReducerState {
+  selectedProductId: string,
+  qty: number,
+  loading: boolean,
+  errors: string[]
+}

--- a/libs/product/src/reducers/product/product.reducer.spec.ts
+++ b/libs/product/src/reducers/product/product.reducer.spec.ts
@@ -1,14 +1,14 @@
 import { 
   initialState, 
   reducer, 
-  State,
   getProductLoading, 
   getSelectedProductId, 
   getProductQty 
-} from '../reducers/product.reducer';
-import { DaffProductLoad, DaffProductLoadSuccess, DaffProductLoadFailure, DaffProductUpdateQty } from '../actions/product.actions';
-import { DaffProduct } from '../models/product';
+} from './product.reducer';
+import { DaffProductLoad, DaffProductLoadSuccess, DaffProductLoadFailure, DaffProductUpdateQty } from '../../actions/product.actions';
+import { DaffProduct } from '../../models/product';
 import { DaffProductFactory } from '@daffodil/product/testing';
+import { DaffProductReducerState } from './product-reducer-state.interface';
 
 describe('Product | Product Reducer', () => {
 
@@ -55,7 +55,7 @@ describe('Product | Product Reducer', () => {
   describe('when ProductLoadSuccessAction is triggered', () => {
 
     let result;
-    let state: State;
+    let state: DaffProductReducerState;
 
     beforeEach(() => {
       state = {
@@ -76,7 +76,7 @@ describe('Product | Product Reducer', () => {
 
     const error = 'error message';
     let result;
-    let state: State;
+    let state: DaffProductReducerState;
 
     beforeEach(() => {
       state = {

--- a/libs/product/src/reducers/product/product.reducer.ts
+++ b/libs/product/src/reducers/product/product.reducer.ts
@@ -1,19 +1,10 @@
-import { DaffProductActionTypes, DaffProductActions } from '../actions/product.actions';
-
-/**
- * Interface for product state.
- */
-export interface State {
-  selectedProductId: string,
-  qty: number,
-  loading: boolean,
-  errors: string[]
-}
+import { DaffProductReducerState } from './product-reducer-state.interface';
+import { DaffProductActionTypes, DaffProductActions } from '../../actions/product.actions';
 
 /**
  * Initial values of the product state.
  */
-export const initialState: State = {
+export const initialState: DaffProductReducerState = {
   selectedProductId: null,
   qty: 1,
   loading: false,
@@ -27,7 +18,7 @@ export const initialState: State = {
  * @param action a product action
  * @returns product state
  */
-export function reducer(state = initialState, action: DaffProductActions): State {
+export function reducer(state = initialState, action: DaffProductActions): DaffProductReducerState {
   switch (action.type) {
     case DaffProductActionTypes.ProductLoadAction:
       return {...state, loading: true, selectedProductId: action.payload};
@@ -50,18 +41,18 @@ export function reducer(state = initialState, action: DaffProductActions): State
  * 
  * @param state current redux state object
  */
-export const getSelectedProductId = (state: State) => state.selectedProductId;
+export const getSelectedProductId = (state: DaffProductReducerState) => state.selectedProductId;
 
 /**
  * Selects the product's quantity.
  * 
  * @param state current redux state object
  */
-export const getProductQty = (state: State) => state.qty;
+export const getProductQty = (state: DaffProductReducerState) => state.qty;
 
 /**
  * Selects the loading status of the product state.
  * 
  * @param state current redux state object
  */
-export const getProductLoading = (state: State) => state.loading;
+export const getProductLoading = (state: DaffProductReducerState) => state.loading;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The reducer state interfaces are all in the reducer files, and all of the different reducers are in the same directory. All the state interfaces are just called `State`, so it's difficult to distinguish between them. 


## What is the new behavior?
The reducers and reducer interfaces are more segregated in preparation for further refactoring of the selectors.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

The only changes were in pulling out the state interfaces, updating file import references, and moving the reducer files. No other changes were made in the tests or actual reducers.