### PR TITLE
fix(product): fix magento configurable product query

### DIFF
--- a/libs/product/src/drivers/magento/models/configurable-product.ts
+++ b/libs/product/src/drivers/magento/models/configurable-product.ts
@@ -18,7 +18,7 @@ export interface MagentoConfigurableProductOption {
 
 export interface MagentoConfigurableProductOptionsValue {
 	label: string;
-	swatch_data: MagentoSwatchDataInterface;
+	swatch_data?: MagentoSwatchDataInterface;
 	value_index: number;
 }
 

--- a/libs/product/src/drivers/magento/queries/fragments/configurable-product.ts
+++ b/libs/product/src/drivers/magento/queries/fragments/configurable-product.ts
@@ -2,43 +2,37 @@ import gql from 'graphql-tag';
 
 export const magentoConfigurableProductFragment = gql`
   fragment magentoConfigurableProduct on ConfigurableProduct {
-		items {
-			configurable_options {
-				attribute_code
-				attribute_id
-				id
+		configurable_options {
+			attribute_code
+			attribute_id
+			id
+			label
+			position
+			product_id
+			values {
 				label
-				position
-				product_id
-				values {
-					label
-					value_index
-					swatch_data {
-						value
-						thumbnail
-					}
-				}
+				value_index
 			}
-			variants {
-				attributes {
-					code
-					label
-					value_index
-				}
-				product {
-					sku
-					price_range {
-						minimum_price {
-							regular_price {
-								value
-								currency
-							}
+		}
+		variants {
+			attributes {
+				code
+				label
+				value_index
+			}
+			product {
+				sku
+				price_range {
+					minimum_price {
+						regular_price {
+							value
+							currency
 						}
 					}
-					image {
-						url
-						label
-					}
+				}
+				image {
+					url
+					label
 				}
 			}
 		}

--- a/libs/product/src/drivers/magento/transforms/configurable-product-transformer.spec.ts
+++ b/libs/product/src/drivers/magento/transforms/configurable-product-transformer.spec.ts
@@ -19,6 +19,9 @@ describe('DaffMagentoConfigurableProductTransformers', () => {
 	daffConfigurableProduct.variants[1].image.id = '0';
 	daffConfigurableProduct.variants[2].image.id = '0';
 	const mediaUrl = 'mediaUrl';
+	delete daffConfigurableProduct.configurableAttributes[0].values[0].swatch
+	delete daffConfigurableProduct.configurableAttributes[0].values[1].swatch
+	delete daffConfigurableProduct.configurableAttributes[0].values[2].swatch
 
 	beforeEach(() => {
     TestBed.configureTestingModule({});
@@ -27,10 +30,15 @@ describe('DaffMagentoConfigurableProductTransformers', () => {
 	describe('transformMagentoConfigurableProduct', () => {
 		
 		it('should transform a magento configurable product into a daffodil configurable product', () => {
-			expect(transformMagentoConfigurableProduct(magentoConfigurableProductData, mediaUrl)).toEqual({
+			const expected: DaffConfigurableProduct = {
 				...daffConfigurableProductData,
 				type: DaffProductTypeEnum.Configurable
-			});
+			};
+			delete expected.configurableAttributes[0].values[0].swatch;
+			delete expected.configurableAttributes[0].values[1].swatch;
+			delete expected.configurableAttributes[0].values[2].swatch;
+
+			expect(transformMagentoConfigurableProduct(magentoConfigurableProductData, mediaUrl)).toEqual(expected);
 		});
 	});
 
@@ -47,27 +55,15 @@ describe('DaffMagentoConfigurableProductTransformers', () => {
 				values: [
 					{
 						value_index: parseInt(daffConfigurableProduct.configurableAttributes[0].values[0].value, 10),
-						label: daffConfigurableProduct.configurableAttributes[0].values[0].label,
-						swatch_data: {
-							value: daffConfigurableProduct.configurableAttributes[0].values[0].swatch.value,
-							thumbnail: daffConfigurableProduct.configurableAttributes[0].values[0].swatch.thumbnail
-						}
+						label: daffConfigurableProduct.configurableAttributes[0].values[0].label
 					},
 					{
 						value_index: parseInt(daffConfigurableProduct.configurableAttributes[0].values[1].value, 10),
-						label: daffConfigurableProduct.configurableAttributes[0].values[1].label,
-						swatch_data: {
-							value: daffConfigurableProduct.configurableAttributes[0].values[1].swatch.value,
-							thumbnail: daffConfigurableProduct.configurableAttributes[0].values[0].swatch.thumbnail
-						}
+						label: daffConfigurableProduct.configurableAttributes[0].values[1].label
 					},
 					{
 						value_index: parseInt(daffConfigurableProduct.configurableAttributes[0].values[2].value, 10),
-						label: daffConfigurableProduct.configurableAttributes[0].values[2].label,
-						swatch_data: {
-							value: daffConfigurableProduct.configurableAttributes[0].values[2].swatch.value,
-							thumbnail: daffConfigurableProduct.configurableAttributes[0].values[0].swatch.thumbnail
-						}
+						label: daffConfigurableProduct.configurableAttributes[0].values[2].label
 					}
 				]
 			};
@@ -81,11 +77,7 @@ describe('DaffMagentoConfigurableProductTransformers', () => {
 		it('should transform a MagentoConfigurableProductOptionsValue into a DaffConfigurableProductOptionValue', () => {
 			const magentoConfigurableOptionValue = {
 				value_index: parseInt(daffConfigurableProduct.configurableAttributes[0].values[0].value, 10),
-				label: daffConfigurableProduct.configurableAttributes[0].values[0].label,
-				swatch_data: {
-					value: daffConfigurableProduct.configurableAttributes[0].values[0].swatch.value,
-					thumbnail: daffConfigurableProduct.configurableAttributes[0].values[0].swatch.thumbnail
-				}
+				label: daffConfigurableProduct.configurableAttributes[0].values[0].label
 			};
 
 			expect(transformOptionValue(magentoConfigurableOptionValue)).toEqual(daffConfigurableProduct.configurableAttributes[0].values[0]);

--- a/libs/product/src/drivers/magento/transforms/configurable-product-transformers.ts
+++ b/libs/product/src/drivers/magento/transforms/configurable-product-transformers.ts
@@ -41,11 +41,7 @@ export function transformOption(option: MagentoConfigurableProductOption): DaffC
 export function transformOptionValue(value: MagentoConfigurableProductOptionsValue): DaffConfigurableProductOptionValue {
 	return {
 		value: value.value_index.toString(),
-		label: value.label,
-		swatch: {
-			value: value.swatch_data.value,
-			thumbnail: value.swatch_data.thumbnail
-		}
+		label: value.label
 	}
 }
 

--- a/libs/product/testing/src/factories/magento/configurable/configurable.factory.ts
+++ b/libs/product/testing/src/factories/magento/configurable/configurable.factory.ts
@@ -21,27 +21,15 @@ export class MockMagentoConfigurableProduct extends MockMagentoCoreProduct imple
 			values: [
 				{
 					label: 'Blue',
-					value_index: 0,
-					swatch_data: {
-						value: '#0000FF',
-						thumbnail: null
-					}
+					value_index: 0
 				},
 				{
 					label: 'Yellow',
-					value_index: 1,
-					swatch_data: {
-						value: '#FFFF00',
-						thumbnail: null
-					}
+					value_index: 1
 				},
 				{
 					label: 'Red',
-					value_index: 2,
-					swatch_data: {
-						value: '#FF0000',
-						thumbnail: null
-					}
+					value_index: 2
 				}
 			]
 		}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The configurable product query fragment was incorrect. It shouldn't be wrapped in the `items { }` object. Also, it seems that there is a bug in magento where you can't get swatches yet, because the graphQL call just fails and says there is no "swatch_data" field on a "ConfigurableProductOptionsValues". And the docs say otherwise (https://devdocs.magento.com/guides/v2.3/graphql/product/configurable-product.html#configProdOptionsValues).

## What is the new behavior?
Configurable product query is fixed. Removed swatch from magento things temporarily.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```