### PR TITLE
feat(design): move design examples docs gen to libs/design

### DIFF
--- a/tools/dgeni/src/transforms/config.ts
+++ b/tools/dgeni/src/transforms/config.ts
@@ -5,6 +5,7 @@ export const PROJECT_ROOT = resolve(__dirname, '../../../..');
 export const DGENI_DIR = resolve(__dirname, '../../');
 export const DAFFFIO_PATH = resolve(PROJECT_ROOT, 'apps/daffio');
 export const DESIGN_LAND_PATH = resolve(PROJECT_ROOT, 'apps/design-land');
+export const DESIGN_PATH = resolve(PROJECT_ROOT, 'libs/design');
 export const TEMPLATES_PATH = resolve(DGENI_DIR, 'src/templates');
 export const API_TEMPLATES_PATH = resolve(TEMPLATES_PATH, 'api');
 export const SRC_PATH = resolve(DAFFFIO_PATH, 'src');

--- a/tools/dgeni/src/transforms/daffodil-design-examples-package/index.ts
+++ b/tools/dgeni/src/transforms/daffodil-design-examples-package/index.ts
@@ -3,7 +3,7 @@ import { Package } from 'dgeni';
 const typescriptPackage = require('dgeni-packages/typescript');
 
 import { daffodilBasePackage } from '../daffodil-base-package';
-import { DESIGN_LAND_PATH, TEMPLATES_PATH } from '../config';
+import { DESIGN_PATH, TEMPLATES_PATH } from '../config';
 import { CleanSelectorsProcessor } from '../../processors/cleanSelectors';
 import { FilterContainedDocsProcessor } from '../../processors/filterDocs';
 import { DesignExampleDocumentCreatorProcessor } from './processors/designExampleDocumentCreator';
@@ -23,9 +23,9 @@ export const designExamplePackage = new Package('daffodil-design-examples', [daf
   .config(function (readFilesProcessor, designExampleReader) {
     readFilesProcessor.$enabled = true;
     readFilesProcessor.fileReaders.push(designExampleReader);
-    readFilesProcessor.basePath = DESIGN_LAND_PATH;
+    readFilesProcessor.basePath = DESIGN_PATH;
     readFilesProcessor.sourceFiles = [
-      { include: ['**/examples/*/*.*']}
+      { include: ['**/examples/src/*/*.*']}
     ]
   })
   .config(function (convertToJson) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, we pull design examples for docs-gen out of `design-land`.

Fixes: N/A


## What is the new behavior?
this moves that lookup to `design`.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
This is an internal-facing break. @xelaint @Nolan-Arnold are the most relevant to inform.

## Other information