### PR TITLE
feat(design): add size options to the button component

### DIFF
--- a/libs/design/src/atoms/button/button.component.scss
+++ b/libs/design/src/atoms/button/button.component.scss
@@ -75,7 +75,27 @@
 	height: 40px;
 	line-height: 40px;
 	padding: 0;
-	width: 40px;
+
+	&.daff-sm {
+		font-size: $small-font-size;
+		line-height: 30px;
+		height: 30px;
+		width: 30px;
+	}
+
+	&.daff-md {
+		font-size: $normal-font-size;
+		line-height: 40px;
+		height: 40px;
+		width: 40px;
+	}
+
+	&.daff-lg {
+		font-size: $medium-font-size;
+		line-height: 50px;
+		height: 50px;
+		width: 50px;
+	}
 }
 
 .daff-stroked-button {
@@ -143,6 +163,18 @@
 			animation: underline-button-hover 700ms ease;
 		}
 	}
+
+	&.daff-sm {
+		font-size: $small-font-size;
+	}
+
+	&.daff-md {
+		font-size: $normal-font-size;
+	}
+
+	&.daff-lg {
+		font-size: $medium-font-size;
+	}
 }
 
 @keyframes underline-button-hover {
@@ -160,5 +192,21 @@
 
 	to {
 		transform: translateX(0);
+	}
+}
+
+.daff-button,
+.daff-raised-button,
+.daff-stroked-button {
+	&.daff-sm {
+		font-size: $small-font-size;
+	}
+
+	&.daff-md {
+		font-size: 1rem;
+	}
+
+	&.daff-lg {
+		font-size: $medium-font-size;
 	}
 }

--- a/libs/design/src/atoms/button/button.component.spec.ts
+++ b/libs/design/src/atoms/button/button.component.spec.ts
@@ -2,26 +2,27 @@ import { Component, DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffButtonComponent } from './button.component';
+import { DaffButtonComponent, DaffButtonSize } from './button.component';
 import { DaffPalette } from '../../core/colorable/colorable';
 
 @Component({
   template: `
-    <a daff-button [color]="color">Link Daff Button</a>
-    <a daff-stroked-button [color]="color">Link Daff Stroked Button</a>
-    <a daff-raised-button [color]="color">Link Daff Raised Button</a>
-    <a daff-icon-button [color]="color">Link Daff Icon Button</a>
-    <a daff-underline-button [color]="color">Link Daff Underline Button</a>
-    <button daff-button [color]="color">Button Daff Button</button>
-    <button daff-stroked-button [color]="color">Button Daff Stroked Button</button>
-    <button daff-raised-button [color]="color">Button Daff Raised Button</button>
-    <button daff-icon-button [color]="color">Button Daff Icon Button</button>
-    <button daff-underline-button [color]="color">Button Daff Underline Button</button>
+    <a daff-button [color]="color" [size]="size">Link Daff Button</a>
+    <a daff-stroked-button [color]="color" [size]="size">Link Daff Stroked Button</a>
+    <a daff-raised-button [color]="color" [size]="size">Link Daff Raised Button</a>
+    <a daff-icon-button [color]="color" [size]="size">Link Daff Icon Button</a>
+    <a daff-underline-button [color]="color" [size]="size">Link Daff Underline Button</a>
+    <button daff-button [color]="color" [size]="size">Button Daff Button</button>
+    <button daff-stroked-button [color]="color" [size]="size">Button Daff Stroked Button</button>
+    <button daff-raised-button [color]="color" [size]="size">Button Daff Raised Button</button>
+    <button daff-icon-button [color]="color" [size]="size">Button Daff Icon Button</button>
+    <button daff-underline-button [color]="color" [size]="size">Button Daff Underline Button</button>
   `
 })
 
 class WrapperComponent {
   color: DaffPalette;
+  size: DaffButtonSize;
 }
 
 describe('DaffButtonComponent', () => {
@@ -52,7 +53,7 @@ describe('DaffButtonComponent', () => {
     expect(wrapper).toBeTruthy();
   });
 
-  describe('daff-button', () => {
+  describe('<daff-button>', () => {
     beforeEach(() => {
       buttonDE = fixture.debugElement.query(By.css('button[daff-button]'));
       anchorDE = fixture.debugElement.query(By.css('a[daff-button]'));
@@ -69,7 +70,7 @@ describe('DaffButtonComponent', () => {
     });
     });
 
-  describe('daff-stroked-button', () => {
+  describe('<daff-stroked-button>', () => {
     beforeEach(() => {
       buttonDE = fixture.debugElement.query(By.css('button[daff-stroked-button]'));
       anchorDE = fixture.debugElement.query(By.css('a[daff-stroked-button]'));
@@ -86,7 +87,7 @@ describe('DaffButtonComponent', () => {
     });
     });
 
-  describe('daff-raised-button', () => {
+  describe('<daff-raised-button>', () => {
     beforeEach(() => {
       buttonDE = fixture.debugElement.query(By.css('button[daff-raised-button]'));
       anchorDE = fixture.debugElement.query(By.css('a[daff-raised-button]'));
@@ -103,7 +104,7 @@ describe('DaffButtonComponent', () => {
     });
   });
 
-  describe('daff-icon-button', () => {
+  describe('<daff-icon-butto>n', () => {
     beforeEach(() => {
       buttonDE = fixture.debugElement.query(By.css('button[daff-icon-button]'));
       anchorDE = fixture.debugElement.query(By.css('a[daff-icon-button]'));
@@ -120,13 +121,13 @@ describe('DaffButtonComponent', () => {
     });
   }); 
 
-  describe('daff-underline-button', () => {
+  describe('<daff-underline-button>', () => {
     beforeEach(() => {
       buttonDE = fixture.debugElement.query(By.css('button[daff-underline-button]'));
       anchorDE = fixture.debugElement.query(By.css('a[daff-underline-button]'));
     });
 
-    it('should add a class of `daff-underline-button` to its host element', () => {
+    it('should add a class of `daff-underline-button` to the host element', () => {
       expect(buttonDE.classes).toEqual(jasmine.objectContaining({
         'daff-underline-button': true,
       }));
@@ -137,8 +138,8 @@ describe('DaffButtonComponent', () => {
     });
   });
 
-  describe('using a colored variant of a button', () => {
-    it('should set a color class on the button', () => {
+  describe('using the color property of a button', () => {
+    it('should add the class of the defined color to the host element', () => {
       wrapper.color = 'primary';
       fixture.detectChanges();
       
@@ -146,8 +147,20 @@ describe('DaffButtonComponent', () => {
     });
 
     it('should not set a default color', () => {
-      buttonDE = fixture.debugElement.query(By.css('button[daff-button]'));
-      expect(buttonDE.nativeElement.classList.toString()).toEqual('daff-button');
+      expect(wrapper.color).toBeFalsy();
     });
   });
+
+  describe('using the size property of a button', () => {
+    it('should add the class of the defined size to the host element', () => {
+      wrapper.size = 'md';
+      fixture.detectChanges();
+
+      expect(de.nativeElement.classList.contains('daff-md')).toEqual(true);
+    });
+
+    it('should set the default size to md', () => {
+      expect(de.nativeElement.classList.contains('daff-md')).toEqual(true);
+    });
+  })
 });

--- a/libs/design/src/atoms/button/button.component.ts
+++ b/libs/design/src/atoms/button/button.component.ts
@@ -4,12 +4,16 @@ import {
 } from '@angular/core';
 
 import { daffColorMixin, DaffColorable, DaffPalette } from '../../core/colorable/colorable';
+
 import { 
   DaffPrefixable, 
   DaffSuffixable, 
   daffPrefixableMixin,
   daffSuffixableMixin
 } from '../../core/prefix-suffix/public_api';
+
+import { daffSizeMixin } from '../../core/sizeable/sizeable-mixin';
+import { DaffSizeable, DaffSizeSmallType, DaffSizeMediumType, DaffSizeLargeType } from '../../core/sizeable/sizeable';
 
 /**
 * List of classes to add to Daff Button instances based on host attributes to style as different variants.
@@ -29,9 +33,16 @@ class DaffButtonBase{
   constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
 }
 
-const _daffButtonBase = daffColorMixin(daffSuffixableMixin(daffPrefixableMixin(DaffButtonBase))); 
+const _daffButtonBase = 
+daffColorMixin(daffSuffixableMixin(daffPrefixableMixin(daffSizeMixin(DaffButtonBase, 'md')))); 
 
 export type DaffButtonType = 'daff-button' | 'daff-stroked-button' | 'daff-raised-button' | 'daff-icon-button' | 'daff-underline-button' | undefined;
+
+/**
+ * The DaffSizeable types that the DaffButtonComponent can implement
+ */
+export type DaffButtonSize = DaffSizeSmallType | DaffSizeMediumType | DaffSizeLargeType;
+
 enum DaffButtonTypeEnum {
   Default = 'daff-button',
   Stroked = 'daff-stroked-button',
@@ -59,10 +70,12 @@ enum DaffButtonTypeEnum {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 
-export class DaffButtonComponent extends _daffButtonBase 
-  implements OnInit, DaffPrefixable, DaffSuffixable, DaffColorable {
+export class DaffButtonComponent
+  extends _daffButtonBase
+  implements OnInit, DaffPrefixable, DaffSuffixable, DaffColorable, DaffSizeable<DaffButtonSize> {
     @Input() color: DaffPalette;
     buttonType: DaffButtonType;
+    @Input() size: DaffButtonSize;
 
     constructor(private elementRef: ElementRef, private renderer: Renderer2) {
       super(elementRef, renderer);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The button component does not have size options.

Fixes: N/A


## What is the new behavior?
Add `sm`, `md`, and `lg` size options for the button with `md` being the default size.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information