### PR TITLE
fix(cart): Magento GraphQL cart address update fails

### DIFF
--- a/libs/cart/src/drivers/magento/transforms/inputs/billing-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/billing-address.service.spec.ts
@@ -49,22 +49,41 @@ describe('Driver | Magento | Cart | Transformer | MagentoBillingAddressInput', (
 
   describe('transform | transforming a shipping address input', () => {
     let transformedBillingAddress;
-    let addressId;
 
-    beforeEach(() => {
-      addressId = '15';
+    describe('when address_id is set', () => {
+      let addressId;
 
-      mockDaffBillingAddress.address_id = addressId;
+      beforeEach(() => {
+        addressId = '15';
 
-      transformedBillingAddress = service.transform(mockDaffBillingAddress);
+        mockDaffBillingAddress.address_id = addressId;
+
+        transformedBillingAddress = service.transform(mockDaffBillingAddress);
+      });
+
+      it('should return an object with the correct customer_address_id', () => {
+        expect(transformedBillingAddress.customer_address_id).toEqual(addressId);
+      });
+
+      it('should return an object without the address field set', () => {
+        expect(transformedBillingAddress.address).toBeFalsy();
+      });
     });
 
-    it('should return an object with the correct values', () => {
-      expect(transformedBillingAddress.customer_address_id).toEqual(addressId);
-    });
+    describe('when address_id is not set', () => {
+      beforeEach(() => {
+        mockDaffBillingAddress.address_id = null;
 
-    it('should call the cart address transformer with the address', () => {
-      expect(cartAddressTransformerSpy.transform).toHaveBeenCalledWith(mockDaffBillingAddress);
+        transformedBillingAddress = service.transform(mockDaffBillingAddress);
+      });
+
+      it('should call the cart address transformer with the address', () => {
+        expect(cartAddressTransformerSpy.transform).toHaveBeenCalledWith(mockDaffBillingAddress);
+      });
+
+      it('should return an object without the customer_address_id field set', () => {
+        expect(transformedBillingAddress.customer_address_id).toBeFalsy();
+      });
     });
   });
 });

--- a/libs/cart/src/drivers/magento/transforms/inputs/billing-address.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/billing-address.service.ts
@@ -9,9 +9,14 @@ export class DaffMagentoBillingAddressInputTransformer {
   constructor(private cartAddressTransformer: DaffMagentoCartAddressInputTransformer) {}
 
   transform(cartAddress: Partial<DaffCartAddress>): MagentoBillingAddressInput {
-    return {
-      address: this.cartAddressTransformer.transform(cartAddress),
-      customer_address_id: cartAddress.address_id,
-    }
+    return cartAddress.address_id
+      ? {
+        address: null,
+        customer_address_id: cartAddress.address_id,
+      }
+      : {
+        address: this.cartAddressTransformer.transform(cartAddress),
+        customer_address_id: null,
+      }
   }
 }

--- a/libs/cart/src/drivers/magento/transforms/inputs/shipping-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/shipping-address.service.spec.ts
@@ -49,22 +49,41 @@ describe('Driver | Magento | Cart | Transformer | MagentoShippingAddressInput', 
 
   describe('transform | transforming a shipping address input', () => {
     let transformedShippingAddress;
-    let addressId;
 
-    beforeEach(() => {
-      addressId = '15';
+    describe('when address_id is set', () => {
+      let addressId;
 
-      mockDaffShippingAddress.address_id = addressId;
+      beforeEach(() => {
+        addressId = '15';
 
-      transformedShippingAddress = service.transform(mockDaffShippingAddress);
+        mockDaffShippingAddress.address_id = addressId;
+
+        transformedShippingAddress = service.transform(mockDaffShippingAddress);
+      });
+
+      it('should return an object with the correct customer_address_id', () => {
+        expect(transformedShippingAddress.customer_address_id).toEqual(addressId);
+      });
+
+      it('should return an object without the address field set', () => {
+        expect(transformedShippingAddress.address).toBeFalsy();
+      });
     });
 
-    it('should return an object with the correct values', () => {
-      expect(transformedShippingAddress.customer_address_id).toEqual(addressId);
-    });
+    describe('when address_id is not set', () => {
+      beforeEach(() => {
+        mockDaffShippingAddress.address_id = null;
 
-    it('should call the cart address transformer with the address', () => {
-      expect(cartAddressTransformerSpy.transform).toHaveBeenCalledWith(mockDaffShippingAddress);
+        transformedShippingAddress = service.transform(mockDaffShippingAddress);
+      });
+
+      it('should call the cart address transformer with the address', () => {
+        expect(cartAddressTransformerSpy.transform).toHaveBeenCalledWith(mockDaffShippingAddress);
+      });
+
+      it('should return an object without the customer_address_id field set', () => {
+        expect(transformedShippingAddress.customer_address_id).toBeFalsy();
+      });
     });
-  })
+  });
 });

--- a/libs/cart/src/drivers/magento/transforms/inputs/shipping-address.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/shipping-address.service.ts
@@ -9,9 +9,14 @@ export class DaffMagentoShippingAddressInputTransformer {
   constructor(private cartAddressTransformer: DaffMagentoCartAddressInputTransformer) {}
 
   transform(cartAddress: Partial<DaffCartAddress>): MagentoShippingAddressInput {
-    return {
-      address: this.cartAddressTransformer.transform(cartAddress),
-      customer_address_id: cartAddress.address_id
-    }
+    return cartAddress.address_id
+      ? {
+        address: null,
+        customer_address_id: cartAddress.address_id,
+      }
+      : {
+        address: this.cartAddressTransformer.transform(cartAddress),
+        customer_address_id: null,
+      }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Updating cart addresses with the Magento driver will fail if both the `address` and `customer_address_id` fields are set. The current address input transformers always output an object with both fields.


## What is the new behavior?
The address input transformers only set the `address` field if `address_id` is not set.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information