### PR TITLE
test(auth, geography, order): fix package names in spec messages

### DIFF
--- a/libs/auth/testing/src/factories/customer-registration.factory.spec.ts
+++ b/libs/auth/testing/src/factories/customer-registration.factory.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { DaffCustomerRegistration } from '@daffodil/auth';
 import { DaffCustomerRegistrationFactory } from './customer-registration.factory';
 
-describe('Core | Testing | Cart | Factories | CustomerRegistrationFactory', () => {
+describe('Auth | Testing | Factories | CustomerRegistrationFactory', () => {
 
   let customerRegistrationFactory: DaffCustomerRegistrationFactory;
 

--- a/libs/geography/testing/src/drivers/in-memory/geography.service.spec.ts
+++ b/libs/geography/testing/src/drivers/in-memory/geography.service.spec.ts
@@ -11,7 +11,7 @@ import { DaffCountryFactory } from '@daffodil/geography/testing';
 
 import { DaffInMemoryGeographyService } from './geography.service';
 
-describe('Driver | In Memory | Cart | CartService', () => {
+describe('Driver | In Memory | Geography | GeographyService', () => {
   let service: DaffInMemoryGeographyService;
   let httpMock: HttpTestingController;
   let countryFactory: DaffCountryFactory;

--- a/libs/geography/testing/src/factories/address.factory.spec.ts
+++ b/libs/geography/testing/src/factories/address.factory.spec.ts
@@ -3,7 +3,7 @@ import { TestBed, async } from '@angular/core/testing';
 import { DaffAddressFactory, MockDaffAddress } from './address.factory';
 import { DaffAddress } from '@daffodil/geography';
 
-describe('Core | Interfaces | Factories | DaffAddressFactory', () => {
+describe('Geography | Interfaces | Factories | DaffAddressFactory', () => {
 
   let daffodilAddressFactory;
 

--- a/libs/order/testing/src/factories/order-address.factory.spec.ts
+++ b/libs/order/testing/src/factories/order-address.factory.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { DaffOrderAddressFactory } from './order-address.factory';
 import { DaffOrderAddress } from '@daffodil/order';
 
-describe('Checkout | Testing | Order | Factories | OrderAddressFactory', () => {
+describe('Order | Testing | Factories | OrderAddressFactory', () => {
 
   let orderAddressFactory: DaffOrderAddressFactory;
 

--- a/libs/order/testing/src/factories/order-coupon.factory.spec.ts
+++ b/libs/order/testing/src/factories/order-coupon.factory.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { DaffOrderFactory } from './order.factory';
 import { DaffOrder } from '@daffodil/order';
 
-describe('Checkout | Testing | Order | Factories | DaffOrderFactory', () => {
+describe('Order | Testing | Factories | DaffOrderFactory', () => {
 
   let orderFactory: DaffOrderFactory;
 

--- a/libs/order/testing/src/factories/order-item.factory.spec.ts
+++ b/libs/order/testing/src/factories/order-item.factory.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { DaffOrderItemFactory } from './order-item.factory';
 import { DaffOrderItem } from '@daffodil/order';
 
-describe('Checkout | Testing | Order | Factories | OrderItemFactory', () => {
+describe('Order | Testing | Factories | OrderItemFactory', () => {
 
   let orderItemFactory: DaffOrderItemFactory;
 

--- a/libs/order/testing/src/factories/order-payment.factory.spec.ts
+++ b/libs/order/testing/src/factories/order-payment.factory.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { DaffOrderPayment } from '@daffodil/order';
 import { DaffOrderPaymentFactory } from './order-payment.factory';
 
-describe('Checkout | Testing | Order | Factories | OrderPaymentFactory', () => {
+describe('Order | Testing | Factories | OrderPaymentFactory', () => {
 
   let orderPaymentFactory: DaffOrderPaymentFactory;
 

--- a/libs/order/testing/src/factories/order-shipping-rate.factory.spec.ts
+++ b/libs/order/testing/src/factories/order-shipping-rate.factory.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import {  DaffOrderShippingMethod } from '@daffodil/order';
 import { DaffOrderShippingMethodFactory } from './order-shipping-rate.factory';
 
-describe('Checkout | Testing | Order | Factories | OrderShippingRateFactory', () => {
+describe('Order | Testing | Factories | OrderShippingRateFactory', () => {
 
   let orderShippingRateFactory: DaffOrderShippingMethodFactory;
 

--- a/libs/order/testing/src/factories/order.factory.spec.ts
+++ b/libs/order/testing/src/factories/order.factory.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { DaffOrderFactory } from './order.factory';
 import { DaffOrder } from '@daffodil/order';
 
-describe('Checkout | Testing | Order | Factories | DaffOrderFactory', () => {
+describe('Order | Testing | Factories | DaffOrderFactory', () => {
 
   let orderFactory: DaffOrderFactory;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Lots of specs have incorrect package names in the `describe` message.


## What is the new behavior?
The specs now have the correct package name.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information