### PR TITLE
feat(paypal): update selectors to be memoized

### DIFF
--- a/libs/paypal/src/facades/paypal.facade.spec.ts
+++ b/libs/paypal/src/facades/paypal.facade.spec.ts
@@ -24,7 +24,7 @@ describe('DaffPaypalFacade', () => {
     TestBed.configureTestingModule({
       imports:[
         StoreModule.forRoot({
-          paypal: combineReducers(daffPaypalReducers())
+          paypal: combineReducers(daffPaypalReducers)
         })
       ],
       providers: [

--- a/libs/paypal/src/facades/paypal.facade.ts
+++ b/libs/paypal/src/facades/paypal.facade.ts
@@ -38,13 +38,21 @@ export class DaffPaypalFacade<T extends DaffPaypalTokenResponse> implements Daff
   error$: Observable<string>;
 
   constructor(private store: Store<DaffPaypalReducersState<T>>) {
-		const selectors = getDaffPaypalSelectors<T>();
-    this.paypalTokenResponse$ = this.store.pipe(select(selectors.selectPaypalTokenResponse));
-    this.paypalToken$ = this.store.pipe(select(selectors.selectPaypalToken));
-    this.paypalStartUrl$ = this.store.pipe(select(selectors.selectPaypalStartUrl));
-    this.paypalEditUrl$ = this.store.pipe(select(selectors.selectPaypalEditUrl));
-    this.loading$ = this.store.pipe(select(selectors.selectPaypalLoading));
-    this.error$ = this.store.pipe(select(selectors.selectPaypalError));
+		const {
+			selectPaypalTokenResponse,
+			selectPaypalToken,
+			selectPaypalStartUrl,
+			selectPaypalEditUrl,
+			selectPaypalLoading,
+			selectPaypalError
+		} = getDaffPaypalSelectors<T>();
+
+    this.paypalTokenResponse$ = this.store.pipe(select(selectPaypalTokenResponse));
+    this.paypalToken$ = this.store.pipe(select(selectPaypalToken));
+    this.paypalStartUrl$ = this.store.pipe(select(selectPaypalStartUrl));
+    this.paypalEditUrl$ = this.store.pipe(select(selectPaypalEditUrl));
+    this.loading$ = this.store.pipe(select(selectPaypalLoading));
+    this.error$ = this.store.pipe(select(selectPaypalError));
   }
 
   /**

--- a/libs/paypal/src/facades/paypal.facade.ts
+++ b/libs/paypal/src/facades/paypal.facade.ts
@@ -6,7 +6,7 @@ import { DaffPaypalModule } from '../paypal.module';
 import { DaffPaypalReducersState } from '../reducers/paypal-reducers.interface';
 import { DaffPaypalFacadeInterface } from '../interfaces/paypal-facade.interface';
 import { DaffPaypalTokenResponse } from '../models/paypal-token-response';
-import { getDaffPaypalSelectors } from '../selectors/paypal.selector';
+import { daffPaypalSelectors } from '../selectors/paypal.selector';
 
 @Injectable({
   providedIn: DaffPaypalModule
@@ -45,7 +45,7 @@ export class DaffPaypalFacade<T extends DaffPaypalTokenResponse> implements Daff
 			selectPaypalEditUrl,
 			selectPaypalLoading,
 			selectPaypalError
-		} = getDaffPaypalSelectors<T>();
+		} = daffPaypalSelectors<T>();
 
     this.paypalTokenResponse$ = this.store.pipe(select(selectPaypalTokenResponse));
     this.paypalToken$ = this.store.pipe(select(selectPaypalToken));

--- a/libs/paypal/src/facades/paypal.facade.ts
+++ b/libs/paypal/src/facades/paypal.facade.ts
@@ -6,14 +6,7 @@ import { DaffPaypalModule } from '../paypal.module';
 import { DaffPaypalReducersState } from '../reducers/paypal-reducers.interface';
 import { DaffPaypalFacadeInterface } from '../interfaces/paypal-facade.interface';
 import { DaffPaypalTokenResponse } from '../models/paypal-token-response';
-import { 
-	selectPaypalTokenResponse,
-	selectPaypalToken,
-	selectPaypalStartUrl,
-	selectPaypalLoading,
-	selectPaypalError,
-	selectPaypalEditUrl
-} from '../selectors/paypal.selector';
+import { getDaffPaypalSelectors } from '../selectors/paypal.selector';
 
 @Injectable({
   providedIn: DaffPaypalModule
@@ -45,12 +38,13 @@ export class DaffPaypalFacade<T extends DaffPaypalTokenResponse> implements Daff
   error$: Observable<string>;
 
   constructor(private store: Store<DaffPaypalReducersState<T>>) {
-    this.paypalTokenResponse$ = this.store.pipe(select(selectPaypalTokenResponse()));
-    this.paypalToken$ = this.store.pipe(select(selectPaypalToken()));
-    this.paypalStartUrl$ = this.store.pipe(select(selectPaypalStartUrl()));
-    this.paypalEditUrl$ = this.store.pipe(select(selectPaypalEditUrl()));
-    this.loading$ = this.store.pipe(select(selectPaypalLoading()));
-    this.error$ = this.store.pipe(select(selectPaypalError()));
+		const selectors = getDaffPaypalSelectors<T>();
+    this.paypalTokenResponse$ = this.store.pipe(select(selectors.selectPaypalTokenResponse));
+    this.paypalToken$ = this.store.pipe(select(selectors.selectPaypalToken));
+    this.paypalStartUrl$ = this.store.pipe(select(selectors.selectPaypalStartUrl));
+    this.paypalEditUrl$ = this.store.pipe(select(selectors.selectPaypalEditUrl));
+    this.loading$ = this.store.pipe(select(selectors.selectPaypalLoading));
+    this.error$ = this.store.pipe(select(selectors.selectPaypalError));
   }
 
   /**

--- a/libs/paypal/src/index.ts
+++ b/libs/paypal/src/index.ts
@@ -22,3 +22,4 @@ export { DaffPaypalReducerState } from './reducers/paypal/paypal-reducer.interfa
 export { daffPaypalReducer } from './reducers/paypal/paypal.reducer';
 export { DaffPaypalStateModule } from './paypal-state.module';
 export { DaffPaypalModule } from './paypal.module';
+export * from './selectors/paypal.selector';

--- a/libs/paypal/src/paypal-state.module.ts
+++ b/libs/paypal/src/paypal-state.module.ts
@@ -7,7 +7,7 @@ import { daffPaypalReducers } from './reducers/paypal-reducers';
 
 @NgModule({
   imports: [
-    StoreModule.forFeature('paypal', daffPaypalReducers()),
+    StoreModule.forFeature('paypal', daffPaypalReducers),
     EffectsModule.forFeature([DaffPaypalEffects])
   ]
 })

--- a/libs/paypal/src/reducers/paypal-reducers.spec.ts
+++ b/libs/paypal/src/reducers/paypal-reducers.spec.ts
@@ -4,6 +4,6 @@ import { daffPaypalReducer } from './paypal/paypal.reducer';
 describe('daffPaypalReducers', () => {
 
   it('should return a reducer map with DaffPaypalReducerState', () => {
-    expect(daffPaypalReducers().paypal).toEqual(daffPaypalReducer);
+    expect(daffPaypalReducers.paypal).toEqual(daffPaypalReducer);
   });
 });

--- a/libs/paypal/src/reducers/paypal-reducers.ts
+++ b/libs/paypal/src/reducers/paypal-reducers.ts
@@ -1,11 +1,5 @@
-import { ActionReducerMap } from '@ngrx/store';
-
 import { daffPaypalReducer } from './paypal/paypal.reducer';
-import { DaffPaypalReducersState } from './paypal-reducers.interface';
-import { DaffPaypalTokenResponse } from '../models/paypal-token-response';
 
-export function daffPaypalReducers <T extends DaffPaypalTokenResponse>(): ActionReducerMap<DaffPaypalReducersState<T>> {
-  return {
-		paypal: daffPaypalReducer
-	}
+export const daffPaypalReducers = {
+	paypal: daffPaypalReducer
 }

--- a/libs/paypal/src/selectors/paypal.selector.spec.ts
+++ b/libs/paypal/src/selectors/paypal.selector.spec.ts
@@ -8,15 +8,7 @@ import { DaffPaypalReducersState } from '../reducers/paypal-reducers.interface';
 import { DaffPaypalTokenResponse } from '../models/paypal-token-response';
 import { daffPaypalReducers } from '../reducers/paypal-reducers';
 import { DaffGeneratePaypalExpressTokenSuccess, DaffGeneratePaypalExpressTokenFailure } from '../actions/paypal.actions';
-import {
-	selectPaypalState,
-	selectPaypalEditUrl,
-	selectPaypalError,
-	selectPaypalLoading,
-	selectPaypalStartUrl,
-	selectPaypalToken,
-	selectPaypalTokenResponse
-} from './paypal.selector';
+import { getDaffPaypalSelectors } from './paypal.selector';
 
 describe('Daff Paypal Selectors', () => {
 
@@ -28,7 +20,7 @@ describe('Daff Paypal Selectors', () => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot({
-          paypal: combineReducers(daffPaypalReducers()),
+          paypal: combineReducers(daffPaypalReducers),
         })
       ]
     });
@@ -47,7 +39,7 @@ describe('Daff Paypal Selectors', () => {
         loading: false,
         error: null
 			};
-			const selector = store.pipe(select(selectPaypalState()));
+			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalState));
 			const expected = cold('a', { a: expectedState });
 			expect(selector).toBeObservable(expected);
 		});
@@ -56,7 +48,7 @@ describe('Daff Paypal Selectors', () => {
 	describe('selectPaypalTokenResponse', () => {
 
 		it('returns the paypal token response', () => {
-			const selector = store.pipe(select(selectPaypalTokenResponse()));
+			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalTokenResponse));
 			const expected = cold('a', { a: stubPaypalTokenResponse });
 			expect(selector).toBeObservable(expected);
 		});
@@ -65,7 +57,7 @@ describe('Daff Paypal Selectors', () => {
 	describe('selectPaypalLoading', () => {
 
 		it('returns the loading state for generating a paypal token nonce', () => {
-			const selector = store.pipe(select(selectPaypalLoading()));
+			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalLoading));
 			const expected = cold('a', { a: false });
 			expect(selector).toBeObservable(expected);
 		});
@@ -76,7 +68,7 @@ describe('Daff Paypal Selectors', () => {
 		it('returns any current errors', () => {
 			const errorMessage = 'there has been an error';
 			store.dispatch(new DaffGeneratePaypalExpressTokenFailure(errorMessage));
-			const selector = store.pipe(select(selectPaypalError()));
+			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalError));
 			const expected = cold('a', { a: errorMessage });
 			expect(selector).toBeObservable(expected);
 		});
@@ -85,7 +77,7 @@ describe('Daff Paypal Selectors', () => {
 	describe('selectPaypalToken', () => {
 
 		it('returns the paypal token nonce', () => {
-			const selector = store.pipe(select(selectPaypalToken()));
+			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalToken));
 			const expected = cold('a', { a: stubPaypalTokenResponse.token });
 			expect(selector).toBeObservable(expected);
 		});
@@ -94,7 +86,7 @@ describe('Daff Paypal Selectors', () => {
 	describe('selectPaypalStartUrl', () => {
 
 		it('returns the paypal start url', () => {
-			const selector = store.pipe(select(selectPaypalStartUrl()));
+			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalStartUrl));
 			const expected = cold('a', { a: stubPaypalTokenResponse.urls.start });
 			expect(selector).toBeObservable(expected);
 		});
@@ -103,7 +95,7 @@ describe('Daff Paypal Selectors', () => {
 	describe('selectPaypalEditUrl', () => {
 
 		it('returns the paypal edit url', () => {
-			const selector = store.pipe(select(selectPaypalEditUrl()));
+			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalEditUrl));
 			const expected = cold('a', { a: stubPaypalTokenResponse.urls.edit });
 			expect(selector).toBeObservable(expected);
 		});

--- a/libs/paypal/src/selectors/paypal.selector.spec.ts
+++ b/libs/paypal/src/selectors/paypal.selector.spec.ts
@@ -14,7 +14,16 @@ describe('Daff Paypal Selectors', () => {
 
   let store: Store<DaffPaypalReducersState<DaffPaypalTokenResponse>>;
   const navigationTreeFactory: DaffPaypalTokenResponseFactory = new DaffPaypalTokenResponseFactory();
-  let stubPaypalTokenResponse: DaffPaypalTokenResponse;
+	let stubPaypalTokenResponse: DaffPaypalTokenResponse;
+	const {
+		selectPaypalState,
+		selectPaypalTokenResponse,
+		selectPaypalToken,
+		selectPaypalStartUrl,
+		selectPaypalEditUrl,
+		selectPaypalLoading,
+		selectPaypalError
+	} = getDaffPaypalSelectors<DaffPaypalTokenResponse>();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -39,7 +48,7 @@ describe('Daff Paypal Selectors', () => {
         loading: false,
         error: null
 			};
-			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalState));
+			const selector = store.pipe(select(selectPaypalState));
 			const expected = cold('a', { a: expectedState });
 			expect(selector).toBeObservable(expected);
 		});
@@ -48,7 +57,7 @@ describe('Daff Paypal Selectors', () => {
 	describe('selectPaypalTokenResponse', () => {
 
 		it('returns the paypal token response', () => {
-			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalTokenResponse));
+			const selector = store.pipe(select(selectPaypalTokenResponse));
 			const expected = cold('a', { a: stubPaypalTokenResponse });
 			expect(selector).toBeObservable(expected);
 		});
@@ -57,7 +66,7 @@ describe('Daff Paypal Selectors', () => {
 	describe('selectPaypalLoading', () => {
 
 		it('returns the loading state for generating a paypal token nonce', () => {
-			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalLoading));
+			const selector = store.pipe(select(selectPaypalLoading));
 			const expected = cold('a', { a: false });
 			expect(selector).toBeObservable(expected);
 		});
@@ -68,7 +77,7 @@ describe('Daff Paypal Selectors', () => {
 		it('returns any current errors', () => {
 			const errorMessage = 'there has been an error';
 			store.dispatch(new DaffGeneratePaypalExpressTokenFailure(errorMessage));
-			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalError));
+			const selector = store.pipe(select(selectPaypalError));
 			const expected = cold('a', { a: errorMessage });
 			expect(selector).toBeObservable(expected);
 		});
@@ -77,7 +86,7 @@ describe('Daff Paypal Selectors', () => {
 	describe('selectPaypalToken', () => {
 
 		it('returns the paypal token nonce', () => {
-			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalToken));
+			const selector = store.pipe(select(selectPaypalToken));
 			const expected = cold('a', { a: stubPaypalTokenResponse.token });
 			expect(selector).toBeObservable(expected);
 		});
@@ -86,7 +95,7 @@ describe('Daff Paypal Selectors', () => {
 	describe('selectPaypalStartUrl', () => {
 
 		it('returns the paypal start url', () => {
-			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalStartUrl));
+			const selector = store.pipe(select(selectPaypalStartUrl));
 			const expected = cold('a', { a: stubPaypalTokenResponse.urls.start });
 			expect(selector).toBeObservable(expected);
 		});
@@ -95,7 +104,7 @@ describe('Daff Paypal Selectors', () => {
 	describe('selectPaypalEditUrl', () => {
 
 		it('returns the paypal edit url', () => {
-			const selector = store.pipe(select(getDaffPaypalSelectors<DaffPaypalTokenResponse>().selectPaypalEditUrl));
+			const selector = store.pipe(select(selectPaypalEditUrl));
 			const expected = cold('a', { a: stubPaypalTokenResponse.urls.edit });
 			expect(selector).toBeObservable(expected);
 		});

--- a/libs/paypal/src/selectors/paypal.selector.spec.ts
+++ b/libs/paypal/src/selectors/paypal.selector.spec.ts
@@ -8,7 +8,7 @@ import { DaffPaypalReducersState } from '../reducers/paypal-reducers.interface';
 import { DaffPaypalTokenResponse } from '../models/paypal-token-response';
 import { daffPaypalReducers } from '../reducers/paypal-reducers';
 import { DaffGeneratePaypalExpressTokenSuccess, DaffGeneratePaypalExpressTokenFailure } from '../actions/paypal.actions';
-import { getDaffPaypalSelectors } from './paypal.selector';
+import { daffPaypalSelectors } from './paypal.selector';
 
 describe('Daff Paypal Selectors', () => {
 
@@ -23,7 +23,7 @@ describe('Daff Paypal Selectors', () => {
 		selectPaypalEditUrl,
 		selectPaypalLoading,
 		selectPaypalError
-	} = getDaffPaypalSelectors<DaffPaypalTokenResponse>();
+	} = daffPaypalSelectors<DaffPaypalTokenResponse>();
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/libs/paypal/src/selectors/paypal.selector.ts
+++ b/libs/paypal/src/selectors/paypal.selector.ts
@@ -51,11 +51,9 @@ const createPaypalSelectors = <T extends DaffPaypalTokenResponse>(): DaffPaypalM
 	}
 }
 
-const memoizeDaffPaypalSelectors = () => {
+export const daffPaypalSelectors = (() => {
 	let cache;
 	return <T extends DaffPaypalTokenResponse>(): DaffPaypalMemoizedSelectors<T> => cache = cache 
 		? cache 
 		: createPaypalSelectors<T>();
-}
-
-export const getDaffPaypalSelectors = memoizeDaffPaypalSelectors();
+})();

--- a/libs/paypal/src/selectors/paypal.selector.ts
+++ b/libs/paypal/src/selectors/paypal.selector.ts
@@ -4,48 +4,58 @@ import { DaffPaypalReducerState } from '../reducers/paypal/paypal-reducer.interf
 import { DaffPaypalReducersState } from '../reducers/paypal-reducers.interface';
 import { DaffPaypalTokenResponse } from '../models/paypal-token-response';
 
-/**
- * Paypal Feature State
- */
-export function selectPaypalFeatureState<T extends DaffPaypalTokenResponse>(): 
-	MemoizedSelector<object, DaffPaypalReducersState<T>> {
-		return createFeatureSelector<DaffPaypalReducersState<T>>('paypal');
-	}
+export interface DaffPaypalMemoizedSelectors<T extends DaffPaypalTokenResponse> {
+	selectPaypalFeatureState: MemoizedSelector<object, DaffPaypalReducersState<T>>;
+	selectPaypalState: MemoizedSelector<object, DaffPaypalReducerState<T>>;
+	selectPaypalTokenResponse: MemoizedSelector<object, T>;
+	selectPaypalLoading: MemoizedSelector<object, boolean>;
+	selectPaypalError: MemoizedSelector<object, string>;
+	selectPaypalToken: MemoizedSelector<object, string>;
+	selectPaypalStartUrl: MemoizedSelector<object, string>;
+	selectPaypalEditUrl: MemoizedSelector<object, string>;
+}
 
-/**
- * Paypal State
- */
-export function selectPaypalState<T extends DaffPaypalTokenResponse>(): 
-	MemoizedSelector<object, DaffPaypalReducerState<T>> {
-		return createSelector(selectPaypalFeatureState(), (state: DaffPaypalReducersState<T>) => state.paypal);
-	}
+const createPaypalSelectors = <T extends DaffPaypalTokenResponse>(): DaffPaypalMemoizedSelectors<T> => {
 
-export function selectPaypalTokenResponse<T extends DaffPaypalTokenResponse>(): 
-	MemoizedSelector<object, T> {
-		return createSelector(selectPaypalState(),(state: DaffPaypalReducerState<T>) => state.paypalTokenResponse);
-	}
+	/**
+	 * Paypal Feature State
+	 */
+	const selectPaypalFeatureState = createFeatureSelector<DaffPaypalReducersState<T>>('paypal');
 
-export function selectPaypalLoading<T extends DaffPaypalTokenResponse>(): 
-	MemoizedSelector<object, boolean> {
-		return createSelector(selectPaypalState(),(state: DaffPaypalReducerState<T>) => state.loading);
-	}
+	/**
+	 * Paypal State
+	 */
+	const selectPaypalState = createSelector(selectPaypalFeatureState, (state: DaffPaypalReducersState<T>) => state.paypal);
 
-export function selectPaypalError<T extends DaffPaypalTokenResponse>(): 
-	MemoizedSelector<object, string> {
-		return createSelector(selectPaypalState(),(state: DaffPaypalReducerState<T>) => state.error);
-	}
+	const selectPaypalTokenResponse = createSelector(selectPaypalState,(state: DaffPaypalReducerState<T>) => state.paypalTokenResponse);
 
-export function selectPaypalToken<T extends DaffPaypalTokenResponse>(): 
-	MemoizedSelector<object, string> {
-		return createSelector(selectPaypalTokenResponse(),(state: T) => state.token);
-	}
+	const selectPaypalLoading = createSelector(selectPaypalState,(state: DaffPaypalReducerState<T>) => state.loading);
 
-export function selectPaypalStartUrl<T extends DaffPaypalTokenResponse>(): 
-	MemoizedSelector<object, string> {
-		return createSelector(selectPaypalTokenResponse(),(state: T) => state.urls.start);
-	}
+	const selectPaypalError = createSelector(selectPaypalState,(state: DaffPaypalReducerState<T>) => state.error);
 
-export function selectPaypalEditUrl<T extends DaffPaypalTokenResponse>(): 
-	MemoizedSelector<object, string> {
-		return createSelector(selectPaypalTokenResponse(),(state: T) => state.urls.edit);
+	const selectPaypalToken = createSelector(selectPaypalTokenResponse,(state: T) => state.token);
+
+	const selectPaypalStartUrl = createSelector(selectPaypalTokenResponse,(state: T) => state.urls.start);
+
+	const selectPaypalEditUrl = createSelector(selectPaypalTokenResponse,(state: T) => state.urls.edit);
+	
+	return { 
+		selectPaypalFeatureState,
+		selectPaypalState,
+		selectPaypalTokenResponse,
+		selectPaypalLoading,
+		selectPaypalError,
+		selectPaypalToken,
+		selectPaypalStartUrl,
+		selectPaypalEditUrl
 	}
+}
+
+const memoizeDaffPaypalSelectors = () => {
+	let cache;
+	return <T extends DaffPaypalTokenResponse>(): DaffPaypalMemoizedSelectors<T> => cache = cache 
+		? cache 
+		: createPaypalSelectors<T>();
+}
+
+export const getDaffPaypalSelectors = memoizeDaffPaypalSelectors();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Paypal selectors aren't actually memoized.

Fixes: N/A

## What is the new behavior?
Paypal selectors are now memoized.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```


## Other information
Breaking change doesn't matter, because no other packages or apps depend on this package. I also make the reducer state type implicit, rather than the unnecessary explicit typing.