### PR TITLE
refactor(cart): separate cart selectors into more digestible files

### DIFF
--- a/libs/cart/src/selectors/cart-feature.selector.ts
+++ b/libs/cart/src/selectors/cart-feature.selector.ts
@@ -1,0 +1,25 @@
+import {
+  createFeatureSelector,
+  MemoizedSelector
+} from '@ngrx/store';
+
+import { DaffCartReducersState } from '../reducers/public_api';
+import { DaffCart } from '../models/cart';
+import { DaffCartOrderResult } from '../models/cart-order-result';
+
+export interface DaffCartFeatureMemoizedSelectors<
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult
+> {
+	selectCartFeatureState: MemoizedSelector<object, DaffCartReducersState<T, V>>;
+}
+
+export const getDaffCartFeatureSelector = (() => {
+	let cache;
+	return <
+    T extends DaffCart = DaffCart,
+    V extends DaffCartOrderResult = DaffCartOrderResult
+  >(): DaffCartFeatureMemoizedSelectors<T, V> => cache = cache
+		? cache
+		: { selectCartFeatureState: createFeatureSelector<DaffCartReducersState<T, V>>('cart') }
+})();

--- a/libs/cart/src/selectors/cart-order/cart-order.selector.spec.ts
+++ b/libs/cart/src/selectors/cart-order/cart-order.selector.spec.ts
@@ -1,0 +1,100 @@
+import { TestBed } from '@angular/core/testing';
+import { StoreModule, combineReducers, Store, select } from '@ngrx/store';
+import { cold } from 'jasmine-marbles';
+
+import { DaffCart } from '@daffodil/cart';
+import { DaffCartFactory } from '@daffodil/cart/testing';
+
+import { DaffCartLoadSuccess, DaffCartPlaceOrderSuccess } from '../../actions/public_api';
+import { daffCartReducers, DaffCartReducersState } from '../../reducers/public_api';
+import { DaffCartErrors } from '../../reducers/cart-errors.type';
+import { getCartOrderSelectors } from './cart-order.selector';
+import { DaffCartOrderReducerState } from '../../reducers/cart-order-state.interface';
+
+describe('Cart | Selector | Cart', () => {
+  let store: Store<DaffCartReducersState>;
+
+  let cartFactory: DaffCartFactory;
+
+  let orderId: string;
+  let cart: DaffCart;
+  let loading: boolean;
+	const {
+    selectCartOrderState,
+    selectCartOrderLoading,
+    selectCartOrderErrors,
+    selectCartOrderValue,
+    selectCartOrderId
+	} = getCartOrderSelectors();
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          cart: combineReducers(daffCartReducers),
+        })
+      ]
+    });
+
+    store = TestBed.get(Store);
+
+    cartFactory = TestBed.get(DaffCartFactory);
+
+    orderId = 'id';
+    cart = cartFactory.create();
+    loading = false;
+
+    store.dispatch(new DaffCartLoadSuccess(cart));
+    store.dispatch(new DaffCartPlaceOrderSuccess({id: orderId}));
+  });
+
+  describe('selectCartOrderState', () => {
+    it('selects whether the place order operation is in progress', () => {
+			const expectedOrderState: DaffCartOrderReducerState = {
+				cartOrderResult: { id: orderId },
+				loading: false,
+				errors: []
+			};
+      const selector = store.pipe(select(selectCartOrderState));
+      const expected = cold('a', {a: expectedOrderState});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartOrderLoading', () => {
+    it('selects whether the place order operation is in progress', () => {
+      const selector = store.pipe(select(selectCartOrderLoading));
+      const expected = cold('a', {a: false});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartOrderErrors', () => {
+    it('selects the errors associated with place order', () => {
+      const selector = store.pipe(select(selectCartOrderErrors));
+      const expected = cold('a', {a: []});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartOrderValue', () => {
+    it('selects the order object', () => {
+      const selector = store.pipe(select(selectCartOrderValue));
+      const expected = cold('a', {a: {id: orderId}});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartOrderId', () => {
+    it('selects the ID of the order object', () => {
+      const selector = store.pipe(select(selectCartOrderId));
+      const expected = cold('a', {a: orderId});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+});

--- a/libs/cart/src/selectors/cart-order/cart-order.selector.ts
+++ b/libs/cart/src/selectors/cart-order/cart-order.selector.ts
@@ -1,0 +1,66 @@
+import {
+  createSelector,
+  MemoizedSelector
+} from '@ngrx/store';
+
+import { DaffCartOrderResult } from '../../models/cart-order-result';
+import { DaffCartOrderReducerState } from '../../reducers/cart-order-state.interface';
+import { getDaffCartFeatureSelector } from '../cart-feature.selector';
+import { DaffCart } from '../../models/cart';
+import { DaffCartReducersState } from '../../reducers/public_api';
+
+export interface DaffCartOrderMemoizedSelectors<
+  T extends DaffCartOrderResult = DaffCartOrderResult
+> {
+  selectCartOrderState: MemoizedSelector<object, DaffCartOrderReducerState<T>>;
+  selectCartOrderLoading: MemoizedSelector<object, boolean>;
+	selectCartOrderErrors: MemoizedSelector<object, DaffCartOrderReducerState<T>['errors']>;
+	selectCartOrderValue: MemoizedSelector<object, DaffCartOrderReducerState<T>['cartOrderResult']>;
+	selectCartOrderId: MemoizedSelector<object, DaffCartOrderReducerState<T>['cartOrderResult']['id']>;
+}
+
+const createCartOrderSelectors = <
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult
+>(): DaffCartOrderMemoizedSelectors<V> => {
+	const selectCartFeatureState = getDaffCartFeatureSelector<T, V>().selectCartFeatureState;
+
+  const selectCartOrderState = createSelector(
+		selectCartFeatureState,
+		(state: DaffCartReducersState<T, V>) => state.order
+  );
+  const selectCartOrderValue = createSelector(
+		selectCartOrderState,
+		(state: DaffCartOrderReducerState<V>) => state.cartOrderResult
+  );
+  const selectCartOrderId = createSelector(
+		selectCartOrderValue,
+		(state: DaffCartOrderReducerState<V>['cartOrderResult']) => state.id
+  );
+  const selectCartOrderLoading = createSelector(
+		selectCartOrderState,
+		(state: DaffCartOrderReducerState<V>) => state.loading
+	);
+	const selectCartOrderErrors = createSelector(
+		selectCartOrderState,
+		(state: DaffCartOrderReducerState<V>) => state.errors
+  );
+
+	return {
+    selectCartOrderState,
+    selectCartOrderLoading,
+    selectCartOrderErrors,
+    selectCartOrderValue,
+    selectCartOrderId
+	}
+}
+
+export const getCartOrderSelectors = (() => {
+	let cache;
+	return <
+    T extends DaffCart = DaffCart,
+    V extends DaffCartOrderResult = DaffCartOrderResult
+  >(): DaffCartOrderMemoizedSelectors<V> => cache = cache
+		? cache
+		: createCartOrderSelectors<T, V>();
+})();

--- a/libs/cart/src/selectors/cart.selector.ts
+++ b/libs/cart/src/selectors/cart.selector.ts
@@ -1,216 +1,25 @@
-import {
-  createFeatureSelector,
-  createSelector,
-  MemoizedSelector
-} from '@ngrx/store';
-
-import {
-  DaffCartReducersState,
-  DaffCartReducerState,
-  DaffCartOrderReducerState
-} from '../reducers/public_api';
-import { DaffCartErrorType } from '../reducers/cart-error-type.enum';
 import { DaffCart } from '../models/cart';
 import { DaffCartOrderResult } from '../models/cart-order-result';
+import { DaffCartFeatureMemoizedSelectors, getDaffCartFeatureSelector } from './cart-feature.selector';
+import { DaffCartOrderMemoizedSelectors, getCartOrderSelectors } from './cart-order/cart-order.selector';
+import { DaffCartStateMemoizedSelectors, getCartSelectors } from './cart/cart.selector';
 
 export interface DaffCartMemoizedSelectors<
   T extends DaffCart = DaffCart,
   V extends DaffCartOrderResult = DaffCartOrderResult
-> {
-	selectCartFeatureState: MemoizedSelector<object, DaffCartReducersState<T, V>>;
-	selectCartState: MemoizedSelector<object, DaffCartReducerState<T>>;
-	selectCartValue: MemoizedSelector<object, T>;
-	selectCartLoading: MemoizedSelector<object, boolean>;
-	selectCartErrorsObject: MemoizedSelector<object, DaffCartReducerState<T>['errors']>;
-	selectCartErrors: MemoizedSelector<object, string[]>;
-	selectBillingAddressErrors: MemoizedSelector<object, string[]>;
-	selectShippingAddressErrors: MemoizedSelector<object, string[]>;
-	selectShippingInformationErrors: MemoizedSelector<object, string[]>;
-	selectShippingMethodsErrors: MemoizedSelector<object, string[]>;
-	selectPaymentErrors: MemoizedSelector<object, string[]>;
-	selectPaymentMethodsErrors: MemoizedSelector<object, string[]>;
-	selectItemErrors: MemoizedSelector<object, string[]>;
-	selectCartId: MemoizedSelector<object, T['id']>;
-	selectCartSubtotal: MemoizedSelector<object, T['subtotal']>;
-	selectCartGrandTotal: MemoizedSelector<object, T['grand_total']>;
-	selectCartCoupons: MemoizedSelector<object, T['coupons']>;
-	selectCartItems: MemoizedSelector<object, T['items']>;
-	selectCartBillingAddress: MemoizedSelector<object, T['billing_address']>;
-	selectCartShippingAddress: MemoizedSelector<object, T['shipping_address']>;
-	selectCartPayment: MemoizedSelector<object, T['payment']>;
-	selectCartTotals: MemoizedSelector<object, T['totals']>;
-	selectCartShippingInformation: MemoizedSelector<object, T['shipping_information']>;
-	selectCartAvailableShippingMethods: MemoizedSelector<object, T['available_shipping_methods']>;
-	selectCartAvailablePaymentMethods: MemoizedSelector<object, T['available_payment_methods']>;
-  selectIsCartEmpty: MemoizedSelector<object, boolean>;
+> extends DaffCartFeatureMemoizedSelectors<T, V>,
+	DaffCartOrderMemoizedSelectors<V>,
+	DaffCartStateMemoizedSelectors<T> {}
 
-  selectCartOrderState: MemoizedSelector<object, DaffCartOrderReducerState<V>>;
-  selectCartOrderLoading: MemoizedSelector<object, boolean>;
-	selectCartOrderErrors: MemoizedSelector<object, DaffCartOrderReducerState<V>['errors']>;
-	selectCartOrderValue: MemoizedSelector<object, DaffCartOrderReducerState<V>['cartOrderResult']>;
-	selectCartOrderId: MemoizedSelector<object, DaffCartOrderReducerState<V>['cartOrderResult']['id']>;
-}
-
-const createCartFeatureSelectors = <
+const createCartSelectors = <
   T extends DaffCart = DaffCart,
   V extends DaffCartOrderResult = DaffCartOrderResult
 >(): DaffCartMemoizedSelectors<T> => {
-	const selectCartFeatureState = createFeatureSelector<DaffCartReducersState<T, V>>('cart');
-	const selectCartState = createSelector(
-		selectCartFeatureState,
-		(state: DaffCartReducersState<T, V>) => state.cart
-	);
-	const selectCartValue = createSelector(
-		selectCartState,
-		(state: DaffCartReducerState<T>) => state.cart
-	);
-	const selectCartLoading = createSelector(
-		selectCartState,
-		(state: DaffCartReducerState<T>) => state.loading
-	);
-	const selectCartErrorsObject = createSelector(
-		selectCartState,
-		(state: DaffCartReducerState<T>) => state.errors
-	);
-	const selectCartErrors = createSelector(
-		selectCartErrorsObject,
-		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.Cart]
-	);
-	const selectBillingAddressErrors = createSelector(
-		selectCartErrorsObject,
-		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.BillingAddress]
-	);
-	const selectShippingAddressErrors = createSelector(
-		selectCartErrorsObject,
-		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.ShippingAddress]
-	);
-	const selectShippingInformationErrors = createSelector(
-		selectCartErrorsObject,
-		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.ShippingInformation]
-	);
-	const selectShippingMethodsErrors = createSelector(
-		selectCartErrorsObject,
-		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.ShippingMethods]
-	);
-	const selectPaymentErrors = createSelector(
-		selectCartErrorsObject,
-		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.Payment]
-	);
-	const selectPaymentMethodsErrors = createSelector(
-		selectCartErrorsObject,
-		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.PaymentMethods]
-	);
-	const selectItemErrors = createSelector(
-		selectCartErrorsObject,
-		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.Item]
-	);
-	const selectCartId = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.id
-	);
-	const selectCartSubtotal = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.subtotal
-	);
-	const selectCartGrandTotal = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.grand_total
-	);
-	const selectCartCoupons = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.coupons
-	);
-	const selectCartItems = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.items
-	);
-	const selectCartBillingAddress = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.billing_address
-	);
-	const selectCartShippingAddress = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.shipping_address
-	);
-	const selectCartPayment = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.payment
-	);
-	const selectCartTotals = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.totals
-	);
-	const selectCartShippingInformation = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.shipping_information
-	);
-	const selectCartAvailableShippingMethods = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.available_shipping_methods
-	);
-	const selectCartAvailablePaymentMethods = createSelector(
-		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.available_payment_methods
-	);
-	const selectIsCartEmpty = createSelector(
-		selectCartValue,
-		cart => !cart || !cart.items || cart.items.length === 0
-  );
-
-  const selectCartOrderState = createSelector(
-		selectCartFeatureState,
-		(state: DaffCartReducersState<T, V>) => state.order
-  );
-  const selectCartOrderValue = createSelector(
-		selectCartOrderState,
-		(state: DaffCartOrderReducerState<V>) => state.cartOrderResult
-  );
-  const selectCartOrderId = createSelector(
-		selectCartOrderValue,
-		(state: DaffCartOrderReducerState<V>['cartOrderResult']) => state.id
-  );
-  const selectCartOrderLoading = createSelector(
-		selectCartOrderState,
-		(state: DaffCartOrderReducerState<V>) => state.loading
-	);
-	const selectCartOrderErrors = createSelector(
-		selectCartOrderState,
-		(state: DaffCartOrderReducerState<V>) => state.errors
-  );
 
 	return {
-		selectCartFeatureState,
-		selectCartState,
-		selectCartValue,
-		selectCartLoading,
-		selectCartErrorsObject,
-		selectCartErrors,
-		selectBillingAddressErrors,
-		selectShippingAddressErrors,
-		selectShippingInformationErrors,
-		selectShippingMethodsErrors,
-		selectPaymentErrors,
-		selectPaymentMethodsErrors,
-		selectItemErrors,
-		selectCartId,
-		selectCartSubtotal,
-		selectCartGrandTotal,
-		selectCartCoupons,
-		selectCartItems,
-		selectCartBillingAddress,
-		selectCartShippingAddress,
-		selectCartPayment,
-		selectCartTotals,
-		selectCartShippingInformation,
-		selectCartAvailableShippingMethods,
-    selectCartAvailablePaymentMethods,
-    selectIsCartEmpty,
-
-    selectCartOrderState,
-    selectCartOrderLoading,
-    selectCartOrderErrors,
-    selectCartOrderValue,
-    selectCartOrderId
+		...getDaffCartFeatureSelector<T, V>(),
+		...getCartOrderSelectors<T, V>(),
+		...getCartSelectors<T>()
 	}
 }
 
@@ -221,5 +30,5 @@ export const getDaffCartSelectors = (() => {
     V extends DaffCartOrderResult = DaffCartOrderResult
   >(): DaffCartMemoizedSelectors<T, V> => cache = cache
 		? cache
-		: createCartFeatureSelectors<T, V>();
+		: createCartSelectors<T, V>();
 })();

--- a/libs/cart/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/src/selectors/cart/cart.selector.spec.ts
@@ -5,11 +5,11 @@ import { cold } from 'jasmine-marbles';
 import { DaffCart } from '@daffodil/cart';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 
-import { DaffCartLoadSuccess, DaffCartPlaceOrderSuccess } from '../actions/public_api';
-import { daffCartReducers, DaffCartReducersState } from '../reducers/public_api';
-import { getDaffCartSelectors } from './cart.selector';
-import { DaffCartErrorType } from '../reducers/cart-error-type.enum';
-import { DaffCartErrors } from '../reducers/cart-errors.type';
+import { DaffCartLoadSuccess, DaffCartPlaceOrderSuccess } from '../../actions/public_api';
+import { daffCartReducers, DaffCartReducersState } from '../../reducers/public_api';
+import { getCartSelectors } from './cart.selector';
+import { DaffCartErrorType } from '../../reducers/cart-error-type.enum';
+import { DaffCartErrors } from '../../reducers/cart-errors.type';
 
 describe('Cart | Selector | Cart', () => {
   let store: Store<DaffCartReducersState>;
@@ -44,14 +44,8 @@ describe('Cart | Selector | Cart', () => {
 		selectCartShippingInformation,
 		selectCartAvailableShippingMethods,
 		selectCartAvailablePaymentMethods,
-    selectIsCartEmpty,
-
-    selectCartOrderState,
-    selectCartOrderLoading,
-    selectCartOrderErrors,
-    selectCartOrderValue,
-    selectCartOrderId
-	} = getDaffCartSelectors();
+    selectIsCartEmpty
+	} = getCartSelectors();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -295,42 +289,6 @@ describe('Cart | Selector | Cart', () => {
     it('selects whether the cart is empty', () => {
       const selector = store.pipe(select(selectIsCartEmpty));
       const expected = cold('a', {a: cart.items.length === 0});
-
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCartOrderLoading', () => {
-    it('selects whether the place order operation is in progress', () => {
-      const selector = store.pipe(select(selectCartOrderLoading));
-      const expected = cold('a', {a: false});
-
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCartOrderErrors', () => {
-    it('selects the errors associated with place order', () => {
-      const selector = store.pipe(select(selectCartOrderErrors));
-      const expected = cold('a', {a: []});
-
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCartOrderValue', () => {
-    it('selects the order object', () => {
-      const selector = store.pipe(select(selectCartOrderValue));
-      const expected = cold('a', {a: {id: orderId}});
-
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCartOrderId', () => {
-    it('selects the ID of the order object', () => {
-      const selector = store.pipe(select(selectCartOrderId));
-      const expected = cold('a', {a: orderId});
 
       expect(selector).toBeObservable(expected);
     });

--- a/libs/cart/src/selectors/cart/cart.selector.ts
+++ b/libs/cart/src/selectors/cart/cart.selector.ts
@@ -1,0 +1,184 @@
+import {
+  createSelector,
+  MemoizedSelector
+} from '@ngrx/store';
+
+import { getDaffCartFeatureSelector } from '../cart-feature.selector';
+import { DaffCart } from '../../models/cart';
+import { DaffCartReducerState, DaffCartReducersState, DaffCartErrorType } from '../../reducers/public_api';
+import { DaffCartOrderResult } from '../../models/cart-order-result';
+
+export interface DaffCartStateMemoizedSelectors<
+  T extends DaffCart = DaffCart
+> {
+	selectCartState: MemoizedSelector<object, DaffCartReducerState<T>>;
+	selectCartValue: MemoizedSelector<object, T>;
+	selectCartLoading: MemoizedSelector<object, boolean>;
+	selectCartErrorsObject: MemoizedSelector<object, DaffCartReducerState<T>['errors']>;
+	selectCartErrors: MemoizedSelector<object, string[]>;
+	selectBillingAddressErrors: MemoizedSelector<object, string[]>;
+	selectShippingAddressErrors: MemoizedSelector<object, string[]>;
+	selectShippingInformationErrors: MemoizedSelector<object, string[]>;
+	selectShippingMethodsErrors: MemoizedSelector<object, string[]>;
+	selectPaymentErrors: MemoizedSelector<object, string[]>;
+	selectPaymentMethodsErrors: MemoizedSelector<object, string[]>;
+	selectItemErrors: MemoizedSelector<object, string[]>;
+	selectCartId: MemoizedSelector<object, T['id']>;
+	selectCartSubtotal: MemoizedSelector<object, T['subtotal']>;
+	selectCartGrandTotal: MemoizedSelector<object, T['grand_total']>;
+	selectCartCoupons: MemoizedSelector<object, T['coupons']>;
+	selectCartItems: MemoizedSelector<object, T['items']>;
+	selectCartBillingAddress: MemoizedSelector<object, T['billing_address']>;
+	selectCartShippingAddress: MemoizedSelector<object, T['shipping_address']>;
+	selectCartPayment: MemoizedSelector<object, T['payment']>;
+	selectCartTotals: MemoizedSelector<object, T['totals']>;
+	selectCartShippingInformation: MemoizedSelector<object, T['shipping_information']>;
+	selectCartAvailableShippingMethods: MemoizedSelector<object, T['available_shipping_methods']>;
+	selectCartAvailablePaymentMethods: MemoizedSelector<object, T['available_payment_methods']>;
+  selectIsCartEmpty: MemoizedSelector<object, boolean>;
+}
+
+const createCartSelectors = <
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult
+>(): DaffCartStateMemoizedSelectors<T> => {
+	const selectCartFeatureState = getDaffCartFeatureSelector<T, V>().selectCartFeatureState;
+	const selectCartState = createSelector(
+		selectCartFeatureState,
+		(state: DaffCartReducersState<T, V>) => state.cart
+	);
+	const selectCartValue = createSelector(
+		selectCartState,
+		(state: DaffCartReducerState<T>) => state.cart
+	);
+	const selectCartLoading = createSelector(
+		selectCartState,
+		(state: DaffCartReducerState<T>) => state.loading
+	);
+	const selectCartErrorsObject = createSelector(
+		selectCartState,
+		(state: DaffCartReducerState<T>) => state.errors
+	);
+	const selectCartErrors = createSelector(
+		selectCartErrorsObject,
+		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.Cart]
+	);
+	const selectBillingAddressErrors = createSelector(
+		selectCartErrorsObject,
+		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.BillingAddress]
+	);
+	const selectShippingAddressErrors = createSelector(
+		selectCartErrorsObject,
+		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.ShippingAddress]
+	);
+	const selectShippingInformationErrors = createSelector(
+		selectCartErrorsObject,
+		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.ShippingInformation]
+	);
+	const selectShippingMethodsErrors = createSelector(
+		selectCartErrorsObject,
+		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.ShippingMethods]
+	);
+	const selectPaymentErrors = createSelector(
+		selectCartErrorsObject,
+		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.Payment]
+	);
+	const selectPaymentMethodsErrors = createSelector(
+		selectCartErrorsObject,
+		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.PaymentMethods]
+	);
+	const selectItemErrors = createSelector(
+		selectCartErrorsObject,
+		(state: DaffCartReducerState<T>['errors']) => state[DaffCartErrorType.Item]
+	);
+	const selectCartId = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.id
+	);
+	const selectCartSubtotal = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.subtotal
+	);
+	const selectCartGrandTotal = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.grand_total
+	);
+	const selectCartCoupons = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.coupons
+	);
+	const selectCartItems = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.items
+	);
+	const selectCartBillingAddress = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.billing_address
+	);
+	const selectCartShippingAddress = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.shipping_address
+	);
+	const selectCartPayment = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.payment
+	);
+	const selectCartTotals = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.totals
+	);
+	const selectCartShippingInformation = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.shipping_information
+	);
+	const selectCartAvailableShippingMethods = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.available_shipping_methods
+	);
+	const selectCartAvailablePaymentMethods = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => state.available_payment_methods
+	);
+	const selectIsCartEmpty = createSelector(
+		selectCartValue,
+		cart => !cart || !cart.items || cart.items.length === 0
+  );
+
+	return {
+		selectCartState,
+		selectCartValue,
+		selectCartLoading,
+		selectCartErrorsObject,
+		selectCartErrors,
+		selectBillingAddressErrors,
+		selectShippingAddressErrors,
+		selectShippingInformationErrors,
+		selectShippingMethodsErrors,
+		selectPaymentErrors,
+		selectPaymentMethodsErrors,
+		selectItemErrors,
+		selectCartId,
+		selectCartSubtotal,
+		selectCartGrandTotal,
+		selectCartCoupons,
+		selectCartItems,
+		selectCartBillingAddress,
+		selectCartShippingAddress,
+		selectCartPayment,
+		selectCartTotals,
+		selectCartShippingInformation,
+		selectCartAvailableShippingMethods,
+    selectCartAvailablePaymentMethods,
+    selectIsCartEmpty
+	}
+}
+
+export const getCartSelectors = (() => {
+	let cache;
+	return <
+    T extends DaffCart = DaffCart,
+    V extends DaffCartOrderResult = DaffCartOrderResult
+  >(): DaffCartStateMemoizedSelectors<T> => cache = cache
+		? cache
+		: createCartSelectors<T, V>();
+})();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
All the cart selectors are in a single, huge file.

## What is the new behavior?
Cart selectors are now broken up into three separate files: feature state, cart state, and cart order state.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```