### PR TITLE
refactor(category): use magento product fragment from the product pac…

### DIFF
--- a/libs/category/src/drivers/magento/queries/get-products.ts
+++ b/libs/category/src/drivers/magento/queries/get-products.ts
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { magentoProductFragment } from '@daffodil/product';
 
 /**
  * This query only exists because products and their associated aggregations/filter cannot
@@ -11,23 +12,7 @@ query MagentoGetProducts($filter: ProductAttributeFilterInput!, $search: String,
 	{
 		total_count
 		items {
-			__typename
-			id
-			name
-			sku
-			url_key
-			image {
-				url
-				label
-			}
-			price_range {
-				maximum_price {
-					regular_price {
-						value
-						currency
-					}
-				}
-			}
+			...product
 		}
 		page_info {
 			page_size
@@ -35,4 +20,6 @@ query MagentoGetProducts($filter: ProductAttributeFilterInput!, $search: String,
 			total_pages
 		}
 	}
-}`
+}
+${magentoProductFragment}
+`

--- a/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ProductNode } from '@daffodil/product';
+import { MagentoProductFactory } from '@daffodil/product/testing';
 import { DaffCategoryFactory, DaffCategoryPageConfigurationStateFactory } from '@daffodil/category/testing';
 
 import { DaffMagentoCategoryPageConfigTransformerService } from './category-page-config-transformer.service';
@@ -90,31 +91,7 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 				options: stubCategoryPageConfigurationState.sort_options
 			};
 
-			products = [
-				{
-					__typename: 'simple',
-					sku: stubCategoryPageConfigurationState.product_ids[0],
-					id: 2,
-					name: 'name',
-					price_range: {
-						maximum_price: {
-							regular_price: {
-								value: 123,
-								currency: null
-							}
-						}
-					},
-					url_key: 'url_key',
-					image: {
-						url: 'url',
-						label: 'label'
-          },
-          thumbnail: {
-						url: 'url',
-						label: 'label'
-					}
-				}
-			];
+			products = [new MagentoProductFactory().create({ sku: stubCategoryPageConfigurationState.product_ids[0]})];
 
 			completeCategoryResponse = {
 				category: category,

--- a/libs/category/src/drivers/magento/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-response-transform.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { DaffCategoryFactory, DaffCategoryPageConfigurationStateFactory } from '@daffodil/category/testing';
 import { DaffProduct, DaffMagentoProductTransformerService, ProductNode } from '@daffodil/product';
-import { DaffProductFactory } from '@daffodil/product/testing';
+import { DaffProductFactory, MagentoProductFactory } from '@daffodil/product/testing';
 
 import { DaffMagentoCategoryResponseTransformService } from './category-response-transform.service';
 import { DaffCategory } from '../../../models/category';
@@ -82,31 +82,7 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
 				options: stubCategoryPageConfigurationState.sort_options
 			};
 
-			const products: ProductNode[] = [
-				{
-					__typename: 'simple',
-					sku: stubCategoryPageConfigurationState.product_ids[0],
-					id: 2,
-					name: 'name',
-					price_range: {
-						maximum_price: {
-							regular_price: {
-								value: 123,
-								currency: null
-							}
-						}
-					},
-					url_key: 'url_key',
-					image: {
-						url: 'url',
-						label: 'label'
-					},
-          thumbnail: {
-						url: 'url',
-						label: 'label'
-					}
-				}
-			];
+			const products: ProductNode[] = new MagentoProductFactory().createMany(1);
 
 			completeCategory = {
 				category: category,


### PR DESCRIPTION
…kage

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The category package defines its own product fragment, which makes it easy to get out of sync with the product package and its transformer.

Fixes: N/A


## What is the new behavior?
The category package uses the fragment defined by the product package.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Note
There seems to be a bug in the magento backend where if you use fragments to get products, the images come back as the "placeholder" images. Sometimes the price doesn't come back either. Making the same call without using fragments works perfectly. Even though the category images will look wrong now in the frontend, this is more correct for the long run.