### PR TITLE
fix(category): fix bug where some effects would not properly make a g…

### DIFF
--- a/libs/category/src/effects/category.effects.spec.ts
+++ b/libs/category/src/effects/category.effects.spec.ts
@@ -213,11 +213,8 @@ describe('DaffCategoryEffects', () => {
       expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
 			expect(effects.changeCategoryPageSize$).toBeObservable(expected);
       expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
-        id: stubCategory.id,
-				page_size: 3,
-				filter_requests: stubCategoryPageConfigurationState.filter_requests,
-				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
-				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction
+				...stubCategoryPageConfigurationState,
+				page_size: 3
       });
     });
   });
@@ -238,12 +235,8 @@ describe('DaffCategoryEffects', () => {
 			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
 			expect(effects.changeCategoryCurrentPage$).toBeObservable(expected);
 			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
-        id: stubCategory.id,
-        page_size: stubCategoryPageConfigurationState.page_size,
-				current_page: 3,
-				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
-				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
-				filter_requests: stubCategoryPageConfigurationState.filter_requests
+				...stubCategoryPageConfigurationState,
+				current_page: 3
       });
     });
   });
@@ -268,10 +261,7 @@ describe('DaffCategoryEffects', () => {
 			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
 			expect(effects.changeCategoryFilters$).toBeObservable(expected);
 			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
-				id: stubCategory.id,
-        page_size: stubCategoryPageConfigurationState.page_size,
-				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
-				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
+				...stubCategoryPageConfigurationState,
 				filter_requests: [{
 					name: 'name',
 					type: DaffCategoryFilterType.Equal,
@@ -307,10 +297,7 @@ describe('DaffCategoryEffects', () => {
 			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
 			expect(effects.toggleCategoryFilter$).toBeObservable(expected);
 			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
-				id: stubCategory.id,
-        page_size: stubCategoryPageConfigurationState.page_size,
-				applied_sort_direction: stubCategoryPageConfigurationState.applied_sort_direction,
-				applied_sort_option: stubCategoryPageConfigurationState.applied_sort_option,
+        ...stubCategoryPageConfigurationState,
 				filter_requests: [appliedFilter]
       });
     });
@@ -335,11 +322,9 @@ describe('DaffCategoryEffects', () => {
 			expected = cold('--(ab)', { a: productGridLoadSuccessAction, b: categoryLoadSuccessAction });
 			expect(effects.changeCategorySort$).toBeObservable(expected);
 			expect(daffCategoryDriver.get).toHaveBeenCalledWith({ 
-				id: stubCategory.id,
-        page_size: stubCategoryPageConfigurationState.page_size,
+				...stubCategoryPageConfigurationState,
 				applied_sort_direction: DaffSortDirectionEnum.Ascending,
-				applied_sort_option: 'option',
-				filter_requests: stubCategoryPageConfigurationState.filter_requests
+				applied_sort_option: 'option'
       });
     });
   });


### PR DESCRIPTION
…et call with a generic request

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Some of the effects in category don't forward unique fields defined by the user on extended DaffCategoryRequests. For example:

```
interface MyCategoryRequest extends DaffCategoryRequest {
   myCustomRequestField: string;
}

class MyCategoryDriver implements DaffCategoryDriverInterface {
   get(request: MyCategoryRequest) {
       // makes a request requiring myCustomRequestField.
   }
}
```
The above will not work, because some effects only pass in the Daffodil defined fields.

Fixes: N/A


## What is the new behavior?
All daffodil effects forward on all custom fields to a custom category driver.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```