### PR TITLE
feat(geography): add personal address factory

### DIFF
--- a/libs/geography/testing/src/factories/address.factory.spec.ts
+++ b/libs/geography/testing/src/factories/address.factory.spec.ts
@@ -4,7 +4,7 @@ import { DaffAddressFactory, MockDaffAddress } from './address.factory';
 import { DaffAddress } from '@daffodil/geography';
 
 describe('Core | Interfaces | Factories | DaffAddressFactory', () => {
-  
+
   let daffodilAddressFactory;
 
   beforeEach(async(() => {
@@ -27,14 +27,6 @@ describe('Core | Interfaces | Factories | DaffAddressFactory', () => {
       result = daffodilAddressFactory.create();
     });
 
-    it('should return an Address with firstname', () => {
-      expect(result.firstname).toBeDefined();
-    });
-
-    it('should return an Address with lastname', () => {
-      expect(result.lastname).toBeDefined();
-    });
-
     it('should return an Address with street', () => {
       expect(result.street).toBeDefined();
     });
@@ -47,19 +39,11 @@ describe('Core | Interfaces | Factories | DaffAddressFactory', () => {
       expect(result.region).toBeDefined();
     });
 
-    it('should return an Address with an email', () => {
-      expect(result.email).toBeDefined();
-    });
-
     it('should return an Address with postcode', () => {
       expect(result.postcode).toBeDefined();
     });
-
-    it('should return an Address with telephone', () => {
-      expect(result.telephone).toBeDefined();
-    });
   });
-  
+
   describe('creating many addresses', () => {
     let result: DaffAddress[];
 

--- a/libs/geography/testing/src/factories/address.factory.ts
+++ b/libs/geography/testing/src/factories/address.factory.ts
@@ -6,14 +6,10 @@ import { DaffAddress } from '@daffodil/geography';
 import * as faker from 'faker/locale/en_US';
 
 export class MockDaffAddress implements DaffAddress {
-  firstname = faker.name.firstName();
-  lastname = faker.name.lastName();
   street = faker.address.streetName();
   city = faker.address.city();
   region = faker.address.stateAbbr();
-  email = faker.internet.email();
   postcode = faker.address.zipCode();
-  telephone = faker.phone.phoneNumber();
 }
 
 @Injectable({

--- a/libs/geography/testing/src/factories/personal-address.factory.spec.ts
+++ b/libs/geography/testing/src/factories/personal-address.factory.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed, async } from '@angular/core/testing';
+
+import { DaffPersonalAddressFactory, MockDaffPersonalAddress } from './personal-address.factory';
+import { DaffPersonalAddress } from '@daffodil/geography';
+
+describe('Geography | Interfaces | Factories | DaffPersonalAddressFactory', () => {
+  let factory;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffPersonalAddressFactory]
+    });
+
+    factory = TestBed.get(DaffPersonalAddressFactory);
+  }));
+
+  it('should be created', () => {
+    expect(factory).toBeTruthy();
+  });
+
+  describe('creating an address', () => {
+    let result: MockDaffPersonalAddress;
+
+    beforeEach(() => {
+      result = factory.create();
+    });
+
+    it('should return an Address with firstname', () => {
+      expect(result.firstname).toBeDefined();
+    });
+
+    it('should return an Address with lastname', () => {
+      expect(result.lastname).toBeDefined();
+    });
+
+    it('should return an Address with an email', () => {
+      expect(result.email).toBeDefined();
+    });
+
+    it('should return an Address with telephone', () => {
+      expect(result.telephone).toBeDefined();
+    });
+  });
+
+  describe('creating many addresses', () => {
+    let result: DaffPersonalAddress[];
+
+    it('should create as many cart addresses as desired', () => {
+      result = factory.createMany(2);
+      expect(result.length).toEqual(2);
+
+      result = factory.createMany(3);
+      expect(result.length).toEqual(3);
+    })
+  });
+});

--- a/libs/geography/testing/src/factories/personal-address.factory.ts
+++ b/libs/geography/testing/src/factories/personal-address.factory.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { DaffModelFactory } from '@daffodil/core/testing';
+import { DaffPersonalAddress } from '@daffodil/geography';
+
+import { MockDaffAddress } from './address.factory';
+
+export class MockDaffPersonalAddress extends MockDaffAddress implements DaffPersonalAddress {
+  firstname = faker.name.firstName();
+  lastname = faker.name.lastName();
+  email = faker.internet.email();
+  telephone = faker.phone.phoneNumber();
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DaffPersonalAddressFactory extends DaffModelFactory<DaffPersonalAddress>{
+  constructor() {
+    super(MockDaffPersonalAddress);
+  }
+}

--- a/libs/geography/testing/src/factories/public_api.ts
+++ b/libs/geography/testing/src/factories/public_api.ts
@@ -1,3 +1,4 @@
-export { DaffAddressFactory } from './address.factory';
-export { DaffCountryFactory } from './country.factory';
-export { DaffSubdivisionFactory } from './subdivision.factory';
+export * from './address.factory';
+export * from './personal-address.factory';
+export * from './country.factory';
+export * from './subdivision.factory';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?
- Adds a `DaffPersonalAddress` factory
- Modifies the `DaffAddress` factory to only generate fields actually in the model
- Exports everything from the factories. It will be useful to extend from the mock model classes in other packages' factories.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information