### PR TITLE
docs(design): change example component names to skip linting

### DIFF
--- a/libs/design/article/examples/src/article-blockquote/article-blockquote.component.ts
+++ b/libs/design/article/examples/src/article-blockquote/article-blockquote.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'daff-article-blockquote',
+  // tslint:disable-next-line:component-selector
+  selector: 'article-blockquote',
   templateUrl: './article-blockquote.component.html'
 })
 export class ArticleBlockquoteComponent {}

--- a/libs/design/article/examples/src/article-code-block/article-code-block.component.ts
+++ b/libs/design/article/examples/src/article-code-block/article-code-block.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'daff-article-code-block',
+  // tslint:disable-next-line:component-selector
+  selector: 'article-code-block',
   templateUrl: './article-code-block.component.html'
 })
 export class ArticleCodeBlockComponent {}

--- a/libs/design/article/examples/src/article-code-inline/article-code-inline.component.ts
+++ b/libs/design/article/examples/src/article-code-inline/article-code-inline.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'daff-article-code-inline',
+  // tslint:disable-next-line:component-selector
+  selector: 'article-code-inline',
   templateUrl: './article-code-inline.component.html'
 })
 export class ArticleCodeInlineComponent {}

--- a/libs/design/article/examples/src/article-headings/article-headings.component.ts
+++ b/libs/design/article/examples/src/article-headings/article-headings.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'daff-article-headings',
+  // tslint:disable-next-line:component-selector
+  selector: 'article-headings',
   templateUrl: './article-headings.component.html'
 })
 export class ArticleHeadingsComponent {}

--- a/libs/design/article/examples/src/article-hr/article-hr.component.ts
+++ b/libs/design/article/examples/src/article-hr/article-hr.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'daff-article-hr',
+  // tslint:disable-next-line:component-selector
+  selector: 'article-hr',
   templateUrl: './article-hr.component.html'
 })
 export class ArticleHrComponent {}

--- a/libs/design/article/examples/src/article-lead/article-lead.component.ts
+++ b/libs/design/article/examples/src/article-lead/article-lead.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'daff-article-lead',
+  // tslint:disable-next-line:component-selector
+  selector: 'article-lead',
   templateUrl: './article-lead.component.html'
 })
 export class ArticleLeadComponent {}

--- a/libs/design/article/examples/src/article-link/article-link.component.ts
+++ b/libs/design/article/examples/src/article-link/article-link.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'daff-article-link',
+  // tslint:disable-next-line:component-selector
+  selector: 'article-link',
   templateUrl: './article-link.component.html'
 })
 export class ArticleLinkComponent {}

--- a/libs/design/article/examples/src/article-meta/article-meta.component.ts
+++ b/libs/design/article/examples/src/article-meta/article-meta.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'daff-article-meta',
+  // tslint:disable-next-line:component-selector
+  selector: 'article-meta',
   templateUrl: './article-meta.component.html'
 })
 export class ArticleMetaComponent {}

--- a/libs/design/article/examples/src/article-ol/article-ol.component.ts
+++ b/libs/design/article/examples/src/article-ol/article-ol.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'daff-article-ol',
+  // tslint:disable-next-line:component-selector
+  selector: 'article-ol',
   templateUrl: './article-ol.component.html'
 })
 export class ArticleOlComponent {}

--- a/libs/design/article/examples/src/article-ul/article-ul.component.ts
+++ b/libs/design/article/examples/src/article-ul/article-ul.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'daff-article-ul',
+  // tslint:disable-next-line:component-selector
+  selector: 'article-ul',
   templateUrl: './article-ul.component.html'
 })
 export class ArticleUlComponent {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Example components used in `design-land` mistakenly had the `daff` prefix applied to them as a result of linting, preventing rendering by the code preview.

Fixes: N/A


## What is the new behavior?
This removes the prefix and skips linting on the component selector.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```