### PR TITLE
feat(category): make the category package generic

### DIFF
--- a/libs/category/src/actions/category.actions.ts
+++ b/libs/category/src/actions/category.actions.ts
@@ -3,6 +3,8 @@ import { Action } from '@ngrx/store';
 import { DaffGetCategoryResponse } from '../models/get-category-response';
 import { DaffCategoryRequest } from '../models/requests/category-request';
 import { DaffCategoryFilterRequest, DaffToggleCategoryFilterRequest } from '../models/requests/filter-request';
+import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
+import { DaffGenericCategory } from '../models/generic-category';
 
 export enum DaffCategoryActionTypes {
   CategoryLoadAction = '[Daff-Category] Category Load Action',
@@ -20,10 +22,10 @@ export enum DaffCategoryActionTypes {
  * 
  * @param request - DaffCategoryRequest object
  */
-export class DaffCategoryLoad implements Action {
+export class DaffCategoryLoad<T extends DaffCategoryRequest> implements Action {
   readonly type = DaffCategoryActionTypes.CategoryLoadAction;
 
-  constructor(public request: DaffCategoryRequest) { }
+  constructor(public request: T) { }
 }
 
 /**
@@ -31,10 +33,10 @@ export class DaffCategoryLoad implements Action {
  * 
  * @param response - DaffGetCategoryResponse object
  */
-export class DaffCategoryLoadSuccess implements Action {
+export class DaffCategoryLoadSuccess<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState> implements Action {
   readonly type = DaffCategoryActionTypes.CategoryLoadSuccessAction;
 
-  constructor(public response: DaffGetCategoryResponse) { }
+  constructor(public response: DaffGetCategoryResponse<T, U>) { }
 }
 
 /**
@@ -108,9 +110,13 @@ export class DaffToggleCategoryFilter implements Action {
   constructor(public filter: DaffToggleCategoryFilterRequest) { }
 }
 
-export type DaffCategoryActions =
-  | DaffCategoryLoad
-  | DaffCategoryLoadSuccess
+export type DaffCategoryActions<
+	T extends DaffCategoryRequest, 
+	U extends DaffGenericCategory<U>, 
+	V extends DaffCategoryPageConfigurationState
+> =
+  | DaffCategoryLoad<T>
+  | DaffCategoryLoadSuccess<U, V>
   | DaffCategoryLoadFailure
 	| DaffChangeCategoryPageSize
 	| DaffChangeCategoryCurrentPage

--- a/libs/category/src/category-state.module.ts
+++ b/libs/category/src/category-state.module.ts
@@ -7,7 +7,7 @@ import { DaffCategoryEffects } from './effects/category.effects';
 
 @NgModule({
   imports: [
-    StoreModule.forFeature('category', categoryReducers),
+    StoreModule.forFeature('category', categoryReducers()),
     EffectsModule.forFeature([DaffCategoryEffects]),
   ]
 })

--- a/libs/category/src/category-state.module.ts
+++ b/libs/category/src/category-state.module.ts
@@ -2,12 +2,12 @@ import { NgModule } from '@angular/core';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 
-import { categoryReducers } from './reducers/category-reducers';
+import { daffCategoryReducers } from './reducers/category-reducers';
 import { DaffCategoryEffects } from './effects/category.effects';
 
 @NgModule({
   imports: [
-    StoreModule.forFeature('category', categoryReducers()),
+    StoreModule.forFeature('category', daffCategoryReducers()),
     EffectsModule.forFeature([DaffCategoryEffects]),
   ]
 })

--- a/libs/category/src/category-state.module.ts
+++ b/libs/category/src/category-state.module.ts
@@ -7,7 +7,7 @@ import { DaffCategoryEffects } from './effects/category.effects';
 
 @NgModule({
   imports: [
-    StoreModule.forFeature('category', daffCategoryReducers()),
+    StoreModule.forFeature('category', daffCategoryReducers),
     EffectsModule.forFeature([DaffCategoryEffects]),
   ]
 })

--- a/libs/category/src/drivers/interfaces/category-service.interface.ts
+++ b/libs/category/src/drivers/interfaces/category-service.interface.ts
@@ -2,7 +2,13 @@ import { Observable } from 'rxjs';
 
 import { DaffGetCategoryResponse } from '../../models/get-category-response';
 import { DaffCategoryRequest } from '../../models/requests/category-request';
+import { DaffCategoryPageConfigurationState } from '../../models/category-page-configuration-state';
+import { DaffGenericCategory } from '../../models/generic-category';
 
-export interface DaffCategoryServiceInterface {
-  get(categoryRequest: DaffCategoryRequest): Observable<DaffGetCategoryResponse>;
+export interface DaffCategoryServiceInterface<
+	T extends DaffCategoryRequest, 
+	U extends DaffGenericCategory<U>,
+	V extends DaffCategoryPageConfigurationState
+> {
+  get(categoryRequest: T): Observable<DaffGetCategoryResponse<U, V>>;
 }

--- a/libs/category/src/drivers/magento/category.service.ts
+++ b/libs/category/src/drivers/magento/category.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable, combineLatest, of } from 'rxjs';
+import { Observable, combineLatest } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { Apollo } from 'apollo-angular';
 
@@ -20,11 +20,13 @@ import { MagentoGetCategoryAggregationsResponse } from './models/get-category-ag
 import { MagentoCustomAttributeMetadataResponse } from './models/custom-attribute-metadata-response';
 import { MagentoGetCustomAttributeMetadata } from './queries/custom-attribute-metadata';
 import { buildCustomMetadataAttribute, addMetadataTypesToAggregates } from './transformers/custom-metadata-attributes-methods';
+import { DaffCategory } from '../../models/category';
+import { DaffCategoryPageConfigurationState } from '../../models/category-page-configuration-state';
 
 @Injectable({
   providedIn: 'root'
 })
-export class DaffMagentoCategoryService implements DaffCategoryServiceInterface {
+export class DaffMagentoCategoryService implements DaffCategoryServiceInterface<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState> {
   
   constructor(
     private apollo: Apollo,
@@ -38,7 +40,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
    * Gets a category based on parameters. Default current_page is 1, and default page_size is 20.
    * @param categoryRequest A DaffCategoryRequest object.
    */
-  get(categoryRequest: DaffCategoryRequest): Observable<DaffGetCategoryResponse> {
+  get(categoryRequest: DaffCategoryRequest): Observable<DaffGetCategoryResponse<DaffCategory, DaffCategoryPageConfigurationState>> {
     return combineLatest([
       this.apollo.query<MagentoGetACategoryResponse>({
 				query: MagentoGetCategoryQuery,

--- a/libs/category/src/drivers/magento/transformers/category-response-transform.service.ts
+++ b/libs/category/src/drivers/magento/transformers/category-response-transform.service.ts
@@ -6,6 +6,8 @@ import { DaffMagentoCategoryPageConfigTransformerService } from './category-page
 import { MagentoCompleteCategoryResponse } from '../models/complete-category-response';
 import { DaffGetCategoryResponse } from '../../../models/get-category-response';
 import { DaffMagentoCategoryTransformerService } from './category-transformer.service';
+import { DaffCategory } from '../../../models/category';
+import { DaffCategoryPageConfigurationState } from '../../../models/category-page-configuration-state';
 
 @Injectable({
   providedIn: 'root'
@@ -18,7 +20,7 @@ export class DaffMagentoCategoryResponseTransformService {
     private magentoProductTransformerService: DaffMagentoProductTransformerService
   ) {}
 
-  transform(completeCategory: MagentoCompleteCategoryResponse): DaffGetCategoryResponse {
+  transform(completeCategory: MagentoCompleteCategoryResponse): DaffGetCategoryResponse<DaffCategory, DaffCategoryPageConfigurationState> {
     return {
 			...{ magentoCompleteCategoryResponse: completeCategory },
       category: this.magentoCategoryTransformerService.transform(completeCategory.category),

--- a/libs/category/src/effects/category.effects.spec.ts
+++ b/libs/category/src/effects/category.effects.spec.ts
@@ -56,7 +56,7 @@ describe('DaffCategoryEffects', () => {
     TestBed.configureTestingModule({
 			imports: [
         StoreModule.forRoot({
-          category: combineReducers(daffCategoryReducers()),
+          category: combineReducers(daffCategoryReducers),
           product: combineReducers(daffProductReducers)
         })
 			],

--- a/libs/category/src/effects/category.effects.spec.ts
+++ b/libs/category/src/effects/category.effects.spec.ts
@@ -2,10 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Observable ,  of } from 'rxjs';
 import { hot, cold } from 'jasmine-marbles';
-import { Store } from '@ngrx/store';
-import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { Store, StoreModule, combineReducers } from '@ngrx/store';
+import { MockStore } from '@ngrx/store/testing';
 
-import { DaffProduct, DaffProductGridLoadSuccess } from '@daffodil/product';
+import { DaffProduct, DaffProductGridLoadSuccess, daffProductReducers } from '@daffodil/product';
 import { DaffProductFactory } from '@daffodil/product/testing';
 import { DaffCategoryFactory, DaffCategoryPageConfigurationStateFactory } from '@daffodil/category/testing';
 
@@ -24,46 +24,49 @@ import { DaffCategory } from '../models/category';
 import { DaffCategoryServiceInterface } from '../drivers/interfaces/category-service.interface';
 import { DaffCategoryDriver } from '../drivers/injection-tokens/category-driver.token';
 import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
-import { 
-	selectSelectedCategoryId, 
-	selectCategoryPageSize,
-	selectCategoryPageFilterRequests, 
-	selectCategoryPageAppliedSortOption, 
-	selectCategoryPageAppliedSortDirection 
-} from '../selectors/category.selector';
-import { DaffSortDirectionEnum } from '../models/requests/category-request';
+import { DaffSortDirectionEnum, DaffCategoryRequest } from '../models/requests/category-request';
 import { DaffCategoryFilterEqualRequest } from '../models/requests/filter-request';
 import { DaffCategoryFilterType } from '../models/category-filter-base';
+import { categoryReducers } from '../reducers/category-reducers';
+
+class MockCategoryDriver implements DaffCategoryServiceInterface<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState> {
+	get(categoryRequest: any): Observable<any> {
+		return null;
+	}
+}
 
 describe('DaffCategoryEffects', () => {
   let actions$: Observable<any>;
-  let effects: DaffCategoryEffects;
+  let effects: DaffCategoryEffects<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState>;
   let stubCategory: DaffCategory;
   let stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState;
   let stubProducts: DaffProduct[];
-  let daffCategoryDriver: DaffCategoryServiceInterface;
+  let daffCategoryDriver: DaffCategoryServiceInterface<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState>;
   const daffCategoryDriverSpy = jasmine.createSpyObj('DaffCategoryDriver', ['get']);
   let store: MockStore<any>;
 
   let categoryFactory: DaffCategoryFactory;
   let categoryPageConfigurationStateFactory: DaffCategoryPageConfigurationStateFactory;
-  let categoryId;
 	let productFactory: DaffProductFactory;
-	let categoryLoadSuccessAction: DaffCategoryLoadSuccess;
+	let categoryLoadSuccessAction: DaffCategoryLoadSuccess<DaffCategory, DaffCategoryPageConfigurationState>;
 	let productGridLoadSuccessAction: DaffProductGridLoadSuccess;
 
   beforeEach(() => {
-    categoryId = 'category id';
 
     TestBed.configureTestingModule({
+			imports: [
+        StoreModule.forRoot({
+          category: combineReducers(categoryReducers()),
+          product: combineReducers(daffProductReducers)
+        })
+			],
       providers: [
         DaffCategoryEffects,
         provideMockActions(() => actions$),
         {
           provide: DaffCategoryDriver, 
-          useValue: daffCategoryDriverSpy
-        },
-        provideMockStore({})
+          useClass: MockCategoryDriver
+        }
       ]
     });
 
@@ -73,16 +76,12 @@ describe('DaffCategoryEffects', () => {
     categoryPageConfigurationStateFactory = TestBed.get(DaffCategoryPageConfigurationStateFactory);
     productFactory = new DaffProductFactory();
 
-    stubCategory = categoryFactory.create();
-    stubCategoryPageConfigurationState = categoryPageConfigurationStateFactory.create();
+		stubCategory = categoryFactory.create();
+		stubCategoryPageConfigurationState = categoryPageConfigurationStateFactory.create();
+		stubCategory.id = stubCategoryPageConfigurationState.id;
 		stubProducts = productFactory.createMany(3);
 		
     daffCategoryDriver = TestBed.get(DaffCategoryDriver);
-    store.overrideSelector(selectSelectedCategoryId, categoryId);
-    store.overrideSelector(selectCategoryPageSize, stubCategoryPageConfigurationState.page_size);
-    store.overrideSelector(selectCategoryPageFilterRequests, stubCategoryPageConfigurationState.filter_requests);
-    store.overrideSelector(selectCategoryPageAppliedSortOption, stubCategoryPageConfigurationState.applied_sort_option);
-		store.overrideSelector(selectCategoryPageAppliedSortDirection, stubCategoryPageConfigurationState.applied_sort_direction);
 		
 		daffCategoryDriverSpy.get.and.returnValue(of({
 			category: stubCategory,
@@ -95,11 +94,9 @@ describe('DaffCategoryEffects', () => {
 			categoryPageConfigurationState: stubCategoryPageConfigurationState,
 			products: stubProducts
 		});
-		productGridLoadSuccessAction = new DaffProductGridLoadSuccess(stubProducts)
-  });
-
-  afterAll(() => {
-    store.resetSelectors();
+		productGridLoadSuccessAction = new DaffProductGridLoadSuccess(stubProducts);
+		store.dispatch(categoryLoadSuccessAction);
+		store.dispatch(productGridLoadSuccessAction);
   });
 
   it('should be created', () => {
@@ -108,8 +105,12 @@ describe('DaffCategoryEffects', () => {
 
   describe('processCategoryGetRequest', () => {
     
-    let expected;
-    const categoryLoadAction = new DaffCategoryLoad({id: categoryId});
+		let expected;
+		let categoryLoadAction;
+
+		beforeEach(() => {
+ 			categoryLoadAction = new DaffCategoryLoad({id: stubCategory.id});
+		})
     
     describe('when the call to CategoryService is successful', () => {
 
@@ -118,6 +119,11 @@ describe('DaffCategoryEffects', () => {
       });
       
       it('should dispatch a DaffCategoryLoadSuccess and a DaffProductGridLoadSuccess action', () => {
+				spyOn(daffCategoryDriver, 'get').and.returnValue(of({
+					category: stubCategory,
+					categoryPageConfigurationState: stubCategoryPageConfigurationState,
+					products: stubProducts
+				}));
         
         expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
         expect(effects.loadCategory$).toBeObservable(expected);
@@ -128,8 +134,8 @@ describe('DaffCategoryEffects', () => {
       
       beforeEach(() => {
         const error = 'Failed to load the category';
-        const response = cold('#', {}, error);
-        daffCategoryDriverSpy.get.and.returnValue(response);
+				const response = cold('#', {}, error);
+				spyOn(daffCategoryDriver, 'get').and.returnValue(response);
         const categoryLoadFailureAction = new DaffCategoryLoadFailure(error);
         actions$ = hot('--a', { a: categoryLoadAction });
         expected = cold('--b', { b: categoryLoadFailureAction });
@@ -176,13 +182,18 @@ describe('DaffCategoryEffects', () => {
     let expected;
     
     it('should call get category with only an id', () => {
-      const categoryLoadAction = new DaffCategoryLoad({ id: categoryId });
+			spyOn(daffCategoryDriver, 'get').and.returnValue(of({
+				category: stubCategory,
+				categoryPageConfigurationState: stubCategoryPageConfigurationState,
+				products: stubProducts
+			}));
+      const categoryLoadAction = new DaffCategoryLoad({ id: stubCategory.id });
       actions$ = hot('--a', { a: categoryLoadAction });
       
       expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
       expect(effects.loadCategory$).toBeObservable(expected);
 
-      expect(daffCategoryDriver.get).toHaveBeenCalledWith({ id: categoryId });
+      expect(daffCategoryDriver.get).toHaveBeenCalledWith({ id: stubCategory.id });
     });
 	});
 
@@ -191,13 +202,18 @@ describe('DaffCategoryEffects', () => {
     let expected;
     
     it('should call get category with an id, page size, applied filters, and an applied sort option', () => {
+			spyOn(daffCategoryDriver, 'get').and.returnValue(of({
+				category: stubCategory,
+				categoryPageConfigurationState: stubCategoryPageConfigurationState,
+				products: stubProducts
+			}));
       const changeCategoryPageSizeAction = new DaffChangeCategoryPageSize(3);
       actions$ = hot('--a', { a: changeCategoryPageSizeAction });
       
       expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
 			expect(effects.changeCategoryPageSize$).toBeObservable(expected);
       expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
-        id: categoryId,
+        id: stubCategory.id,
 				page_size: 3,
 				filter_requests: stubCategoryPageConfigurationState.filter_requests,
 				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
@@ -211,13 +227,18 @@ describe('DaffCategoryEffects', () => {
     let expected;
     
     it('should call get category with every available parameter', () => {
+			spyOn(daffCategoryDriver, 'get').and.returnValue(of({
+				category: stubCategory,
+				categoryPageConfigurationState: stubCategoryPageConfigurationState,
+				products: stubProducts
+			}));
       const changeCategoryCurrentPageAction = new DaffChangeCategoryCurrentPage(3);
       actions$ = hot('--a', { a: changeCategoryCurrentPageAction });
 			
 			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
 			expect(effects.changeCategoryCurrentPage$).toBeObservable(expected);
 			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
-        id: categoryId,
+        id: stubCategory.id,
         page_size: stubCategoryPageConfigurationState.page_size,
 				current_page: 3,
 				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
@@ -232,6 +253,11 @@ describe('DaffCategoryEffects', () => {
     let expected;
     
     it('should call get category with an id, page size, applied filters, and an applied sorting option', () => {
+			spyOn(daffCategoryDriver, 'get').and.returnValue(of({
+				category: stubCategory,
+				categoryPageConfigurationState: stubCategoryPageConfigurationState,
+				products: stubProducts
+			}));
       const changeCategoryFiltersAction = new DaffChangeCategoryFilters([{
 				name: 'name',
 				type: DaffCategoryFilterType.Equal,
@@ -242,7 +268,7 @@ describe('DaffCategoryEffects', () => {
 			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
 			expect(effects.changeCategoryFilters$).toBeObservable(expected);
 			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
-				id: categoryId,
+				id: stubCategory.id,
         page_size: stubCategoryPageConfigurationState.page_size,
 				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
 				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
@@ -260,24 +286,28 @@ describe('DaffCategoryEffects', () => {
     let expected;
     
     it('should call get category with an id, page size, applied filters, and an applied sorting option', () => {
+			spyOn(daffCategoryDriver, 'get').and.returnValue(of({
+				category: stubCategory,
+				categoryPageConfigurationState: stubCategoryPageConfigurationState,
+				products: stubProducts
+			}));
 			const appliedFilter: DaffCategoryFilterEqualRequest = {
 				name: 'name',
 				type: DaffCategoryFilterType.Equal,
 				value: ['value']
 			}
-			store.overrideSelector(selectCategoryPageFilterRequests, [appliedFilter]);
-			store.setState({});
       const toggleCategoryFilterAction = new DaffToggleCategoryFilter({
 				name: 'name',
 				type: DaffCategoryFilterType.Equal,
 				value: 'value'
 			});
+			store.dispatch(toggleCategoryFilterAction);
       actions$ = hot('--a', { a: toggleCategoryFilterAction });
 			
 			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
 			expect(effects.toggleCategoryFilter$).toBeObservable(expected);
 			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
-				id: categoryId,
+				id: stubCategory.id,
         page_size: stubCategoryPageConfigurationState.page_size,
 				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
 				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
@@ -291,6 +321,11 @@ describe('DaffCategoryEffects', () => {
     let expected;
     
     it('should call get category with an id, page size, applied filters, and an applied sorting option', () => {
+			spyOn(daffCategoryDriver, 'get').and.returnValue(of({
+				category: stubCategory,
+				categoryPageConfigurationState: stubCategoryPageConfigurationState,
+				products: stubProducts
+			}));
       const changeCategorySortingOption = new DaffChangeCategorySortingOption({
 				option: 'option',
 				direction: DaffSortDirectionEnum.Ascending
@@ -300,7 +335,7 @@ describe('DaffCategoryEffects', () => {
 			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
 			expect(effects.changeCategorySort$).toBeObservable(expected);
 			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
-				id: categoryId,
+				id: stubCategory.id,
         page_size: stubCategoryPageConfigurationState.page_size,
 				applied_sort_direction: DaffSortDirectionEnum.Ascending,
 				applied_sort_option: 'option',

--- a/libs/category/src/effects/category.effects.spec.ts
+++ b/libs/category/src/effects/category.effects.spec.ts
@@ -27,7 +27,7 @@ import { DaffCategoryPageConfigurationState } from '../models/category-page-conf
 import { DaffSortDirectionEnum, DaffCategoryRequest } from '../models/requests/category-request';
 import { DaffCategoryFilterEqualRequest } from '../models/requests/filter-request';
 import { DaffCategoryFilterType } from '../models/category-filter-base';
-import { categoryReducers } from '../reducers/category-reducers';
+import { daffCategoryReducers } from '../reducers/category-reducers';
 
 class MockCategoryDriver implements DaffCategoryServiceInterface<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState> {
 	get(categoryRequest: any): Observable<any> {
@@ -56,7 +56,7 @@ describe('DaffCategoryEffects', () => {
     TestBed.configureTestingModule({
 			imports: [
         StoreModule.forRoot({
-          category: combineReducers(categoryReducers()),
+          category: combineReducers(daffCategoryReducers()),
           product: combineReducers(daffProductReducers)
         })
 			],

--- a/libs/category/src/effects/category.effects.ts
+++ b/libs/category/src/effects/category.effects.ts
@@ -38,7 +38,9 @@ export class DaffCategoryEffects<
     private actions$: Actions,
     @Inject(DaffCategoryDriver) private driver: DaffCategoryServiceInterface<T, U, V>,
     private store: Store<any>
-  ){}
+	){}
+	
+	private categorySelectors = getDaffCategorySelectors<U, V>();
 
   @Effect()
   loadCategory$ : Observable<any> = this.actions$.pipe(
@@ -53,10 +55,10 @@ export class DaffCategoryEffects<
   changeCategoryPageSize$ : Observable<any> = this.actions$.pipe(
 		ofType(DaffCategoryActionTypes.ChangeCategoryPageSizeAction),
     withLatestFrom(
-			this.store.pipe(select(getDaffCategorySelectors<U, V>().selectSelectedCategoryId)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageFilterRequests)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortOption)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortDirection))
+			this.store.pipe(select(this.categorySelectors.selectSelectedCategoryId)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageFilterRequests)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedSortOption)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedSortDirection))
 		),
     switchMap((
 			[action, categoryId, filterRequests, appliedSortOption, appliedSortDirection]: 
@@ -74,11 +76,11 @@ export class DaffCategoryEffects<
   changeCategoryCurrentPage$ : Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.ChangeCategoryCurrentPageAction),
     withLatestFrom(
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectSelectedCategoryId)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageSize)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageFilterRequests)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortOption)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortDirection))
+      this.store.pipe(select(this.categorySelectors.selectSelectedCategoryId)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageSize)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageFilterRequests)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedSortOption)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedSortDirection))
     ),
     switchMap((
 			[action, categoryId, pageSize, filterRequests, appliedSortOption, appliedSortDirection]: 
@@ -97,10 +99,10 @@ export class DaffCategoryEffects<
   changeCategoryFilters$ : Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.ChangeCategoryFiltersAction),
     withLatestFrom(
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectSelectedCategoryId)), 
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageSize)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortOption)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortDirection))
+      this.store.pipe(select(this.categorySelectors.selectSelectedCategoryId)), 
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageSize)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedSortOption)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedSortDirection))
     ),
     switchMap((
 			[action, categoryId, pageSize, appliedSortOption, appliedSortDirection]: 
@@ -121,11 +123,11 @@ export class DaffCategoryEffects<
   toggleCategoryFilter$ : Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.ToggleCategoryFilterAction),
     withLatestFrom(
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectSelectedCategoryId)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageSize)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageFilterRequests)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortOption)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortDirection))
+      this.store.pipe(select(this.categorySelectors.selectSelectedCategoryId)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageSize)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageFilterRequests)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedSortOption)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedSortDirection))
     ),
     switchMap((
 			[action, categoryId, pageSize, filterRequests, appliedSortOption, appliedSortDirection]: 
@@ -146,9 +148,9 @@ export class DaffCategoryEffects<
   changeCategorySort$ : Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.ChangeCategorySortingOptionAction),
     withLatestFrom(
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectSelectedCategoryId)), 
-			this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageSize)),
-      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageFilterRequests))
+      this.store.pipe(select(this.categorySelectors.selectSelectedCategoryId)), 
+			this.store.pipe(select(this.categorySelectors.selectCategoryPageSize)),
+      this.store.pipe(select(this.categorySelectors.selectCategoryPageFilterRequests))
     ),
     switchMap((
 			[action, categoryId, pageSize, filterRequests]: 

--- a/libs/category/src/effects/category.effects.ts
+++ b/libs/category/src/effects/category.effects.ts
@@ -20,13 +20,7 @@ import {
 import { DaffCategoryDriver } from '../drivers/injection-tokens/category-driver.token';
 import { DaffCategoryServiceInterface } from '../drivers/interfaces/category-service.interface';
 import { DaffGetCategoryResponse } from '../models/get-category-response';
-import { 
-	selectSelectedCategoryId, 
-	selectCategoryPageSize, 
-	selectCategoryPageAppliedSortOption,
-	selectCategoryPageAppliedSortDirection, 
-	selectCategoryPageFilterRequests
-} from '../selectors/category.selector';
+import { getDaffCategorySelectors } from '../selectors/category.selector';
 import { DaffCategoryRequest, DaffSortDirectionEnum } from '../models/requests/category-request';
 import { DaffCategoryFilterRequest, DaffCategoryFromToFilterSeparator } from '../models/requests/filter-request';
 import { DaffCategoryFilterType } from '../models/category-filter-base';
@@ -59,10 +53,10 @@ export class DaffCategoryEffects<
   changeCategoryPageSize$ : Observable<any> = this.actions$.pipe(
 		ofType(DaffCategoryActionTypes.ChangeCategoryPageSizeAction),
     withLatestFrom(
-			this.store.pipe(select(selectSelectedCategoryId())),
-      this.store.pipe(select(selectCategoryPageFilterRequests())),
-      this.store.pipe(select(selectCategoryPageAppliedSortOption())),
-      this.store.pipe(select(selectCategoryPageAppliedSortDirection()))
+			this.store.pipe(select(getDaffCategorySelectors<U, V>().selectSelectedCategoryId)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageFilterRequests)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortOption)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortDirection))
 		),
     switchMap((
 			[action, categoryId, filterRequests, appliedSortOption, appliedSortDirection]: 
@@ -80,11 +74,11 @@ export class DaffCategoryEffects<
   changeCategoryCurrentPage$ : Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.ChangeCategoryCurrentPageAction),
     withLatestFrom(
-      this.store.pipe(select(selectSelectedCategoryId())),
-      this.store.pipe(select(selectCategoryPageSize())),
-      this.store.pipe(select(selectCategoryPageFilterRequests())),
-      this.store.pipe(select(selectCategoryPageAppliedSortOption())),
-      this.store.pipe(select(selectCategoryPageAppliedSortDirection()))
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectSelectedCategoryId)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageSize)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageFilterRequests)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortOption)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortDirection))
     ),
     switchMap((
 			[action, categoryId, pageSize, filterRequests, appliedSortOption, appliedSortDirection]: 
@@ -103,10 +97,10 @@ export class DaffCategoryEffects<
   changeCategoryFilters$ : Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.ChangeCategoryFiltersAction),
     withLatestFrom(
-      this.store.pipe(select(selectSelectedCategoryId())), 
-      this.store.pipe(select(selectCategoryPageSize())),
-      this.store.pipe(select(selectCategoryPageAppliedSortOption())),
-      this.store.pipe(select(selectCategoryPageAppliedSortDirection()))
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectSelectedCategoryId)), 
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageSize)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortOption)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortDirection))
     ),
     switchMap((
 			[action, categoryId, pageSize, appliedSortOption, appliedSortDirection]: 
@@ -127,11 +121,11 @@ export class DaffCategoryEffects<
   toggleCategoryFilter$ : Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.ToggleCategoryFilterAction),
     withLatestFrom(
-      this.store.pipe(select(selectSelectedCategoryId())),
-      this.store.pipe(select(selectCategoryPageSize())),
-      this.store.pipe(select(selectCategoryPageFilterRequests())),
-      this.store.pipe(select(selectCategoryPageAppliedSortOption())),
-      this.store.pipe(select(selectCategoryPageAppliedSortDirection()))
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectSelectedCategoryId)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageSize)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageFilterRequests)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortOption)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageAppliedSortDirection))
     ),
     switchMap((
 			[action, categoryId, pageSize, filterRequests, appliedSortOption, appliedSortDirection]: 
@@ -152,9 +146,9 @@ export class DaffCategoryEffects<
   changeCategorySort$ : Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.ChangeCategorySortingOptionAction),
     withLatestFrom(
-      this.store.pipe(select(selectSelectedCategoryId())), 
-			this.store.pipe(select(selectCategoryPageSize())),
-      this.store.pipe(select(selectCategoryPageFilterRequests()))
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectSelectedCategoryId)), 
+			this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageSize)),
+      this.store.pipe(select(getDaffCategorySelectors<U, V>().selectCategoryPageFilterRequests))
     ),
     switchMap((
 			[action, categoryId, pageSize, filterRequests]: 

--- a/libs/category/src/facades/category.facade.spec.ts
+++ b/libs/category/src/facades/category.facade.spec.ts
@@ -28,7 +28,7 @@ describe('DaffCategoryFacade', () => {
     TestBed.configureTestingModule({
       imports:[
         StoreModule.forRoot({
-          category: combineReducers(daffCategoryReducers()),
+          category: combineReducers(daffCategoryReducers),
           product: combineReducers(daffProductReducers)
         })
       ],

--- a/libs/category/src/facades/category.facade.spec.ts
+++ b/libs/category/src/facades/category.facade.spec.ts
@@ -16,7 +16,7 @@ import { DaffCategoryFilterType } from '../models/category-filter-base';
 
 describe('DaffCategoryFacade', () => {
   let store: MockStore<any>;
-  let facade: DaffCategoryFacade;
+  let facade: DaffCategoryFacade<DaffCategory, DaffCategoryPageConfigurationState>;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
   const categoryPageConfigurationFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
   const productFactory: DaffProductFactory = new DaffProductFactory();
@@ -28,7 +28,7 @@ describe('DaffCategoryFacade', () => {
     TestBed.configureTestingModule({
       imports:[
         StoreModule.forRoot({
-          category: combineReducers(categoryReducers),
+          category: combineReducers(categoryReducers()),
           product: combineReducers(daffProductReducers)
         })
       ],

--- a/libs/category/src/facades/category.facade.spec.ts
+++ b/libs/category/src/facades/category.facade.spec.ts
@@ -9,7 +9,7 @@ import { DaffProductUnion, DaffProductGridLoadSuccess, daffProductReducers } fro
 
 import { DaffCategoryFacade } from './category.facade';
 import { DaffCategoryLoad, DaffCategoryLoadFailure, DaffCategoryLoadSuccess } from '../actions/category.actions';
-import { categoryReducers } from '../reducers/category-reducers';
+import { daffCategoryReducers } from '../reducers/category-reducers';
 import { DaffCategory } from '../models/category';
 import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
 import { DaffCategoryFilterType } from '../models/category-filter-base';
@@ -28,7 +28,7 @@ describe('DaffCategoryFacade', () => {
     TestBed.configureTestingModule({
       imports:[
         StoreModule.forRoot({
-          category: combineReducers(categoryReducers()),
+          category: combineReducers(daffCategoryReducers()),
           product: combineReducers(daffProductReducers)
         })
       ],

--- a/libs/category/src/facades/category.facade.ts
+++ b/libs/category/src/facades/category.facade.ts
@@ -6,28 +6,8 @@ import { DaffStoreFacade } from '@daffodil/core';
 import { DaffProductUnion } from '@daffodil/product';
 
 import { DaffCategoryModule } from '../category.module';
-import {
-  selectCategoryLoading,
-  selectCategoryErrors,
-  selectSelectedCategory,
-  selectCategoryPageConfigurationState,
-  selectCategoryPageProducts,
-  selectCategoryCurrentPage,
-  selectCategoryTotalPages,
-  selectCategoryPageSize,
-  selectCategoryFilters,
-  selectCategorySortOptions,
-	selectCategory,
-	selectProductsByCategory,
-	selectCategoryPageTotalProducts,
-	selectCategoryPageAppliedFilters,
-	selectCategoryPageAppliedSortOption,
-	selectCategoryPageAppliedSortDirection,
-	selectTotalProductsByCategory,
-	selectCategoryProductsLoading,
-	selectIsCategoryPageEmpty
-} from '../selectors/category.selector';
-import { CategoryReducersState } from '../reducers/category-reducers.interface';
+import { getDaffCategorySelectors } from '../selectors/category.selector';
+import { DaffCategoryReducersState } from '../reducers/category-reducers.interface';
 import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
 import { DaffCategoryFilter } from '../models/category-filter';
 import { DaffCategorySortOption } from '../models/category-sort-option';
@@ -41,7 +21,7 @@ import { DaffGenericCategory } from '../models/generic-category';
 @Injectable({
   providedIn: DaffCategoryModule
 })
-export class DaffCategoryFacade<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState> implements DaffStoreFacade<Action> {
+export class DaffCategoryFacade<T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState> implements DaffStoreFacade<Action> {
   /**
    * The currently selected category.
    */
@@ -49,7 +29,7 @@ export class DaffCategoryFacade<T extends DaffGenericCategory<T>, U extends Daff
   /**
    * The page configuration state for the selected category.
    */
-  pageConfigurationState$: Observable<U>;
+  pageConfigurationState$: Observable<V>;
   /**
    * The current page of products for the selected category.
    */
@@ -112,7 +92,7 @@ export class DaffCategoryFacade<T extends DaffGenericCategory<T>, U extends Daff
 	 * @param id 
 	 */
 	getCategoryById(id: string): Observable<T> {
-		return this.store.pipe(select(selectCategory(), {id: id}));
+		return this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategory, {id: id}));
 	}
 
 	/**
@@ -120,7 +100,7 @@ export class DaffCategoryFacade<T extends DaffGenericCategory<T>, U extends Daff
 	 * @param categoryId 
 	 */
 	getProductsByCategory(categoryId: string): Observable<DaffProductUnion[]> {
-		return this.store.pipe(select(selectProductsByCategory(), {id: categoryId}))
+		return this.store.pipe(select(getDaffCategorySelectors<T, V>().selectProductsByCategory, {id: categoryId}))
 	}
 
 	/**
@@ -128,26 +108,26 @@ export class DaffCategoryFacade<T extends DaffGenericCategory<T>, U extends Daff
 	 * @param categoryId 
 	 */
 	getTotalProductsByCategory(categoryId: string): Observable<number> {
-		return this.store.pipe(select(selectTotalProductsByCategory(), {id: categoryId}))
+		return this.store.pipe(select(getDaffCategorySelectors<T, V>().selectTotalProductsByCategory, {id: categoryId}))
 	}
 
-  constructor(private store: Store<CategoryReducersState<T, U>>) {
-    this.category$ = this.store.pipe(select(selectSelectedCategory()));
-		this.products$ = this.store.pipe(select(selectCategoryPageProducts()));
-		this.totalProducts$ = this.store.pipe(select(selectCategoryPageTotalProducts()));
-    this.pageConfigurationState$ = this.store.pipe(select(selectCategoryPageConfigurationState()));
-    this.currentPage$ = this.store.pipe(select(selectCategoryCurrentPage()));
-    this.totalPages$ = this.store.pipe(select(selectCategoryTotalPages()));
-    this.pageSize$ = this.store.pipe(select(selectCategoryPageSize()));
-    this.filters$ = this.store.pipe(select(selectCategoryFilters()));
-    this.sortOptions$ = this.store.pipe(select(selectCategorySortOptions()));
-    this.appliedFilters$ = this.store.pipe(select(selectCategoryPageAppliedFilters()));
-    this.appliedSortOption$ = this.store.pipe(select(selectCategoryPageAppliedSortOption()));
-    this.appliedSortDirection$ = this.store.pipe(select(selectCategoryPageAppliedSortDirection()));
-    this.categoryLoading$ = this.store.pipe(select(selectCategoryLoading()));
-    this.productsLoading$ = this.store.pipe(select(selectCategoryProductsLoading()));
-		this.errors$ = this.store.pipe(select(selectCategoryErrors()));
-		this.isCategoryEmpty$ = this.store.pipe(select(selectIsCategoryPageEmpty()));
+  constructor(private store: Store<DaffCategoryReducersState<T, V>>) {
+    this.category$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectSelectedCategory));
+		this.products$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageProducts));
+		this.totalProducts$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageTotalProducts));
+    this.pageConfigurationState$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageConfigurationState));
+    this.currentPage$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryCurrentPage));
+    this.totalPages$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryTotalPages));
+    this.pageSize$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageSize));
+    this.filters$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryFilters));
+    this.sortOptions$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategorySortOptions));
+    this.appliedFilters$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageAppliedFilters));
+    this.appliedSortOption$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageAppliedSortOption));
+    this.appliedSortDirection$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageAppliedSortDirection));
+    this.categoryLoading$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryLoading));
+    this.productsLoading$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryProductsLoading));
+		this.errors$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryErrors));
+		this.isCategoryEmpty$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectIsCategoryPageEmpty));
 	}
 
   /**

--- a/libs/category/src/facades/category.facade.ts
+++ b/libs/category/src/facades/category.facade.ts
@@ -5,7 +5,6 @@ import { Store, select, Action } from '@ngrx/store';
 import { DaffStoreFacade } from '@daffodil/core';
 import { DaffProductUnion } from '@daffodil/product';
 
-import { DaffCategory } from '../models/category';
 import { DaffCategoryModule } from '../category.module';
 import {
   selectCategoryLoading,
@@ -34,6 +33,7 @@ import { DaffCategoryFilter } from '../models/category-filter';
 import { DaffCategorySortOption } from '../models/category-sort-option';
 import { DaffSortDirectionEnum } from '../models/requests/category-request';
 import { DaffCategoryAppliedFilter } from '../models/category-applied-filter';
+import { DaffGenericCategory } from '../models/generic-category';
 
 /**
  * A facade for accessing state for the currently selected category.
@@ -41,15 +41,15 @@ import { DaffCategoryAppliedFilter } from '../models/category-applied-filter';
 @Injectable({
   providedIn: DaffCategoryModule
 })
-export class DaffCategoryFacade implements DaffStoreFacade<Action> {
+export class DaffCategoryFacade<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState> implements DaffStoreFacade<Action> {
   /**
    * The currently selected category.
    */
-  category$: Observable<DaffCategory>;
+  category$: Observable<T>;
   /**
    * The page configuration state for the selected category.
    */
-  pageConfigurationState$: Observable<DaffCategoryPageConfigurationState>;
+  pageConfigurationState$: Observable<U>;
   /**
    * The current page of products for the selected category.
    */
@@ -111,8 +111,8 @@ export class DaffCategoryFacade implements DaffStoreFacade<Action> {
 	 * Get a category by the provided Id.
 	 * @param id 
 	 */
-	getCategoryById(id: string): Observable<DaffCategory> {
-		return this.store.pipe(select(selectCategory, {id: id}));
+	getCategoryById(id: string): Observable<T> {
+		return this.store.pipe(select(selectCategory(), {id: id}));
 	}
 
 	/**
@@ -120,7 +120,7 @@ export class DaffCategoryFacade implements DaffStoreFacade<Action> {
 	 * @param categoryId 
 	 */
 	getProductsByCategory(categoryId: string): Observable<DaffProductUnion[]> {
-		return this.store.pipe(select(selectProductsByCategory, {id: categoryId}))
+		return this.store.pipe(select(selectProductsByCategory(), {id: categoryId}))
 	}
 
 	/**
@@ -128,26 +128,26 @@ export class DaffCategoryFacade implements DaffStoreFacade<Action> {
 	 * @param categoryId 
 	 */
 	getTotalProductsByCategory(categoryId: string): Observable<number> {
-		return this.store.pipe(select(selectTotalProductsByCategory, {id: categoryId}))
+		return this.store.pipe(select(selectTotalProductsByCategory(), {id: categoryId}))
 	}
 
-  constructor(private store: Store<CategoryReducersState>) {
-    this.category$ = this.store.pipe(select(selectSelectedCategory));
-		this.products$ = this.store.pipe(select(selectCategoryPageProducts));
-		this.totalProducts$ = this.store.pipe(select(selectCategoryPageTotalProducts));
-    this.pageConfigurationState$ = this.store.pipe(select(selectCategoryPageConfigurationState));
-    this.currentPage$ = this.store.pipe(select(selectCategoryCurrentPage));
-    this.totalPages$ = this.store.pipe(select(selectCategoryTotalPages));
-    this.pageSize$ = this.store.pipe(select(selectCategoryPageSize));
-    this.filters$ = this.store.pipe(select(selectCategoryFilters));
-    this.sortOptions$ = this.store.pipe(select(selectCategorySortOptions));
-    this.appliedFilters$ = this.store.pipe(select(selectCategoryPageAppliedFilters));
-    this.appliedSortOption$ = this.store.pipe(select(selectCategoryPageAppliedSortOption));
-    this.appliedSortDirection$ = this.store.pipe(select(selectCategoryPageAppliedSortDirection));
-    this.categoryLoading$ = this.store.pipe(select(selectCategoryLoading));
-    this.productsLoading$ = this.store.pipe(select(selectCategoryProductsLoading));
-		this.errors$ = this.store.pipe(select(selectCategoryErrors));
-		this.isCategoryEmpty$ = this.store.pipe(select(selectIsCategoryPageEmpty));
+  constructor(private store: Store<CategoryReducersState<T, U>>) {
+    this.category$ = this.store.pipe(select(selectSelectedCategory()));
+		this.products$ = this.store.pipe(select(selectCategoryPageProducts()));
+		this.totalProducts$ = this.store.pipe(select(selectCategoryPageTotalProducts()));
+    this.pageConfigurationState$ = this.store.pipe(select(selectCategoryPageConfigurationState()));
+    this.currentPage$ = this.store.pipe(select(selectCategoryCurrentPage()));
+    this.totalPages$ = this.store.pipe(select(selectCategoryTotalPages()));
+    this.pageSize$ = this.store.pipe(select(selectCategoryPageSize()));
+    this.filters$ = this.store.pipe(select(selectCategoryFilters()));
+    this.sortOptions$ = this.store.pipe(select(selectCategorySortOptions()));
+    this.appliedFilters$ = this.store.pipe(select(selectCategoryPageAppliedFilters()));
+    this.appliedSortOption$ = this.store.pipe(select(selectCategoryPageAppliedSortOption()));
+    this.appliedSortDirection$ = this.store.pipe(select(selectCategoryPageAppliedSortDirection()));
+    this.categoryLoading$ = this.store.pipe(select(selectCategoryLoading()));
+    this.productsLoading$ = this.store.pipe(select(selectCategoryProductsLoading()));
+		this.errors$ = this.store.pipe(select(selectCategoryErrors()));
+		this.isCategoryEmpty$ = this.store.pipe(select(selectIsCategoryPageEmpty()));
 	}
 
   /**

--- a/libs/category/src/facades/category.facade.ts
+++ b/libs/category/src/facades/category.facade.ts
@@ -22,7 +22,9 @@ import { DaffGenericCategory } from '../models/generic-category';
   providedIn: DaffCategoryModule
 })
 export class DaffCategoryFacade<T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState> implements DaffStoreFacade<Action> {
-  /**
+	private categorySelectors = getDaffCategorySelectors<T, V>();
+	
+	/**
    * The currently selected category.
    */
   category$: Observable<T>;
@@ -92,7 +94,7 @@ export class DaffCategoryFacade<T extends DaffGenericCategory<T>, V extends Daff
 	 * @param id 
 	 */
 	getCategoryById(id: string): Observable<T> {
-		return this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategory, {id: id}));
+		return this.store.pipe(select(this.categorySelectors.selectCategory, {id: id}));
 	}
 
 	/**
@@ -100,7 +102,7 @@ export class DaffCategoryFacade<T extends DaffGenericCategory<T>, V extends Daff
 	 * @param categoryId 
 	 */
 	getProductsByCategory(categoryId: string): Observable<DaffProductUnion[]> {
-		return this.store.pipe(select(getDaffCategorySelectors<T, V>().selectProductsByCategory, {id: categoryId}))
+		return this.store.pipe(select(this.categorySelectors.selectProductsByCategory, {id: categoryId}))
 	}
 
 	/**
@@ -108,26 +110,26 @@ export class DaffCategoryFacade<T extends DaffGenericCategory<T>, V extends Daff
 	 * @param categoryId 
 	 */
 	getTotalProductsByCategory(categoryId: string): Observable<number> {
-		return this.store.pipe(select(getDaffCategorySelectors<T, V>().selectTotalProductsByCategory, {id: categoryId}))
+		return this.store.pipe(select(this.categorySelectors.selectTotalProductsByCategory, {id: categoryId}))
 	}
 
   constructor(private store: Store<DaffCategoryReducersState<T, V>>) {
-    this.category$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectSelectedCategory));
-		this.products$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageProducts));
-		this.totalProducts$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageTotalProducts));
-    this.pageConfigurationState$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageConfigurationState));
-    this.currentPage$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryCurrentPage));
-    this.totalPages$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryTotalPages));
-    this.pageSize$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageSize));
-    this.filters$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryFilters));
-    this.sortOptions$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategorySortOptions));
-    this.appliedFilters$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageAppliedFilters));
-    this.appliedSortOption$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageAppliedSortOption));
-    this.appliedSortDirection$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryPageAppliedSortDirection));
-    this.categoryLoading$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryLoading));
-    this.productsLoading$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryProductsLoading));
-		this.errors$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectCategoryErrors));
-		this.isCategoryEmpty$ = this.store.pipe(select(getDaffCategorySelectors<T, V>().selectIsCategoryPageEmpty));
+    this.category$ = this.store.pipe(select(this.categorySelectors.selectSelectedCategory));
+		this.products$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageProducts));
+		this.totalProducts$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageTotalProducts));
+    this.pageConfigurationState$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageConfigurationState));
+    this.currentPage$ = this.store.pipe(select(this.categorySelectors.selectCategoryCurrentPage));
+    this.totalPages$ = this.store.pipe(select(this.categorySelectors.selectCategoryTotalPages));
+    this.pageSize$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageSize));
+    this.filters$ = this.store.pipe(select(this.categorySelectors.selectCategoryFilters));
+    this.sortOptions$ = this.store.pipe(select(this.categorySelectors.selectCategorySortOptions));
+    this.appliedFilters$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedFilters));
+    this.appliedSortOption$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedSortOption));
+    this.appliedSortDirection$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageAppliedSortDirection));
+    this.categoryLoading$ = this.store.pipe(select(this.categorySelectors.selectCategoryLoading));
+    this.productsLoading$ = this.store.pipe(select(this.categorySelectors.selectCategoryProductsLoading));
+		this.errors$ = this.store.pipe(select(this.categorySelectors.selectCategoryErrors));
+		this.isCategoryEmpty$ = this.store.pipe(select(this.categorySelectors.selectIsCategoryPageEmpty));
 	}
 
   /**

--- a/libs/category/src/index.ts
+++ b/libs/category/src/index.ts
@@ -16,6 +16,7 @@ export { DaffCategoryFilterType } from './models/category-filter-base';
 export { DaffCategoryPageConfigurationState } from './models/category-page-configuration-state';
 export { DaffCategoryBreadcrumb } from './models/category-breadcrumb'
 export { DaffCategory } from './models/category'
+export { DaffGenericCategory } from './models/generic-category'
 export { 
 	DaffCategoryRequest,
 	DaffSortDirectionEnum

--- a/libs/category/src/index.ts
+++ b/libs/category/src/index.ts
@@ -1,6 +1,6 @@
 export * from './actions/category.actions';
 
-export { categoryReducers } from './reducers/category-reducers';
+export { daffCategoryReducers } from './reducers/category-reducers';
 export { DaffCategoryFacade } from './facades/category.facade';
 
 export { DaffCategoryModule } from './category.module';

--- a/libs/category/src/models/category.ts
+++ b/libs/category/src/models/category.ts
@@ -1,12 +1,6 @@
-import { DaffCategoryBreadcrumb } from './category-breadcrumb';
+import { DaffGenericCategory } from './generic-category';
 
-export interface DaffCategory {
-  id: string;
-	name: string;
-	description?: string;
-  children_count?: number;
-  total_products?: number;
-  children?: DaffCategory[];
-  product_ids?: string[];
-  breadcrumbs?: DaffCategoryBreadcrumb[];
-}
+/**
+ * This model is needed as a reference in concrete classes, because the DaffGenericCategory is recursive.
+ */
+export interface DaffCategory extends DaffGenericCategory<DaffCategory> {}

--- a/libs/category/src/models/generic-category.ts
+++ b/libs/category/src/models/generic-category.ts
@@ -1,0 +1,15 @@
+import { DaffCategoryBreadcrumb } from './category-breadcrumb';
+
+/**
+ * The DaffGenericCategory should be used only in extension when defining a new model.
+ */
+export interface DaffGenericCategory<T extends DaffGenericCategory<T>> {
+  id: string;
+	name: string;
+	description?: string;
+  children_count?: number;
+  total_products?: number;
+  children?: T[];
+  product_ids?: string[];
+  breadcrumbs?: DaffCategoryBreadcrumb[];
+}

--- a/libs/category/src/models/get-category-response.ts
+++ b/libs/category/src/models/get-category-response.ts
@@ -1,10 +1,13 @@
 import { DaffProductUnion } from '@daffodil/product';
 
-import { DaffCategory } from './category';
 import { DaffCategoryPageConfigurationState } from './category-page-configuration-state';
+import { DaffGenericCategory } from './generic-category';
 
-export interface DaffGetCategoryResponse {
+export interface DaffGetCategoryResponse<
+	T extends DaffGenericCategory<T>, 
+	U extends DaffCategoryPageConfigurationState
+> {
   products: DaffProductUnion[];
-  category: DaffCategory;
-  categoryPageConfigurationState: DaffCategoryPageConfigurationState;
+  category: T;
+  categoryPageConfigurationState: U;
 }

--- a/libs/category/src/reducers/category-entities/category-entities-adapter.ts
+++ b/libs/category/src/reducers/category-entities/category-entities-adapter.ts
@@ -1,6 +1,6 @@
 import { EntityAdapter, createEntityAdapter } from '@ngrx/entity';
 import { DaffGenericCategory } from '../../models/generic-category';
 
-export function categoryEntitiesAdapter<T extends DaffGenericCategory<T>>(): EntityAdapter<T> {
+export function daffCategoryEntitiesAdapter<T extends DaffGenericCategory<T>>(): EntityAdapter<T> {
 	return createEntityAdapter<T>();
 } 

--- a/libs/category/src/reducers/category-entities/category-entities-adapter.ts
+++ b/libs/category/src/reducers/category-entities/category-entities-adapter.ts
@@ -1,4 +1,6 @@
 import { EntityAdapter, createEntityAdapter } from '@ngrx/entity';
-import { DaffCategory } from '../../models/category';
+import { DaffGenericCategory } from '../../models/generic-category';
 
-export const categoryEntitiesAdapter : EntityAdapter<DaffCategory> = createEntityAdapter<DaffCategory>();
+export function categoryEntitiesAdapter<T extends DaffGenericCategory<T>>(): EntityAdapter<T> {
+	return createEntityAdapter<T>();
+} 

--- a/libs/category/src/reducers/category-entities/category-entities.reducer.spec.ts
+++ b/libs/category/src/reducers/category-entities/category-entities.reducer.spec.ts
@@ -1,8 +1,9 @@
 import { DaffCategoryFactory } from '@daffodil/category/testing';
 
 import { DaffCategoryLoadSuccess } from '../../actions/category.actions';
-import { initialState, categoryEntitiesReducer } from './category-entities.reducer';
+import { categoryEntitiesReducer } from './category-entities.reducer';
 import { DaffCategory } from '../../models/category';
+import { categoryEntitiesAdapter } from './category-entities-adapter';
 
 describe('Category | Category Entities Reducer', () => {
 
@@ -17,9 +18,9 @@ describe('Category | Category Entities Reducer', () => {
     it('should return the current state', () => {
       const action = {} as any;
 
-      const result = categoryEntitiesReducer(initialState, action);
+      const result = categoryEntitiesReducer(categoryEntitiesAdapter<DaffCategory>().getInitialState(), action);
 
-      expect(result).toBe(initialState);
+      expect(result).toEqual(categoryEntitiesAdapter<DaffCategory>().getInitialState());
     });
   });
 
@@ -35,7 +36,7 @@ describe('Category | Category Entities Reducer', () => {
       
       const categoryLoadSuccess = new DaffCategoryLoadSuccess({category: category, categoryPageConfigurationState: null, products: null});
       
-      result = categoryEntitiesReducer(initialState, categoryLoadSuccess);
+      result = categoryEntitiesReducer(categoryEntitiesAdapter<DaffCategory>().getInitialState(), categoryLoadSuccess);
     });
 
     it('sets expected category on state', () => {

--- a/libs/category/src/reducers/category-entities/category-entities.reducer.spec.ts
+++ b/libs/category/src/reducers/category-entities/category-entities.reducer.spec.ts
@@ -1,9 +1,9 @@
 import { DaffCategoryFactory } from '@daffodil/category/testing';
 
 import { DaffCategoryLoadSuccess } from '../../actions/category.actions';
-import { categoryEntitiesReducer } from './category-entities.reducer';
+import { daffCategoryEntitiesReducer } from './category-entities.reducer';
 import { DaffCategory } from '../../models/category';
-import { categoryEntitiesAdapter } from './category-entities-adapter';
+import { daffCategoryEntitiesAdapter } from './category-entities-adapter';
 
 describe('Category | Category Entities Reducer', () => {
 
@@ -18,9 +18,9 @@ describe('Category | Category Entities Reducer', () => {
     it('should return the current state', () => {
       const action = {} as any;
 
-      const result = categoryEntitiesReducer(categoryEntitiesAdapter<DaffCategory>().getInitialState(), action);
+      const result = daffCategoryEntitiesReducer(daffCategoryEntitiesAdapter<DaffCategory>().getInitialState(), action);
 
-      expect(result).toEqual(categoryEntitiesAdapter<DaffCategory>().getInitialState());
+      expect(result).toEqual(daffCategoryEntitiesAdapter<DaffCategory>().getInitialState());
     });
   });
 
@@ -36,7 +36,7 @@ describe('Category | Category Entities Reducer', () => {
       
       const categoryLoadSuccess = new DaffCategoryLoadSuccess({category: category, categoryPageConfigurationState: null, products: null});
       
-      result = categoryEntitiesReducer(categoryEntitiesAdapter<DaffCategory>().getInitialState(), categoryLoadSuccess);
+      result = daffCategoryEntitiesReducer(daffCategoryEntitiesAdapter<DaffCategory>().getInitialState(), categoryLoadSuccess);
     });
 
     it('sets expected category on state', () => {

--- a/libs/category/src/reducers/category-entities/category-entities.reducer.ts
+++ b/libs/category/src/reducers/category-entities/category-entities.reducer.ts
@@ -1,18 +1,18 @@
 import { EntityState } from '@ngrx/entity';
 
-import { categoryEntitiesAdapter } from './category-entities-adapter';
+import { daffCategoryEntitiesAdapter } from './category-entities-adapter';
 import { DaffCategoryActionTypes, DaffCategoryActions } from '../../actions/category.actions';
 import { DaffCategoryRequest } from '../../models/requests/category-request';
 import { DaffCategoryPageConfigurationState } from '../../models/category-page-configuration-state';
 import { DaffGenericCategory } from '../../models/generic-category';
 
-export function categoryEntitiesReducer<T extends DaffCategoryRequest, U extends DaffGenericCategory<U>, V extends DaffCategoryPageConfigurationState>(
-  state = categoryEntitiesAdapter<U>().getInitialState(), 
+export function daffCategoryEntitiesReducer<T extends DaffCategoryRequest, U extends DaffGenericCategory<U>, V extends DaffCategoryPageConfigurationState>(
+  state = daffCategoryEntitiesAdapter<U>().getInitialState(), 
 	action: DaffCategoryActions<T, U, V>
 ): EntityState<U> {
   switch (action.type) {
     case DaffCategoryActionTypes.CategoryLoadSuccessAction:
-      return categoryEntitiesAdapter<U>().upsertOne(
+      return daffCategoryEntitiesAdapter<U>().upsertOne(
         { 
           id: action.response.category.id, 
           ...action.response.category

--- a/libs/category/src/reducers/category-entities/category-entities.reducer.ts
+++ b/libs/category/src/reducers/category-entities/category-entities.reducer.ts
@@ -2,16 +2,17 @@ import { EntityState } from '@ngrx/entity';
 
 import { categoryEntitiesAdapter } from './category-entities-adapter';
 import { DaffCategoryActionTypes, DaffCategoryActions } from '../../actions/category.actions';
-import { DaffCategory } from '../../models/category';
+import { DaffCategoryRequest } from '../../models/requests/category-request';
+import { DaffCategoryPageConfigurationState } from '../../models/category-page-configuration-state';
+import { DaffGenericCategory } from '../../models/generic-category';
 
-export const initialState: EntityState<DaffCategory> = categoryEntitiesAdapter.getInitialState();
-
-export function categoryEntitiesReducer(
-  state = initialState, 
-  action: DaffCategoryActions): EntityState<DaffCategory> {
+export function categoryEntitiesReducer<T extends DaffCategoryRequest, U extends DaffGenericCategory<U>, V extends DaffCategoryPageConfigurationState>(
+  state = categoryEntitiesAdapter<U>().getInitialState(), 
+	action: DaffCategoryActions<T, U, V>
+): EntityState<U> {
   switch (action.type) {
     case DaffCategoryActionTypes.CategoryLoadSuccessAction:
-      return categoryEntitiesAdapter.upsertOne(
+      return categoryEntitiesAdapter<U>().upsertOne(
         { 
           id: action.response.category.id, 
           ...action.response.category

--- a/libs/category/src/reducers/category-reducers.interface.ts
+++ b/libs/category/src/reducers/category-reducers.interface.ts
@@ -1,10 +1,10 @@
 import { EntityState } from '@ngrx/entity';
 
-import { CategoryReducerState } from '../reducers/category/category-reducer-state.interface';
+import { DaffCategoryReducerState } from '../reducers/category/category-reducer-state.interface';
 import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
 import { DaffGenericCategory } from '../models/generic-category';
 
-export interface CategoryReducersState<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState> {
-  category: CategoryReducerState<U>;
+export interface DaffCategoryReducersState<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState> {
+  category: DaffCategoryReducerState<U>;
   categoryEntities: EntityState<T>;
 }

--- a/libs/category/src/reducers/category-reducers.interface.ts
+++ b/libs/category/src/reducers/category-reducers.interface.ts
@@ -1,8 +1,10 @@
 import { EntityState } from '@ngrx/entity';
-import { CategoryReducerState } from '../reducers/category/category-reducer-state.interface';
-import { DaffCategory } from '../models/category';
 
-export interface CategoryReducersState {
-  category: CategoryReducerState;
-  categoryEntities: EntityState<DaffCategory>;
+import { CategoryReducerState } from '../reducers/category/category-reducer-state.interface';
+import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
+import { DaffGenericCategory } from '../models/generic-category';
+
+export interface CategoryReducersState<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState> {
+  category: CategoryReducerState<U>;
+  categoryEntities: EntityState<T>;
 }

--- a/libs/category/src/reducers/category-reducers.spec.ts
+++ b/libs/category/src/reducers/category-reducers.spec.ts
@@ -5,10 +5,10 @@ import { daffCategoryEntitiesReducer } from './category-entities/category-entiti
 describe('selectCategoryState', () => {
 
   it('should return a reducer map with CategoryReducer', () => {
-    expect(daffCategoryReducers().category).toEqual(daffCategoryReducer);
+    expect(daffCategoryReducers.category).toEqual(daffCategoryReducer);
   });
 
   it('should return a reducer map with CategoryEntitiesReducer', () => {
-    expect(daffCategoryReducers().categoryEntities).toEqual(daffCategoryEntitiesReducer);
+    expect(daffCategoryReducers.categoryEntities).toEqual(daffCategoryEntitiesReducer);
   });
 });

--- a/libs/category/src/reducers/category-reducers.spec.ts
+++ b/libs/category/src/reducers/category-reducers.spec.ts
@@ -5,10 +5,10 @@ import { categoryEntitiesReducer } from './category-entities/category-entities.r
 describe('selectCategoryState', () => {
 
   it('should return a reducer map with CategoryReducer', () => {
-    expect(categoryReducers.category).toEqual(categoryReducer);
+    expect(categoryReducers().category).toEqual(categoryReducer);
   });
 
   it('should return a reducer map with CategoryEntitiesReducer', () => {
-    expect(categoryReducers.categoryEntities).toEqual(categoryEntitiesReducer);
+    expect(categoryReducers().categoryEntities).toEqual(categoryEntitiesReducer);
   });
 });

--- a/libs/category/src/reducers/category-reducers.spec.ts
+++ b/libs/category/src/reducers/category-reducers.spec.ts
@@ -1,14 +1,14 @@
-import { categoryReducers } from './category-reducers';
-import { categoryReducer } from './category/category.reducer';
-import { categoryEntitiesReducer } from './category-entities/category-entities.reducer';
+import { daffCategoryReducers } from './category-reducers';
+import { daffCategoryReducer } from './category/category.reducer';
+import { daffCategoryEntitiesReducer } from './category-entities/category-entities.reducer';
 
 describe('selectCategoryState', () => {
 
   it('should return a reducer map with CategoryReducer', () => {
-    expect(categoryReducers().category).toEqual(categoryReducer);
+    expect(daffCategoryReducers().category).toEqual(daffCategoryReducer);
   });
 
   it('should return a reducer map with CategoryEntitiesReducer', () => {
-    expect(categoryReducers().categoryEntities).toEqual(categoryEntitiesReducer);
+    expect(daffCategoryReducers().categoryEntities).toEqual(daffCategoryEntitiesReducer);
   });
 });

--- a/libs/category/src/reducers/category-reducers.ts
+++ b/libs/category/src/reducers/category-reducers.ts
@@ -3,8 +3,12 @@ import { ActionReducerMap } from '@ngrx/store';
 import { CategoryReducersState } from './category-reducers.interface';
 import { categoryReducer } from './category/category.reducer';
 import { categoryEntitiesReducer } from './category-entities/category-entities.reducer';
+import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
+import { DaffGenericCategory } from '../models/generic-category';
 
-export const categoryReducers: ActionReducerMap<CategoryReducersState> = {
-  category: categoryReducer,
-  categoryEntities: categoryEntitiesReducer
+export function categoryReducers<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState>(): ActionReducerMap<CategoryReducersState<T, U>> {
+	return {
+		category: categoryReducer,
+		categoryEntities: categoryEntitiesReducer
+	};
 }

--- a/libs/category/src/reducers/category-reducers.ts
+++ b/libs/category/src/reducers/category-reducers.ts
@@ -1,14 +1,14 @@
 import { ActionReducerMap } from '@ngrx/store';
 
-import { CategoryReducersState } from './category-reducers.interface';
-import { categoryReducer } from './category/category.reducer';
-import { categoryEntitiesReducer } from './category-entities/category-entities.reducer';
+import { DaffCategoryReducersState } from './category-reducers.interface';
+import { daffCategoryReducer } from './category/category.reducer';
+import { daffCategoryEntitiesReducer } from './category-entities/category-entities.reducer';
 import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
 import { DaffGenericCategory } from '../models/generic-category';
 
-export function categoryReducers<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState>(): ActionReducerMap<CategoryReducersState<T, U>> {
+export function daffCategoryReducers<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState>(): ActionReducerMap<DaffCategoryReducersState<T, U>> {
 	return {
-		category: categoryReducer,
-		categoryEntities: categoryEntitiesReducer
+		category: daffCategoryReducer,
+		categoryEntities: daffCategoryEntitiesReducer
 	};
 }

--- a/libs/category/src/reducers/category-reducers.ts
+++ b/libs/category/src/reducers/category-reducers.ts
@@ -1,14 +1,7 @@
-import { ActionReducerMap } from '@ngrx/store';
-
-import { DaffCategoryReducersState } from './category-reducers.interface';
 import { daffCategoryReducer } from './category/category.reducer';
 import { daffCategoryEntitiesReducer } from './category-entities/category-entities.reducer';
-import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
-import { DaffGenericCategory } from '../models/generic-category';
 
-export function daffCategoryReducers<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState>(): ActionReducerMap<DaffCategoryReducersState<T, U>> {
-	return {
-		category: daffCategoryReducer,
-		categoryEntities: daffCategoryEntitiesReducer
-	};
-}
+export const daffCategoryReducers = {
+	category: daffCategoryReducer,
+	categoryEntities: daffCategoryEntitiesReducer
+};

--- a/libs/category/src/reducers/category/category-reducer-state.interface.ts
+++ b/libs/category/src/reducers/category/category-reducer-state.interface.ts
@@ -1,6 +1,6 @@
 import { DaffCategoryPageConfigurationState } from '../../models/category-page-configuration-state';
 
-export interface CategoryReducerState<T extends DaffCategoryPageConfigurationState> {
+export interface DaffCategoryReducerState<T extends DaffCategoryPageConfigurationState> {
   categoryPageConfigurationState: T,
   categoryLoading: boolean,
   productsLoading: boolean,

--- a/libs/category/src/reducers/category/category-reducer-state.interface.ts
+++ b/libs/category/src/reducers/category/category-reducer-state.interface.ts
@@ -1,7 +1,7 @@
 import { DaffCategoryPageConfigurationState } from '../../models/category-page-configuration-state';
 
-export interface CategoryReducerState {
-  categoryPageConfigurationState: DaffCategoryPageConfigurationState,
+export interface CategoryReducerState<T extends DaffCategoryPageConfigurationState> {
+  categoryPageConfigurationState: T,
   categoryLoading: boolean,
   productsLoading: boolean,
   errors: string[]

--- a/libs/category/src/reducers/category/category.reducer.spec.ts
+++ b/libs/category/src/reducers/category/category.reducer.spec.ts
@@ -1,8 +1,8 @@
 import { DaffCategoryFactory, DaffCategoryPageConfigurationStateFactory } from '@daffodil/category/testing';
 
-import { CategoryReducerState } from './category-reducer-state.interface';
+import { DaffCategoryReducerState } from './category-reducer-state.interface';
 import { DaffCategoryLoad, DaffCategoryLoadSuccess, DaffCategoryLoadFailure, DaffChangeCategoryPageSize, DaffChangeCategoryCurrentPage, DaffChangeCategorySortingOption, DaffChangeCategoryFilters, DaffToggleCategoryFilter } from '../../actions/category.actions';
-import { categoryReducer } from './category.reducer';
+import { daffCategoryReducer } from './category.reducer';
 import { DaffCategory } from '../../models/category';
 import { DaffCategoryPageConfigurationState } from '../../models/category-page-configuration-state';
 import { DaffCategoryRequest, DaffSortDirectionEnum } from '../../models/requests/category-request';
@@ -16,7 +16,7 @@ describe('Category | Category Reducer', () => {
   let category: DaffCategory;
   let categoryPageConfigurationState: DaffCategoryPageConfigurationState;
   let categoryId: string;
-  const initialState: CategoryReducerState<DaffCategoryPageConfigurationState> = {
+  const initialState: DaffCategoryReducerState<DaffCategoryPageConfigurationState> = {
     categoryPageConfigurationState: {
       id: null,
       filter_requests: [],
@@ -49,7 +49,7 @@ describe('Category | Category Reducer', () => {
     it('should return the current state', () => {
       const action = {} as any;
 
-      const result = categoryReducer(initialState, action);
+      const result = daffCategoryReducer(initialState, action);
 
       expect(result).toBe(initialState);
     });
@@ -70,7 +70,7 @@ describe('Category | Category Reducer', () => {
       }
       const categoryLoadAction: DaffCategoryLoad<DaffCategoryRequest> = new DaffCategoryLoad(categoryRequest);
 
-      result = categoryReducer(initialState, categoryLoadAction);
+      result = daffCategoryReducer(initialState, categoryLoadAction);
     });
 
     it('sets categoryLoading state to true', () => {
@@ -97,7 +97,7 @@ describe('Category | Category Reducer', () => {
     beforeEach(() => {
       const changeCategoryPageSize: DaffChangeCategoryPageSize = new DaffChangeCategoryPageSize(3);
 
-      result = categoryReducer(initialState, changeCategoryPageSize);
+      result = daffCategoryReducer(initialState, changeCategoryPageSize);
     });
 
     it('does not change the categoryLoading state', () => {
@@ -119,7 +119,7 @@ describe('Category | Category Reducer', () => {
     beforeEach(() => {
       const changeCategoryCurrentPage: DaffChangeCategoryCurrentPage = new DaffChangeCategoryCurrentPage(3);
 
-      result = categoryReducer(initialState, changeCategoryCurrentPage);
+      result = daffCategoryReducer(initialState, changeCategoryCurrentPage);
     });
 
     it('does not change the categoryLoading state', () => {
@@ -144,7 +144,7 @@ describe('Category | Category Reducer', () => {
 				direction: DaffSortDirectionEnum.Ascending
 			});
 
-      result = categoryReducer(initialState, changeCategorySortingOption);
+      result = daffCategoryReducer(initialState, changeCategorySortingOption);
     });
 
     it('does not change the categoryLoading state', () => {
@@ -187,7 +187,7 @@ describe('Category | Category Reducer', () => {
 				}
 
 				const toggleCategoryFilter: DaffToggleCategoryFilter = new DaffToggleCategoryFilter(toggledFilter);
-				result = categoryReducer(initialStateWithFilter, toggleCategoryFilter);
+				result = daffCategoryReducer(initialStateWithFilter, toggleCategoryFilter);
 
 				expect(result.categoryPageConfigurationState.filter_requests).toEqual([]);
 			});
@@ -212,7 +212,7 @@ describe('Category | Category Reducer', () => {
 				}
 
 				const toggleCategoryFilter: DaffToggleCategoryFilter = new DaffToggleCategoryFilter(toggledFilter);
-				result = categoryReducer(initialStateWithFilter, toggleCategoryFilter);
+				result = daffCategoryReducer(initialStateWithFilter, toggleCategoryFilter);
 				expect(result.categoryPageConfigurationState.filter_requests).toEqual([]);
 			});
 
@@ -242,7 +242,7 @@ describe('Category | Category Reducer', () => {
 				];
 
 				const toggleCategoryFilter: DaffToggleCategoryFilter = new DaffToggleCategoryFilter(toggledFilter);
-				result = categoryReducer(initialStateWithFilter, toggleCategoryFilter);
+				result = daffCategoryReducer(initialStateWithFilter, toggleCategoryFilter);
 				expect(result.categoryPageConfigurationState.filter_requests).toEqual(expectedFilters);
 			});
 		});
@@ -270,7 +270,7 @@ describe('Category | Category Reducer', () => {
 				];
 
 				const toggleCategoryFilter: DaffToggleCategoryFilter = new DaffToggleCategoryFilter(toggledFilter);
-				result = categoryReducer(initialStateWithFilter, toggleCategoryFilter);
+				result = daffCategoryReducer(initialStateWithFilter, toggleCategoryFilter);
 				expect(result.categoryPageConfigurationState.filter_requests).toEqual(expectedFilters);
 			});
 
@@ -296,7 +296,7 @@ describe('Category | Category Reducer', () => {
 				];
 
 				const toggleCategoryFilter: DaffToggleCategoryFilter = new DaffToggleCategoryFilter(toggledFilter);
-				result = categoryReducer(initialStateWithFilter, toggleCategoryFilter);
+				result = daffCategoryReducer(initialStateWithFilter, toggleCategoryFilter);
 				expect(result.categoryPageConfigurationState.filter_requests).toEqual(expectedFilters);
 			});
 
@@ -327,7 +327,7 @@ describe('Category | Category Reducer', () => {
 				];
 
 				const toggleCategoryFilter: DaffToggleCategoryFilter = new DaffToggleCategoryFilter(toggledFilter);
-				result = categoryReducer(initialStateWithFilter, toggleCategoryFilter);
+				result = daffCategoryReducer(initialStateWithFilter, toggleCategoryFilter);
 				expect(result.categoryPageConfigurationState.filter_requests).toEqual(expectedFilters);
 			});
 
@@ -353,7 +353,7 @@ describe('Category | Category Reducer', () => {
 				];
 
 				const toggleCategoryFilter: DaffToggleCategoryFilter = new DaffToggleCategoryFilter(toggledFilter);
-				result = categoryReducer(initialStateWithFilter, toggleCategoryFilter);
+				result = daffCategoryReducer(initialStateWithFilter, toggleCategoryFilter);
 				expect(result.categoryPageConfigurationState.filter_requests).toEqual(expectedFilters);
 			});
 
@@ -384,7 +384,7 @@ describe('Category | Category Reducer', () => {
 				];
 
 				const toggleCategoryFilter: DaffToggleCategoryFilter = new DaffToggleCategoryFilter(toggledFilter);
-				result = categoryReducer(initialStateWithFilter, toggleCategoryFilter);
+				result = daffCategoryReducer(initialStateWithFilter, toggleCategoryFilter);
 				expect(result.categoryPageConfigurationState.filter_requests).toEqual(expectedFilters);
 			});
 		});
@@ -404,7 +404,7 @@ describe('Category | Category Reducer', () => {
 			}
 
 			const toggleCategoryFilter: DaffToggleCategoryFilter = new DaffToggleCategoryFilter(toggledFilter);
-			result = categoryReducer(initialStateWithFilter, toggleCategoryFilter);
+			result = daffCategoryReducer(initialStateWithFilter, toggleCategoryFilter);
 
       expect(result.categoryLoading).toEqual(false);
     });
@@ -424,7 +424,7 @@ describe('Category | Category Reducer', () => {
 			}
 
 			const toggleCategoryFilter: DaffToggleCategoryFilter = new DaffToggleCategoryFilter(toggledFilter);
-			result = categoryReducer(initialStateWithFilter, toggleCategoryFilter);
+			result = daffCategoryReducer(initialStateWithFilter, toggleCategoryFilter);
 
       expect(result.productsLoading).toEqual(true);
 		});
@@ -442,7 +442,7 @@ describe('Category | Category Reducer', () => {
 			}];
       const changeCategoryFilters: DaffChangeCategoryFilters = new DaffChangeCategoryFilters(expectedFilters);
 
-      result = categoryReducer(initialState, changeCategoryFilters);
+      result = daffCategoryReducer(initialState, changeCategoryFilters);
     });
 
     it('does not change the categoryLoading state', () => {
@@ -460,8 +460,8 @@ describe('Category | Category Reducer', () => {
 
   describe('when CategoryLoadSuccessAction is triggered', () => {
 
-    let result: CategoryReducerState<DaffCategoryPageConfigurationState>;
-    let state: CategoryReducerState<DaffCategoryPageConfigurationState>;
+    let result: DaffCategoryReducerState<DaffCategoryPageConfigurationState>;
+    let state: DaffCategoryReducerState<DaffCategoryPageConfigurationState>;
 
     beforeEach(() => {
       state = {
@@ -471,7 +471,7 @@ describe('Category | Category Reducer', () => {
       }
 
       const categoryLoadSuccess = new DaffCategoryLoadSuccess({ category: category, categoryPageConfigurationState: categoryPageConfigurationState, products: null });
-      result = categoryReducer(state, categoryLoadSuccess);
+      result = daffCategoryReducer(state, categoryLoadSuccess);
     });
 
     it('sets categoryLoading to false', () => {
@@ -491,7 +491,7 @@ describe('Category | Category Reducer', () => {
 
     const error = 'error message';
     let result;
-    let state: CategoryReducerState<DaffCategoryPageConfigurationState>;
+    let state: DaffCategoryReducerState<DaffCategoryPageConfigurationState>;
 
     beforeEach(() => {
       state = {
@@ -503,7 +503,7 @@ describe('Category | Category Reducer', () => {
 
       const categoryLoadFailure = new DaffCategoryLoadFailure(error);
 
-      result = categoryReducer(state, categoryLoadFailure);
+      result = daffCategoryReducer(state, categoryLoadFailure);
     });
 
     it('sets categoryLoading to false', () => {

--- a/libs/category/src/reducers/category/category.reducer.spec.ts
+++ b/libs/category/src/reducers/category/category.reducer.spec.ts
@@ -16,7 +16,7 @@ describe('Category | Category Reducer', () => {
   let category: DaffCategory;
   let categoryPageConfigurationState: DaffCategoryPageConfigurationState;
   let categoryId: string;
-  const initialState: CategoryReducerState = {
+  const initialState: CategoryReducerState<DaffCategoryPageConfigurationState> = {
     categoryPageConfigurationState: {
       id: null,
       filter_requests: [],
@@ -68,7 +68,7 @@ describe('Category | Category Reducer', () => {
         applied_sort_direction: categoryPageConfigurationState.applied_sort_direction,
         current_page: categoryPageConfigurationState.current_page
       }
-      const categoryLoadAction: DaffCategoryLoad = new DaffCategoryLoad(categoryRequest);
+      const categoryLoadAction: DaffCategoryLoad<DaffCategoryRequest> = new DaffCategoryLoad(categoryRequest);
 
       result = categoryReducer(initialState, categoryLoadAction);
     });
@@ -460,8 +460,8 @@ describe('Category | Category Reducer', () => {
 
   describe('when CategoryLoadSuccessAction is triggered', () => {
 
-    let result: CategoryReducerState;
-    let state: CategoryReducerState;
+    let result: CategoryReducerState<DaffCategoryPageConfigurationState>;
+    let state: CategoryReducerState<DaffCategoryPageConfigurationState>;
 
     beforeEach(() => {
       state = {
@@ -491,7 +491,7 @@ describe('Category | Category Reducer', () => {
 
     const error = 'error message';
     let result;
-    let state: CategoryReducerState;
+    let state: CategoryReducerState<DaffCategoryPageConfigurationState>;
 
     beforeEach(() => {
       state = {

--- a/libs/category/src/reducers/category/category.reducer.ts
+++ b/libs/category/src/reducers/category/category.reducer.ts
@@ -1,8 +1,11 @@
 import { DaffCategoryActionTypes, DaffCategoryActions } from '../../actions/category.actions';
 import { CategoryReducerState } from './category-reducer-state.interface';
 import { toggleCategoryFilter } from './toggle-filter/core';
+import { DaffCategoryRequest } from '../../models/requests/category-request';
+import { DaffCategoryPageConfigurationState } from '../../models/category-page-configuration-state';
+import { DaffGenericCategory } from '../../models/generic-category';
 
-const initialState: CategoryReducerState = {
+const initialState: CategoryReducerState<any> = {
   categoryPageConfigurationState: {
     id: null,
 		filter_requests: [],
@@ -21,7 +24,8 @@ const initialState: CategoryReducerState = {
   errors: []
 };
 
-export function categoryReducer(state = initialState, action: DaffCategoryActions): CategoryReducerState {
+export function categoryReducer<T extends DaffCategoryRequest, U extends DaffGenericCategory<U>, V extends DaffCategoryPageConfigurationState>
+	(state = initialState, action: DaffCategoryActions<T, U, V>): CategoryReducerState<V> {
   switch (action.type) {
     // This reducer must assume the call will be successful, and immediately set the applied filters to state, because the 
     // GetCategory magento call doesn't return currently applied filters. If there is a bug where the wrong filters are somehow

--- a/libs/category/src/reducers/category/category.reducer.ts
+++ b/libs/category/src/reducers/category/category.reducer.ts
@@ -1,11 +1,11 @@
 import { DaffCategoryActionTypes, DaffCategoryActions } from '../../actions/category.actions';
-import { CategoryReducerState } from './category-reducer-state.interface';
+import { DaffCategoryReducerState } from './category-reducer-state.interface';
 import { toggleCategoryFilter } from './toggle-filter/core';
 import { DaffCategoryRequest } from '../../models/requests/category-request';
 import { DaffCategoryPageConfigurationState } from '../../models/category-page-configuration-state';
 import { DaffGenericCategory } from '../../models/generic-category';
 
-const initialState: CategoryReducerState<any> = {
+const initialState: DaffCategoryReducerState<any> = {
   categoryPageConfigurationState: {
     id: null,
 		filter_requests: [],
@@ -24,8 +24,8 @@ const initialState: CategoryReducerState<any> = {
   errors: []
 };
 
-export function categoryReducer<T extends DaffCategoryRequest, U extends DaffGenericCategory<U>, V extends DaffCategoryPageConfigurationState>
-	(state = initialState, action: DaffCategoryActions<T, U, V>): CategoryReducerState<V> {
+export function daffCategoryReducer<T extends DaffCategoryRequest, U extends DaffGenericCategory<U>, V extends DaffCategoryPageConfigurationState>
+	(state = initialState, action: DaffCategoryActions<T, U, V>): DaffCategoryReducerState<V> {
   switch (action.type) {
     // This reducer must assume the call will be successful, and immediately set the applied filters to state, because the 
     // GetCategory magento call doesn't return currently applied filters. If there is a bug where the wrong filters are somehow

--- a/libs/category/src/selectors/category.selector.spec.ts
+++ b/libs/category/src/selectors/category.selector.spec.ts
@@ -26,6 +26,7 @@ describe('DaffCategorySelectors', () => {
 	let stubCategory: DaffCategory;
   const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState = categoryPageConfigurationFactory.create();
 	let product: DaffProductUnion;
+	const categorySelectors = getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -79,7 +80,7 @@ describe('DaffCategorySelectors', () => {
         productsLoading: false,
         errors: []
       }
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryState));
+      const selector = store.pipe(select(categorySelectors.selectCategoryState));
       const expected = cold('a', { a: expectedFeatureState });
       expect(selector).toBeObservable(expected);
     });
@@ -88,7 +89,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageConfigurationState', () => {
 
     it('selects the category page configuration state', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageConfigurationState));
+      const selector = store.pipe(select(categorySelectors.selectCategoryPageConfigurationState));
       const expected = cold('a', { a: stubCategoryPageConfigurationState });
       expect(selector).toBeObservable(expected);
     });
@@ -97,7 +98,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryCurrentPage', () => {
 
     it('selects the current page of the current category', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryCurrentPage));
+      const selector = store.pipe(select(categorySelectors.selectCategoryCurrentPage));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.current_page });
       expect(selector).toBeObservable(expected);
     });
@@ -106,7 +107,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryTotalPages', () => {
 
     it('selects the total pages of products of the current category', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryTotalPages));
+      const selector = store.pipe(select(categorySelectors.selectCategoryTotalPages));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.total_pages });
       expect(selector).toBeObservable(expected);
     });
@@ -115,7 +116,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageSize', () => {
 
     it('selects the page size of the current category', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageSize));
+      const selector = store.pipe(select(categorySelectors.selectCategoryPageSize));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.page_size });
       expect(selector).toBeObservable(expected);
     });
@@ -124,7 +125,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryFilters', () => {
 
     it('selects filters of the current category', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryFilters));
+      const selector = store.pipe(select(categorySelectors.selectCategoryFilters));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.filters });
       expect(selector).toBeObservable(expected);
     });
@@ -148,7 +149,7 @@ describe('DaffCategorySelectors', () => {
 				id: stubCategoryPageConfigurationState.id,
 				filter_requests: filterRequests
 			}));
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageAppliedFilters));
+      const selector = store.pipe(select(categorySelectors.selectCategoryPageAppliedFilters));
       const expected = cold('a', { a: expectedAppliedFilters });
       expect(selector).toBeObservable(expected);
     });
@@ -175,7 +176,7 @@ describe('DaffCategorySelectors', () => {
 				id: stubCategoryPageConfigurationState.id,
 				filter_requests: filterRequests
 			}));
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageAppliedFilters));
+      const selector = store.pipe(select(categorySelectors.selectCategoryPageAppliedFilters));
       const expected = cold('a', { a: expectedAppliedFilters });
       expect(selector).toBeObservable(expected);
     });
@@ -184,7 +185,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategorySortOptions', () => {
 
     it('selects the category sort options of the current category', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategorySortOptions));
+      const selector = store.pipe(select(categorySelectors.selectCategorySortOptions));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.sort_options });
       expect(selector).toBeObservable(expected);
     });
@@ -193,7 +194,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageProductIds', () => {
 
     it('selects the product_ids of the current category page', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageProductIds));
+      const selector = store.pipe(select(categorySelectors.selectCategoryPageProductIds));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.product_ids });
       expect(selector).toBeObservable(expected);
     });
@@ -202,7 +203,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectIsCategoryPageEmpty', () => {
 
     it('selects whether the current category page is empty of products', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectIsCategoryPageEmpty));
+      const selector = store.pipe(select(categorySelectors.selectIsCategoryPageEmpty));
       const expected = cold('a', { a: !stubCategoryPageConfigurationState.product_ids.length });
       expect(selector).toBeObservable(expected);
     });
@@ -212,7 +213,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageTotalProducts', () => {
 
     it('selects the total number of products of the current category page', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageTotalProducts));
+      const selector = store.pipe(select(categorySelectors.selectCategoryPageTotalProducts));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.total_products });
       expect(selector).toBeObservable(expected);
     });
@@ -221,7 +222,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageFilterRequests', () => {
 
     it('selects the filter requests of the current category page', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageFilterRequests));
+      const selector = store.pipe(select(categorySelectors.selectCategoryPageFilterRequests));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.filter_requests });
       expect(selector).toBeObservable(expected);
     });
@@ -230,7 +231,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageAppliedSortOption', () => {
 
     it('selects the applied sort option of the current category page', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageAppliedSortOption));
+      const selector = store.pipe(select(categorySelectors.selectCategoryPageAppliedSortOption));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.applied_sort_option });
       expect(selector).toBeObservable(expected);
     });
@@ -239,7 +240,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageAppliedSortDirection', () => {
 
     it('selects the applied sort direction of the current category page', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageAppliedSortDirection));
+      const selector = store.pipe(select(categorySelectors.selectCategoryPageAppliedSortDirection));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.applied_sort_direction });
       expect(selector).toBeObservable(expected);
     });
@@ -248,7 +249,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectSelectedCategoryId', () => {
 
     it('selects the id of the selected category', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectSelectedCategoryId));
+      const selector = store.pipe(select(categorySelectors.selectSelectedCategoryId));
       const expected = cold('a', { a: stubCategory.id });
       expect(selector).toBeObservable(expected);
     });
@@ -257,7 +258,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryLoading', () => {
 
     it('selects the loading state of the category', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryLoading));
+      const selector = store.pipe(select(categorySelectors.selectCategoryLoading));
       const expected = cold('a', { a: false });
       expect(selector).toBeObservable(expected);
     });
@@ -266,7 +267,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryProductsLoading', () => {
 
     it('selects the loading state of the category products', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryProductsLoading));
+      const selector = store.pipe(select(categorySelectors.selectCategoryProductsLoading));
       const expected = cold('a', { a: false });
       expect(selector).toBeObservable(expected);
     });
@@ -275,7 +276,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryErrors', () => {
 
     it('returns the selected category id', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryErrors));
+      const selector = store.pipe(select(categorySelectors.selectCategoryErrors));
       const expected = cold('a', { a: [] });
       expect(selector).toBeObservable(expected);
     });
@@ -284,7 +285,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryIds', () => {
 
     it('returns all category ids', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryIds));
+      const selector = store.pipe(select(categorySelectors.selectCategoryIds));
       const expected = cold('a', { a: [stubCategory.id] });
       expect(selector).toBeObservable(expected);
     });
@@ -296,7 +297,7 @@ describe('DaffCategorySelectors', () => {
       const expectedDictionary = new Object();
       expectedDictionary[stubCategory.id] = stubCategory;
 
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryEntities));
+      const selector = store.pipe(select(categorySelectors.selectCategoryEntities));
       const expected = cold('a', { a: expectedDictionary });
       expect(selector).toBeObservable(expected);
     });
@@ -305,7 +306,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectAllCategories', () => {
 
     it('returns all categories as an array', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectAllCategories));
+      const selector = store.pipe(select(categorySelectors.selectAllCategories));
       const expected = cold('a', { a: [stubCategory] });
       expect(selector).toBeObservable(expected);
     });
@@ -314,7 +315,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryTotal', () => {
 
     it('returns the total number of categories', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryTotal));
+      const selector = store.pipe(select(categorySelectors.selectCategoryTotal));
       const expected = cold('a', { a: 1 });
       expect(selector).toBeObservable(expected);
     });
@@ -323,7 +324,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectSelectedCategory', () => {
 
     it('selects the selected category', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectSelectedCategory));
+      const selector = store.pipe(select(categorySelectors.selectSelectedCategory));
       const expected = cold('a', { a: stubCategory });
       expect(selector).toBeObservable(expected);
     });
@@ -331,13 +332,13 @@ describe('DaffCategorySelectors', () => {
 
   describe('selectCategoryPageProducts', () => {
 		it('selects the products of the selected category', () => {
-			const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageProducts));
+			const selector = store.pipe(select(categorySelectors.selectCategoryPageProducts));
 			const expected = cold('a', { a: [product] });
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('selects the products in the right order', () => {
-			const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageProducts));
+			const selector = store.pipe(select(categorySelectors.selectCategoryPageProducts));
 
 			const productA = productFactory.create();
 			const productB = productFactory.create();
@@ -396,7 +397,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategory', () => {
 
     it('selects the category by id', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategory, { id: stubCategory.id }));
+      const selector = store.pipe(select(categorySelectors.selectCategory, { id: stubCategory.id }));
       const expected = cold('a', { a: stubCategory });
       expect(selector).toBeObservable(expected);
     });
@@ -405,7 +406,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectProductsByCategory', () => {
 
     it('selects products by category', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectProductsByCategory, { id: stubCategory.id }));
+      const selector = store.pipe(select(categorySelectors.selectProductsByCategory, { id: stubCategory.id }));
       const expected = cold('a', { a: [product] });
       expect(selector).toBeObservable(expected);
     });
@@ -414,7 +415,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectTotalProductsByCategory', () => {
 
     it('selects products by category', () => {
-      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectTotalProductsByCategory, { id: stubCategory.id }));
+      const selector = store.pipe(select(categorySelectors.selectTotalProductsByCategory, { id: stubCategory.id }));
       const expected = cold('a', { a: 1 });
       expect(selector).toBeObservable(expected);
     });

--- a/libs/category/src/selectors/category.selector.spec.ts
+++ b/libs/category/src/selectors/category.selector.spec.ts
@@ -7,37 +7,9 @@ import { DaffCategoryFactory, DaffCategoryPageConfigurationStateFactory } from '
 import { DaffProductFactory } from '@daffodil/product/testing';
 
 import { DaffCategoryLoadSuccess } from '../actions/category.actions';
-import { 
-  selectCategoryLoading, 
-  selectCategoryErrors, 
-  selectCategoryIds, 
-  selectCategoryEntities, 
-  selectAllCategories, 
-  selectCategoryTotal, 
-  selectCategoryPageConfigurationState,
-  selectCategoryState, 
-  selectSelectedCategoryId,
-  selectSelectedCategory,
-  selectCategoryPageProducts,
-  selectCategoryCurrentPage,
-  selectCategoryTotalPages,
-  selectCategoryPageSize,
-  selectCategoryFilters,
-  selectCategorySortOptions,
-	selectCategory,
-	selectProductsByCategory,
-	selectCategoryPageProductIds,
-	selectCategoryPageTotalProducts,
-	selectCategoryPageAppliedSortOption,
-	selectCategoryPageAppliedSortDirection,
-	selectTotalProductsByCategory,
-	selectCategoryProductsLoading,
-	selectCategoryPageFilterRequests,
-	selectCategoryPageAppliedFilters,
-	selectIsCategoryPageEmpty
-} from './category.selector';
-import { CategoryReducersState } from '../reducers/category-reducers.interface';
-import { categoryReducers } from '../reducers/category-reducers';
+import { getDaffCategorySelectors } from './category.selector';
+import { DaffCategoryReducersState } from '../reducers/category-reducers.interface';
+import { daffCategoryReducers } from '../reducers/category-reducers';
 import { DaffCategory } from '../models/category';
 import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
 import { DaffCategoryFilterType } from '../models/category-filter-base';
@@ -47,7 +19,7 @@ import { DaffCategoryFilterRequest } from '../models/requests/filter-request';
 
 describe('DaffCategorySelectors', () => {
 
-  let store: Store<CategoryReducersState<DaffCategory, DaffCategoryPageConfigurationState>>;
+  let store: Store<DaffCategoryReducersState<DaffCategory, DaffCategoryPageConfigurationState>>;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
   const categoryPageConfigurationFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
   const productFactory: DaffProductFactory = new DaffProductFactory();
@@ -59,7 +31,7 @@ describe('DaffCategorySelectors', () => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
-          category: combineReducers(categoryReducers()),
+          category: combineReducers(daffCategoryReducers()),
           product: combineReducers(daffProductReducers)
         })
       ]
@@ -107,7 +79,7 @@ describe('DaffCategorySelectors', () => {
         productsLoading: false,
         errors: []
       }
-      const selector = store.pipe(select(selectCategoryState()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryState));
       const expected = cold('a', { a: expectedFeatureState });
       expect(selector).toBeObservable(expected);
     });
@@ -116,7 +88,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageConfigurationState', () => {
 
     it('selects the category page configuration state', () => {
-      const selector = store.pipe(select(selectCategoryPageConfigurationState()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageConfigurationState));
       const expected = cold('a', { a: stubCategoryPageConfigurationState });
       expect(selector).toBeObservable(expected);
     });
@@ -125,7 +97,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryCurrentPage', () => {
 
     it('selects the current page of the current category', () => {
-      const selector = store.pipe(select(selectCategoryCurrentPage()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryCurrentPage));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.current_page });
       expect(selector).toBeObservable(expected);
     });
@@ -134,7 +106,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryTotalPages', () => {
 
     it('selects the total pages of products of the current category', () => {
-      const selector = store.pipe(select(selectCategoryTotalPages()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryTotalPages));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.total_pages });
       expect(selector).toBeObservable(expected);
     });
@@ -143,7 +115,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageSize', () => {
 
     it('selects the page size of the current category', () => {
-      const selector = store.pipe(select(selectCategoryPageSize()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageSize));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.page_size });
       expect(selector).toBeObservable(expected);
     });
@@ -152,7 +124,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryFilters', () => {
 
     it('selects filters of the current category', () => {
-      const selector = store.pipe(select(selectCategoryFilters()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryFilters));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.filters });
       expect(selector).toBeObservable(expected);
     });
@@ -176,7 +148,7 @@ describe('DaffCategorySelectors', () => {
 				id: stubCategoryPageConfigurationState.id,
 				filter_requests: filterRequests
 			}));
-      const selector = store.pipe(select(selectCategoryPageAppliedFilters()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageAppliedFilters));
       const expected = cold('a', { a: expectedAppliedFilters });
       expect(selector).toBeObservable(expected);
     });
@@ -203,7 +175,7 @@ describe('DaffCategorySelectors', () => {
 				id: stubCategoryPageConfigurationState.id,
 				filter_requests: filterRequests
 			}));
-      const selector = store.pipe(select(selectCategoryPageAppliedFilters()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageAppliedFilters));
       const expected = cold('a', { a: expectedAppliedFilters });
       expect(selector).toBeObservable(expected);
     });
@@ -212,7 +184,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategorySortOptions', () => {
 
     it('selects the category sort options of the current category', () => {
-      const selector = store.pipe(select(selectCategorySortOptions()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategorySortOptions));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.sort_options });
       expect(selector).toBeObservable(expected);
     });
@@ -221,7 +193,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageProductIds', () => {
 
     it('selects the product_ids of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageProductIds()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageProductIds));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.product_ids });
       expect(selector).toBeObservable(expected);
     });
@@ -230,7 +202,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectIsCategoryPageEmpty', () => {
 
     it('selects whether the current category page is empty of products', () => {
-      const selector = store.pipe(select(selectIsCategoryPageEmpty()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectIsCategoryPageEmpty));
       const expected = cold('a', { a: !stubCategoryPageConfigurationState.product_ids.length });
       expect(selector).toBeObservable(expected);
     });
@@ -240,7 +212,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageTotalProducts', () => {
 
     it('selects the total number of products of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageTotalProducts()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageTotalProducts));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.total_products });
       expect(selector).toBeObservable(expected);
     });
@@ -249,7 +221,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageFilterRequests', () => {
 
     it('selects the filter requests of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageFilterRequests()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageFilterRequests));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.filter_requests });
       expect(selector).toBeObservable(expected);
     });
@@ -258,7 +230,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageAppliedSortOption', () => {
 
     it('selects the applied sort option of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageAppliedSortOption()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageAppliedSortOption));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.applied_sort_option });
       expect(selector).toBeObservable(expected);
     });
@@ -267,7 +239,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageAppliedSortDirection', () => {
 
     it('selects the applied sort direction of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageAppliedSortDirection()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageAppliedSortDirection));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.applied_sort_direction });
       expect(selector).toBeObservable(expected);
     });
@@ -276,7 +248,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectSelectedCategoryId', () => {
 
     it('selects the id of the selected category', () => {
-      const selector = store.pipe(select(selectSelectedCategoryId()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectSelectedCategoryId));
       const expected = cold('a', { a: stubCategory.id });
       expect(selector).toBeObservable(expected);
     });
@@ -285,7 +257,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryLoading', () => {
 
     it('selects the loading state of the category', () => {
-      const selector = store.pipe(select(selectCategoryLoading()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryLoading));
       const expected = cold('a', { a: false });
       expect(selector).toBeObservable(expected);
     });
@@ -294,7 +266,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryProductsLoading', () => {
 
     it('selects the loading state of the category products', () => {
-      const selector = store.pipe(select(selectCategoryProductsLoading()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryProductsLoading));
       const expected = cold('a', { a: false });
       expect(selector).toBeObservable(expected);
     });
@@ -303,7 +275,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryErrors', () => {
 
     it('returns the selected category id', () => {
-      const selector = store.pipe(select(selectCategoryErrors()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryErrors));
       const expected = cold('a', { a: [] });
       expect(selector).toBeObservable(expected);
     });
@@ -312,7 +284,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryIds', () => {
 
     it('returns all category ids', () => {
-      const selector = store.pipe(select(selectCategoryIds()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryIds));
       const expected = cold('a', { a: [stubCategory.id] });
       expect(selector).toBeObservable(expected);
     });
@@ -324,7 +296,7 @@ describe('DaffCategorySelectors', () => {
       const expectedDictionary = new Object();
       expectedDictionary[stubCategory.id] = stubCategory;
 
-      const selector = store.pipe(select(selectCategoryEntities()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryEntities));
       const expected = cold('a', { a: expectedDictionary });
       expect(selector).toBeObservable(expected);
     });
@@ -333,7 +305,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectAllCategories', () => {
 
     it('returns all categories as an array', () => {
-      const selector = store.pipe(select(selectAllCategories()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectAllCategories));
       const expected = cold('a', { a: [stubCategory] });
       expect(selector).toBeObservable(expected);
     });
@@ -342,7 +314,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryTotal', () => {
 
     it('returns the total number of categories', () => {
-      const selector = store.pipe(select(selectCategoryTotal()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryTotal));
       const expected = cold('a', { a: 1 });
       expect(selector).toBeObservable(expected);
     });
@@ -351,7 +323,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectSelectedCategory', () => {
 
     it('selects the selected category', () => {
-      const selector = store.pipe(select(selectSelectedCategory()));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectSelectedCategory));
       const expected = cold('a', { a: stubCategory });
       expect(selector).toBeObservable(expected);
     });
@@ -359,13 +331,13 @@ describe('DaffCategorySelectors', () => {
 
   describe('selectCategoryPageProducts', () => {
 		it('selects the products of the selected category', () => {
-			const selector = store.pipe(select(selectCategoryPageProducts()));
+			const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageProducts));
 			const expected = cold('a', { a: [product] });
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('selects the products in the right order', () => {
-			const selector = store.pipe(select(selectCategoryPageProducts()));
+			const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategoryPageProducts));
 
 			const productA = productFactory.create();
 			const productB = productFactory.create();
@@ -424,7 +396,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategory', () => {
 
     it('selects the category by id', () => {
-      const selector = store.pipe(select(selectCategory(), { id: stubCategory.id }));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectCategory, { id: stubCategory.id }));
       const expected = cold('a', { a: stubCategory });
       expect(selector).toBeObservable(expected);
     });
@@ -433,7 +405,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectProductsByCategory', () => {
 
     it('selects products by category', () => {
-      const selector = store.pipe(select(selectProductsByCategory(), { id: stubCategory.id }));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectProductsByCategory, { id: stubCategory.id }));
       const expected = cold('a', { a: [product] });
       expect(selector).toBeObservable(expected);
     });
@@ -442,7 +414,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectTotalProductsByCategory', () => {
 
     it('selects products by category', () => {
-      const selector = store.pipe(select(selectTotalProductsByCategory(), { id: stubCategory.id }));
+      const selector = store.pipe(select(getDaffCategorySelectors<DaffCategory, DaffCategoryPageConfigurationState>().selectTotalProductsByCategory, { id: stubCategory.id }));
       const expected = cold('a', { a: 1 });
       expect(selector).toBeObservable(expected);
     });

--- a/libs/category/src/selectors/category.selector.spec.ts
+++ b/libs/category/src/selectors/category.selector.spec.ts
@@ -31,7 +31,7 @@ describe('DaffCategorySelectors', () => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
-          category: combineReducers(daffCategoryReducers()),
+          category: combineReducers(daffCategoryReducers),
           product: combineReducers(daffProductReducers)
         })
       ]

--- a/libs/category/src/selectors/category.selector.spec.ts
+++ b/libs/category/src/selectors/category.selector.spec.ts
@@ -47,7 +47,7 @@ import { DaffCategoryFilterRequest } from '../models/requests/filter-request';
 
 describe('DaffCategorySelectors', () => {
 
-  let store: Store<CategoryReducersState>;
+  let store: Store<CategoryReducersState<DaffCategory, DaffCategoryPageConfigurationState>>;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
   const categoryPageConfigurationFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
   const productFactory: DaffProductFactory = new DaffProductFactory();
@@ -59,7 +59,7 @@ describe('DaffCategorySelectors', () => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
-          category: combineReducers(categoryReducers),
+          category: combineReducers(categoryReducers()),
           product: combineReducers(daffProductReducers)
         })
       ]
@@ -107,7 +107,7 @@ describe('DaffCategorySelectors', () => {
         productsLoading: false,
         errors: []
       }
-      const selector = store.pipe(select(selectCategoryState));
+      const selector = store.pipe(select(selectCategoryState()));
       const expected = cold('a', { a: expectedFeatureState });
       expect(selector).toBeObservable(expected);
     });
@@ -116,7 +116,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageConfigurationState', () => {
 
     it('selects the category page configuration state', () => {
-      const selector = store.pipe(select(selectCategoryPageConfigurationState));
+      const selector = store.pipe(select(selectCategoryPageConfigurationState()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState });
       expect(selector).toBeObservable(expected);
     });
@@ -125,7 +125,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryCurrentPage', () => {
 
     it('selects the current page of the current category', () => {
-      const selector = store.pipe(select(selectCategoryCurrentPage));
+      const selector = store.pipe(select(selectCategoryCurrentPage()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.current_page });
       expect(selector).toBeObservable(expected);
     });
@@ -134,7 +134,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryTotalPages', () => {
 
     it('selects the total pages of products of the current category', () => {
-      const selector = store.pipe(select(selectCategoryTotalPages));
+      const selector = store.pipe(select(selectCategoryTotalPages()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.total_pages });
       expect(selector).toBeObservable(expected);
     });
@@ -143,7 +143,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageSize', () => {
 
     it('selects the page size of the current category', () => {
-      const selector = store.pipe(select(selectCategoryPageSize));
+      const selector = store.pipe(select(selectCategoryPageSize()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.page_size });
       expect(selector).toBeObservable(expected);
     });
@@ -152,7 +152,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryFilters', () => {
 
     it('selects filters of the current category', () => {
-      const selector = store.pipe(select(selectCategoryFilters));
+      const selector = store.pipe(select(selectCategoryFilters()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.filters });
       expect(selector).toBeObservable(expected);
     });
@@ -176,7 +176,7 @@ describe('DaffCategorySelectors', () => {
 				id: stubCategoryPageConfigurationState.id,
 				filter_requests: filterRequests
 			}));
-      const selector = store.pipe(select(selectCategoryPageAppliedFilters));
+      const selector = store.pipe(select(selectCategoryPageAppliedFilters()));
       const expected = cold('a', { a: expectedAppliedFilters });
       expect(selector).toBeObservable(expected);
     });
@@ -203,7 +203,7 @@ describe('DaffCategorySelectors', () => {
 				id: stubCategoryPageConfigurationState.id,
 				filter_requests: filterRequests
 			}));
-      const selector = store.pipe(select(selectCategoryPageAppliedFilters));
+      const selector = store.pipe(select(selectCategoryPageAppliedFilters()));
       const expected = cold('a', { a: expectedAppliedFilters });
       expect(selector).toBeObservable(expected);
     });
@@ -212,7 +212,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategorySortOptions', () => {
 
     it('selects the category sort options of the current category', () => {
-      const selector = store.pipe(select(selectCategorySortOptions));
+      const selector = store.pipe(select(selectCategorySortOptions()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.sort_options });
       expect(selector).toBeObservable(expected);
     });
@@ -221,7 +221,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageProductIds', () => {
 
     it('selects the product_ids of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageProductIds));
+      const selector = store.pipe(select(selectCategoryPageProductIds()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.product_ids });
       expect(selector).toBeObservable(expected);
     });
@@ -230,7 +230,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectIsCategoryPageEmpty', () => {
 
     it('selects whether the current category page is empty of products', () => {
-      const selector = store.pipe(select(selectIsCategoryPageEmpty));
+      const selector = store.pipe(select(selectIsCategoryPageEmpty()));
       const expected = cold('a', { a: !stubCategoryPageConfigurationState.product_ids.length });
       expect(selector).toBeObservable(expected);
     });
@@ -240,7 +240,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageTotalProducts', () => {
 
     it('selects the total number of products of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageTotalProducts));
+      const selector = store.pipe(select(selectCategoryPageTotalProducts()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.total_products });
       expect(selector).toBeObservable(expected);
     });
@@ -249,7 +249,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageFilterRequests', () => {
 
     it('selects the filter requests of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageFilterRequests));
+      const selector = store.pipe(select(selectCategoryPageFilterRequests()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.filter_requests });
       expect(selector).toBeObservable(expected);
     });
@@ -258,7 +258,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageAppliedSortOption', () => {
 
     it('selects the applied sort option of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageAppliedSortOption));
+      const selector = store.pipe(select(selectCategoryPageAppliedSortOption()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.applied_sort_option });
       expect(selector).toBeObservable(expected);
     });
@@ -267,7 +267,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryPageAppliedSortDirection', () => {
 
     it('selects the applied sort direction of the current category page', () => {
-      const selector = store.pipe(select(selectCategoryPageAppliedSortDirection));
+      const selector = store.pipe(select(selectCategoryPageAppliedSortDirection()));
       const expected = cold('a', { a: stubCategoryPageConfigurationState.applied_sort_direction });
       expect(selector).toBeObservable(expected);
     });
@@ -276,7 +276,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectSelectedCategoryId', () => {
 
     it('selects the id of the selected category', () => {
-      const selector = store.pipe(select(selectSelectedCategoryId));
+      const selector = store.pipe(select(selectSelectedCategoryId()));
       const expected = cold('a', { a: stubCategory.id });
       expect(selector).toBeObservable(expected);
     });
@@ -285,7 +285,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryLoading', () => {
 
     it('selects the loading state of the category', () => {
-      const selector = store.pipe(select(selectCategoryLoading));
+      const selector = store.pipe(select(selectCategoryLoading()));
       const expected = cold('a', { a: false });
       expect(selector).toBeObservable(expected);
     });
@@ -294,7 +294,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryProductsLoading', () => {
 
     it('selects the loading state of the category products', () => {
-      const selector = store.pipe(select(selectCategoryProductsLoading));
+      const selector = store.pipe(select(selectCategoryProductsLoading()));
       const expected = cold('a', { a: false });
       expect(selector).toBeObservable(expected);
     });
@@ -303,7 +303,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryErrors', () => {
 
     it('returns the selected category id', () => {
-      const selector = store.pipe(select(selectCategoryErrors));
+      const selector = store.pipe(select(selectCategoryErrors()));
       const expected = cold('a', { a: [] });
       expect(selector).toBeObservable(expected);
     });
@@ -312,7 +312,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryIds', () => {
 
     it('returns all category ids', () => {
-      const selector = store.pipe(select(selectCategoryIds));
+      const selector = store.pipe(select(selectCategoryIds()));
       const expected = cold('a', { a: [stubCategory.id] });
       expect(selector).toBeObservable(expected);
     });
@@ -324,7 +324,7 @@ describe('DaffCategorySelectors', () => {
       const expectedDictionary = new Object();
       expectedDictionary[stubCategory.id] = stubCategory;
 
-      const selector = store.pipe(select(selectCategoryEntities));
+      const selector = store.pipe(select(selectCategoryEntities()));
       const expected = cold('a', { a: expectedDictionary });
       expect(selector).toBeObservable(expected);
     });
@@ -333,7 +333,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectAllCategories', () => {
 
     it('returns all categories as an array', () => {
-      const selector = store.pipe(select(selectAllCategories));
+      const selector = store.pipe(select(selectAllCategories()));
       const expected = cold('a', { a: [stubCategory] });
       expect(selector).toBeObservable(expected);
     });
@@ -342,7 +342,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategoryTotal', () => {
 
     it('returns the total number of categories', () => {
-      const selector = store.pipe(select(selectCategoryTotal));
+      const selector = store.pipe(select(selectCategoryTotal()));
       const expected = cold('a', { a: 1 });
       expect(selector).toBeObservable(expected);
     });
@@ -351,7 +351,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectSelectedCategory', () => {
 
     it('selects the selected category', () => {
-      const selector = store.pipe(select(selectSelectedCategory));
+      const selector = store.pipe(select(selectSelectedCategory()));
       const expected = cold('a', { a: stubCategory });
       expect(selector).toBeObservable(expected);
     });
@@ -359,13 +359,13 @@ describe('DaffCategorySelectors', () => {
 
   describe('selectCategoryPageProducts', () => {
 		it('selects the products of the selected category', () => {
-			const selector = store.pipe(select(selectCategoryPageProducts));
+			const selector = store.pipe(select(selectCategoryPageProducts()));
 			const expected = cold('a', { a: [product] });
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('selects the products in the right order', () => {
-			const selector = store.pipe(select(selectCategoryPageProducts));
+			const selector = store.pipe(select(selectCategoryPageProducts()));
 
 			const productA = productFactory.create();
 			const productB = productFactory.create();
@@ -424,7 +424,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectCategory', () => {
 
     it('selects the category by id', () => {
-      const selector = store.pipe(select(selectCategory, { id: stubCategory.id }));
+      const selector = store.pipe(select(selectCategory(), { id: stubCategory.id }));
       const expected = cold('a', { a: stubCategory });
       expect(selector).toBeObservable(expected);
     });
@@ -433,7 +433,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectProductsByCategory', () => {
 
     it('selects products by category', () => {
-      const selector = store.pipe(select(selectProductsByCategory, { id: stubCategory.id }));
+      const selector = store.pipe(select(selectProductsByCategory(), { id: stubCategory.id }));
       const expected = cold('a', { a: [product] });
       expect(selector).toBeObservable(expected);
     });
@@ -442,7 +442,7 @@ describe('DaffCategorySelectors', () => {
   describe('selectTotalProductsByCategory', () => {
 
     it('selects products by category', () => {
-      const selector = store.pipe(select(selectTotalProductsByCategory, { id: stubCategory.id }));
+      const selector = store.pipe(select(selectTotalProductsByCategory(), { id: stubCategory.id }));
       const expected = cold('a', { a: 1 });
       expect(selector).toBeObservable(expected);
     });

--- a/libs/category/src/selectors/category.selector.ts
+++ b/libs/category/src/selectors/category.selector.ts
@@ -1,5 +1,5 @@
-import { createSelector, createFeatureSelector } from '@ngrx/store';
-import { Dictionary } from '@ngrx/entity';
+import { createSelector, createFeatureSelector, MemoizedSelector, MemoizedSelectorWithProps } from '@ngrx/store';
+import { Dictionary, EntityState } from '@ngrx/entity';
 
 import { DaffProductUnion, selectProductEntities, selectAllProducts } from '@daffodil/product';
 
@@ -7,196 +7,281 @@ import { CategoryReducerState } from '../reducers/category/category-reducer-stat
 import { CategoryReducersState } from '../reducers/category-reducers.interface';
 import { categoryEntitiesAdapter } from '../reducers/category-entities/category-entities-adapter';
 import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
-import { DaffCategory } from '../models/category';
 import { DaffCategoryAppliedFilter } from '../models/category-applied-filter';
 import { DaffCategoryFilterRequest } from '../models/requests/filter-request';
 import { DaffCategoryFilter } from '../models/category-filter';
 import { buildAppliedFilter } from './applied-filter/applied-filter-methods';
-
-const { selectIds, selectEntities, selectAll, selectTotal } = categoryEntitiesAdapter.getSelectors();
+import { DaffGenericCategory } from '../models/generic-category';
 
 /**
  * Category Feature State
  */
-export const selectCategoryFeatureState = createFeatureSelector<CategoryReducersState>('category');
+export function selectCategoryFeatureState<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState>(): 
+	MemoizedSelector<object, CategoryReducersState<T, U>> {
+	return createFeatureSelector<CategoryReducersState<T, U>>('category');
+}
 
 /**
  * Category State
  */
-export const selectCategoryState = createSelector(
-  selectCategoryFeatureState,
-  (state: CategoryReducersState) => state.category
-);
+export function selectCategoryState<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState>():
+	MemoizedSelector<object, CategoryReducerState<U>> {
+	return createSelector(
+		selectCategoryFeatureState(),
+		(state: CategoryReducersState<T, U>) => state.category
+	);
+}
 
 /**
  * CategoryPageConfigurationState State
  */
-export const selectCategoryPageConfigurationState = createSelector(
-  selectCategoryState,
-  (state: CategoryReducerState) => state.categoryPageConfigurationState
-);
+export function selectCategoryPageConfigurationState<T extends DaffCategoryPageConfigurationState>():
+	MemoizedSelector<object, T> {
+	return createSelector(
+		selectCategoryState(),
+		(state: CategoryReducerState<T>) => state.categoryPageConfigurationState
+	);
+}
 
-export const selectCategoryCurrentPage = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.current_page
-);
+export function selectCategoryCurrentPage():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['current_page']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.current_page
+	);
+}
 
-export const selectCategoryTotalPages = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.total_pages
-);
+export function selectCategoryTotalPages():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['total_pages']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.total_pages
+	);
+}
 
-export const selectCategoryPageSize = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.page_size
-);
+export function selectCategoryPageSize():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['page_size']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.page_size
+	);
+}
 
-export const selectCategoryFilters = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.filters
-);
+export function selectCategoryFilters():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['filters']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.filters
+	);
+}
 
-export const selectCategorySortOptions = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.sort_options
-);
+export function selectCategorySortOptions():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['sort_options']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.sort_options
+	);
+}
 
-export const selectCategoryPageProductIds = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.product_ids
-);
+export function selectCategoryPageProductIds():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['product_ids']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.product_ids
+	);
+}
 
-export const selectIsCategoryPageEmpty = createSelector(
-	selectCategoryPageProductIds,
-	(state: string[]) => !state.length
-);
+export function selectIsCategoryPageEmpty():
+	MemoizedSelector<object, boolean> {
+	return createSelector(
+		selectCategoryPageProductIds(),
+		(state: DaffCategoryPageConfigurationState['product_ids']) => !state.length
+	);
+}
 
-export const selectCategoryPageTotalProducts = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.total_products
-);
+export function selectCategoryPageTotalProducts():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['total_products']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.total_products
+	);
+}
 
-export const selectCategoryPageFilterRequests = createSelector(
-	selectCategoryPageConfigurationState,
-	(state: DaffCategoryPageConfigurationState) => state.filter_requests
-);
+export function selectCategoryPageFilterRequests():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['filter_requests']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.filter_requests
+	);
+}
 
-export const selectCategoryPageAppliedFilters = createSelector(
-	selectCategoryPageFilterRequests,
-	selectCategoryFilters,
-	(filterRequests: DaffCategoryFilterRequest[], availableFilters: DaffCategoryFilter[]): DaffCategoryAppliedFilter[] => {
-		if(!availableFilters.length) return [];
-		return filterRequests.map(request => 
-			availableFilters
-				.filter(availableFilter => availableFilter.name === request.name)
-				.map(filter => buildAppliedFilter(filter, request)).shift()
-		);
-	}
-);
+export function selectCategoryPageAppliedFilters():
+	MemoizedSelector<object, DaffCategoryAppliedFilter[]> {
+	return createSelector(
+		selectCategoryPageFilterRequests(),
+		selectCategoryFilters(),
+		(filterRequests: DaffCategoryFilterRequest[], availableFilters: DaffCategoryFilter[]): DaffCategoryAppliedFilter[] => {
+			if(!availableFilters.length) return [];
+			return filterRequests.map(request => 
+				availableFilters
+					.filter(availableFilter => availableFilter.name === request.name)
+					.map(filter => buildAppliedFilter(filter, request)).shift()
+			);
+		}
+	);
+}
 
-export const selectCategoryPageAppliedSortOption = createSelector(
-	selectCategoryPageConfigurationState,
-	(state: DaffCategoryPageConfigurationState) => state.applied_sort_option
-);
+export function selectCategoryPageAppliedSortOption():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['applied_sort_option']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.applied_sort_option
+	);
+}
 
-export const selectCategoryPageAppliedSortDirection = createSelector(
-	selectCategoryPageConfigurationState,
-	(state: DaffCategoryPageConfigurationState) => state.applied_sort_direction
-);
+export function selectCategoryPageAppliedSortDirection():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['applied_sort_direction']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.applied_sort_direction
+	);
+}
 
 /**
  * Selected Category Id State
  */
-export const selectSelectedCategoryId = createSelector(
-  selectCategoryPageConfigurationState,
-  (state: DaffCategoryPageConfigurationState) => state.id
-);
+export function selectSelectedCategoryId():
+	MemoizedSelector<object, DaffCategoryPageConfigurationState['id']> {
+	return createSelector(
+		selectCategoryPageConfigurationState(),
+		(state: DaffCategoryPageConfigurationState) => state.id
+	);
+}
 
 /**
  * Category Loading State
  */
-export const selectCategoryLoading = createSelector(
-  selectCategoryState,
-  (state: CategoryReducerState) => state.categoryLoading
-);
+export function selectCategoryLoading():
+	MemoizedSelector<object, boolean> {
+	return createSelector(
+		selectCategoryState(),
+		(state: CategoryReducerState<DaffCategoryPageConfigurationState>) => state.categoryLoading
+	);
+}
 
 /**
  * Category Products Loading State
  */
-export const selectCategoryProductsLoading = createSelector(
-  selectCategoryState,
-  (state: CategoryReducerState) => state.productsLoading
-);
+export function selectCategoryProductsLoading():
+	MemoizedSelector<object, boolean> {
+	return createSelector(
+		selectCategoryState(),
+		(state: CategoryReducerState<DaffCategoryPageConfigurationState>) => state.productsLoading
+	);
+}
 
 /**
  * Load Category Errors
  */
-export const selectCategoryErrors = createSelector(
-  selectCategoryState,
-  (state: CategoryReducerState) => state.errors
-);
+export function selectCategoryErrors():
+	MemoizedSelector<object, string[]> {
+	return createSelector(
+		selectCategoryState(),
+		(state: CategoryReducerState<DaffCategoryPageConfigurationState>) => state.errors
+	);
+}
 
 /**
  * Category Entities State
  */
-export const selectCategoryEntitiesState = createSelector(
-  selectCategoryFeatureState,
-  (state: CategoryReducersState) => state.categoryEntities
-);
+export function selectCategoryEntitiesState<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState>():
+	MemoizedSelector<object, EntityState<T>> {
+	return createSelector(
+		selectCategoryFeatureState(),
+		(state: CategoryReducersState<T, U>) => state.categoryEntities
+	);
+}
 
-export const selectCategoryIds = createSelector(
-  selectCategoryEntitiesState,
-  selectIds
-);
+export function selectCategoryIds<T extends DaffGenericCategory<T>>():
+	MemoizedSelector<object, EntityState<T>['ids']> { 
+	return createSelector(
+		selectCategoryEntitiesState(),
+		categoryEntitiesAdapter<T>().getSelectors().selectIds
+	);
+}
 
-export const selectCategoryEntities = createSelector(
-  selectCategoryEntitiesState,
-  selectEntities
-);
+export function selectCategoryEntities<T extends DaffGenericCategory<T>>():
+	MemoizedSelector<object, Dictionary<T>> { 
+	return createSelector(
+		selectCategoryEntitiesState(),
+		categoryEntitiesAdapter<T>().getSelectors().selectEntities
+	);
+}
 
-export const selectAllCategories = createSelector(
-  selectCategoryEntitiesState,
-  selectAll
-);
+export function selectAllCategories<T extends DaffGenericCategory<T>>():
+	MemoizedSelector<object, T[]> { 
+	return createSelector(
+		selectCategoryEntitiesState(),
+		categoryEntitiesAdapter<T>().getSelectors().selectAll
+	);
+}
 
-export const selectCategoryTotal = createSelector(
-  selectCategoryEntitiesState,
-  selectTotal
-);
+export function selectCategoryTotal<T extends DaffGenericCategory<T>>():
+	MemoizedSelector<object, number> { 
+	return createSelector(
+		selectCategoryEntitiesState(),
+		categoryEntitiesAdapter<T>().getSelectors().selectTotal
+	);
+}
 
 /**
  * Combinatoric Category Selectors
  */
-export const selectSelectedCategory = createSelector(
-  selectCategoryEntities,
-  selectSelectedCategoryId,
-  (entities: Dictionary<DaffCategory>, selectedCategoryId: string) => entities[selectedCategoryId]
-);
+export function selectSelectedCategory<T extends DaffGenericCategory<T>>():
+	MemoizedSelector<object, T> {
+	return createSelector(
+		selectCategoryEntities(),
+		selectSelectedCategoryId(),
+		(entities: Dictionary<T>, selectedCategoryId: string) => entities[selectedCategoryId]
+	);
+}
 
-export const selectCategoryPageProducts = createSelector(
-	selectCategoryPageProductIds,
-	selectProductEntities,
-	(ids, products: Dictionary<DaffProductUnion>) =>
-		ids.map(id => products[id]).filter(p => p != null),
-);
+export function selectCategoryPageProducts():
+	MemoizedSelector<object, DaffProductUnion[]> { 
+	return createSelector(
+		selectCategoryPageProductIds(),
+		selectProductEntities,
+		(ids, products: Dictionary<DaffProductUnion>) =>
+			ids.map(id => products[id]).filter(p => p != null),
+	);
+}
 
-export const selectCategory = createSelector(
-	selectCategoryEntities,
-	(entities, props) =>  entities[props.id]
-);
+export function selectCategory<T extends DaffGenericCategory<T>>():
+	MemoizedSelectorWithProps<object, object, T> { 
+	return createSelector(
+		selectCategoryEntities(),
+		(entities: Dictionary<T>, props) =>  entities[props.id]
+	);
+}
 
-export const selectProductsByCategory = createSelector(
-	selectCategoryEntities,
-	selectAllProducts,
-	(entities, products, props) => entities[props.id] && entities[props.id].product_ids
-		? products.filter(product => entities[props.id].product_ids.indexOf(product.id) >= 0)
-		: null
-);
+	export function selectProductsByCategory():
+	MemoizedSelectorWithProps<object, object, DaffProductUnion[]> { 
+	return createSelector(
+		selectCategoryEntities(),
+		selectAllProducts,
+		(entities, products, props) => entities[props.id] && entities[props.id].product_ids
+			? products.filter(product => entities[props.id].product_ids.indexOf(product.id) >= 0)
+			: null
+	);
+}
 
-export const selectTotalProductsByCategory = createSelector(
-	selectCategoryEntities,
-	selectAllProducts,
-	(entities, products, props) => selectProductsByCategory.projector(entities, products, { id: props.id })
-		? selectProductsByCategory.projector(entities, products, { id: props.id }).length
-		: null
-);
+export function selectTotalProductsByCategory():
+	MemoizedSelectorWithProps<object, object, number> { 
+	return createSelector(
+		selectCategoryEntities(),
+		selectAllProducts,
+		(entities, products, props) => selectProductsByCategory().projector(entities, products, { id: props.id })
+			? selectProductsByCategory().projector(entities, products, { id: props.id }).length
+			: null
+	);
+}

--- a/libs/category/src/selectors/category.selector.ts
+++ b/libs/category/src/selectors/category.selector.ts
@@ -13,7 +13,7 @@ import { DaffCategoryFilter } from '../models/category-filter';
 import { buildAppliedFilter } from './applied-filter/applied-filter-methods';
 import { DaffGenericCategory } from '../models/generic-category';
 
-interface DaffCategoryMemoizedSelectors<T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState> {
+export interface DaffCategoryMemoizedSelectors<T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState> {
 	selectCategoryFeatureState: MemoizedSelector<object, DaffCategoryReducersState<T, V>>;
 	selectCategoryState: MemoizedSelector<object, DaffCategoryReducerState<V>>;
 	selectCategoryPageConfigurationState: MemoizedSelector<object, V>;
@@ -45,7 +45,7 @@ interface DaffCategoryMemoizedSelectors<T extends DaffGenericCategory<T>, V exte
 	selectTotalProductsByCategory: MemoizedSelectorWithProps<object, object, number>;
 }
 
-export const createCategoryFeatureSelectors = <T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState>(): DaffCategoryMemoizedSelectors<T, V> => {
+const createCategoryFeatureSelectors = <T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState>(): DaffCategoryMemoizedSelectors<T, V> => {
 	const selectCategoryFeatureState = createFeatureSelector<DaffCategoryReducersState<T, V>>('category');
 
 	/**
@@ -261,7 +261,7 @@ export const createCategoryFeatureSelectors = <T extends DaffGenericCategory<T>,
 	}
 }
 
-export const memoizeDaffCategoryFeatureSelectors = () => {
+const memoizeDaffCategoryFeatureSelectors = () => {
 	let cache;
 	return <T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState>(): DaffCategoryMemoizedSelectors<T, V> => cache = cache 
 		? cache 

--- a/libs/category/src/selectors/category.selector.ts
+++ b/libs/category/src/selectors/category.selector.ts
@@ -3,9 +3,9 @@ import { Dictionary, EntityState } from '@ngrx/entity';
 
 import { DaffProductUnion, selectProductEntities, selectAllProducts } from '@daffodil/product';
 
-import { CategoryReducerState } from '../reducers/category/category-reducer-state.interface';
-import { CategoryReducersState } from '../reducers/category-reducers.interface';
-import { categoryEntitiesAdapter } from '../reducers/category-entities/category-entities-adapter';
+import { DaffCategoryReducerState } from '../reducers/category/category-reducer-state.interface';
+import { DaffCategoryReducersState } from '../reducers/category-reducers.interface';
+import { daffCategoryEntitiesAdapter } from '../reducers/category-entities/category-entities-adapter';
 import { DaffCategoryPageConfigurationState } from '../models/category-page-configuration-state';
 import { DaffCategoryAppliedFilter } from '../models/category-applied-filter';
 import { DaffCategoryFilterRequest } from '../models/requests/filter-request';
@@ -13,113 +13,105 @@ import { DaffCategoryFilter } from '../models/category-filter';
 import { buildAppliedFilter } from './applied-filter/applied-filter-methods';
 import { DaffGenericCategory } from '../models/generic-category';
 
-/**
- * Category Feature State
- */
-export function selectCategoryFeatureState<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState>(): 
-	MemoizedSelector<object, CategoryReducersState<T, U>> {
-	return createFeatureSelector<CategoryReducersState<T, U>>('category');
+interface DaffCategoryMemoizedSelectors<T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState> {
+	selectCategoryFeatureState: MemoizedSelector<object, DaffCategoryReducersState<T, V>>;
+	selectCategoryState: MemoizedSelector<object, DaffCategoryReducerState<V>>;
+	selectCategoryPageConfigurationState: MemoizedSelector<object, V>;
+	selectCategoryCurrentPage: MemoizedSelector<object, V['current_page']>;
+	selectCategoryTotalPages: MemoizedSelector<object, V['total_pages']>;
+	selectCategoryPageSize: MemoizedSelector<object, V['page_size']>;
+	selectCategoryFilters: MemoizedSelector<object, V['filters']>;
+	selectCategorySortOptions: MemoizedSelector<object, V['sort_options']>;
+	selectCategoryPageProductIds: MemoizedSelector<object, V['product_ids']>;
+	selectIsCategoryPageEmpty: MemoizedSelector<object, boolean>;
+	selectCategoryPageTotalProducts: MemoizedSelector<object, V['total_products']>;
+	selectCategoryPageFilterRequests: MemoizedSelector<object, V['filter_requests']>;
+	selectCategoryPageAppliedFilters: MemoizedSelector<object, DaffCategoryAppliedFilter[]>;
+	selectCategoryPageAppliedSortOption: MemoizedSelector<object, V['applied_sort_option']>;
+	selectCategoryPageAppliedSortDirection: MemoizedSelector<object, V['applied_sort_direction']>;
+	selectSelectedCategoryId: MemoizedSelector<object, V['id']>;
+	selectCategoryLoading: MemoizedSelector<object, boolean>;
+	selectCategoryProductsLoading: MemoizedSelector<object, boolean>;
+	selectCategoryErrors: MemoizedSelector<object, string[]>;
+	selectCategoryEntitiesState: MemoizedSelector<object, EntityState<T>>;
+	selectCategoryIds: MemoizedSelector<object, EntityState<T>['ids']>;
+	selectCategoryEntities: MemoizedSelector<object, Dictionary<T>>;
+	selectAllCategories: MemoizedSelector<object, T[]>;
+	selectCategoryTotal: MemoizedSelector<object, number>;
+	selectSelectedCategory: MemoizedSelector<object, T>;
+	selectCategoryPageProducts: MemoizedSelector<object, DaffProductUnion[]>;
+	selectCategory: MemoizedSelectorWithProps<object, object, T>;
+	selectProductsByCategory: MemoizedSelectorWithProps<object, object, DaffProductUnion[]>;
+	selectTotalProductsByCategory: MemoizedSelectorWithProps<object, object, number>;
 }
 
-/**
- * Category State
- */
-export function selectCategoryState<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState>():
-	MemoizedSelector<object, CategoryReducerState<U>> {
-	return createSelector(
-		selectCategoryFeatureState(),
-		(state: CategoryReducersState<T, U>) => state.category
+export const createCategoryFeatureSelectors = <T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState>(): DaffCategoryMemoizedSelectors<T, V> => {
+	const selectCategoryFeatureState = createFeatureSelector<DaffCategoryReducersState<T, V>>('category');
+
+	/**
+	 * Category State
+	 */
+	const selectCategoryState = createSelector(
+		selectCategoryFeatureState,
+		(state: DaffCategoryReducersState<T, V>) => state.category
 	);
-}
 
-/**
- * CategoryPageConfigurationState State
- */
-export function selectCategoryPageConfigurationState<T extends DaffCategoryPageConfigurationState>():
-	MemoizedSelector<object, T> {
-	return createSelector(
-		selectCategoryState(),
-		(state: CategoryReducerState<T>) => state.categoryPageConfigurationState
+	/**
+	 * CategoryPageConfigurationState State
+	 */
+	const selectCategoryPageConfigurationState = createSelector(
+		selectCategoryState,
+		(state: DaffCategoryReducerState<V>) => state.categoryPageConfigurationState
 	);
-}
 
-export function selectCategoryCurrentPage():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['current_page']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.current_page
+	const selectCategoryCurrentPage = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.current_page
 	);
-}
 
-export function selectCategoryTotalPages():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['total_pages']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.total_pages
+	const selectCategoryTotalPages = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.total_pages
 	);
-}
 
-export function selectCategoryPageSize():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['page_size']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.page_size
+	const selectCategoryPageSize = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.page_size
 	);
-}
 
-export function selectCategoryFilters():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['filters']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.filters
+	const selectCategoryFilters = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.filters
 	);
-}
 
-export function selectCategorySortOptions():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['sort_options']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.sort_options
+	const selectCategorySortOptions = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.sort_options
 	);
-}
 
-export function selectCategoryPageProductIds():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['product_ids']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.product_ids
+	const selectCategoryPageProductIds = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.product_ids
 	);
-}
 
-export function selectIsCategoryPageEmpty():
-	MemoizedSelector<object, boolean> {
-	return createSelector(
-		selectCategoryPageProductIds(),
-		(state: DaffCategoryPageConfigurationState['product_ids']) => !state.length
+	const selectIsCategoryPageEmpty = createSelector(
+		selectCategoryPageProductIds,
+		(state: V['product_ids']) => !state.length
 	);
-}
 
-export function selectCategoryPageTotalProducts():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['total_products']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.total_products
+	const selectCategoryPageTotalProducts = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.total_products
 	);
-}
 
-export function selectCategoryPageFilterRequests():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['filter_requests']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.filter_requests
+	const selectCategoryPageFilterRequests = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.filter_requests
 	);
-}
 
-export function selectCategoryPageAppliedFilters():
-	MemoizedSelector<object, DaffCategoryAppliedFilter[]> {
-	return createSelector(
-		selectCategoryPageFilterRequests(),
-		selectCategoryFilters(),
+	const selectCategoryPageAppliedFilters = createSelector(
+		selectCategoryPageFilterRequests,
+		selectCategoryFilters,
 		(filterRequests: DaffCategoryFilterRequest[], availableFilters: DaffCategoryFilter[]): DaffCategoryAppliedFilter[] => {
 			if(!availableFilters.length) return [];
 			return filterRequests.map(request => 
@@ -129,159 +121,151 @@ export function selectCategoryPageAppliedFilters():
 			);
 		}
 	);
-}
 
-export function selectCategoryPageAppliedSortOption():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['applied_sort_option']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.applied_sort_option
+	const selectCategoryPageAppliedSortOption = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.applied_sort_option
 	);
-}
 
-export function selectCategoryPageAppliedSortDirection():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['applied_sort_direction']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.applied_sort_direction
+	const selectCategoryPageAppliedSortDirection = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.applied_sort_direction
 	);
-}
 
-/**
- * Selected Category Id State
- */
-export function selectSelectedCategoryId():
-	MemoizedSelector<object, DaffCategoryPageConfigurationState['id']> {
-	return createSelector(
-		selectCategoryPageConfigurationState(),
-		(state: DaffCategoryPageConfigurationState) => state.id
+	/**
+	 * Selected Category Id State
+	 */
+	const selectSelectedCategoryId = createSelector(
+		selectCategoryPageConfigurationState,
+		(state: V) => state.id
 	);
-}
 
-/**
- * Category Loading State
- */
-export function selectCategoryLoading():
-	MemoizedSelector<object, boolean> {
-	return createSelector(
-		selectCategoryState(),
-		(state: CategoryReducerState<DaffCategoryPageConfigurationState>) => state.categoryLoading
+	/**
+	 * Category Loading State
+	 */
+	const selectCategoryLoading = createSelector(
+		selectCategoryState,
+		(state: DaffCategoryReducerState<V>) => state.categoryLoading
 	);
-}
 
-/**
- * Category Products Loading State
- */
-export function selectCategoryProductsLoading():
-	MemoizedSelector<object, boolean> {
-	return createSelector(
-		selectCategoryState(),
-		(state: CategoryReducerState<DaffCategoryPageConfigurationState>) => state.productsLoading
+	/**
+	 * Category Products Loading State
+	 */
+	const selectCategoryProductsLoading = createSelector(
+		selectCategoryState,
+		(state: DaffCategoryReducerState<V>) => state.productsLoading
 	);
-}
 
-/**
- * Load Category Errors
- */
-export function selectCategoryErrors():
-	MemoizedSelector<object, string[]> {
-	return createSelector(
-		selectCategoryState(),
-		(state: CategoryReducerState<DaffCategoryPageConfigurationState>) => state.errors
+	/**
+	 * Load Category Errors
+	 */
+	const selectCategoryErrors = createSelector(
+		selectCategoryState,
+		(state: DaffCategoryReducerState<V>) => state.errors
 	);
-}
 
-/**
- * Category Entities State
- */
-export function selectCategoryEntitiesState<T extends DaffGenericCategory<T>, U extends DaffCategoryPageConfigurationState>():
-	MemoizedSelector<object, EntityState<T>> {
-	return createSelector(
-		selectCategoryFeatureState(),
-		(state: CategoryReducersState<T, U>) => state.categoryEntities
+	/**
+	 * Category Entities State
+	 */
+	const selectCategoryEntitiesState = createSelector(
+		selectCategoryFeatureState,
+		(state: DaffCategoryReducersState<T, V>) => state.categoryEntities
 	);
-}
 
-export function selectCategoryIds<T extends DaffGenericCategory<T>>():
-	MemoizedSelector<object, EntityState<T>['ids']> { 
-	return createSelector(
-		selectCategoryEntitiesState(),
-		categoryEntitiesAdapter<T>().getSelectors().selectIds
+	const selectCategoryIds = createSelector(
+		selectCategoryEntitiesState,
+		daffCategoryEntitiesAdapter<T>().getSelectors().selectIds
 	);
-}
 
-export function selectCategoryEntities<T extends DaffGenericCategory<T>>():
-	MemoizedSelector<object, Dictionary<T>> { 
-	return createSelector(
-		selectCategoryEntitiesState(),
-		categoryEntitiesAdapter<T>().getSelectors().selectEntities
+	const selectCategoryEntities = createSelector(
+		selectCategoryEntitiesState,
+		daffCategoryEntitiesAdapter<T>().getSelectors().selectEntities
 	);
-}
 
-export function selectAllCategories<T extends DaffGenericCategory<T>>():
-	MemoizedSelector<object, T[]> { 
-	return createSelector(
-		selectCategoryEntitiesState(),
-		categoryEntitiesAdapter<T>().getSelectors().selectAll
+	const selectAllCategories = createSelector(
+		selectCategoryEntitiesState,
+		daffCategoryEntitiesAdapter<T>().getSelectors().selectAll
 	);
-}
 
-export function selectCategoryTotal<T extends DaffGenericCategory<T>>():
-	MemoizedSelector<object, number> { 
-	return createSelector(
-		selectCategoryEntitiesState(),
-		categoryEntitiesAdapter<T>().getSelectors().selectTotal
+	const selectCategoryTotal = createSelector(
+		selectCategoryEntitiesState,
+		daffCategoryEntitiesAdapter<T>().getSelectors().selectTotal
 	);
-}
 
-/**
- * Combinatoric Category Selectors
- */
-export function selectSelectedCategory<T extends DaffGenericCategory<T>>():
-	MemoizedSelector<object, T> {
-	return createSelector(
-		selectCategoryEntities(),
-		selectSelectedCategoryId(),
+	/**
+	 * Combinatoric Category Selectors
+	 */
+	const selectSelectedCategory = createSelector(
+		selectCategoryEntities,
+		selectSelectedCategoryId,
 		(entities: Dictionary<T>, selectedCategoryId: string) => entities[selectedCategoryId]
 	);
-}
 
-export function selectCategoryPageProducts():
-	MemoizedSelector<object, DaffProductUnion[]> { 
-	return createSelector(
-		selectCategoryPageProductIds(),
+	const selectCategoryPageProducts = createSelector(
+		selectCategoryPageProductIds,
 		selectProductEntities,
-		(ids, products: Dictionary<DaffProductUnion>) =>
-			ids.map(id => products[id]).filter(p => p != null),
+		(ids, products: Dictionary<DaffProductUnion>) => ids.map(id => products[id]).filter(p => p != null)
 	);
-}
 
-export function selectCategory<T extends DaffGenericCategory<T>>():
-	MemoizedSelectorWithProps<object, object, T> { 
-	return createSelector(
-		selectCategoryEntities(),
+	const selectCategory = createSelector(
+		selectCategoryEntities,
 		(entities: Dictionary<T>, props) =>  entities[props.id]
 	);
-}
 
-	export function selectProductsByCategory():
-	MemoizedSelectorWithProps<object, object, DaffProductUnion[]> { 
-	return createSelector(
-		selectCategoryEntities(),
+	const selectProductsByCategory = createSelector(
+		selectCategoryEntities,
 		selectAllProducts,
 		(entities, products, props) => entities[props.id] && entities[props.id].product_ids
 			? products.filter(product => entities[props.id].product_ids.indexOf(product.id) >= 0)
 			: null
 	);
-}
 
-export function selectTotalProductsByCategory():
-	MemoizedSelectorWithProps<object, object, number> { 
-	return createSelector(
-		selectCategoryEntities(),
+	const selectTotalProductsByCategory = createSelector(
+		selectCategoryEntities,
 		selectAllProducts,
-		(entities, products, props) => selectProductsByCategory().projector(entities, products, { id: props.id })
-			? selectProductsByCategory().projector(entities, products, { id: props.id }).length
+		(entities, products, props) => selectProductsByCategory.projector(entities, products, { id: props.id })
+			? selectProductsByCategory.projector(entities, products, { id: props.id }).length
 			: null
 	);
+
+	return { 
+		selectCategoryFeatureState,
+		selectCategoryState,
+		selectCategoryPageConfigurationState,
+		selectCategoryCurrentPage,
+		selectCategoryTotalPages,
+		selectCategoryPageSize,
+		selectCategoryFilters,
+		selectCategorySortOptions,
+		selectCategoryPageProductIds,
+		selectIsCategoryPageEmpty,
+		selectCategoryPageTotalProducts,
+		selectCategoryPageFilterRequests,
+		selectCategoryPageAppliedFilters,
+		selectCategoryPageAppliedSortOption,
+		selectCategoryPageAppliedSortDirection,
+		selectSelectedCategoryId,
+		selectCategoryLoading,
+		selectCategoryProductsLoading,
+		selectCategoryErrors,
+		selectCategoryEntitiesState,
+		selectCategoryIds,
+		selectCategoryEntities,
+		selectAllCategories,
+		selectCategoryTotal,
+		selectSelectedCategory,
+		selectCategoryPageProducts,
+		selectCategory,
+		selectProductsByCategory,
+		selectTotalProductsByCategory
+	}
 }
+
+export const memoizeDaffCategoryFeatureSelectors = () => {
+	let cache;
+	return <T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState>(): DaffCategoryMemoizedSelectors<T, V> => cache = cache 
+		? cache 
+		: createCategoryFeatureSelectors<T, V>();
+}
+
+export const getDaffCategorySelectors = memoizeDaffCategoryFeatureSelectors();

--- a/libs/category/src/selectors/category.selector.ts
+++ b/libs/category/src/selectors/category.selector.ts
@@ -261,11 +261,9 @@ const createCategoryFeatureSelectors = <T extends DaffGenericCategory<T>, V exte
 	}
 }
 
-const memoizeDaffCategoryFeatureSelectors = () => {
+export const getDaffCategorySelectors = (() => {
 	let cache;
 	return <T extends DaffGenericCategory<T>, V extends DaffCategoryPageConfigurationState>(): DaffCategoryMemoizedSelectors<T, V> => cache = cache 
 		? cache 
 		: createCategoryFeatureSelectors<T, V>();
-}
-
-export const getDaffCategorySelectors = memoizeDaffCategoryFeatureSelectors();
+})();

--- a/libs/category/testing/src/drivers/in-memory/category.service.ts
+++ b/libs/category/testing/src/drivers/in-memory/category.service.ts
@@ -2,21 +2,21 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { DaffCategoryServiceInterface, DaffGetCategoryResponse, DaffCategoryRequest } from '@daffodil/category';
+import { DaffCategoryServiceInterface, DaffGetCategoryResponse, DaffCategoryRequest, DaffCategoryPageConfigurationState, DaffCategory } from '@daffodil/category';
 
 @Injectable({
   providedIn: 'root'
 })
-export class DaffInMemoryCategoryService implements DaffCategoryServiceInterface {
+export class DaffInMemoryCategoryService implements DaffCategoryServiceInterface<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState> {
   url = '/api/category/';
 
   constructor(private http: HttpClient) {}
 
-  get(categoryRequest: DaffCategoryRequest): Observable<DaffGetCategoryResponse> {
+  get(categoryRequest: DaffCategoryRequest): Observable<DaffGetCategoryResponse<DaffCategory, DaffCategoryPageConfigurationState>> {
 		const params = new HttpParams()
 			.set('page_size', categoryRequest.page_size ? categoryRequest.page_size.toString() : null)
 			.set('current_page', categoryRequest.current_page ? categoryRequest.current_page.toString() : null);
 		
-    return this.http.get<DaffGetCategoryResponse>(this.url + categoryRequest.id, {params: params});
+    return this.http.get<DaffGetCategoryResponse<DaffCategory, DaffCategoryPageConfigurationState>>(this.url + categoryRequest.id, {params: params});
   }
 }

--- a/libs/category/testing/src/drivers/testing/category.service.ts
+++ b/libs/category/testing/src/drivers/testing/category.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 
-import { DaffGetCategoryResponse, DaffCategoryServiceInterface } from '@daffodil/category';
+import { DaffGetCategoryResponse, DaffCategoryServiceInterface, DaffCategory, DaffCategoryPageConfigurationState } from '@daffodil/category';
 import { DaffProductFactory } from '@daffodil/product/testing';
 import { DaffCategoryRequest } from '@daffodil/category';
 
@@ -11,7 +11,7 @@ import { DaffCategoryPageConfigurationStateFactory } from '../../factories/categ
 @Injectable({
   providedIn: 'root'
 })
-export class DaffTestingCategoryService implements DaffCategoryServiceInterface {
+export class DaffTestingCategoryService implements DaffCategoryServiceInterface<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState> {
  
   constructor(
     private categoryFactory: DaffCategoryFactory,
@@ -19,7 +19,7 @@ export class DaffTestingCategoryService implements DaffCategoryServiceInterface 
     private productFactory: DaffProductFactory
   ) {}
 
-  get(categoryRequest: DaffCategoryRequest): Observable<DaffGetCategoryResponse> {
+  get(categoryRequest: DaffCategoryRequest): Observable<DaffGetCategoryResponse<DaffCategory, DaffCategoryPageConfigurationState>> {
     return of({
       category: this.categoryFactory.create(),
       categoryPageConfigurationState: this.categoryPageConfigurationStateFactory.create(),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```


## Other information
I needed to make extra changes to the category.effect.spec.ts, because the `overrideSelector` function became really unwieldy when the generics were introduced. I tried to figure it out, but after a few hours I figured it wasn't really worth it. So I basically don't mock the selectors anymore, and just call the actual actions which goes through redux state like normal.