### PR TITLE
fix(cart): default available shipping methods value to an array

### DIFF
--- a/libs/cart/src/drivers/magento/transforms/outputs/cart.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart.service.spec.ts
@@ -232,5 +232,20 @@ describe('Driver | Magento | Cart | Transformer | MagentoCart', () => {
         expect(cartShippingRateTransformerSpy.transform).not.toHaveBeenCalled();
       });
     });
+
+    describe('when the shipping methods are null', () => {
+      beforeEach(() => {
+        mockMagentoCart.shipping_addresses[0].available_shipping_methods = null;
+        transformedCart = service.transform(mockMagentoCart);
+      });
+
+      it('should set available_shipping_methods to an empty array', () => {
+        expect(transformedCart.available_shipping_methods).toEqual([]);
+      });
+
+      it('should not call the shipping rate transformer', () => {
+        expect(cartShippingRateTransformerSpy.transform).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart.service.ts
@@ -119,7 +119,7 @@ export class DaffMagentoCartTransformer {
         ? cart.shipping_addresses[0].available_shipping_methods.map(method =>
           this.shippingRateTransformer.transform(method)
         )
-        : null
+        : []
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?
Changes the Magento cart transformer to set `available_shipping_methods` to an empty array instead of `null`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information