### PR TITLE
feat(design): add `daff-nav-list` variant of a list

### DIFF
--- a/apps/design-land/src/app/list/list.component.html
+++ b/apps/design-land/src/app/list/list.component.html
@@ -10,6 +10,12 @@
 
 <h3>List Types</h3>
 
+<daff-nav-list>
+  <daff-list-item>Nav List</daff-list-item>
+  <daff-list-item>Nav List</daff-list-item>
+  <daff-list-item>Nav List</daff-list-item>
+</daff-nav-list>
+
 <h4>Link List</h4>
 
 <daff-list type="link">

--- a/libs/design/src/molecules/list/list-theme.scss
+++ b/libs/design/src/molecules/list/list-theme.scss
@@ -1,0 +1,53 @@
+@mixin daff-list-theme($theme) {
+	$base: daff-map-deep-get($theme, 'core.base');
+	$base-contrast: daff-map-deep-get($theme, 'core.base-contrast');
+
+	.daff-list {
+		.daff-list-item {
+			&__content {
+				*:nth-child(1) { /* stylelint-disable-line scss/selector-nest-combinators */
+					color: $base-contrast;
+				}
+
+				*:nth-child(n + 2) { /* stylelint-disable-line scss/selector-nest-combinators */
+					color: daff-illuminate($base-contrast, $daff-gray, 3);
+				}
+			}
+		}
+
+		// deprecated in v1.0.0
+		&--navigation {
+			.daff-list-item {
+				&:hover {
+					background-color: daff-illuminate($base, $daff-gray, 1);
+				}
+			}
+		}
+
+		// deprecated in v1.0.0
+		&--multi-line {
+			.daff-list-item {
+				&__content {
+					*:nth-child(1) { /* stylelint-disable-line scss/selector-nest-combinators */
+						color: $base-contrast;
+					}
+
+					*:nth-child(n + 2) { /* stylelint-disable-line scss/selector-nest-combinators */
+						color: daff-illuminate($base-contrast, $daff-gray, 3);
+					}
+				}
+			}
+		}
+	}
+
+	.daff-nav-list {
+		.daff-list-item {
+			background-color: $base;
+			transition: background-color 150ms;
+
+			&:hover {
+				background-color: daff-illuminate($base, $daff-gray, 1);
+			}
+		}
+	}
+}

--- a/libs/design/src/molecules/list/list/list.component.scss
+++ b/libs/design/src/molecules/list/list/list.component.scss
@@ -1,11 +1,53 @@
 @import '../../../scss/daff-util';
 @import '../../../scss/daff-theme';
 
-.daff-list {
+@mixin daff-list() {
 	$root: &;
 	display: block;
 	margin: 0;
 	padding: 0;
+
+	.daff-list-item {
+		$root: &;
+		display: flex;
+		padding: 12px 16px;
+
+		&__content {
+			flex-grow: 1;
+
+			*:nth-child(1) { /* stylelint-disable-line scss/selector-nest-combinators */
+				@include embolden();
+				font-size: $normal-font-size;
+				line-height: 1.5em;
+				margin: 0;
+				padding: 0;
+			}
+
+			*:nth-child(n + 2) { /* stylelint-disable-line scss/selector-nest-combinators */
+				font-size: $normal-font-size;
+				margin: 0;
+				padding: 0;
+			}
+		}
+
+		.daff-prefix,
+		.daff-suffix {
+			display: flex;
+			align-items: center;
+		}
+
+		.daff-prefix {
+			margin-right: 24px;
+		}
+
+		.daff-suffix {
+			margin-left: 24px;
+		}
+	}
+}
+
+.daff-list {
+	@include daff-list();
 
 	&__subheader {
 		@include embolden();
@@ -55,21 +97,12 @@
 	}
 }
 
-.daff-list-item {
-	$root: &;
-	display: flex;
-	padding: 8px 0;
-	text-align: left;
+.daff-nav-list {
+	@include daff-list();
 
-	&:first-of-type {
-		padding: 0 0 8px;
-	}
-
-	.daff-prefix {
-		margin-right: 16px;
-	}
-
-	.daff-suffix {
-		margin-left: 16px;
+	.daff-list-item {
+		@include clickable();
+		outline: none;
+		text-decoration: none;
 	}
 }

--- a/libs/design/src/molecules/list/list/list.component.spec.ts
+++ b/libs/design/src/molecules/list/list/list.component.spec.ts
@@ -20,6 +20,7 @@ describe('DaffListComponent', () => {
   let de: DebugElement;
   let fixture: ComponentFixture<WrapperComponent>;
   let navDE: DebugElement;
+  let navList: DaffListComponent;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -48,6 +49,27 @@ describe('DaffListComponent', () => {
       expect(de.classes).toEqual(jasmine.objectContaining({
         'daff-list': true,
       }));
+    });
+
+    it('should have a role of list', () => {
+      expect(component.role).toBe('list');
+    });
+  });
+
+  describe('<daff-nav-list>', () => {
+    beforeEach(() => {
+      navDE = fixture.debugElement.query(By.css('daff-nav-list'));
+      navList = navDE.componentInstance;
+    });
+
+    it('should add a class of "daff-nav-list" to the host element', () => {
+      expect(navDE.classes).toEqual(jasmine.objectContaining({
+        'daff-nav-list': true,
+      }));
+    });
+
+    it('should have a role of navigation', () => {
+      expect(navList.role).toBe('navigation');
     });
   });
 
@@ -87,18 +109,6 @@ describe('DaffListComponent', () => {
           'daff-list--navigation': true
         }));
       });
-    });
-  });
-
-  describe('<daff-nav-list>', () => {
-    beforeEach(() => {
-      navDE = fixture.debugElement.query(By.css('daff-nav-list'));
-    });
-
-    it('should add a class of "daff-nav-list" to the host element', () => {
-      expect(navDE.classes).toEqual(jasmine.objectContaining({
-        'daff-nav-list': true,
-      }));
     });
   });
 });

--- a/libs/design/src/molecules/list/list/list.component.spec.ts
+++ b/libs/design/src/molecules/list/list/list.component.spec.ts
@@ -5,7 +5,10 @@ import { By } from '@angular/platform-browser';
 import { DaffListComponent, DaffListMode } from './list.component';
 
 @Component({
-  template: `<daff-list [mode]="mode"></daff-list>`
+  template: `
+    <daff-list [mode]="mode"></daff-list>
+    <daff-nav-list></daff-nav-list>
+  `
 })
 class WrapperComponent {
   mode: DaffListMode;
@@ -16,6 +19,7 @@ describe('DaffListComponent', () => {
   let component: DaffListComponent;
   let de: DebugElement;
   let fixture: ComponentFixture<WrapperComponent>;
+  let navDE: DebugElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -83,6 +87,18 @@ describe('DaffListComponent', () => {
           'daff-list--navigation': true
         }));
       });
+    });
+  });
+
+  describe('<daff-nav-list>', () => {
+    beforeEach(() => {
+      navDE = fixture.debugElement.query(By.css('daff-nav-list'));
+    });
+
+    it('should add a class of "daff-nav-list" to the host element', () => {
+      expect(navDE.classes).toEqual(jasmine.objectContaining({
+        'daff-nav-list': true,
+      }));
     });
   });
 });

--- a/libs/design/src/molecules/list/list/list.component.ts
+++ b/libs/design/src/molecules/list/list/list.component.ts
@@ -32,11 +32,11 @@ enum DaffListTypeEnum {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 
-export class DaffListComponent implements OnInit {
+export class DaffListComponent {
   @Input() mode: DaffListMode;
 
   @HostBinding('class.daff-list') get list() {
-    return this.listType === DaffListTypeEnum.Default || this.listType === undefined;
+    return this.listType === DaffListTypeEnum.Default;
   }
 
   @HostBinding('class.daff-list--multi-line') get multiline() {
@@ -52,17 +52,12 @@ export class DaffListComponent implements OnInit {
     return this.mode === DaffListModeEnum.Navigation;
   }
   
-  listType: DaffListType;
+  get listType(): DaffListType {
+    return this._getHostElement().localName;
+   }
 
-  constructor(private elementRef: ElementRef, private renderer: Renderer2) {}
+  constructor(private elementRef: ElementRef) {}
 
-  ngOnInit() {
-    for (const attr of LIST_HOST_ATTRIBUTES) {
-      if (this._hasHostAttributes(attr)) {
-        this.listType = attr;
-      }
-    }
-  }
 
   @HostBinding('class.daff-nav-list') get nav() {
     return this.listType === DaffListTypeEnum.Nav;
@@ -77,10 +72,5 @@ export class DaffListComponent implements OnInit {
 
   _getHostElement() {
     return this.elementRef.nativeElement;
-  }
-
-  /** Gets whether a list has one of the given attributes. */
-  _hasHostAttributes(...attributes: string[]) {
-    return attributes.some(attribute => this._getHostElement().localName === attribute);
   }
 }

--- a/libs/design/src/molecules/list/list/list.component.ts
+++ b/libs/design/src/molecules/list/list/list.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation, ChangeDetectionStrategy, Input, HostBinding, ElementRef, Renderer2, OnInit } from '@angular/core';
+import { Component, ViewEncapsulation, ChangeDetectionStrategy, Input, HostBinding, ElementRef } from '@angular/core';
 
 export type DaffListMode = 'multi-line' | 'link' | 'navigation' | undefined;
 export enum DaffListModeEnum {
@@ -7,15 +7,7 @@ export enum DaffListModeEnum {
   Navigation = 'navigation'
 }
 
-/**
-* List of classes to add to DaffListComponent instances based on host attributes to style as different variants.
-*/
-const LIST_HOST_ATTRIBUTES: DaffListType[] = [
-  'daff-list',
-  'daff-nav-list'
-];
-
-export type DaffListType = 'daff-list' | 'daff-nav-list' | undefined;
+export type DaffListType = 'daff-list' | 'daff-nav-list';
 
 enum DaffListTypeEnum {
   Default = 'daff-list',
@@ -70,7 +62,7 @@ export class DaffListComponent {
     return this.listType === DaffListTypeEnum.Nav ? 'navigation' : 'list';
   };
 
-  _getHostElement() {
+  private _getHostElement() {
     return this.elementRef.nativeElement;
   }
 }

--- a/libs/design/src/molecules/list/list/list.component.ts
+++ b/libs/design/src/molecules/list/list/list.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation, ChangeDetectionStrategy, Input, HostBinding } from '@angular/core';
+import { Component, ViewEncapsulation, ChangeDetectionStrategy, Input, HostBinding, ElementRef, Renderer2, OnInit } from '@angular/core';
 
 export type DaffListMode = 'multi-line' | 'link' | 'navigation' | undefined;
 export enum DaffListModeEnum {
@@ -7,18 +7,37 @@ export enum DaffListModeEnum {
   Navigation = 'navigation'
 }
 
+/**
+* List of classes to add to DaffListComponent instances based on host attributes to style as different variants.
+*/
+const LIST_HOST_ATTRIBUTES: DaffListType[] = [
+  'daff-list',
+  'daff-nav-list'
+];
+
+export type DaffListType = 'daff-list' | 'daff-nav-list' | undefined;
+
+enum DaffListTypeEnum {
+  Default = 'daff-list',
+  Nav = 'daff-nav-list'
+}
+
 @Component({
-  selector: 'daff-list',
+  selector:
+    'daff-list' + ',' +
+    'daff-nav-list',
   template: '<ng-content></ng-content>',
   styleUrls: ['./list.component.scss'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 
-export class DaffListComponent {
+export class DaffListComponent implements OnInit {
   @Input() mode: DaffListMode;
 
-  @HostBinding('class.daff-list') class = true;
+  @HostBinding('class.daff-list') get list() {
+    return this.listType === DaffListTypeEnum.Default || this.listType === undefined;
+  }
 
   @HostBinding('class.daff-list--multi-line') get multiline() {
     return this.mode === DaffListModeEnum.Multiline;
@@ -31,5 +50,37 @@ export class DaffListComponent {
 
   @HostBinding('class.daff-list--navigation') get navigation() {
     return this.mode === DaffListModeEnum.Navigation;
+  }
+  
+  listType: DaffListType;
+
+  constructor(private elementRef: ElementRef, private renderer: Renderer2) {}
+
+  ngOnInit() {
+    for (const attr of LIST_HOST_ATTRIBUTES) {
+      if (this._hasHostAttributes(attr)) {
+        this.listType = attr;
+      }
+    }
+  }
+
+  @HostBinding('class.daff-nav-list') get nav() {
+    return this.listType === DaffListTypeEnum.Nav;
+  }
+
+  /**
+   * Sets the role for a `<daff-nav-list>` to navigation.
+   */
+  @HostBinding('attr.role') get role() {
+    return this.listType === DaffListTypeEnum.Nav ? 'navigation' : 'list';
+  };
+
+  _getHostElement() {
+    return this.elementRef.nativeElement;
+  }
+
+  /** Gets whether a list has one of the given attributes. */
+  _hasHostAttributes(...attributes: string[]) {
+    return attributes.some(attribute => this._getHostElement().localName === attribute);
   }
 }

--- a/libs/design/src/molecules/list/public_api.ts
+++ b/libs/design/src/molecules/list/public_api.ts
@@ -1,4 +1,4 @@
 export { DaffListModule } from './list.module';
-export * from './list/list.component';
-export * from './list-subheader/list-subheader.directive';
-export * from './list-item/list-item.component';
+export { DaffListComponent } from './list/list.component';
+export { DaffListSubheaderDirective } from './list-subheader/list-subheader.directive';
+export { DaffListItemComponent } from './list-item/list-item.component';

--- a/libs/design/src/molecules/list/public_api.ts
+++ b/libs/design/src/molecules/list/public_api.ts
@@ -1,4 +1,4 @@
 export { DaffListModule } from './list.module';
-export { DaffListComponent } from './list/list.component';
-export { DaffListSubheaderDirective } from './list-subheader/list-subheader.directive';
-export { DaffListItemComponent } from './list-item/list-item.component';
+export * from './list/list.component';
+export * from './list-subheader/list-subheader.directive';
+export * from './list-item/list-item.component';

--- a/libs/design/src/scss/theming/_theme.scss
+++ b/libs/design/src/scss/theming/_theme.scss
@@ -11,6 +11,7 @@
 @import '../../molecules/callout/callout-theme';
 @import '../../molecules/card/card/card-theme';
 @import '../../molecules/hero/hero-theme';
+@import '../../molecules/list/list-theme';
 @import '../../molecules/modal/modal-theme';
 @import '../../molecules/navbar/navbar-theme';
 @import '../../molecules/paginator/paginator-theme';
@@ -40,6 +41,7 @@
 	@include daff-callout-theme($theme);
 	@include daff-card-theme($theme);
 	@include daff-hero-theme($theme);
+	@include daff-list-theme($theme);
 	@include daff-modal-theme($theme);
 	@include daff-navbar-theme($theme);
 	@include daff-paginator-theme($theme);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The styles for the variations of lists are incomplete. `link` is a variation that should be deprecated.

Fixes: #806

## What is the new behavior?
Updated and completed styles for the variations of lists. Added deprecation notice for `link`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
We discussed adding `divided` as a boolean that can be applied to all lists, but I'm thinking we can update the `section-divider` mixin to a component so that it can be used with any component. This also means components that may have the `divided` feature don't need that extra input.

We also discussed updating navigation and multi-line to booleans, depending on what the style update is. This needs to be discussed.

I left out the compact design because that depends on that DaffCompactable interface (WIP).