### PR TITLE
refactor(auth): separate selectors into sub directories

### DIFF
--- a/libs/auth/src/selectors/auth-all.selector.ts
+++ b/libs/auth/src/selectors/auth-all.selector.ts
@@ -1,8 +1,8 @@
 import { MemoizedSelector } from '@ngrx/store';
 
-import { getAuthSelectors, AuthSelectors } from './auth.selector';
-import { getDaffAuthLoginSelectors, DaffAuthLoginSelectors } from './login.selector';
-import { getDaffAuthRegisterSelectors, DaffAuthRegisterSelectors } from './register.selector';
+import { getAuthSelectors, AuthSelectors } from './auth/auth.selector';
+import { getDaffAuthLoginSelectors, DaffAuthLoginSelectors } from './login/login.selector';
+import { getDaffAuthRegisterSelectors, DaffAuthRegisterSelectors } from './register/register.selector';
 import { DaffAuthToken } from '../models/auth-token';
 import { DaffAuthFeatureState } from '../reducers/public_api';
 import { getDaffAuthFeatureStateSelector } from './auth-feature.selector';

--- a/libs/auth/src/selectors/auth/auth.selector.spec.ts
+++ b/libs/auth/src/selectors/auth/auth.selector.spec.ts
@@ -10,8 +10,8 @@ import {
   daffAuthReducers,
   DAFF_AUTH_STORE_FEATURE_KEY,
   DaffAuthReducerState
-} from '../reducers/public_api';
-import { DaffAuthToken } from '../models/auth-token';
+} from '../../reducers/public_api';
+import { DaffAuthToken } from '../../models/auth-token';
 
 describe('Auth | Selector | Auth', () => {
   let store: Store<DaffAuthFeatureState<DaffAuthToken>>;

--- a/libs/auth/src/selectors/auth/auth.selector.ts
+++ b/libs/auth/src/selectors/auth/auth.selector.ts
@@ -1,10 +1,10 @@
 import { createSelector, MemoizedSelector } from '@ngrx/store';
 
-import { getDaffAuthFeatureStateSelector } from './auth-feature.selector';
-import { DaffAuthToken } from '../models/auth-token';
+import { getDaffAuthFeatureStateSelector } from '../auth-feature.selector';
+import { DaffAuthToken } from '../../models/auth-token';
 import {
   DaffAuthReducerState
-} from '../reducers/public_api';
+} from '../../reducers/public_api';
 
 
 export interface AuthSelectors {

--- a/libs/auth/src/selectors/login/login.selector.spec.ts
+++ b/libs/auth/src/selectors/login/login.selector.spec.ts
@@ -6,14 +6,14 @@ import {
   DaffAuthTokenFactory
 } from '@daffodil/auth/testing';
 
-import { DaffAuthLoginSuccess } from '../actions/auth.actions';
+import { DaffAuthLoginSuccess } from '../../actions/auth.actions';
 import {
   DaffAuthFeatureState,
   DAFF_AUTH_STORE_FEATURE_KEY,
   daffAuthReducers,
   DaffAuthLoginReducerState
-} from '../reducers/public_api';
-import { DaffAuthToken } from '../models/auth-token';
+} from '../../reducers/public_api';
+import { DaffAuthToken } from '../../models/auth-token';
 import {
   getDaffAuthLoginSelectors
 } from './login.selector';

--- a/libs/auth/src/selectors/login/login.selector.ts
+++ b/libs/auth/src/selectors/login/login.selector.ts
@@ -1,9 +1,9 @@
 import { createSelector, MemoizedSelector } from '@ngrx/store';
 
-import { getDaffAuthFeatureStateSelector } from './auth-feature.selector';
-import { DaffAuthToken } from '../models/auth-token';
-import { DaffAuthFeatureState } from '../reducers/auth-feature-state.interface';
-import { DaffAuthLoginReducerState } from '../reducers/public_api';
+import { getDaffAuthFeatureStateSelector } from '../auth-feature.selector';
+import { DaffAuthToken } from '../../models/auth-token';
+import { DaffAuthFeatureState } from '../../reducers/auth-feature-state.interface';
+import { DaffAuthLoginReducerState } from '../../reducers/public_api';
 
 export interface DaffAuthLoginSelectors<T extends DaffAuthToken> {
   selectAuthLoginState: MemoizedSelector<object, DaffAuthLoginReducerState<T>>;

--- a/libs/auth/src/selectors/register/register.selector.spec.ts
+++ b/libs/auth/src/selectors/register/register.selector.spec.ts
@@ -7,8 +7,8 @@ import {
   DAFF_AUTH_STORE_FEATURE_KEY,
   daffAuthReducers,
   DaffAuthRegisterReducerState
-} from '../reducers/public_api';
-import { DaffAuthToken } from '../models/auth-token';
+} from '../../reducers/public_api';
+import { DaffAuthToken } from '../../models/auth-token';
 import {
   getDaffAuthRegisterSelectors
 } from './register.selector';

--- a/libs/auth/src/selectors/register/register.selector.ts
+++ b/libs/auth/src/selectors/register/register.selector.ts
@@ -1,10 +1,10 @@
 import { createSelector, MemoizedSelector } from '@ngrx/store';
 
-import { getDaffAuthFeatureStateSelector } from './auth-feature.selector';
-import { DaffAuthToken } from '../models/auth-token';
+import { getDaffAuthFeatureStateSelector } from '../auth-feature.selector';
+import { DaffAuthToken } from '../../models/auth-token';
 import {
   DaffAuthRegisterReducerState,
-} from '../reducers/public_api';
+} from '../../reducers/public_api';
 
 export interface DaffAuthRegisterSelectors {
   selectAuthRegisterState: MemoizedSelector<object, DaffAuthRegisterReducerState>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
All the auth selectors exist in the same directory.

## What is the new behavior?
The auth selectors are separated into different sub directories to make them more digestible.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```