### PR TITLE
feat(product): add a field to the product facade for selecting a prod…

### DIFF
--- a/libs/product/src/facades/product/product-facade.interface.ts
+++ b/libs/product/src/facades/product/product-facade.interface.ts
@@ -7,5 +7,10 @@ import { DaffProduct } from '../../models/product';
 
 export interface DaffProductFacadeInterface<T extends DaffProduct = DaffProduct> extends DaffStoreFacade<Action> {
 	loading$: Observable<boolean>;
+	/**
+	 * @deprecated use getProduct instead.
+	 */
 	product$: Observable<T>;
+
+	getProduct(id: string): Observable<T>;
 }

--- a/libs/product/src/facades/product/product.facade.spec.ts
+++ b/libs/product/src/facades/product/product.facade.spec.ts
@@ -3,10 +3,14 @@ import { MockStore } from '@ngrx/store/testing';
 import { Store, StoreModule, combineReducers } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 
+import {
+	DaffProductLoad, 
+	DaffProductLoadSuccess,
+	daffProductReducers,
+	DaffProductReducersState
+} from '@daffodil/product';
+
 import { DaffProductFacade } from './product.facade';
-import { DaffProductLoad, DaffProductLoadSuccess } from '../../actions/product.actions';
-import { daffProductReducers } from '../../reducers/product-reducers';
-import { DaffProductReducersState } from '../../reducers/product-reducers-state.interface';
 
 describe('DaffProductFacade', () => {
   let store: MockStore<Partial<DaffProductReducersState>>;
@@ -67,5 +71,15 @@ describe('DaffProductFacade', () => {
       store.dispatch(new DaffProductLoadSuccess(product));
       expect(facade.product$).toBeObservable(expected);
     })
-  });
+	});
+	
+	describe('getProduct()', () => {
+		it('should be an observable of a product', () => {
+			const product = {id: '1', name: 'Some Name'};
+      const expected = cold('a', { a: product});
+      store.dispatch(new DaffProductLoad(product.id));
+      store.dispatch(new DaffProductLoadSuccess(product));
+      expect(facade.getProduct(product.id)).toBeObservable(expected);
+		});
+	});
 });

--- a/libs/product/src/facades/product/product.facade.ts
+++ b/libs/product/src/facades/product/product.facade.ts
@@ -26,7 +26,7 @@ export class DaffProductFacade<T extends DaffProduct = DaffProduct> implements D
    */
   product$: Observable<T>;
 
-	selectors = getDaffProductSelectors<T>();
+	private selectors = getDaffProductSelectors<T>();
 
   constructor(private store: Store<DaffProductReducersState<T>>) {
     this.loading$ = this.store.pipe(select(this.selectors.selectSelectedProductLoadingState));

--- a/libs/product/src/facades/product/product.facade.ts
+++ b/libs/product/src/facades/product/product.facade.ts
@@ -17,23 +17,25 @@ import { DaffProductFacadeInterface } from './product-facade.interface';
 })
 export class DaffProductFacade<T extends DaffProduct = DaffProduct> implements DaffProductFacadeInterface<T> {
   /**
-   * The loading state of the currently selected product.
+   * The loading state of the product.
    */
   loading$: Observable<boolean>;
   /**
    * The currently selected product.
+	 * @deprecate use getProduct instead.
    */
   product$: Observable<T>;
 
-  constructor(private store: Store<DaffProductReducersState<T>>) {
-		const {
-			selectSelectedProductLoadingState,
-			selectSelectedProduct
-		} = getDaffProductSelectors<T>();
+	selectors = getDaffProductSelectors<T>();
 
-    this.loading$ = this.store.pipe(select(selectSelectedProductLoadingState));
-    this.product$ = this.store.pipe(select(selectSelectedProduct));
-  }
+  constructor(private store: Store<DaffProductReducersState<T>>) {
+    this.loading$ = this.store.pipe(select(this.selectors.selectSelectedProductLoadingState));
+		this.product$ = this.store.pipe(select(this.selectors.selectSelectedProduct));
+	}
+	
+	getProduct(id: string): Observable<T> {
+		return this.store.pipe(select(this.selectors.selectProduct, { id }));
+	}
 
   /**
    * Dispatches an action to the rxjs action stream.

--- a/libs/product/src/selectors/product/product.selectors.ts
+++ b/libs/product/src/selectors/product/product.selectors.ts
@@ -20,7 +20,7 @@ const createProductPageSelectors = <T extends DaffProduct>(): DaffProductPageMem
 	} = getDaffProductFeatureSelector<T>();
 
 	/**
-	 * Selector for the selected product.
+	 * Selector for product state.
 	 */
 	const selectSelectedProductState = createSelector(
 		selectProductState,
@@ -29,6 +29,7 @@ const createProductPageSelectors = <T extends DaffProduct>(): DaffProductPageMem
 
 	/**
 	 * Selector for the selected product's ID.
+	 * @deprecated
 	 */
 	const selectSelectedProductId = createSelector(
 		selectSelectedProductState,
@@ -37,6 +38,7 @@ const createProductPageSelectors = <T extends DaffProduct>(): DaffProductPageMem
 
 	/**
 	 * Selector for the quantity of the product.
+	 * @deprecated
 	 */
 	const selectSelectedProductQty = createSelector(
 		selectSelectedProductState,
@@ -53,6 +55,7 @@ const createProductPageSelectors = <T extends DaffProduct>(): DaffProductPageMem
 
 	/**
 	 * Selects the selected product from product state and the selected product ID.
+	 * @deprecated use selectProduct entities selector instead.
 	 */
 	const selectSelectedProduct = createSelector(
 		selectProductState,

--- a/libs/product/testing/src/helpers/mock-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-product-facade.ts
@@ -4,6 +4,12 @@ import { DaffProduct, DaffProductFacadeInterface } from '@daffodil/product';
 
 export class MockDaffProductFacade implements DaffProductFacadeInterface {
 	loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+	/**
+	 * @deprecated use getProduct instead.
+	 */
 	product$: BehaviorSubject<DaffProduct> = new BehaviorSubject(null);
+	getProduct(id: string): BehaviorSubject<DaffProduct> {
+		return new BehaviorSubject(null);
+	}
 	dispatch() {};
 }


### PR DESCRIPTION
…uct by ID. Deprecate selected product state.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Looking back on it, saving a "selected product" on state doesn't make a lot of sense. Makes more sense, I think, to select a product by ID rather than having daffodil save some concept of a selected product.

## What is the new behavior?
Getting a single product is now done through a selector where the product id needs to be provided.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```