### PR TITLE
style(design): remove inline-block style from hero title and subtitle

### DIFF
--- a/libs/design/src/molecules/hero/hero/hero.component.scss
+++ b/libs/design/src/molecules/hero/hero/hero.component.scss
@@ -11,7 +11,6 @@
 
 	&__title {
 		@include heading-xl();
-		display: inline-block;
 		margin: 0;
 		max-width: 1040px;
 		overflow-wrap: break-word;
@@ -19,7 +18,6 @@
 	}
 
 	&__subtitle {
-		display: inline-block;
 		font-size: $large-font-size;
 		font-weight: normal;
 		margin: 15px 0 0;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Hero title and subtitle are displayed inline-block. This causes them to not display correctly on larger screens.

Fixes: N/A


## What is the new behavior?
Remove the display properties.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information