### PR TITLE
feat(product): cover edge cases for configurable product state

### DIFF
--- a/libs/product/src/drivers/magento/transforms/configurable-product-transformer.spec.ts
+++ b/libs/product/src/drivers/magento/transforms/configurable-product-transformer.spec.ts
@@ -34,9 +34,6 @@ describe('DaffMagentoConfigurableProductTransformers', () => {
 				...daffConfigurableProductData,
 				type: DaffProductTypeEnum.Configurable
 			};
-			delete expected.configurableAttributes[0].values[0].swatch;
-			delete expected.configurableAttributes[0].values[1].swatch;
-			delete expected.configurableAttributes[0].values[2].swatch;
 
 			expect(transformMagentoConfigurableProduct(magentoConfigurableProductData, mediaUrl)).toEqual(expected);
 		});
@@ -93,6 +90,16 @@ describe('DaffMagentoConfigurableProductTransformers', () => {
 						code: daffConfigurableProduct.configurableAttributes[0].code,
 						label: daffConfigurableProduct.configurableAttributes[0].label,
 						value_index: parseInt(daffConfigurableProduct.configurableAttributes[0].values[0].value, 10)
+					},
+					{
+						code: daffConfigurableProduct.configurableAttributes[1].code,
+						label: daffConfigurableProduct.configurableAttributes[1].label,
+						value_index: parseInt(daffConfigurableProduct.configurableAttributes[1].values[0].value, 10)
+					},
+					{
+						code: daffConfigurableProduct.configurableAttributes[2].code,
+						label: daffConfigurableProduct.configurableAttributes[2].label,
+						value_index: parseInt(daffConfigurableProduct.configurableAttributes[2].values[0].value, 10)
 					}
 				],
 				product: {
@@ -129,6 +136,16 @@ describe('DaffMagentoConfigurableProductTransformers', () => {
 					code: daffConfigurableProduct.configurableAttributes[0].code,
 					label: daffConfigurableProduct.configurableAttributes[0].label,
 					value_index: parseInt(daffConfigurableProduct.configurableAttributes[0].values[0].value, 10)
+				},
+				{
+					code: daffConfigurableProduct.configurableAttributes[1].code,
+					label: daffConfigurableProduct.configurableAttributes[1].label,
+					value_index: parseInt(daffConfigurableProduct.configurableAttributes[1].values[0].value, 10)
+				},
+				{
+					code: daffConfigurableProduct.configurableAttributes[2].code,
+					label: daffConfigurableProduct.configurableAttributes[2].label,
+					value_index: parseInt(daffConfigurableProduct.configurableAttributes[2].values[0].value, 10)
 				}
 			];
 

--- a/libs/product/src/drivers/magento/transforms/spec-data/daff-configurable-product.json
+++ b/libs/product/src/drivers/magento/transforms/spec-data/daff-configurable-product.json
@@ -99,7 +99,7 @@
 				"size": "1",
 				"material": "0"
 			},
-			"price": "20",
+			"price": 20,
 			"discount": {
 				"amount": 2,
 				"percent": 10
@@ -117,7 +117,7 @@
 				"size": "1",
 				"material": "2"
 			},
-			"price": "25",
+			"price": 25,
 			"discount": {
 				"amount": 5,
 				"percent": 20
@@ -135,7 +135,7 @@
 				"size": "2",
 				"material": "0"
 			},
-			"price": "20",
+			"price": 20,
 			"discount": {
 				"amount": 2,
 				"percent": 10
@@ -171,7 +171,7 @@
 				"size": "0",
 				"material": "2"
 			},
-			"price": "25",
+			"price": 25,
 			"discount": {
 				"amount": 5,
 				"percent": 20
@@ -189,7 +189,7 @@
 				"size": "2",
 				"material": "0"
 			},
-			"price": "20",
+			"price": 20,
 			"discount": {
 				"amount": 2,
 				"percent": 10
@@ -225,7 +225,7 @@
 				"size": "0",
 				"material": "0"
 			},
-			"price": "20",
+			"price": 20,
 			"discount": {
 				"amount": 2,
 				"percent": 10
@@ -244,7 +244,7 @@
 				"size": "2",
 				"material": "0"
 			},
-			"price": "20",
+			"price": 20,
 			"discount": {
 				"amount": 2,
 				"percent": 10

--- a/libs/product/src/drivers/magento/transforms/spec-data/daff-configurable-product.json
+++ b/libs/product/src/drivers/magento/transforms/spec-data/daff-configurable-product.json
@@ -23,27 +23,53 @@
 			"values": [
 				{
 					"value": "0",
-					"label": "Blue",
-					"swatch": {
-						"value": "#0000FF",
-						"thumbnail": null
-					}
+					"label": "Blue"
 				},
 				{
 					"value": "1",
-					"label": "Yellow",
-					"swatch": {
-						"value": "#FFFF00",
-						"thumbnail": null
-					}
+					"label": "Yellow"
 				},
 				{
 					"value": "2",
-					"label": "Red",
-					"swatch": {
-						"value": "#FF0000",
-						"thumbnail": null
-					}
+					"label": "Red"
+				}
+			]
+		},
+		{
+			"code": "size",
+			"label": "Size",
+			"order": 1,
+			"values": [
+				{
+					"value": "0",
+					"label": "Small"
+				},
+				{
+					"value": "1",
+					"label": "Medium"
+				},
+				{
+					"value": "2",
+					"label": "Large"
+				}
+			]
+		},
+		{
+			"code": "material",
+			"label": "Material",
+			"order": 2,
+			"values": [
+				{
+					"value": "0",
+					"label": "Cotton"
+				},
+				{
+					"value": "1",
+					"label": "Polyester"
+				},
+				{
+					"value": "2",
+					"label": "Spandex"
 				}
 			]
 		}
@@ -51,7 +77,9 @@
 	"variants": [
 		{
 			"appliedAttributes": {
-				"color": "0"
+				"color": "0",
+				"size": "0",
+				"material": "0"
 			},
 			"price": 20,
 			"discount": {
@@ -67,12 +95,68 @@
 		},
 		{
 			"appliedAttributes": {
-				"color": "1"
+				"color": "0",
+				"size": "1",
+				"material": "0"
 			},
-			"price": 23,
+			"price": "20",
 			"discount": {
 				"amount": 2,
-				"percent": 8.7
+				"percent": 10
+			},
+			"id": "22-11",
+			"image": {
+				"id": "0",
+				"url": "url-01",
+				"label": "image-label-01"
+			}
+		},
+		{
+			"appliedAttributes": {
+				"color": "0",
+				"size": "1",
+				"material": "2"
+			},
+			"price": "25",
+			"discount": {
+				"amount": 5,
+				"percent": 20
+			},
+			"id": "22-12",
+			"image": {
+				"id": "0",
+				"url": "url-02",
+				"label": "image-label-02"
+			}
+		},
+		{
+			"appliedAttributes": {
+				"color": "0",
+				"size": "2",
+				"material": "0"
+			},
+			"price": "20",
+			"discount": {
+				"amount": 2,
+				"percent": 10
+			},
+			"id": "22-13",
+			"image": {
+				"id": "0",
+				"url": "url-03",
+				"label": "image-label-03"
+			}
+		},
+		{
+			"appliedAttributes": {
+				"color": "1",
+				"size": "0",
+				"material": "0"
+			},
+			"price": 20,
+			"discount": {
+				"amount": 2,
+				"percent": 10
 			},
 			"id": "22-2",
 			"image": {
@@ -83,18 +167,93 @@
 		},
 		{
 			"appliedAttributes": {
-				"color": "2"
+				"color": "1",
+				"size": "0",
+				"material": "2"
 			},
-			"price": 23,
+			"price": "25",
+			"discount": {
+				"amount": 5,
+				"percent": 20
+			},
+			"id": "22-21",
+			"image": {
+				"id": "0",
+				"url": "url-11",
+				"label": "image-label-11"
+			}
+		},
+		{
+			"appliedAttributes": {
+				"color": "1",
+				"size": "2",
+				"material": "0"
+			},
+			"price": "20",
 			"discount": {
 				"amount": 2,
-				"percent": 8.7
+				"percent": 10
+			},
+			"id": "22-22",
+			"image": {
+				"id": "0",
+				"url": "url-12",
+				"label": "image-label-12"
+			}
+		},
+		{
+			"appliedAttributes": {
+				"color": "1",
+				"size": "2",
+				"material": "1"
+			},
+			"price": 20,
+			"discount": {
+				"amount": 2,
+				"percent": 10
+			},
+			"id": "22-23",
+			"image": {
+				"id": "0",
+				"url": "url-13",
+				"label": "image-label-13"
+			}
+		},
+		{
+			"appliedAttributes": {
+				"color": "2",
+				"size": "0",
+				"material": "0"
+			},
+			"price": "20",
+			"discount": {
+				"amount": 2,
+				"percent": 10
 			},
 			"id": "22-3",
 			"image": {
 				"id": "0",
 				"url": "url-2",
 				"label": "image-label-2"
+			}
+		},
+
+		{
+			"appliedAttributes": {
+				"color": "2",
+				"size": "2",
+				"material": "0"
+			},
+			"price": "20",
+			"discount": {
+				"amount": 2,
+				"percent": 10
+			},
+			"id": "22-31",
+			"image": {
+				"id": "0",
+				"url": "url-21",
+				"label": "image-label-21"
 			}
 		}
 	]

--- a/libs/product/src/drivers/magento/transforms/spec-data/magento-configurable-product.json
+++ b/libs/product/src/drivers/magento/transforms/spec-data/magento-configurable-product.json
@@ -58,6 +58,56 @@
 			"attribute_id": null,
 			"product_id": null,
 			"id": null
+		},
+		{
+			"position": 1,
+			"attribute_code": "size",
+			"label": "Size",
+			"values": [
+				{
+					"value_index": 0,
+					"label": "Small",
+					"swatch_data": null
+				},
+				{
+					"value_index": 1,
+					"label": "Medium",
+					"swatch_data": null
+				},
+				{
+					"value_index": 2,
+					"label": "Large",
+					"swatch_data": null
+				}
+			],
+			"attribute_id": null,
+			"product_id": null,
+			"id": null
+		},
+		{
+			"position": 2,
+			"attribute_code": "material",
+			"label": "Material",
+			"values": [
+				{
+					"value_index": 0,
+					"label": "Cotton",
+					"swatch_data": null
+				},
+				{
+					"value_index": 1,
+					"label": "Polyester",
+					"swatch_data": null
+				},
+				{
+					"value_index": 2,
+					"label": "Spandex",
+					"swatch_data": null
+				}
+			],
+			"attribute_id": null,
+			"product_id": null,
+			"id": null
 		}
 	],
 	"variants": [
@@ -66,6 +116,16 @@
 				{
 					"code": "color",
 					"label": "Blue",
+					"value_index": 0
+				},
+				{
+					"code": "size",
+					"label": "Small",
+					"value_index": 0
+				},
+				{
+					"code": "material",
+					"label": "Cotton",
 					"value_index": 0
 				}
 			],
@@ -98,8 +158,147 @@
 			"attributes": [
 				{
 					"code": "color",
+					"label": "Blue",
+					"value_index": 0
+				},
+				{
+					"code": "size",
+					"label": "Medium",
+					"value_index": 1
+				},
+				{
+					"code": "material",
+					"label": "Cotton",
+					"value_index": 0
+				}
+			],
+			"product": {
+				"image": {
+					"url": "url-01",
+					"label": "image-label-01"
+				},
+				"price_range": {
+					"maximum_price": {
+						"regular_price": {
+							"value": 20,
+							"currency": null
+						},
+						"discount": {
+							"amount_off": 2,
+							"percent_off": 10
+						}
+					}
+				},
+				"sku": "22-11", 
+				"id": null, 
+				"name": null, 
+				"__typename": null,
+				"url_key": null, 
+				"thumbnail": null
+			}
+		},
+		{
+			"attributes": [
+				{
+					"code": "color",
+					"label": "Blue",
+					"value_index": 0
+				},
+				{
+					"code": "size",
+					"label": "Medium",
+					"value_index": 1
+				},
+				{
+					"code": "material",
+					"label": "Spandex",
+					"value_index": 2
+				}
+			],
+			"product": {
+				"image": {
+					"url": "url-02",
+					"label": "image-label-02"
+				},
+				"price_range": {
+					"maximum_price": {
+						"regular_price": {
+							"value": 25,
+							"currency": null
+						},
+						"discount": {
+							"amount_off": 5,
+							"percent_off": 20
+						}
+					}
+				},
+				"sku": "22-12", 
+				"id": null, 
+				"name": null, 
+				"__typename": null,
+				"url_key": null, 
+				"thumbnail": null
+			}
+		},
+		{
+			"attributes": [
+				{
+					"code": "color",
+					"label": "Blue",
+					"value_index": 0
+				},
+				{
+					"code": "size",
+					"label": "Large",
+					"value_index": 2
+				},
+				{
+					"code": "material",
+					"label": "Cotton",
+					"value_index": 0
+				}
+			],
+			"product": {
+				"image": {
+					"url": "url-03",
+					"label": "image-label-03"
+				},
+				"price_range": {
+					"maximum_price": {
+						"regular_price": {
+							"value": 20,
+							"currency": null
+						},
+						"discount": {
+							"amount_off": 2,
+							"percent_off": 10
+						}
+					}
+				},
+				"sku": "22-13", 
+				"id": null, 
+				"name": null, 
+				"__typename": null,
+				"url_key": null, 
+				"thumbnail": null
+			}
+		},
+		{
+			"attributes": [
+				{
+					"code": "color",
 					"label": "Yellow",
 					"value_index": 1
+				},
+				{
+					"code": "size",
+					"label": "Small",
+					"value_index": 0
+				},
+				{
+					"code": "material",
+					"label": "Cotton",
+					"value_index": 0
 				}
 			],
 			"product": {
@@ -110,12 +309,12 @@
 				"price_range": {
 					"maximum_price": {
 						"regular_price": {
-							"value": 23,
+							"value": 20,
 							"currency": null
 						},
 						"discount": {
 							"amount_off": 2,
-							"percent_off": 8.7
+							"percent_off": 10
 						}
 					}
 				},
@@ -131,8 +330,147 @@
 			"attributes": [
 				{
 					"code": "color",
+					"label": "Yellow",
+					"value_index": 1
+				},
+				{
+					"code": "size",
+					"label": "Small",
+					"value_index": 0
+				},
+				{
+					"code": "material",
+					"label": "Spandex",
+					"value_index": 2
+				}
+			],
+			"product": {
+				"image": {
+					"url": "url-11",
+					"label": "image-label-11"
+				},
+				"price_range": {
+					"maximum_price": {
+						"regular_price": {
+							"value": 25,
+							"currency": null
+						},
+						"discount": {
+							"amount_off": 5,
+							"percent_off": 20
+						}
+					}
+				},
+				"sku": "22-21", 
+				"id": null, 
+				"name": null, 
+				"__typename": null,
+				"url_key": null, 
+				"thumbnail": null
+			}
+		},
+		{
+			"attributes": [
+				{
+					"code": "color",
+					"label": "Yellow",
+					"value_index": 1
+				},
+				{
+					"code": "size",
+					"label": "Large",
+					"value_index": 2
+				},
+				{
+					"code": "material",
+					"label": "Cotton",
+					"value_index": 0
+				}
+			],
+			"product": {
+				"image": {
+					"url": "url-12",
+					"label": "image-label-12"
+				},
+				"price_range": {
+					"maximum_price": {
+						"regular_price": {
+							"value": 20,
+							"currency": null
+						},
+						"discount": {
+							"amount_off": 2,
+							"percent_off": 10
+						}
+					}
+				},
+				"sku": "22-22", 
+				"id": null, 
+				"name": null, 
+				"__typename": null,
+				"url_key": null, 
+				"thumbnail": null
+			}
+		},
+		{
+			"attributes": [
+				{
+					"code": "color",
+					"label": "Yellow",
+					"value_index": 1
+				},
+				{
+					"code": "size",
+					"label": "Large",
+					"value_index": 2
+				},
+				{
+					"code": "material",
+					"label": "Polyester",
+					"value_index": 1
+				}
+			],
+			"product": {
+				"image": {
+					"url": "url-13",
+					"label": "image-label-13"
+				},
+				"price_range": {
+					"maximum_price": {
+						"regular_price": {
+							"value": 20,
+							"currency": null
+						},
+						"discount": {
+							"amount_off": 2,
+							"percent_off": 10
+						}
+					}
+				},
+				"sku": "22-23", 
+				"id": null, 
+				"name": null, 
+				"__typename": null,
+				"url_key": null, 
+				"thumbnail": null
+			}
+		},
+		{
+			"attributes": [
+				{
+					"code": "color",
 					"label": "Red",
 					"value_index": 2
+				},
+				{
+					"code": "size",
+					"label": "Small",
+					"value_index": 0
+				},
+				{
+					"code": "material",
+					"label": "Cotton",
+					"value_index": 0
 				}
 			],
 			"product": {
@@ -143,16 +481,59 @@
 				"price_range": {
 					"maximum_price": {
 						"regular_price": {
-							"value": 23,
+							"value": 20,
 							"currency": null
 						},
 						"discount": {
 							"amount_off": 2,
-							"percent_off": 8.7
+							"percent_off": 10
 						}
 					}
 				},
 				"sku": "22-3", 
+				"id": null, 
+				"name": null, 
+				"__typename": null,
+				"url_key": null, 
+				"thumbnail": null
+			}
+		},
+		{
+			"attributes": [
+				{
+					"code": "color",
+					"label": "Red",
+					"value_index": 2
+				},
+				{
+					"code": "size",
+					"label": "Large",
+					"value_index": 2
+				},
+				{
+					"code": "material",
+					"label": "Cotton",
+					"value_index": 0
+				}
+			],
+			"product": {
+				"image": {
+					"url": "url-21",
+					"label": "image-label-21"
+				},
+				"price_range": {
+					"maximum_price": {
+						"regular_price": {
+							"value": 20,
+							"currency": null
+						},
+						"discount": {
+							"amount_off": 2,
+							"percent_off": 10
+						}
+					}
+				},
+				"sku": "22-31", 
 				"id": null, 
 				"name": null, 
 				"__typename": null,

--- a/libs/product/src/facades/configurable-product/configurable-product-facade.interface.ts
+++ b/libs/product/src/facades/configurable-product/configurable-product-facade.interface.ts
@@ -7,6 +7,12 @@ import { DaffStoreFacade } from '@daffodil/core';
 export interface DaffConfigurableProductFacadeInterface extends DaffStoreFacade<Action> {
 
 	/**
+	 * All attributes of a configurable product.
+	 * @param id the id of the configurable product.
+	 */
+	getAllAttributes(id: string): Observable<Dictionary<string[]>>;
+
+	/**
 	 * The applied attributes of a configurable product.
 	 * @param id the id of the configurable product.
 	 */
@@ -20,9 +26,9 @@ export interface DaffConfigurableProductFacadeInterface extends DaffStoreFacade<
 	getPrice(id: string): Observable<string>;
 
 	/**
-	 * The attributes that have not been determined by selected attributes. These are determined
-	 * by the variants that are still possible.
+	 * Selectable configurable product attributes derived from the remaining variants and the order of currently applied attributes.
+	 * The remaining variants of the product are derived from the currently applied attributes.
 	 * @param id the id of the configurable product.
 	 */
-	getUndeterminedAttributes(id: string): Observable<Dictionary<string[]>>;
+	getSelectableAttributes(id: string): Observable<Dictionary<string[]>>;
 }

--- a/libs/product/src/facades/configurable-product/configurable-product.facade.spec.ts
+++ b/libs/product/src/facades/configurable-product/configurable-product.facade.spec.ts
@@ -50,12 +50,42 @@ describe('DaffConfigurableProductFacade', () => {
     expect(store.dispatch).toHaveBeenCalledTimes(1);
   });
 
+  describe('getAllAttributes', () => {
+
+    it('should return an Observable dictionary of all attributes', () => {
+			const expected = cold('a', { 
+				a: {
+					[stubConfigurableProduct.configurableAttributes[0].code]: [
+						stubConfigurableProduct.configurableAttributes[0].values[0].value,
+						stubConfigurableProduct.configurableAttributes[0].values[1].value,
+						stubConfigurableProduct.configurableAttributes[0].values[2].value
+					],
+					[stubConfigurableProduct.configurableAttributes[1].code]: [
+						stubConfigurableProduct.configurableAttributes[1].values[0].value,
+						stubConfigurableProduct.configurableAttributes[1].values[1].value,
+						stubConfigurableProduct.configurableAttributes[1].values[2].value
+					],
+					[stubConfigurableProduct.configurableAttributes[2].code]: [
+						stubConfigurableProduct.configurableAttributes[2].values[0].value,
+						stubConfigurableProduct.configurableAttributes[2].values[1].value,
+						stubConfigurableProduct.configurableAttributes[2].values[2].value,
+					]
+				} 
+			});
+      store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				stubConfigurableProduct.configurableAttributes[0].code,
+				stubConfigurableProduct.configurableAttributes[0].values[0].value
+			));
+			expect(facade.getAllAttributes(stubConfigurableProduct.id)).toBeObservable(expected);
+		});
+  });
+
   describe('getAppliedAttributes', () => {
 
     it('should return an Observable dictionary of applied attributes', () => {
 			const expected = cold('a', { 
 				a: {
-					id: stubConfigurableProduct.id,
 					[stubConfigurableProduct.configurableAttributes[0].code]: stubConfigurableProduct.configurableAttributes[0].values[0].value
 				} 
 			});
@@ -77,11 +107,21 @@ describe('DaffConfigurableProductFacade', () => {
 				stubConfigurableProduct.configurableAttributes[0].code,
 				stubConfigurableProduct.configurableAttributes[0].values[0].value
 			));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				stubConfigurableProduct.configurableAttributes[1].code,
+				stubConfigurableProduct.configurableAttributes[1].values[0].value
+			));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				stubConfigurableProduct.configurableAttributes[2].code,
+				stubConfigurableProduct.configurableAttributes[2].values[0].value
+			));
 			expect(facade.getPrice(stubConfigurableProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getUndeterminedAttributes', () => {
+  describe('getSelectableAttributes', () => {
 
     it('should return an Observable string of the price/price-range for a configurable product', () => {
 			const expected = cold('a', { 
@@ -90,11 +130,21 @@ describe('DaffConfigurableProductFacade', () => {
 						stubConfigurableProduct.configurableAttributes[0].values[0].value,
 						stubConfigurableProduct.configurableAttributes[0].values[1].value,
 						stubConfigurableProduct.configurableAttributes[0].values[2].value
+					],
+					[stubConfigurableProduct.configurableAttributes[1].code]: [
+						stubConfigurableProduct.configurableAttributes[1].values[0].value,
+						stubConfigurableProduct.configurableAttributes[1].values[1].value,
+						stubConfigurableProduct.configurableAttributes[1].values[2].value
+					],
+					[stubConfigurableProduct.configurableAttributes[2].code]: [
+						stubConfigurableProduct.configurableAttributes[2].values[0].value,
+						stubConfigurableProduct.configurableAttributes[2].values[1].value,
+						stubConfigurableProduct.configurableAttributes[2].values[2].value
 					]
 				}
 			});
 
-			expect(facade.getUndeterminedAttributes(stubConfigurableProduct.id)).toBeObservable(expected);
+			expect(facade.getSelectableAttributes(stubConfigurableProduct.id)).toBeObservable(expected);
 		});
   });
 });

--- a/libs/product/src/facades/configurable-product/configurable-product.facade.spec.ts
+++ b/libs/product/src/facades/configurable-product/configurable-product.facade.spec.ts
@@ -123,7 +123,7 @@ describe('DaffConfigurableProductFacade', () => {
 
   describe('getSelectableAttributes', () => {
 
-    it('should return an Observable string of the price/price-range for a configurable product', () => {
+    it('should return the selectable attributes for a configurable product', () => {
 			const expected = cold('a', { 
 				a: {
 					[stubConfigurableProduct.configurableAttributes[0].code]: [

--- a/libs/product/src/facades/configurable-product/configurable-product.facade.ts
+++ b/libs/product/src/facades/configurable-product/configurable-product.facade.ts
@@ -19,18 +19,22 @@ export class DaffConfigurableProductFacade<T extends DaffProduct = DaffProduct> 
 
 	selectors = getDaffProductSelectors<T>();
 	
-  constructor(private store: Store<DaffProductReducersState<T>>) {}
+	constructor(private store: Store<DaffProductReducersState<T>>) {}
+	
+	getAllAttributes(id: string): Observable<Dictionary<string[]>> {
+		return this.store.pipe(select(this.selectors.selectAllConfigurableProductAttributes, { id }));
+	}
 	
 	getAppliedAttributes(id: string): Observable<Dictionary<string>> {
-		return this.store.pipe(select(this.selectors.selectConfigurableProductAppliedAttributes, { id }))
+		return this.store.pipe(select(this.selectors.selectConfigurableProductAppliedAttributesAsDictionary, { id }));
 	}
 
 	getPrice(id: string): Observable<string> {
 		return this.store.pipe(select(this.selectors.selectConfigurableProductPrice, { id }));
 	}
 
-	getUndeterminedAttributes(id: string): Observable<Dictionary<string[]>> {
-		return this.store.pipe(select(this.selectors.selectUndeterminedConfigurableProductAttributes, { id }));
+	getSelectableAttributes(id: string): Observable<Dictionary<string[]>> {
+		return this.store.pipe(select(this.selectors.selectSelectableConfigurableProductAttributes, { id }));
 	}
 
   /**

--- a/libs/product/src/reducers/configurable-product-entities/configurable-product-entities-reducer-adapter.ts
+++ b/libs/product/src/reducers/configurable-product-entities/configurable-product-entities-reducer-adapter.ts
@@ -1,12 +1,12 @@
 import { EntityAdapter, createEntityAdapter } from '@ngrx/entity';
 
-import { DaffProductVariantAttributesDictionary } from '../../models/configurable-product';
+import { DaffConfigurableProductEntity } from './configurable-product-entity';
 
 /**
  * Configurable Product Applied Attributes Adapter for changing/overwriting entity state.
  */
 export const daffConfigurableProductAppliedAttributesEntitiesAdapter = (() => {
 	let cache;
-  return (): EntityAdapter<DaffProductVariantAttributesDictionary> =>
-    cache = cache || createEntityAdapter<DaffProductVariantAttributesDictionary>();
+  return (): EntityAdapter<DaffConfigurableProductEntity> =>
+    cache = cache || createEntityAdapter<DaffConfigurableProductEntity>();
 })();

--- a/libs/product/src/reducers/configurable-product-entities/configurable-product-entities.reducer.spec.ts
+++ b/libs/product/src/reducers/configurable-product-entities/configurable-product-entities.reducer.spec.ts
@@ -94,7 +94,7 @@ describe('Product | Product Entities Reducer', () => {
     it('sets a configurable product entity when the given product is configurable', () => {
 			const productLoadSuccess = new DaffProductLoadSuccess(configurableProduct);
 			result = daffConfigurableProductEntitiesReducer(initialState, productLoadSuccess);
-			expect(result.entities[configurableProduct.id]).toEqual({ id: configurableProduct.id });
+			expect(result.entities[configurableProduct.id]).toEqual({ id: configurableProduct.id, attributes: [] });
     });
 		
     it('does not set a configurable product entity when the given product is not configurable', () => {
@@ -113,7 +113,8 @@ describe('Product | Product Entities Reducer', () => {
 				ids: [configurableProduct.id],
 				entities: {
 					[configurableProduct.id]: {
-						id: configurableProduct.id
+						id: configurableProduct.id,
+						attributes: []
 					}
 				}
 			}
@@ -130,7 +131,10 @@ describe('Product | Product Entities Reducer', () => {
     it('adds a configurable product attribute to its corresponding entity', () => {
       expect(result.entities[configurableProduct.id]).toEqual({
 				id: configurableProduct.id,
-				[configurableProduct.configurableAttributes[0].code]: configurableProduct.configurableAttributes[0].values[0].value
+				attributes: [{
+					code: configurableProduct.configurableAttributes[0].code,
+					value: configurableProduct.configurableAttributes[0].values[0].value
+				}]
 			});
     });
   });
@@ -145,7 +149,10 @@ describe('Product | Product Entities Reducer', () => {
 				entities: {
 					[configurableProduct.id]: {
 						id: configurableProduct.id,
-						[configurableProduct.configurableAttributes[0].code]: configurableProduct.configurableAttributes[0].values[0].value
+						attributes: [{
+							code: configurableProduct.configurableAttributes[0].code,
+							value: configurableProduct.configurableAttributes[0].values[0].value
+						}]
 					}
 				}
 			}
@@ -160,7 +167,8 @@ describe('Product | Product Entities Reducer', () => {
 
     it('removes a configurable product attribute from its corresponding entity', () => {
       expect(result.entities[configurableProduct.id]).toEqual({
-				id: configurableProduct.id
+				id: configurableProduct.id,
+				attributes: []
 			});
     });
   });
@@ -176,7 +184,10 @@ describe('Product | Product Entities Reducer', () => {
 					entities: {
 						[configurableProduct.id]: {
 							id: configurableProduct.id,
-							[configurableProduct.configurableAttributes[0].code]: configurableProduct.configurableAttributes[0].values[0].value
+							attributes: [{
+								code: configurableProduct.configurableAttributes[0].code,
+								value: configurableProduct.configurableAttributes[0].values[0].value
+							}]
 						}
 					}
 				}
@@ -192,7 +203,8 @@ describe('Product | Product Entities Reducer', () => {
 	
 			it('removes a configurable product attribute from its corresponding entity', () => {
 				expect(result.entities[configurableProduct.id]).toEqual({
-					id: configurableProduct.id
+					id: configurableProduct.id,
+					attributes: []
 				});
 			});
 		});
@@ -204,7 +216,8 @@ describe('Product | Product Entities Reducer', () => {
 					ids: [configurableProduct.id],
 					entities: {
 						[configurableProduct.id]: {
-							id: configurableProduct.id
+							id: configurableProduct.id,
+							attributes: []
 						}
 					}
 				}
@@ -221,7 +234,10 @@ describe('Product | Product Entities Reducer', () => {
 			it('adds a configurable product attribute to its corresponding entity', () => {
 				expect(result.entities[configurableProduct.id]).toEqual({ 
 					id: configurableProduct.id, 
-					[configurableProduct.configurableAttributes[0].code]: configurableProduct.configurableAttributes[0].values[0].value
+					attributes: [{
+						code: configurableProduct.configurableAttributes[0].code,
+						value: configurableProduct.configurableAttributes[0].values[0].value
+					}]
 				});
 			});
 		});
@@ -234,7 +250,10 @@ describe('Product | Product Entities Reducer', () => {
 					entities: {
 						[configurableProduct.id]: {
 							id: configurableProduct.id,
-							[configurableProduct.configurableAttributes[0].code]: configurableProduct.configurableAttributes[0].values[0].value
+							attributes: [{
+								code: configurableProduct.configurableAttributes[0].code,
+								value: configurableProduct.configurableAttributes[0].values[0].value
+							}]
 						}
 					}
 				}
@@ -251,7 +270,10 @@ describe('Product | Product Entities Reducer', () => {
 			it('adds a configurable product attribute to its corresponding entity', () => {
 				expect(result.entities[configurableProduct.id]).toEqual({ 
 					id: configurableProduct.id, 
-					[configurableProduct.configurableAttributes[0].code]: configurableProduct.configurableAttributes[0].values[1].value
+					attributes: [{
+						code: configurableProduct.configurableAttributes[0].code,
+						value: configurableProduct.configurableAttributes[0].values[1].value
+					}]
 				});
 			});
 		});

--- a/libs/product/src/reducers/configurable-product-entities/configurable-product-entities.reducer.ts
+++ b/libs/product/src/reducers/configurable-product-entities/configurable-product-entities.reducer.ts
@@ -26,13 +26,13 @@ export function daffConfigurableProductEntitiesReducer<T extends DaffProduct, V 
 			return adapter.upsertMany(
 				action.payload
 					.filter(product => product.type === DaffProductTypeEnum.Configurable)
-					.map((product) => buildConfigurableProductAppliedAttributesEntity(product.id)), 
+					.map(buildConfigurableProductAppliedAttributesEntity), 
 				state
 			);
     case DaffProductActionTypes.ProductLoadSuccessAction:
 			if(action.payload.type === DaffProductTypeEnum.Configurable) {
 				return adapter.upsertOne(
-					buildConfigurableProductAppliedAttributesEntity(action.payload.id),
+					buildConfigurableProductAppliedAttributesEntity(action.payload),
 					state
 				);
 			};
@@ -68,9 +68,9 @@ export function daffConfigurableProductEntitiesReducer<T extends DaffProduct, V 
   }
 }
 
-function buildConfigurableProductAppliedAttributesEntity(productId: string): DaffConfigurableProductEntity {
+function buildConfigurableProductAppliedAttributesEntity(product: DaffProduct): DaffConfigurableProductEntity {
 	return {
-		id: productId,
+		id: product.id,
 		attributes: []
 	}
 }

--- a/libs/product/src/reducers/configurable-product-entities/configurable-product-entity.ts
+++ b/libs/product/src/reducers/configurable-product-entities/configurable-product-entity.ts
@@ -1,0 +1,9 @@
+export interface DaffConfigurableProductEntity {
+	id: string;
+	attributes: DaffConfigurableProductEntityAttribute[];
+}
+
+export interface DaffConfigurableProductEntityAttribute {
+	code: string;
+	value: string;
+}

--- a/libs/product/src/reducers/product-reducers-state.interface.ts
+++ b/libs/product/src/reducers/product-reducers-state.interface.ts
@@ -4,7 +4,7 @@ import { DaffProduct } from '../models/product';
 import { DaffProductGridReducerState } from './product-grid/product-grid-reducer-state.interface';
 import { DaffProductReducerState } from './product/product-reducer-state.interface';
 import { DaffBestSellersReducerState } from './best-sellers/best-sellers-reducer-state.interface';
-import { DaffProductVariantAttributesDictionary } from '../models/configurable-product';
+import { DaffConfigurableProductEntity } from './configurable-product-entities/configurable-product-entity';
 
 /**
  * Interface for product redux store.
@@ -14,5 +14,5 @@ export interface DaffProductReducersState<T extends DaffProduct = DaffProduct> {
   productGrid: DaffProductGridReducerState<T>;
   product: DaffProductReducerState;
 	bestSellers: DaffBestSellersReducerState;
-	configurableProductAttributes: EntityState<DaffProductVariantAttributesDictionary>;
+	configurableProductAttributes: EntityState<DaffConfigurableProductEntity>;
 }

--- a/libs/product/src/selectors/configurable-product-entities/configurable-product-entities.selectors.spec.ts
+++ b/libs/product/src/selectors/configurable-product-entities/configurable-product-entities.selectors.spec.ts
@@ -21,7 +21,6 @@ describe('selectConfigurableProductEntitiesState', () => {
 	const {
 		selectConfigurableProductIds,
 		selectConfigurableProductAppliedAttributesEntities,
-		selectAllConfigurableProductAppliedAttributeDictionaries,
 		selectConfigurableProductTotal,
 		selectConfigurableProductAppliedAttributes,
 		selectConfigurableProductAppliedAttributesAsDictionary
@@ -60,38 +59,20 @@ describe('selectConfigurableProductEntitiesState', () => {
 	describe('selectConfigurableProductAppliedAttributesEntities', () => {
 		
 		it('selects configurable product attributes as a dictionary object', () => {
-			const expectedDictionary = new Object();
-			expectedDictionary[stubConfigurableProduct.id] = {
-				id: stubConfigurableProduct.id,
-				attributes: [
-					{
-						code: stubConfigurableProduct.configurableAttributes[0].code, 
-						value: stubConfigurableProduct.configurableAttributes[0].values[0].value
-					}
-				]
-			}
-
-			const selector = store.pipe(select(selectConfigurableProductAppliedAttributesEntities));
-			const expected = cold('a', { a: expectedDictionary });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectAllConfigurableProductAppliedAttributeDictionaries', () => {
-		
-		it('selects all configurable product attributes as an array', () => {
-			const selector = store.pipe(select(selectAllConfigurableProductAppliedAttributeDictionaries));
-			const expected = cold('a', { 
-				a: [{ 
-					id: stubConfigurableProduct.id, attributes: [
+			const expectedDictionary = {
+				[stubConfigurableProduct.id]: {
+					id: stubConfigurableProduct.id,
+					attributes: [
 						{
 							code: stubConfigurableProduct.configurableAttributes[0].code, 
 							value: stubConfigurableProduct.configurableAttributes[0].values[0].value
 						}
-					] 
-				}]
-			});
+					]
+				}
+			}
+
+			const selector = store.pipe(select(selectConfigurableProductAppliedAttributesEntities));
+			const expected = cold('a', { a: expectedDictionary });
 
 			expect(selector).toBeObservable(expected);
 		});

--- a/libs/product/src/selectors/configurable-product-entities/configurable-product-entities.selectors.spec.ts
+++ b/libs/product/src/selectors/configurable-product-entities/configurable-product-entities.selectors.spec.ts
@@ -7,7 +7,8 @@ import {
 	DaffProductGridLoadSuccess,
 	DaffProductReducersState,
 	daffProductReducers,
-	DaffConfigurableProduct
+	DaffConfigurableProduct,
+	DaffConfigurableProductApplyAttribute
 } from '@daffodil/product';
 
 import { getDaffConfigurableProductEntitiesSelectors } from './configurable-product-entities.selectors';
@@ -22,7 +23,8 @@ describe('selectConfigurableProductEntitiesState', () => {
 		selectConfigurableProductAppliedAttributesEntities,
 		selectAllConfigurableProductAppliedAttributeDictionaries,
 		selectConfigurableProductTotal,
-		selectConfigurableProductAppliedAttributes
+		selectConfigurableProductAppliedAttributes,
+		selectConfigurableProductAppliedAttributesAsDictionary
 	} = getDaffConfigurableProductEntitiesSelectors();
   
   beforeEach(() => {
@@ -38,6 +40,11 @@ describe('selectConfigurableProductEntitiesState', () => {
     store = TestBed.get(Store);
 
     store.dispatch(new DaffProductGridLoadSuccess(new Array(stubConfigurableProduct)));
+    store.dispatch(new DaffConfigurableProductApplyAttribute(
+			stubConfigurableProduct.id, 
+			stubConfigurableProduct.configurableAttributes[0].code, 
+			stubConfigurableProduct.configurableAttributes[0].values[0].value
+		));
   });
     
 	describe('selectConfigurableProductIds', () => {
@@ -55,7 +62,13 @@ describe('selectConfigurableProductEntitiesState', () => {
 		it('selects configurable product attributes as a dictionary object', () => {
 			const expectedDictionary = new Object();
 			expectedDictionary[stubConfigurableProduct.id] = {
-				id: stubConfigurableProduct.id
+				id: stubConfigurableProduct.id,
+				attributes: [
+					{
+						code: stubConfigurableProduct.configurableAttributes[0].code, 
+						value: stubConfigurableProduct.configurableAttributes[0].values[0].value
+					}
+				]
 			}
 
 			const selector = store.pipe(select(selectConfigurableProductAppliedAttributesEntities));
@@ -69,7 +82,16 @@ describe('selectConfigurableProductEntitiesState', () => {
 		
 		it('selects all configurable product attributes as an array', () => {
 			const selector = store.pipe(select(selectAllConfigurableProductAppliedAttributeDictionaries));
-			const expected = cold('a', { a: [{ id: stubConfigurableProduct.id }] });
+			const expected = cold('a', { 
+				a: [{ 
+					id: stubConfigurableProduct.id, attributes: [
+						{
+							code: stubConfigurableProduct.configurableAttributes[0].code, 
+							value: stubConfigurableProduct.configurableAttributes[0].values[0].value
+						}
+					] 
+				}]
+			});
 
 			expect(selector).toBeObservable(expected);
 		});
@@ -83,13 +105,32 @@ describe('selectConfigurableProductEntitiesState', () => {
 
 			expect(selector).toBeObservable(expected);
 		});
-	});  
+	});
 
   describe('selectConfigurableProductAppliedAttributes', () => {
     
     it('selects the configurable product attributes of the given id', () => {
 			const selector = store.pipe(select(selectConfigurableProductAppliedAttributes, { id: stubConfigurableProduct.id }));
-			const expected = cold('a', { a: { id: stubConfigurableProduct.id} });
+			const expected = cold('a', { 
+				a: [{
+					code: stubConfigurableProduct.configurableAttributes[0].code, 
+					value: stubConfigurableProduct.configurableAttributes[0].values[0].value
+				}] 
+			});
+
+			expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectConfigurableProductAppliedAttributesAsDictionary', () => {
+    
+    it('selects the configurable product attributes of the given id as a dictionary', () => {
+			const selector = store.pipe(select(selectConfigurableProductAppliedAttributesAsDictionary, { id: stubConfigurableProduct.id }));
+			const expected = cold('a', { 
+				a: {
+					[stubConfigurableProduct.configurableAttributes[0].code]: stubConfigurableProduct.configurableAttributes[0].values[0].value
+				}
+			});
 
 			expect(selector).toBeObservable(expected);
     });

--- a/libs/product/src/selectors/configurable-product-entities/configurable-product-entities.selectors.ts
+++ b/libs/product/src/selectors/configurable-product-entities/configurable-product-entities.selectors.ts
@@ -63,10 +63,10 @@ const createConfigurableProductAppliedAttributesEntitiesSelectors = <T extends D
 
 	const selectConfigurableProductAppliedAttributesAsDictionary = createSelector(
 		selectConfigurableProductAppliedAttributesEntitiesState,
-		(products, props) => selectConfigurableProductAppliedAttributes.projector(products, { id: props.id }).reduce((acc, attribute) => {
-			acc[attribute.code] = attribute.value;
-			return acc;
-		}, {})
+		(products, props) => selectConfigurableProductAppliedAttributes.projector(products, { id: props.id }).reduce((acc, attribute) => ({
+			...acc,
+			[attribute.code]: attribute.value
+		}), {})
 	)
 
 	return { 

--- a/libs/product/src/selectors/configurable-product-entities/configurable-product-entities.selectors.ts
+++ b/libs/product/src/selectors/configurable-product-entities/configurable-product-entities.selectors.ts
@@ -11,7 +11,6 @@ export interface DaffConfigurableProductEntitiesMemoizedSelectors {
 	selectConfigurableProductAppliedAttributesEntitiesState: MemoizedSelector<object, EntityState<DaffConfigurableProductEntity>>;
 	selectConfigurableProductIds: MemoizedSelector<object, EntityState<DaffConfigurableProductEntity>['ids']>;
 	selectConfigurableProductAppliedAttributesEntities: MemoizedSelector<object, EntityState<DaffConfigurableProductEntity>['entities']>;
-	selectAllConfigurableProductAppliedAttributeDictionaries: MemoizedSelector<object, DaffConfigurableProductEntity[]>;
 	selectConfigurableProductTotal: MemoizedSelector<object, number>;
 	selectConfigurableProductAppliedAttributes: MemoizedSelectorWithProps<object, object, DaffConfigurableProductEntityAttribute[]>;
 	selectConfigurableProductAppliedAttributesAsDictionary: MemoizedSelectorWithProps<object, object, Dictionary<string>>;
@@ -47,14 +46,6 @@ const createConfigurableProductAppliedAttributesEntitiesSelectors = <T extends D
 	);
 
 	/**
-	 * Selector for all configurable product applied attributes as dictionaries.
-	 */
-	const selectAllConfigurableProductAppliedAttributeDictionaries = createSelector(
-		selectConfigurableProductAppliedAttributesEntitiesState,
-		(state) => adapterSelectors.selectAll(state)
-	);
-
-	/**
 	 * Selector for the total number of configurable products.
 	 */
 	const selectConfigurableProductTotal = createSelector(
@@ -72,19 +63,16 @@ const createConfigurableProductAppliedAttributesEntitiesSelectors = <T extends D
 
 	const selectConfigurableProductAppliedAttributesAsDictionary = createSelector(
 		selectConfigurableProductAppliedAttributesEntitiesState,
-		(products, props) => {
-			return selectConfigurableProductAppliedAttributes.projector(products, { id: props.id }).reduce((acc, attribute) => {
-				acc[attribute.code] = attribute.value;
-				return acc;
-			}, {});
-		}
+		(products, props) => selectConfigurableProductAppliedAttributes.projector(products, { id: props.id }).reduce((acc, attribute) => {
+			acc[attribute.code] = attribute.value;
+			return acc;
+		}, {})
 	)
 
 	return { 
 		selectConfigurableProductAppliedAttributesEntitiesState,
 		selectConfigurableProductIds,
 		selectConfigurableProductAppliedAttributesEntities,
-		selectAllConfigurableProductAppliedAttributeDictionaries,
 		selectConfigurableProductTotal,
 		selectConfigurableProductAppliedAttributes,
 		selectConfigurableProductAppliedAttributesAsDictionary

--- a/libs/product/src/selectors/configurable-product-entities/configurable-product-entities.selectors.ts
+++ b/libs/product/src/selectors/configurable-product-entities/configurable-product-entities.selectors.ts
@@ -1,19 +1,20 @@
 import { createSelector, MemoizedSelector, MemoizedSelectorWithProps } from '@ngrx/store';
-import { EntityState } from '@ngrx/entity';
+import { EntityState, Dictionary } from '@ngrx/entity';
 
 import { getDaffProductFeatureSelector } from '../product-feature.selector';
 import { DaffProductReducersState } from '../../reducers/product-reducers-state.interface';
 import { DaffProduct } from '../../models/product';
 import { daffConfigurableProductAppliedAttributesEntitiesAdapter } from '../../reducers/configurable-product-entities/configurable-product-entities-reducer-adapter';
-import { DaffProductVariantAttributesDictionary } from '../../models/configurable-product';
+import { DaffConfigurableProductEntity, DaffConfigurableProductEntityAttribute } from '../../reducers/configurable-product-entities/configurable-product-entity';
 
 export interface DaffConfigurableProductEntitiesMemoizedSelectors {
-	selectConfigurableProductAppliedAttributesEntitiesState: MemoizedSelector<object, EntityState<DaffProductVariantAttributesDictionary>>;
-	selectConfigurableProductIds: MemoizedSelector<object, EntityState<DaffProductVariantAttributesDictionary>['ids']>;
-	selectConfigurableProductAppliedAttributesEntities: MemoizedSelector<object, EntityState<DaffProductVariantAttributesDictionary>['entities']>;
-	selectAllConfigurableProductAppliedAttributeDictionaries: MemoizedSelector<object, DaffProductVariantAttributesDictionary[]>;
+	selectConfigurableProductAppliedAttributesEntitiesState: MemoizedSelector<object, EntityState<DaffConfigurableProductEntity>>;
+	selectConfigurableProductIds: MemoizedSelector<object, EntityState<DaffConfigurableProductEntity>['ids']>;
+	selectConfigurableProductAppliedAttributesEntities: MemoizedSelector<object, EntityState<DaffConfigurableProductEntity>['entities']>;
+	selectAllConfigurableProductAppliedAttributeDictionaries: MemoizedSelector<object, DaffConfigurableProductEntity[]>;
 	selectConfigurableProductTotal: MemoizedSelector<object, number>;
-	selectConfigurableProductAppliedAttributes: MemoizedSelectorWithProps<object, object, DaffProductVariantAttributesDictionary>;
+	selectConfigurableProductAppliedAttributes: MemoizedSelectorWithProps<object, object, DaffConfigurableProductEntityAttribute[]>;
+	selectConfigurableProductAppliedAttributesAsDictionary: MemoizedSelectorWithProps<object, object, Dictionary<string>>;
 }
 
 const createConfigurableProductAppliedAttributesEntitiesSelectors = <T extends DaffProduct>(): DaffConfigurableProductEntitiesMemoizedSelectors => {
@@ -66,8 +67,18 @@ const createConfigurableProductAppliedAttributesEntitiesSelectors = <T extends D
 	 */
 	const selectConfigurableProductAppliedAttributes = createSelector(
 		selectConfigurableProductAppliedAttributesEntitiesState,
-		(products, props) => products.entities[props.id]
+		(products, props) => products.entities[props.id].attributes
 	);
+
+	const selectConfigurableProductAppliedAttributesAsDictionary = createSelector(
+		selectConfigurableProductAppliedAttributesEntitiesState,
+		(products, props) => {
+			return selectConfigurableProductAppliedAttributes.projector(products, { id: props.id }).reduce((acc, attribute) => {
+				acc[attribute.code] = attribute.value;
+				return acc;
+			}, {});
+		}
+	)
 
 	return { 
 		selectConfigurableProductAppliedAttributesEntitiesState,
@@ -75,7 +86,8 @@ const createConfigurableProductAppliedAttributesEntitiesSelectors = <T extends D
 		selectConfigurableProductAppliedAttributesEntities,
 		selectAllConfigurableProductAppliedAttributeDictionaries,
 		selectConfigurableProductTotal,
-		selectConfigurableProductAppliedAttributes
+		selectConfigurableProductAppliedAttributes,
+		selectConfigurableProductAppliedAttributesAsDictionary
 	}
 }
 

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.integration.spec.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.integration.spec.ts
@@ -1,0 +1,159 @@
+import { TestBed } from '@angular/core/testing';
+import { StoreModule, combineReducers, Store, select } from '@ngrx/store';
+import { cold } from 'jasmine-marbles';
+
+import { DaffConfigurableProductFactory } from '@daffodil/product/testing';
+import { 
+	DaffConfigurableProduct, 
+	DaffProductLoadSuccess,
+	daffProductReducers,
+	DaffProductReducersState,
+	DaffConfigurableProductApplyAttribute,
+} from '@daffodil/product';
+
+import { getDaffConfigurableProductSelectors } from './configurable-product.selectors';
+import { getDaffConfigurableProductEntitiesSelectors } from '../configurable-product-entities/configurable-product-entities.selectors';
+
+describe('Configurable Product Selectors | integration tests', () => {
+
+  let store: Store<DaffProductReducersState>;
+  const configurableProductFactory: DaffConfigurableProductFactory = new DaffConfigurableProductFactory();
+	let stubConfigurableProduct: DaffConfigurableProduct;
+	const {
+		selectSelectableConfigurableProductAttributes
+	} = getDaffConfigurableProductSelectors();
+
+	const {
+		selectConfigurableProductAppliedAttributesAsDictionary
+	} = getDaffConfigurableProductEntitiesSelectors();
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          product: combineReducers(daffProductReducers),
+        })
+      ]
+    });
+
+    stubConfigurableProduct = configurableProductFactory.create();
+    store = TestBed.get(Store);
+  });
+
+	describe('when one attribute (material) is chosen', () => {
+		
+		beforeEach(() => {
+			store.dispatch(new DaffProductLoadSuccess(stubConfigurableProduct));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				'material',
+				'2'
+			));
+		});
+
+		it(`should include all attribute values for the selected attribute code;
+				should include only attributes values for the remaining attribute codes that match variants having the selected attribute value`, () => {
+			const selector = store.pipe(select(selectSelectableConfigurableProductAttributes, { id: stubConfigurableProduct.id }));
+			const expected = cold('a', { 
+				a: {
+					color: ['0', '1'],
+					size: ['1', '0'],
+					material: ['0', '2', '1']
+				} 
+			});
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('when more than one attribute (color and size) is chosen', () => {
+		
+		beforeEach(() => {
+			store.dispatch(new DaffProductLoadSuccess(stubConfigurableProduct));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				'color',
+				'0'
+			));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				'size',
+				'1'
+			));
+		});
+
+		it(`should include all attribute values for the attribute code that was selected first;
+				should include only attribute values for the second selected attribute code that match variants having the first selected attribute value;
+				should include only attribute values for the remaining attribute codes that match variants having both the first and second selected attribute values`, () => {
+			const selector = store.pipe(select(selectSelectableConfigurableProductAttributes, { id: stubConfigurableProduct.id }));
+			const expected = cold('a', { 
+				a: {
+					color: ['0', '1', '2'],
+					size: ['0', '1', '2'],
+					material: ['0', '2']
+				} 
+			});
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		describe('and a different first selection (color) is chosen', () => {
+			
+			beforeEach(() => {
+				store.dispatch(new DaffConfigurableProductApplyAttribute(
+					stubConfigurableProduct.id,
+					'color',
+					'1'
+				));
+			});
+
+			it('should clear the second selection (size)', () => {
+				const selector = store.pipe(select(selectConfigurableProductAppliedAttributesAsDictionary, { id: stubConfigurableProduct.id }));
+				const expected = cold('a', {
+					a: {
+						color: '1'
+					}
+				});
+
+				expect(selector).toBeObservable(expected);
+			});
+		});
+
+		describe('and a different second selection (size) is chosen', () => {
+			
+			beforeEach(() => {
+				store.dispatch(new DaffConfigurableProductApplyAttribute(
+					stubConfigurableProduct.id,
+					'size',
+					'0'
+				));
+			});
+
+			it('should not clear the first selection (color)', () => {
+				const selector = store.pipe(select(selectConfigurableProductAppliedAttributesAsDictionary, { id: stubConfigurableProduct.id }));
+				const expected = cold('a', {
+					a: {
+						color: '0',
+						size: '0'
+					}
+				});
+
+				expect(selector).toBeObservable(expected);
+			});
+		});
+	});
+	
+	it('returns a dictionary of attribute values that are still selectable', () => {
+		store.dispatch(new DaffProductLoadSuccess(stubConfigurableProduct));
+		const selector = store.pipe(select(selectSelectableConfigurableProductAttributes, { id: stubConfigurableProduct.id }));
+		const expected = cold('a', { 
+			a: {
+				color: ['0', '1', '2'],
+				size: ['0', '1', '2'],
+				material: ['0', '1', '2']
+			} 
+		});
+
+		expect(selector).toBeObservable(expected);
+	});
+});

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
@@ -62,12 +62,10 @@ const createConfigurableProductSelectors = (): DaffConfigurableProductMemoizedSe
 			if(product.type !== DaffProductTypeEnum.Configurable) {
 				return {};
 			}
-			return product.configurableAttributes.reduce((acc, attribute) => {
-				return {
-					...acc,
-					[attribute.code]: attribute.values.map(value => value.value)
-				};
-			}, {});
+			return product.configurableAttributes.reduce((acc, attribute) => ({
+				...acc,
+				[attribute.code]: attribute.values.map(value => value.value)
+			}), {});
 		}
 	);
 
@@ -169,12 +167,10 @@ function getMaximumPrice(variants: DaffConfigurableProductVariant[]): string {
 }
 
 function initializeSelectableAttributes(attributes: DaffConfigurableProductAttribute[]): Dictionary<string[]> {
-	return attributes.reduce((acc, attribute) => {
-		return {
-			...acc,
-			[attribute.code]: []
-		};
-	}, {});
+	return attributes.reduce((acc, attribute) => ({
+		...acc,
+		[attribute.code]: []
+	}), {});
 }
 
 function isVariantAttributeMarkedAsSelectable(attributeArray: string[], variantValue: string) {

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
@@ -4,12 +4,14 @@ import { DaffProductTypeEnum } from '../../models/product';
 import { Dictionary } from '@ngrx/entity';
 import { getDaffConfigurableProductEntitiesSelectors } from '../configurable-product-entities/configurable-product-entities.selectors';
 import { getDaffProductEntitiesSelectors } from '../product-entities/product-entities.selectors';
-import { DaffConfigurableProductVariant, DaffConfigurableProduct, DaffProductVariantAttributesDictionary, DaffConfigurableProductAttribute } from '../../models/configurable-product';
+import { DaffConfigurableProductVariant, DaffConfigurableProduct, DaffConfigurableProductAttribute } from '../../models/configurable-product';
+import { DaffConfigurableProductEntityAttribute } from '../../reducers/configurable-product-entities/configurable-product-entity';
 
 export interface DaffConfigurableProductMemoizedSelectors {
+	selectAllConfigurableProductAttributes: MemoizedSelectorWithProps<object, object, Dictionary<string[]>>;
 	selectMatchingConfigurableProductVariants: MemoizedSelectorWithProps<object, object, DaffConfigurableProductVariant[]>;
 	selectConfigurableProductPrice: MemoizedSelectorWithProps<object, object, string>;
-	selectUndeterminedConfigurableProductAttributes: MemoizedSelectorWithProps<object, object, Dictionary<string[]>>;
+	selectSelectableConfigurableProductAttributes: MemoizedSelectorWithProps<object, object, Dictionary<string[]>>;
 }
 
 const createConfigurableProductSelectors = (): DaffConfigurableProductMemoizedSelectors => {
@@ -20,7 +22,8 @@ const createConfigurableProductSelectors = (): DaffConfigurableProductMemoizedSe
 	} = getDaffConfigurableProductEntitiesSelectors();
 
 	const {
-		selectProductEntities
+		selectProductEntities,
+		selectProduct
 	} = getDaffProductEntitiesSelectors();
 
 	/**
@@ -30,12 +33,12 @@ const createConfigurableProductSelectors = (): DaffConfigurableProductMemoizedSe
 		selectProductEntities,
 		selectConfigurableProductAppliedAttributesEntitiesState,
 		(products, appliedAttributesEntities, props) => {
-			const product: DaffConfigurableProduct = products[props.id];
+			const product = <DaffConfigurableProduct>selectProduct.projector(products, { id: props.id });
 			if(!product || product.type !== DaffProductTypeEnum.Configurable) {
 				return [];
 			}
 			const appliedAttributes = selectConfigurableProductAppliedAttributes.projector(appliedAttributesEntities, { id: props.id });
-			return product.variants.filter(variant => isVariantAvailable(product.configurableAttributes, appliedAttributes, variant))
+			return product.variants.filter(variant => isVariantAvailable(appliedAttributes, variant))
 		}
 	);
 
@@ -52,41 +55,72 @@ const createConfigurableProductSelectors = (): DaffConfigurableProductMemoizedSe
 		}
 	);
 
-	/**
-	 * Selector for undetermined configurable product attributes derived from the remaining variants.
-	 * The remaining variants of the product are derived from the currently applied attributes.
-	 */
-	const selectUndeterminedConfigurableProductAttributes = createSelector(
+	const selectAllConfigurableProductAttributes = createSelector(
 		selectProductEntities,
-		selectConfigurableProductAppliedAttributesEntitiesState,
-		(products, appliedAttributesEntities, props) => {
-			const product: DaffConfigurableProduct = products[props.id];
+		(products, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
 			if(product.type !== DaffProductTypeEnum.Configurable) {
 				return {};
 			}
-			const appliedAttributes: Dictionary<string> = selectConfigurableProductAppliedAttributes.projector(appliedAttributesEntities, { id: props.id });
-			const matchingVariants: DaffConfigurableProductVariant[] = selectMatchingConfigurableProductVariants.projector(products, appliedAttributesEntities, { id: props.id });
-			const unselectedAttributes = product.configurableAttributes
-				.filter(option => !appliedAttributes[option.code]);
-			
-			const undeterminedAttributes = {};
-			unselectedAttributes.forEach((attribute) => {
-				undeterminedAttributes[attribute.code] = [];
-				matchingVariants.forEach(variant => {
-					if(!isVariantAttributeMarkedAsUndetermined(undeterminedAttributes[attribute.code], variant.appliedAttributes[attribute.code])) {
-						undeterminedAttributes[attribute.code].push(variant.appliedAttributes[attribute.code]);
-					}
-				})
-			})
+			return products[props.id].configurableAttributes.reduce((acc, attribute) => {
+				return {
+					...acc,
+					[attribute.code]: attribute.values.map(value => value.value)
+				};
+			}, {});
+		}
+	);
 
-			return undeterminedAttributes;
+	/**
+	 * Selector for selectable configurable product attributes derived from the remaining variants and the order of currently applied attributes.
+	 * The remaining variants of the product are derived from the currently applied attributes.
+	 */
+	const selectSelectableConfigurableProductAttributes = createSelector(
+		selectProductEntities,
+		selectConfigurableProductAppliedAttributesEntitiesState,
+		(products, appliedAttributesEntities, props) => {
+			const product = <DaffConfigurableProduct>selectProduct.projector(products, { id: props.id });
+			if(product.type !== DaffProductTypeEnum.Configurable) {
+				return {};
+			}
+			const appliedAttributes: DaffConfigurableProductEntityAttribute[] = selectConfigurableProductAppliedAttributes.projector(appliedAttributesEntities, { id: props.id });
+			if(appliedAttributes.length === 0) return selectAllConfigurableProductAttributes.projector(products, { id: props.id });
+			
+			const selectableAttributes = initializeSelectableAttributes(product.configurableAttributes);
+			let matchingVariants: DaffConfigurableProductVariant[] = product.variants;
+			// Set which values of applied attribute codes should be set as selectable based on the order that they were selected
+			for(let i=0; i<=appliedAttributes.length; i++) {
+				matchingVariants = matchingVariants.filter(variant => isVariantAvailable(appliedAttributes.slice(0, i), variant));
+				if(i<appliedAttributes.length) {
+					matchingVariants.forEach(variant => {
+						if(!isVariantAttributeMarkedAsSelectable(selectableAttributes[appliedAttributes[i].code], variant.appliedAttributes[appliedAttributes[i].code])) {
+							selectableAttributes[appliedAttributes[i].code].push(variant.appliedAttributes[appliedAttributes[i].code]);
+						}
+					});
+				}
+			}
+			
+			// Set which values of the unapplied attribute codes should be set as selectable based on the matching variants of all
+			// applied attributes.
+			product.configurableAttributes.forEach(attribute => {
+				if(!selectableAttributes[attribute.code].length) {
+					matchingVariants.forEach(variant => {
+						if(!isVariantAttributeMarkedAsSelectable(selectableAttributes[attribute.code], variant.appliedAttributes[attribute.code])) {
+							selectableAttributes[attribute.code].push(variant.appliedAttributes[attribute.code]);
+						}
+					});
+				}
+			})
+			
+			return selectableAttributes;
 		}
 	);
 
 	return { 
+		selectAllConfigurableProductAttributes,
 		selectConfigurableProductPrice,
 		selectMatchingConfigurableProductVariants,
-		selectUndeterminedConfigurableProductAttributes
+		selectSelectableConfigurableProductAttributes
 	}
 }
 
@@ -98,22 +132,13 @@ export const getDaffConfigurableProductSelectors = (() => {
 })();
 
 function isVariantAvailable(
-	configurableAttributes: DaffConfigurableProductAttribute[],
-	appliedAttributes: DaffProductVariantAttributesDictionary, 
+	appliedAttributes: DaffConfigurableProductEntityAttribute[], 
 	variant: DaffConfigurableProductVariant
 ): boolean {
-	return configurableAttributes.reduce((acc, option) => 
-		acc && !(isAttributeApplied(option.code, appliedAttributes) && !doesAppliedAttributeMatchVariantAttribute(appliedAttributes[option.code], variant.appliedAttributes[option.code])),
+	return appliedAttributes.reduce((acc, attribute) => 
+		acc && attribute.value === variant.appliedAttributes[attribute.code],
 		true
 	)
-}
-
-function isAttributeApplied(attributeCode: string, appliedAttributes: DaffProductVariantAttributesDictionary): boolean {
-	return !!appliedAttributes[attributeCode];
-}
-
-function doesAppliedAttributeMatchVariantAttribute(appliedAttribute: string, variantAttribute: string): boolean {
-	return variantAttribute === appliedAttribute
 }
 
 function getMinimumPrice(variants: DaffConfigurableProductVariant[]): string {
@@ -136,6 +161,15 @@ function getMaximumPrice(variants: DaffConfigurableProductVariant[]): string {
 	).toString();
 }
 
-function isVariantAttributeMarkedAsUndetermined(attributeArray: string[], variantValue: string) {
+function initializeSelectableAttributes(attributes: DaffConfigurableProductAttribute[]): Dictionary<string[]> {
+	return attributes.reduce((acc, attribute) => {
+		return {
+			...acc,
+			[attribute.code]: []
+		};
+	}, {});
+}
+
+function isVariantAttributeMarkedAsSelectable(attributeArray: string[], variantValue: string) {
 	return attributeArray.indexOf(variantValue) > -1
 }

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.unit.spec.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.unit.spec.ts
@@ -14,7 +14,7 @@ import {
 
 import { getDaffConfigurableProductSelectors } from './configurable-product.selectors';
 
-describe('Configurable Product Selectors', () => {
+describe('Configurable Product Selectors | unit tests', () => {
 
   let store: Store<DaffProductReducersState>;
   const configurableProductFactory: DaffConfigurableProductFactory = new DaffConfigurableProductFactory();
@@ -22,7 +22,7 @@ describe('Configurable Product Selectors', () => {
 	const {
 		selectConfigurableProductPrice,
 		selectMatchingConfigurableProductVariants,
-		selectUndeterminedConfigurableProductAttributes
+		selectSelectableConfigurableProductAttributes
 	} = getDaffConfigurableProductSelectors();
   
   beforeEach(() => {
@@ -46,9 +46,15 @@ describe('Configurable Product Selectors', () => {
 				stubConfigurableProduct.variants[0].price = 2;
 				stubConfigurableProduct.variants[1].price = 1;
 				stubConfigurableProduct.variants[2].price = 3;
+				stubConfigurableProduct.variants[3].price = 4;
 				store.dispatch(new DaffProductGridLoadSuccess([stubConfigurableProduct]));
+				store.dispatch(new DaffConfigurableProductApplyAttribute(
+					stubConfigurableProduct.id,
+					stubConfigurableProduct.configurableAttributes[0].code,
+					stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[0].code]
+				));
 				const selector = store.pipe(select(selectConfigurableProductPrice, { id: stubConfigurableProduct.id }));
-				const expected = cold('a', { a: '1-3' });
+				const expected = cold('a', { a: '1-4' });
 
 				expect(selector).toBeObservable(expected);
 			});
@@ -62,6 +68,16 @@ describe('Configurable Product Selectors', () => {
 					stubConfigurableProduct.id,
 					stubConfigurableProduct.configurableAttributes[0].code,
 					stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[0].code]
+				));
+				store.dispatch(new DaffConfigurableProductApplyAttribute(
+					stubConfigurableProduct.id,
+					stubConfigurableProduct.configurableAttributes[1].code,
+					stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[1].code]
+				));
+				store.dispatch(new DaffConfigurableProductApplyAttribute(
+					stubConfigurableProduct.id,
+					stubConfigurableProduct.configurableAttributes[2].code,
+					stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[2].code]
 				));
 				const selector = store.pipe(select(selectConfigurableProductPrice, { id: stubConfigurableProduct.id }));
 				const expected = cold('a', { a: stubConfigurableProduct.variants[0].price.toString() });
@@ -81,20 +97,24 @@ describe('Configurable Product Selectors', () => {
 				stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[0].code]
 			));
 			const selector = store.pipe(select(selectMatchingConfigurableProductVariants, { id: stubConfigurableProduct.id }));
-			const expected = cold('a', { a: [stubConfigurableProduct.variants[0]] });
+			const expected = cold('a', { a: 
+				stubConfigurableProduct.variants.slice(0, 4)
+			});
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectUndeterminedConfigurableProductAttributes', () => {
+	describe('selectSelectableConfigurableProductAttributes', () => {
 		
-		it('returns a dictionary of attribute values that are undetermined by the matched variants and applied attributes', () => {
+		it('returns a dictionary of attribute values that are still selectable', () => {
 			store.dispatch(new DaffProductLoadSuccess(stubConfigurableProduct));
-			const selector = store.pipe(select(selectUndeterminedConfigurableProductAttributes, { id: stubConfigurableProduct.id }));
+			const selector = store.pipe(select(selectSelectableConfigurableProductAttributes, { id: stubConfigurableProduct.id }));
 			const expected = cold('a', { 
 				a: {
-					color: ['0', '1', '2']
+					color: ['0', '1', '2'],
+					size: ['0', '1', '2'],
+					material: ['0', '1', '2']
 				} 
 			});
 

--- a/libs/product/src/selectors/product-entities/product-entities.selectors.ts
+++ b/libs/product/src/selectors/product-entities/product-entities.selectors.ts
@@ -69,8 +69,8 @@ const createProductEntitiesSelectors = <T extends DaffProduct>(): DaffProductEnt
 	);
 
 	const selectProduct = createSelector(
-		selectProductEntitiesState,
-		(products, props) => products.entities[props.id]
+		selectProductEntities,
+		(products, props) => products[props.id]
 	);
 
 	return { 

--- a/libs/product/testing/src/factories/configurable-product.factory.ts
+++ b/libs/product/testing/src/factories/configurable-product.factory.ts
@@ -52,12 +52,136 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 					}
 				}
 			]
+		},
+		{
+			code: 'size',
+			label: 'Size',
+			order: 1,
+			values: [
+				{
+					value: '0',
+					label: 'Small',
+					swatch: null
+				},
+				{
+					value: '1',
+					label: 'Medium',
+					swatch: null
+				},
+				{
+					value: '2',
+					label: 'Large',
+					swatch: null
+				}
+			]
+		},
+		{
+			code: 'material',
+			label: 'Material',
+			order: 2,
+			values: [
+				{
+					value: '0',
+					label: 'Cotton',
+					swatch: null
+				},
+				{
+					value: '1',
+					label: 'Polyester',
+					swatch: null
+				},
+				{
+					value: '2',
+					label: 'Spandex',
+					swatch: null
+				}
+			]
 		}
 	];
 	variants = [
 		{
 			appliedAttributes: {
-				color: '0'
+				color: '0',
+				size: '0',
+				material: '0'
+			},
+			price: this.stubPriceVariant1.toString(),
+			discount: {
+				amount: this.stubDiscountVariant1,
+				percent: this.stubDiscountVariant1/this.stubPriceVariant1
+			},
+			id: faker.random.alphaNumeric(16)
+		},
+		{
+			appliedAttributes: {
+				color: '0',
+				size: '1',
+				material: '0'
+			},
+			price: this.stubPriceVariant1.toString(),
+			discount: {
+				amount: this.stubDiscountVariant1,
+				percent: this.stubDiscountVariant1/this.stubPriceVariant1
+			},
+			id: faker.random.alphaNumeric(16)
+		},
+		{
+			appliedAttributes: {
+				color: '0',
+				size: '1',
+				material: '2'
+			},
+			price: this.stubPriceVariant3.toString(),
+			discount: {
+				amount: this.stubDiscountVariant3,
+				percent: this.stubDiscountVariant3/this.stubPriceVariant3
+			},
+			id: faker.random.alphaNumeric(16)
+		},
+		{
+			appliedAttributes: {
+				color: '0',
+				size: '2',
+				material: '0'
+			},
+			price: this.stubPriceVariant1.toString(),
+			discount: {
+				amount: this.stubDiscountVariant1,
+				percent: this.stubDiscountVariant1/this.stubPriceVariant1
+			},
+			id: faker.random.alphaNumeric(16)
+		},
+		{
+			appliedAttributes: {
+				color: '1',
+				size: '0',
+				material: '0'
+			},
+			price: this.stubPriceVariant1.toString(),
+			discount: {
+				amount: this.stubDiscountVariant1,
+				percent: this.stubDiscountVariant1/this.stubPriceVariant1
+			},
+			id: faker.random.alphaNumeric(16)
+		},
+		{
+			appliedAttributes: {
+				color: '1',
+				size: '0',
+				material: '2'
+			},
+			price: this.stubPriceVariant3.toString(),
+			discount: {
+				amount: this.stubDiscountVariant3,
+				percent: this.stubDiscountVariant3/this.stubPriceVariant3
+			},
+			id: faker.random.alphaNumeric(16)
+		},
+		{
+			appliedAttributes: {
+				color: '1',
+				size: '2',
+				material: '0'
 			},
 			price: this.stubPriceVariant1,
 			discount: {
@@ -68,7 +192,9 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 		},
 		{
 			appliedAttributes: {
-				color: '1'
+				color: '1',
+				size: '2',
+				material: '1'
 			},
 			price: this.stubPriceVariant2,
 			discount: {
@@ -79,12 +205,27 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 		},
 		{
 			appliedAttributes: {
-				color: '2'
+				color: '2',
+				size: '0',
+				material: '0'
 			},
 			price: this.stubPriceVariant3,
 			discount: {
 				amount: this.stubDiscountVariant3,
 				percent: this.stubDiscountVariant3/this.stubPriceVariant3
+			},
+			id: faker.random.alphaNumeric(16)
+		},
+		{
+			appliedAttributes: {
+				color: '2',
+				size: '2',
+				material: '0'
+			},
+			price: this.stubPriceVariant1.toString(),
+			discount: {
+				amount: this.stubDiscountVariant1,
+				percent: this.stubDiscountVariant1/this.stubPriceVariant1
 			},
 			id: faker.random.alphaNumeric(16)
 		}

--- a/libs/product/testing/src/helpers/mock-configurable-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-configurable-product-facade.ts
@@ -4,14 +4,17 @@ import { Dictionary } from '@ngrx/entity';
 import { DaffConfigurableProductFacadeInterface } from '@daffodil/product';
 
 export class MockDaffConfigurableProductFacade implements DaffConfigurableProductFacadeInterface {
+	getAllAttributes(id: string): BehaviorSubject<Dictionary<string[]>> {
+		return new BehaviorSubject({});
+	};
 	getAppliedAttributes(id: string): BehaviorSubject<Dictionary<string>> {
 		return new BehaviorSubject({});
 	};
 	getPrice(id: string): BehaviorSubject<string> {
 		return new BehaviorSubject(null);
 	};
-	getUndeterminedAttributes(id: string): BehaviorSubject<Dictionary<string[]>> {
+	getSelectableAttributes(id: string): BehaviorSubject<Dictionary<string[]>> {
 		return new BehaviorSubject({});
 	};
-	dispatch() {};
+	dispatch(action) {};
 }


### PR DESCRIPTION
BREAKING CHANGE

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```


## Other information
This PR is a complicated one, and it centers around configurable product attributes and how the end user will interact with those attributes. The main selector for this used to be the `selectUndeterminedConfigurableAttributes` selector, but upon further thought, the result of that system did not always produce the ideal user experience. For example, if a user selects a color and size for a shirt, all other colors and sizes would be disabled, but I believe the ideal user experience would be to see all of the colors still selectable while only seeing the sizes that are available under the selected color as selectable. This would communicate to the user everything necessary to narrow their search, while providing the broadest array of options moving forward.

So this new system is based on the order in which the attributes are selected. The first attribute selected will always include all options for that attribute as selectable, but for the remaining attributes only the variants matching that first selected option will be selectable. If the user selects a second attribute, all of the attributes available to that second attribute (after filtering by the first selected attribute) will still be marked as selectable, while all other attributes (excluding the first selected one) will be filtered by both the first and second selected attributes. This way, the user can narrow their search for the configuration they want, while at the same time, they shouldn't feel pigeon-holed into the first and second attributes they've selected. For example, if they went back and selected a different first attribute, the second selected attribute would be reset to being unselected. It also doesn't matter which attribute the user picks first, and if they wanted to choose a new "first selected attribute" the user could deselect their first selected attribute. This cascade effect works as you'd expect if you picked a new second selection too; i.e. the first selection remains, and all other selectable attributes are recomputed. I've included integration tests to cover these scenarios if all of this isn't too clear.

Because the order of applied attributes now matters, the entity state for applied attributes had to change to an array instead of a dictionary. However, all data given to the app dev through the configurable product facade is still in dictionary form, since the order of applied attributes doesn't matter for them.