### PR TITLE
feat(geography): track the fully loaded countries in state

### DIFF
--- a/libs/geography/src/facades/geography/geography-facade.interface.ts
+++ b/libs/geography/src/facades/geography/geography-facade.interface.ts
@@ -16,4 +16,5 @@ export interface DaffGeographyFacadeInterface<T extends DaffCountry = DaffCountr
 
   getCountry(id: T['id']): Observable<T>;
   getCountrySubdivisions(id: T['id']): Observable<T['subdivisions']>;
+  isCountryFullyLoaded(id: T['id']): Observable<boolean>
 }

--- a/libs/geography/src/facades/geography/geography.facade.spec.ts
+++ b/libs/geography/src/facades/geography/geography.facade.spec.ts
@@ -10,7 +10,8 @@ import {
   DaffCountry,
   DaffGeographyFeatureState,
   daffGeographyReducers,
-  DAFF_GEOGRAPHY_STORE_FEATURE_KEY
+  DAFF_GEOGRAPHY_STORE_FEATURE_KEY,
+  DaffCountryListSuccess
 } from '@daffodil/geography';
 import { DaffCountryFactory, DaffSubdivisionFactory } from '@daffodil/geography/testing';
 
@@ -96,10 +97,9 @@ describe('DaffGeographyFacade', () => {
     });
 
     it('should be the countries upon a successful load', () => {
+      const expected = cold('a', { a: [jasmine.objectContaining(mockCountry)] });
       store.dispatch(new DaffCountryLoadSuccess(mockCountry));
-      facade.countries$.subscribe(countries => {
-        expect(countries).toEqual([jasmine.objectContaining(mockCountry)])
-      });
+      expect(facade.countries$).toBeObservable(expected);
     });
   });
 
@@ -136,10 +136,9 @@ describe('DaffGeographyFacade', () => {
     });
 
     it('should contain the country upon a successful country load', () => {
+      const expected = cold('a', { a: {[countryId]: jasmine.objectContaining(mockCountry)} });
       store.dispatch(new DaffCountryLoadSuccess(mockCountry));
-      facade.countryEntities$.subscribe(countries => {
-        expect(countries).toEqual({[countryId]: jasmine.objectContaining(mockCountry)})
-      });
+      expect(facade.countryEntities$).toBeObservable(expected);
     });
   });
 
@@ -150,10 +149,9 @@ describe('DaffGeographyFacade', () => {
     });
 
     it('should be the country upon a successful country load', () => {
+      const expected = cold('a', { a: jasmine.objectContaining(mockCountry) });
       store.dispatch(new DaffCountryLoadSuccess(mockCountry));
-      facade.getCountry(countryId).subscribe(country => {
-        expect(country).toEqual(jasmine.objectContaining(mockCountry))
-      });
+      expect(facade.getCountry(countryId)).toBeObservable(expected);
     });
   });
 
@@ -171,10 +169,14 @@ describe('DaffGeographyFacade', () => {
   });
 
   describe('selectIsCountryFullyLoaded', () => {
+    beforeEach(() => {
+      store.dispatch(new DaffCountryListSuccess([mockCountry]));
+    });
+
     it('should initially be false', () => {
-      facade.isCountryFullyLoaded(countryId).subscribe(res => {
-        expect(res).toBeFalsy();
-      });
+      const expected = cold('a', { a: false });
+
+      expect(facade.isCountryFullyLoaded(countryId)).toBeObservable(expected);
     });
 
     describe('when a country is loaded', () => {
@@ -183,7 +185,7 @@ describe('DaffGeographyFacade', () => {
       });
 
       it('should be true', () => {
-        const expected = cold('a', {a: true});
+        const expected = cold('a', { a: true });
 
         expect(facade.isCountryFullyLoaded(countryId)).toBeObservable(expected);
       });

--- a/libs/geography/src/facades/geography/geography.facade.ts
+++ b/libs/geography/src/facades/geography/geography.facade.ts
@@ -13,7 +13,7 @@ import { DaffGeographyFacadeInterface } from './geography-facade.interface';
 @Injectable({
   providedIn: 'root'
 })
-export class DaffGeographyFacade<T extends DaffCountry> implements DaffGeographyFacadeInterface<T> {
+export class DaffGeographyFacade<T extends DaffCountry = DaffCountry> implements DaffGeographyFacadeInterface<T> {
   loading$: Observable<boolean>;
   errors$: Observable<string[]>;
 
@@ -24,6 +24,7 @@ export class DaffGeographyFacade<T extends DaffCountry> implements DaffGeography
 
   private _selectCountry: DaffGeographyAllSelectors<T>['selectCountry'];
   private _selectCountrySubdivisions: DaffGeographyAllSelectors<T>['selectCountrySubdivisions'];
+  private _selectIsCountryFullyLoaded: DaffGeographyAllSelectors<T>['selectIsCountryFullyLoaded'];
 
   constructor(private store: Store<DaffGeographyFeatureState<T>>) {
     const {
@@ -34,11 +35,13 @@ export class DaffGeographyFacade<T extends DaffCountry> implements DaffGeography
       selectGeographyLoading,
       selectGeographyErrors,
       selectCountry,
-      selectCountrySubdivisions
+      selectCountrySubdivisions,
+      selectIsCountryFullyLoaded
     } = getDaffGeographySelectors<T>();
 
     this._selectCountry = selectCountry;
     this._selectCountrySubdivisions = selectCountrySubdivisions;
+    this._selectIsCountryFullyLoaded = selectIsCountryFullyLoaded;
 
     this.loading$ = this.store.pipe(select(selectGeographyLoading));
     this.errors$ = this.store.pipe(select(selectGeographyErrors));
@@ -55,6 +58,10 @@ export class DaffGeographyFacade<T extends DaffCountry> implements DaffGeography
 
   getCountrySubdivisions(id: T['id']): Observable<T['subdivisions']> {
     return this.store.pipe(select(this._selectCountrySubdivisions, { id }))
+  }
+
+  isCountryFullyLoaded(id: T['id']): Observable<boolean> {
+    return this.store.pipe(select(this._selectIsCountryFullyLoaded, { id }))
   }
 
   dispatch(action: Action) {

--- a/libs/geography/src/lib/nothing.spec.ts
+++ b/libs/geography/src/lib/nothing.spec.ts
@@ -1,5 +1,0 @@
-describe('The `@daffodil/geography` package', () => {
-	it('should test nothing', () => {
-		expect(true).toEqual(true);
-	});
-});

--- a/libs/geography/src/models/country.ts
+++ b/libs/geography/src/models/country.ts
@@ -10,5 +10,10 @@ export interface DaffCountry {
 	name_en: string;
 	alpha2: string;
 	alpha3: string;
-	subdivisions: DaffSubdivision[];
+  subdivisions: DaffSubdivision[];
+  /**
+   * Whether or not the country has been fully loaded.
+   * If true, the subdivisions field will be populated if any exist.
+   */
+  loaded?: boolean;
 }

--- a/libs/geography/src/reducers/country-entities/country-entities-adapter.ts
+++ b/libs/geography/src/reducers/country-entities/country-entities-adapter.ts
@@ -7,6 +7,6 @@ import { DaffCountry } from '../../models/country';
  */
 export const getCountryAdapter = (() => {
   let cache;
-  return <T extends DaffCountry>(): EntityAdapter<T> =>
+  return <T extends DaffCountry = DaffCountry>(): EntityAdapter<T> =>
     cache = cache || createEntityAdapter<T>();
 })();

--- a/libs/geography/src/reducers/country-entities/country-entities-state.interface.ts
+++ b/libs/geography/src/reducers/country-entities/country-entities-state.interface.ts
@@ -5,4 +5,4 @@ import { DaffCountry } from '../../models/country';
 /**
  * Interface for country entity state.
  */
-export interface DaffCountryEntityState<T extends DaffCountry> extends EntityState<T> {}
+export interface DaffCountryEntityState<T extends DaffCountry = DaffCountry> extends EntityState<T> {}

--- a/libs/geography/src/reducers/country-entities/country-entities.reducer.spec.ts
+++ b/libs/geography/src/reducers/country-entities/country-entities.reducer.spec.ts
@@ -42,7 +42,11 @@ describe('Geography | Reducer | CountryEntities', () => {
     });
 
     it('should set country from action.payload', () => {
-      expect(result.entities[countryId]).toEqual(country)
+      expect(result.entities[countryId]).toEqual(jasmine.objectContaining(country))
+    });
+
+    it('should indicate that the country has been fully loaded', () => {
+      expect(result.entities[countryId].loaded).toBeTruthy();
     });
   });
 

--- a/libs/geography/src/reducers/country-entities/country-entities.reducer.spec.ts
+++ b/libs/geography/src/reducers/country-entities/country-entities.reducer.spec.ts
@@ -80,8 +80,46 @@ describe('Geography | Reducer | CountryEntities', () => {
         result = reducer(inter, countryListSuccess);
       });
 
-      it('should not overwrite the subdivisions', () => {
-        expect(result.entities[mockCountry.id].subdivisions).toEqual([mockSubdivision]);
+      describe('and the payload does not have subdivisions', () => {
+        beforeEach(() => {
+          const countryLoadSuccess = new DaffCountryLoadSuccess({
+            ...mockCountry,
+            subdivisions: [mockSubdivision]
+          });
+          const countryListSuccess = new DaffCountryListSuccess([mockCountry]);
+
+          const inter = reducer(initialState, countryLoadSuccess);
+
+          result = reducer(inter, countryListSuccess);
+        });
+
+        it('should not overwrite the subdivisions', () => {
+          expect(result.entities[mockCountry.id].subdivisions).toEqual([mockSubdivision]);
+        });
+      });
+
+      describe('and the payload has subdivisions', () => {
+        let newSubdivisions;
+
+        beforeEach(() => {
+          newSubdivisions = subdivisionFactory.createMany(2);
+          const countryLoadSuccess = new DaffCountryLoadSuccess({
+            ...mockCountry,
+            subdivisions: [mockSubdivision]
+          });
+          const countryListSuccess = new DaffCountryListSuccess([{
+            ...mockCountry,
+            subdivisions: newSubdivisions
+          }]);
+
+          const inter = reducer(initialState, countryLoadSuccess);
+
+          result = reducer(inter, countryListSuccess);
+        });
+
+        it('should overwrite the subdivisions', () => {
+          expect(result.entities[mockCountry.id].subdivisions).toEqual(newSubdivisions);
+        });
       });
 
       it('should not overwrite the loaded state', () => {

--- a/libs/geography/src/reducers/country-entities/country-entities.reducer.spec.ts
+++ b/libs/geography/src/reducers/country-entities/country-entities.reducer.spec.ts
@@ -60,7 +60,7 @@ describe('Geography | Reducer | CountryEntities', () => {
     });
 
     it('should set countries from action.payload', () => {
-      expect(result.entities).toEqual({[countryId]: country})
+      expect(result.entities).toEqual({[countryId]: jasmine.objectContaining(country)})
     });
   });
 });

--- a/libs/geography/src/reducers/country-entities/country-entities.reducer.spec.ts
+++ b/libs/geography/src/reducers/country-entities/country-entities.reducer.spec.ts
@@ -1,4 +1,5 @@
-import { DaffCountryFactory } from '@daffodil/geography/testing';
+import { DaffCountry, DaffSubdivision } from '@daffodil/geography';
+import { DaffCountryFactory, DaffSubdivisionFactory } from '@daffodil/geography/testing';
 
 import {
   DaffCountryLoadSuccess,
@@ -8,18 +9,21 @@ import {
   daffCountryEntitiesReducer as reducer,
 } from './country-entities.reducer';
 import { daffCountryEntitiesInitialState as initialState } from './country-entities-initial-state';
-import { DaffCountry } from '../../models/country';
 
 describe('Geography | Reducer | CountryEntities', () => {
   let countryFactory: DaffCountryFactory;
-  let country: DaffCountry;
+  let subdivisionFactory: DaffSubdivisionFactory;
+  let mockCountry: DaffCountry;
+  let mockSubdivision: DaffSubdivision;
   let countryId: DaffCountry['id'];
 
   beforeEach(() => {
     countryFactory = new DaffCountryFactory();
+    subdivisionFactory = new DaffSubdivisionFactory();
 
-    country = countryFactory.create();
-    countryId = country.id;
+    mockCountry = countryFactory.create();
+    mockSubdivision = subdivisionFactory.create();
+    countryId = mockCountry.id;
   });
 
   describe('when an unknown action is triggered', () => {
@@ -36,13 +40,13 @@ describe('Geography | Reducer | CountryEntities', () => {
     let result;
 
     beforeEach(() => {
-      const countryLoadSuccess = new DaffCountryLoadSuccess<DaffCountry>(country);
+      const countryLoadSuccess = new DaffCountryLoadSuccess<DaffCountry>(mockCountry);
 
       result = reducer(initialState, countryLoadSuccess);
     });
 
     it('should set country from action.payload', () => {
-      expect(result.entities[countryId]).toEqual(jasmine.objectContaining(country))
+      expect(result.entities[countryId]).toEqual(jasmine.objectContaining(mockCountry))
     });
 
     it('should indicate that the country has been fully loaded', () => {
@@ -54,13 +58,35 @@ describe('Geography | Reducer | CountryEntities', () => {
     let result;
 
     beforeEach(() => {
-      const countryListSuccess = new DaffCountryListSuccess([country]);
+      const countryListSuccess = new DaffCountryListSuccess([mockCountry]);
 
       result = reducer(initialState, countryListSuccess);
     });
 
     it('should set countries from action.payload', () => {
-      expect(result.entities).toEqual({[countryId]: jasmine.objectContaining(country)})
+      expect(result.entities).toEqual({[countryId]: jasmine.objectContaining(mockCountry)})
+    });
+
+    describe('when a country has previously been fully loaded', () => {
+      beforeEach(() => {
+        const countryLoadSuccess = new DaffCountryLoadSuccess({
+          ...mockCountry,
+          subdivisions: [mockSubdivision]
+        });
+        const countryListSuccess = new DaffCountryListSuccess([mockCountry]);
+
+        const inter = reducer(initialState, countryLoadSuccess);
+
+        result = reducer(inter, countryListSuccess);
+      });
+
+      it('should not overwrite the subdivisions', () => {
+        expect(result.entities[mockCountry.id].subdivisions).toEqual([mockSubdivision]);
+      });
+
+      it('should not overwrite the loaded state', () => {
+        expect(result.entities[mockCountry.id].loaded).toBeTruthy();
+      });
     });
   });
 });

--- a/libs/geography/src/reducers/country-entities/country-entities.reducer.ts
+++ b/libs/geography/src/reducers/country-entities/country-entities.reducer.ts
@@ -7,7 +7,7 @@ import { daffCountryEntitiesInitialState } from './country-entities-initial-stat
 /**
  * Reducer function that catches actions and changes/overwrites country entities state.
  */
-export function daffCountryEntitiesReducer<T extends DaffCountry>(
+export function daffCountryEntitiesReducer<T extends DaffCountry = DaffCountry>(
   state = daffCountryEntitiesInitialState,
   action: DaffGeographyActions<T>
 ): DaffCountryEntityState<T> {
@@ -15,7 +15,10 @@ export function daffCountryEntitiesReducer<T extends DaffCountry>(
 
   switch (action.type) {
     case DaffGeographyActionTypes.CountryLoadSuccessAction:
-      return adapter.upsertOne(action.payload, state);
+      return adapter.upsertOne({
+        ...action.payload,
+        loaded: true
+      }, state);
 
     case DaffGeographyActionTypes.CountryListSuccessAction:
       return adapter.upsertMany(action.payload, state);

--- a/libs/geography/src/reducers/country-entities/country-entities.reducer.ts
+++ b/libs/geography/src/reducers/country-entities/country-entities.reducer.ts
@@ -21,7 +21,13 @@ export function daffCountryEntitiesReducer<T extends DaffCountry = DaffCountry>(
       }, state);
 
     case DaffGeographyActionTypes.CountryListSuccessAction:
-      return adapter.upsertMany(action.payload, state);
+      return adapter.upsertMany(
+        action.payload.map(country => ({
+          ...country,
+          loaded: false
+        })),
+        state
+      );
 
     default:
       return state;

--- a/libs/geography/src/reducers/country-entities/country-entities.reducer.ts
+++ b/libs/geography/src/reducers/country-entities/country-entities.reducer.ts
@@ -24,7 +24,12 @@ export function daffCountryEntitiesReducer<T extends DaffCountry = DaffCountry>(
       return adapter.upsertMany(
         action.payload.map(country => ({
           ...country,
-          loaded: false
+          // defer to the loaded state of the country already in state (if it exists) but init field to false if it does not
+          loaded: (state.entities[country.id] && state.entities[country.id].loaded) || false,
+          // if the country coming in has no subdivisions and the same country in state does, use the subdivisions in state
+          subdivisions: country.subdivisions.length === 0 && state.entities[country.id] && state.entities[country.id].subdivisions.length > 0
+            ? state.entities[country.id].subdivisions
+            : country.subdivisions
         })),
         state
       );

--- a/libs/geography/src/reducers/geography-reducers-state.interface.ts
+++ b/libs/geography/src/reducers/geography-reducers-state.interface.ts
@@ -2,7 +2,7 @@ import { DaffGeographyReducerState } from './geography/geography-state.interface
 import { DaffCountryEntityState } from './country-entities/country-entities-state.interface';
 import { DaffCountry } from '../models/country';
 
-export interface DaffGeographyFeatureState<T extends DaffCountry> {
+export interface DaffGeographyFeatureState<T extends DaffCountry = DaffCountry> {
   geography: DaffGeographyReducerState,
   countries: DaffCountryEntityState<T>
 }

--- a/libs/geography/src/reducers/geography/geography-initial-state.ts
+++ b/libs/geography/src/reducers/geography/geography-initial-state.ts
@@ -1,6 +1,6 @@
 import { DaffGeographyReducerState } from './geography-state.interface';
 
-export const daffGeographyInitialState: DaffGeographyReducerState = Object.freeze({
+export const daffGeographyInitialState: DaffGeographyReducerState = {
   loading: false,
-  errors: []
-});
+  errors: [],
+};

--- a/libs/geography/src/reducers/geography/geography.reducer.ts
+++ b/libs/geography/src/reducers/geography/geography.reducer.ts
@@ -13,6 +13,12 @@ export function daffGeographyReducer<T extends DaffCountry>(
       return { ...state, loading: true };
 
     case DaffGeographyActionTypes.CountryLoadSuccessAction:
+      return {
+        ...state,
+        errors: [],
+        loading: false,
+      };
+
     case DaffGeographyActionTypes.CountryListSuccessAction:
       return {
         ...state,

--- a/libs/geography/src/reducers/geography/geography.reducer.ts
+++ b/libs/geography/src/reducers/geography/geography.reducer.ts
@@ -13,12 +13,6 @@ export function daffGeographyReducer<T extends DaffCountry>(
       return { ...state, loading: true };
 
     case DaffGeographyActionTypes.CountryLoadSuccessAction:
-      return {
-        ...state,
-        errors: [],
-        loading: false,
-      };
-
     case DaffGeographyActionTypes.CountryListSuccessAction:
       return {
         ...state,

--- a/libs/geography/src/selectors/country-entities.selector.spec.ts
+++ b/libs/geography/src/selectors/country-entities.selector.spec.ts
@@ -2,7 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { Store, StoreModule, select, combineReducers } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 
-import { DaffCountry } from '@daffodil/geography';
+import {
+  DaffCountry,
+  DaffCountryLoadSuccess
+} from '@daffodil/geography';
 import { DaffCountryFactory } from '@daffodil/geography/testing';
 
 import {
@@ -29,7 +32,8 @@ describe('Geography | Selector | CountryEntities', () => {
     selectCountryIds,
     selectCountryTotal,
     selectCountry,
-    selectCountrySubdivisions
+    selectCountrySubdivisions,
+    selectIsCountryFullyLoaded
   } = getDaffCountryEntitySelectors();
 
   beforeEach(() => {
@@ -101,6 +105,27 @@ describe('Geography | Selector | CountryEntities', () => {
       const expected = cold('a', {a: mockCountry.subdivisions});
 
       expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectIsCountryFullyLoaded', () => {
+    it('should initially be false', () => {
+      store.pipe(select(selectIsCountryFullyLoaded, {id: mockCountry.id})).subscribe(res => {
+        expect(res).toBeFalsy();
+      });
+    });
+
+    describe('when a country is loaded', () => {
+      beforeEach(() => {
+        store.dispatch(new DaffCountryLoadSuccess(mockCountry));
+      });
+
+      it('should be true', () => {
+        const selector = store.pipe(select(selectIsCountryFullyLoaded, {id: mockCountry.id}));
+        const expected = cold('a', {a: true});
+
+        expect(selector).toBeObservable(expected);
+      });
     });
   });
 });

--- a/libs/geography/src/selectors/country-entities.selector.spec.ts
+++ b/libs/geography/src/selectors/country-entities.selector.spec.ts
@@ -57,7 +57,7 @@ describe('Geography | Selector | CountryEntities', () => {
   describe('selectAllCountries', () => {
     it('should select all of the countries', () => {
       const selector = store.pipe(select(selectAllCountries));
-      const expected = cold('a', {a: [mockCountry]});
+      const expected = cold('a', {a: [jasmine.objectContaining(mockCountry)]});
 
       expect(selector).toBeObservable(expected);
     });
@@ -66,7 +66,7 @@ describe('Geography | Selector | CountryEntities', () => {
   describe('selectCountryEntities', () => {
     it('should select all of the countries', () => {
       const selector = store.pipe(select(selectCountryEntities));
-      const expected = cold('a', {a: {[countryId]: mockCountry}});
+      const expected = cold('a', {a: {[countryId]: jasmine.objectContaining(mockCountry)}});
 
       expect(selector).toBeObservable(expected);
     });
@@ -93,7 +93,7 @@ describe('Geography | Selector | CountryEntities', () => {
   describe('selectCountry', () => {
     it('should select a specific country by ID', () => {
       const selector = store.pipe(select(selectCountry, { id: mockCountry.id }));
-      const expected = cold('a', {a: mockCountry});
+      const expected = cold('a', {a: jasmine.objectContaining(mockCountry)});
 
       expect(selector).toBeObservable(expected);
     });
@@ -110,9 +110,10 @@ describe('Geography | Selector | CountryEntities', () => {
 
   describe('selectIsCountryFullyLoaded', () => {
     it('should initially be false', () => {
-      store.pipe(select(selectIsCountryFullyLoaded, {id: mockCountry.id})).subscribe(res => {
-        expect(res).toBeFalsy();
-      });
+      const selector = store.pipe(select(selectIsCountryFullyLoaded, {id: mockCountry.id}));
+      const expected = cold('a', {a: false});
+
+      expect(selector).toBeObservable(expected);
     });
 
     describe('when a country is loaded', () => {

--- a/libs/geography/src/selectors/country-entities.selector.ts
+++ b/libs/geography/src/selectors/country-entities.selector.ts
@@ -19,9 +19,10 @@ export interface DaffCountryEntitySelectors<T extends DaffCountry> {
   selectCountryTotal: MemoizedSelector<object, number>;
   selectCountry: MemoizedSelectorWithProps<object, {id: string | number}, T>;
   selectCountrySubdivisions: MemoizedSelectorWithProps<object, {id: string | number}, T['subdivisions']>;
+  selectIsCountryFullyLoaded: MemoizedSelector<object, boolean>;
 }
 
-const createCountryEntitySelectors = <T extends DaffCountry>() => {
+const createCountryEntitySelectors = <T extends DaffCountry = DaffCountry>() => {
   const { selectGeographyFeatureState } = getDaffGeographyFeatureStateSelector<T>();
   const selectCountryEntitiesState = createSelector(
     selectGeographyFeatureState,
@@ -41,6 +42,14 @@ const createCountryEntitySelectors = <T extends DaffCountry>() => {
       return country ? country.subdivisions : []
     }
   )
+
+  const selectIsCountryFullyLoaded = createSelector(
+    selectEntities,
+    (countries: Dictionary<T>, props: {id: T['id']}) => {
+      const country = selectCountry.projector(countries, { id: props.id });
+      return country && country.loaded
+    }
+  );
 
   return {
     selectCountryEntitiesState,
@@ -67,7 +76,11 @@ const createCountryEntitySelectors = <T extends DaffCountry>() => {
     /**
      * Selector for a specific country's subdivisions.
      */
-    selectCountrySubdivisions
+    selectCountrySubdivisions,
+    /**
+     * Selector for checking if a country has been fully loaded.
+     */
+    selectIsCountryFullyLoaded
   }
 }
 

--- a/libs/geography/src/selectors/country-entities.selector.ts
+++ b/libs/geography/src/selectors/country-entities.selector.ts
@@ -79,6 +79,7 @@ const createCountryEntitySelectors = <T extends DaffCountry = DaffCountry>() => 
     selectCountrySubdivisions,
     /**
      * Selector for checking if a country has been fully loaded.
+     * If true, then a country's subdivisions will be populated if any exist.
      */
     selectIsCountryFullyLoaded
   }

--- a/libs/geography/src/selectors/geography-all.selector.ts
+++ b/libs/geography/src/selectors/geography-all.selector.ts
@@ -3,14 +3,14 @@ import { DaffCountryEntitySelectors, getDaffCountryEntitySelectors } from './cou
 import { DaffGeographySelectors, getGeographySelectors } from './geography.selector';
 import { DaffGeographyFeatureSelector, getDaffGeographyFeatureStateSelector } from './geography-feature.selector';
 
-export interface DaffGeographyAllSelectors<T extends DaffCountry> extends
+export interface DaffGeographyAllSelectors<T extends DaffCountry = DaffCountry> extends
   DaffCountryEntitySelectors<T>,
   DaffGeographySelectors,
   DaffGeographyFeatureSelector<T> {}
 
 export const getDaffGeographySelectors = (() => {
   let cache;
-  return <T extends DaffCountry>(): DaffGeographyAllSelectors<T> =>
+  return <T extends DaffCountry = DaffCountry>(): DaffGeographyAllSelectors<T> =>
     cache = cache || {
       ...getGeographySelectors<T>(),
       ...getDaffCountryEntitySelectors<T>(),

--- a/libs/geography/src/selectors/geography-feature.selector.ts
+++ b/libs/geography/src/selectors/geography-feature.selector.ts
@@ -3,13 +3,13 @@ import { createFeatureSelector, MemoizedSelector } from '@ngrx/store';
 import { DaffGeographyFeatureState, DAFF_GEOGRAPHY_STORE_FEATURE_KEY } from '../reducers/public_api';
 import { DaffCountry } from '../models/country';
 
-export interface DaffGeographyFeatureSelector<T extends DaffCountry> {
+export interface DaffGeographyFeatureSelector<T extends DaffCountry = DaffCountry> {
   selectGeographyFeatureState: MemoizedSelector<object, DaffGeographyFeatureState<T>>
 }
 
 export const getDaffGeographyFeatureStateSelector = (() => {
   let cache;
-  return <T extends DaffCountry>(): DaffGeographyFeatureSelector<T> =>
+  return <T extends DaffCountry = DaffCountry>(): DaffGeographyFeatureSelector<T> =>
     cache = cache || {
       selectGeographyFeatureState: createFeatureSelector<DaffGeographyFeatureState<T>>(DAFF_GEOGRAPHY_STORE_FEATURE_KEY)
     }

--- a/libs/geography/src/selectors/geography.selector.spec.ts
+++ b/libs/geography/src/selectors/geography.selector.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { Store, StoreModule, select, combineReducers } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 
-import { DaffCountry } from '@daffodil/geography';
+import { DaffCountry, DaffCountryLoadSuccess } from '@daffodil/geography';
 import { DaffCountryFactory } from '@daffodil/geography/testing';
 
 import {
@@ -16,7 +16,7 @@ import {
 import { DaffCountryListSuccess } from '../actions/public_api';
 
 describe('Geography | Selector | Geography', () => {
-  let store: Store<DaffGeographyFeatureState<DaffCountry>>;
+  let store: Store<DaffGeographyFeatureState>;
 
   let countryFactory: DaffCountryFactory
 

--- a/libs/geography/src/selectors/geography.selector.spec.ts
+++ b/libs/geography/src/selectors/geography.selector.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { Store, StoreModule, select, combineReducers } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 
-import { DaffCountry, DaffCountryLoadSuccess } from '@daffodil/geography';
+import { DaffCountry } from '@daffodil/geography';
 import { DaffCountryFactory } from '@daffodil/geography/testing';
 
 import {

--- a/libs/geography/src/selectors/geography.selector.ts
+++ b/libs/geography/src/selectors/geography.selector.ts
@@ -10,9 +10,10 @@ export interface DaffGeographySelectors {
   selectGeographyState: MemoizedSelector<object, DaffGeographyReducerState>;
   selectGeographyLoading: MemoizedSelector<object, boolean>;
   selectGeographyErrors: MemoizedSelector<object, string[]>;
+
 }
 
-const createGeographySelectors = <T extends DaffCountry>() => {
+const createGeographySelectors = <T extends DaffCountry = DaffCountry>() => {
   const { selectGeographyFeatureState } = getDaffGeographyFeatureStateSelector<T>();
   const selectGeographyState = createSelector(
     selectGeographyFeatureState,
@@ -38,6 +39,6 @@ const createGeographySelectors = <T extends DaffCountry>() => {
 
 export const getGeographySelectors = (() => {
   let cache;
-  return <T extends DaffCountry>(): DaffGeographySelectors =>
+  return <T extends DaffCountry = DaffCountry>(): DaffGeographySelectors =>
     cache = cache || createGeographySelectors<T>()
 })();

--- a/libs/geography/src/selectors/geography.selector.ts
+++ b/libs/geography/src/selectors/geography.selector.ts
@@ -10,7 +10,6 @@ export interface DaffGeographySelectors {
   selectGeographyState: MemoizedSelector<object, DaffGeographyReducerState>;
   selectGeographyLoading: MemoizedSelector<object, boolean>;
   selectGeographyErrors: MemoizedSelector<object, string[]>;
-
 }
 
 const createGeographySelectors = <T extends DaffCountry = DaffCountry>() => {

--- a/libs/geography/testing/src/helpers/mock-geography-facade.ts
+++ b/libs/geography/testing/src/helpers/mock-geography-facade.ts
@@ -20,5 +20,9 @@ export class MockDaffGeographyFacade implements DaffGeographyFacadeInterface {
     return new BehaviorSubject([]);
   }
 
+  isCountryFullyLoaded(id) {
+    return new BehaviorSubject(false)
+  }
+
   dispatch(action: Action) {};
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?
- Adds state for tracking the fully loaded countries
- Adds selectors for checking if a country is fully loaded
- Adds some generic default values

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is needed because a country's subdivision should be not a required value only when the country has been fully loaded _and_ no subdivions are present. Otherwise there is no way to determine whether or not a country has subdivisions without actually trying to load them all.