### PR TITLE
feat(design): add heading mixin to set font standards

### DIFF
--- a/libs/design/src/scss/daff-typography.scss
+++ b/libs/design/src/scss/daff-typography.scss
@@ -18,20 +18,18 @@
 @import './responsive/breakpoint';
 @import './typography/variables';
 @import './typography/mixins';
+@import './typography/sizes/mixins';
 
 @import '~modern-normalize/modern-normalize.css';
 
 body,
 html {
 	font-family: $body-font-family;
-	font-size: $mobile-font-size;
+	font-size: 16px;
 	font-weight: 400;
+	line-height: 1.5;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-
-	@include breakpoint(mobile) {
-		font-size: $desktop-font-size;
-	}
 }
 
 a {
@@ -40,10 +38,6 @@ a {
 	&:hover {
 		text-decoration: none;
 	}
-}
-
-p {
-	line-height: 1.5rem;
 }
 
 h1,

--- a/libs/design/src/scss/daff-util.scss
+++ b/libs/design/src/scss/daff-util.scss
@@ -25,3 +25,4 @@
 @import 'interaction/mouse/clickable';
 @import 'responsive/breakpoint';
 @import 'typography/mixins';
+@import 'typography/sizes/mixins';

--- a/libs/design/src/scss/typography/_variables.scss
+++ b/libs/design/src/scss/typography/_variables.scss
@@ -1,8 +1,11 @@
 $body-font-family: proxima-nova, sans-serif;
 $base-font-family: $body-font-family;
-$desktop-font-size: 14px;
+
+// deprecated
+$desktop-font-size: 16px;
 $mobile-font-size: 16px;
 
-$large-font-size: 2rem;
-$medium-font-size: 1.125rem;
-$small-font-size: 0.875rem;
+$large-font-size: 1.5rem;
+$medium-font-size: 1.25rem;
+$normal-font-size: 1rem;
+$small-font-size: 0.75rem;

--- a/libs/design/src/scss/typography/sizes/_mixins.scss
+++ b/libs/design/src/scss/typography/sizes/_mixins.scss
@@ -16,7 +16,7 @@
 	font-size: 2.25rem;
 	line-height: 1.1em;
 	letter-spacing: -0.5px;
-	
+
 	@include breakpoint(tablet) {
 		font-size: 3rem;
 	}

--- a/libs/design/src/scss/typography/sizes/_mixins.scss
+++ b/libs/design/src/scss/typography/sizes/_mixins.scss
@@ -1,4 +1,4 @@
-/* Sets the font size to 52/64px */
+// Sets the font size to 52/64px
 @mixin heading-xl() {
 	@include embolden();
 	font-size: 3.25rem;
@@ -10,7 +10,7 @@
 	}
 }
 
-/* Sets the font size to 36/48px */
+// Sets the font size to 36/48px
 @mixin heading-lg() {
 	@include embolden();
 	font-size: 2.25rem;
@@ -22,7 +22,7 @@
 	}
 }
 
-/* Sets the font size to 28/40px */
+// Sets the font size to 28/40px
 @mixin heading-md() {
 	@include embolden();
 	font-size: 1.75rem;
@@ -34,7 +34,7 @@
 	}
 }
 
-/* Sets the font size to 24/32px */
+// Sets the font size to 24/32px
 @mixin heading-sm() {
 	@include embolden();
 	font-size: 1.5rem;
@@ -46,7 +46,7 @@
 	}
 }
 
-/* Sets the font size to 20/24px */
+// Sets the font size to 20/24px
 @mixin heading-xs() {
 	@include embolden();
 	font-size: 1.25rem;

--- a/libs/design/src/scss/typography/sizes/_mixins.scss
+++ b/libs/design/src/scss/typography/sizes/_mixins.scss
@@ -1,0 +1,66 @@
+/* Sets the font size to 52/64px */
+@mixin heading-xl() {
+	@include embolden();
+	font-size: 3.25rem;
+	line-height: 1.1em;
+	letter-spacing: -1.5px;
+
+	@include breakpoint(tablet) {
+		font-size: 4rem;
+	}
+}
+
+/* Sets the font size to 36/48px */
+@mixin heading-lg() {
+	@include embolden();
+	font-size: 2.25rem;
+	line-height: 1.1em;
+	letter-spacing: -0.5px;
+	
+	@include breakpoint(tablet) {
+		font-size: 3rem;
+	}
+}
+
+/* Sets the font size to 28/40px */
+@mixin heading-md() {
+	@include embolden();
+	font-size: 1.75rem;
+	line-height: 1.1em;
+	letter-spacing: 0;
+
+	@include breakpoint(tablet) {
+		font-size: 2.5rem;
+	}
+}
+
+/* Sets the font size to 24/32px */
+@mixin heading-sm() {
+	@include embolden();
+	font-size: 1.5rem;
+	line-height: 1.1em;
+	letter-spacing: 0;
+
+	@include breakpoint(tablet) {
+		font-size: 2rem;
+	}
+}
+
+/* Sets the font size to 20/24px */
+@mixin heading-xs() {
+	@include embolden();
+	font-size: 1.25rem;
+	line-height: 1.1em;
+	letter-spacing: 0;
+
+	@include breakpoint(tablet) {
+		font-size: 1.5rem;
+	}
+}
+
+@mixin subheading() {
+	@include embolden();
+	@include uppercase();
+	font-size: 1rem;
+	letter-spacing: 1px;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Font sizes are used in components with no guidelines in place.
Fixes: N/A


## What is the new behavior?
With the heading mixins and variables updates, setting sizes on components can be consistent and easy to determine. Breakpoints no longer need to be set for every instance a heading style is used on a page or component.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information