### PR TITLE
feat(product): change configurable product prices to be a min and max price

### DIFF
--- a/libs/product/src/facades/configurable-product/configurable-product-facade.interface.ts
+++ b/libs/product/src/facades/configurable-product/configurable-product-facade.interface.ts
@@ -19,11 +19,22 @@ export interface DaffConfigurableProductFacadeInterface extends DaffStoreFacade<
 	getAppliedAttributes(id: string): Observable<Dictionary<string>>;
 
 	/**
-	 * Get the current price/price-range of a configurable product based on the applied
-	 * attributes.
+	 * Get the current minimum price possible based on the applied attributes and remaining variants.
 	 * @param id the id of the configurable product.
 	 */
-	getPrice(id: string): Observable<string>;
+	getMinimumPrice(id: string): Observable<number>;
+
+	/**
+	 * Get the current maximum price possible based on the applied attributes and remaining variants.
+	 * @param id the id of the configurable product.
+	 */
+	getMaximumPrice(id: string): Observable<number>;
+
+	/**
+	 * Returns whether the possible price for the configurable product is a range of different prices
+	 * @param id the id of the configurable product.
+	 */
+	isPriceRanged(id: string): Observable<boolean>;
 
 	/**
 	 * Selectable configurable product attributes derived from the remaining variants and the order of currently applied attributes.

--- a/libs/product/src/facades/configurable-product/configurable-product.facade.spec.ts
+++ b/libs/product/src/facades/configurable-product/configurable-product.facade.spec.ts
@@ -98,26 +98,57 @@ describe('DaffConfigurableProductFacade', () => {
 		});
   });
 
-  describe('getPrice', () => {
+  describe('getMinimumPrice', () => {
 
-    it('should return an Observable string of the price/price-range for a configurable product', () => {
-			const expected = cold('a', { a: stubConfigurableProduct.variants[0].price.toString() });
+    it('should return the minimum possible price for a configurable product', () => {
+			stubConfigurableProduct.variants[0].price = 2;
+			stubConfigurableProduct.variants[1].price = 1;
+			stubConfigurableProduct.variants[2].price = 4;
+			stubConfigurableProduct.variants[3].price = 3;
+			const expected = cold('a', { a: 1 });
+
       store.dispatch(new DaffConfigurableProductApplyAttribute(
 				stubConfigurableProduct.id,
 				stubConfigurableProduct.configurableAttributes[0].code,
 				stubConfigurableProduct.configurableAttributes[0].values[0].value
 			));
-			store.dispatch(new DaffConfigurableProductApplyAttribute(
+			expect(facade.getMinimumPrice(stubConfigurableProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('getMaximumPrice', () => {
+
+    it('should return the minimum possible price for a configurable product', () => {
+			stubConfigurableProduct.variants[0].price = 2;
+			stubConfigurableProduct.variants[1].price = 1;
+			stubConfigurableProduct.variants[2].price = 4;
+			stubConfigurableProduct.variants[3].price = 3;
+			const expected = cold('a', { a: 4 });
+
+      store.dispatch(new DaffConfigurableProductApplyAttribute(
 				stubConfigurableProduct.id,
-				stubConfigurableProduct.configurableAttributes[1].code,
-				stubConfigurableProduct.configurableAttributes[1].values[0].value
+				stubConfigurableProduct.configurableAttributes[0].code,
+				stubConfigurableProduct.configurableAttributes[0].values[0].value
 			));
-			store.dispatch(new DaffConfigurableProductApplyAttribute(
+			expect(facade.getMaximumPrice(stubConfigurableProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('isPriceRanged', () => {
+
+    it('should return whether the possible price is a range of prices', () => {
+			stubConfigurableProduct.variants[0].price = 2;
+			stubConfigurableProduct.variants[1].price = 1;
+			stubConfigurableProduct.variants[2].price = 4;
+			stubConfigurableProduct.variants[3].price = 3;
+			const expected = cold('a', { a: true });
+
+      store.dispatch(new DaffConfigurableProductApplyAttribute(
 				stubConfigurableProduct.id,
-				stubConfigurableProduct.configurableAttributes[2].code,
-				stubConfigurableProduct.configurableAttributes[2].values[0].value
+				stubConfigurableProduct.configurableAttributes[0].code,
+				stubConfigurableProduct.configurableAttributes[0].values[0].value
 			));
-			expect(facade.getPrice(stubConfigurableProduct.id)).toBeObservable(expected);
+			expect(facade.isPriceRanged(stubConfigurableProduct.id)).toBeObservable(expected);
 		});
   });
 

--- a/libs/product/src/facades/configurable-product/configurable-product.facade.ts
+++ b/libs/product/src/facades/configurable-product/configurable-product.facade.ts
@@ -29,8 +29,16 @@ export class DaffConfigurableProductFacade<T extends DaffProduct = DaffProduct> 
 		return this.store.pipe(select(this.selectors.selectConfigurableProductAppliedAttributesAsDictionary, { id }));
 	}
 
-	getPrice(id: string): Observable<string> {
-		return this.store.pipe(select(this.selectors.selectConfigurableProductPrice, { id }));
+	getMinimumPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectConfigurableProductMinimumPrice, { id }));
+	}
+
+	getMaximumPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectConfigurableProductMaximumPrice, { id }));
+	}
+	
+	isPriceRanged(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.isConfigurablePriceRanged, { id }));
 	}
 
 	getSelectableAttributes(id: string): Observable<Dictionary<string[]>> {

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
@@ -188,18 +188,14 @@ function isVariantAvailable(
 
 function getMinimumPrice(prices: number[]): number {
 	return prices.reduce(
-		(acc, price) => {
-			return price < acc ? price : acc;
-		},
+		(acc, price) => price < acc ? price : acc,
 		prices[0]
 	);
 }
 
 function getMaximumPrice(prices: number[]): number {
 	return prices.reduce(
-		(acc, price) => {
-			return price > acc ? price : acc;
-		},
+		(acc, price) => price > acc ? price : acc,
 		prices[0]
 	);
 }

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
@@ -10,7 +10,10 @@ import { DaffConfigurableProductEntityAttribute } from '../../reducers/configura
 export interface DaffConfigurableProductMemoizedSelectors {
 	selectAllConfigurableProductAttributes: MemoizedSelectorWithProps<object, object, Dictionary<string[]>>;
 	selectMatchingConfigurableProductVariants: MemoizedSelectorWithProps<object, object, DaffConfigurableProductVariant[]>;
-	selectConfigurableProductPrice: MemoizedSelectorWithProps<object, object, string>;
+	selectConfigurableProductPrices: MemoizedSelectorWithProps<object, object, number[]>;
+	selectConfigurableProductMinimumPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectConfigurableProductMaximumPrice: MemoizedSelectorWithProps<object, object, number>;
+	isConfigurablePriceRanged: MemoizedSelectorWithProps<object, object, boolean>;
 	selectSelectableConfigurableProductAttributes: MemoizedSelectorWithProps<object, object, Dictionary<string[]>>;
 }
 
@@ -45,15 +48,49 @@ const createConfigurableProductSelectors = (): DaffConfigurableProductMemoizedSe
 	/**
 	 * Selector for the range of price for current configuration of the configurable product.
 	 */
-	const selectConfigurableProductPrice = createSelector(
+	const selectConfigurableProductPrices = createSelector(
 		selectProductEntities,
 		selectConfigurableProductAppliedAttributesEntitiesState,
 		(products, appliedAttributesEntities, props) => {
-			const matchingVariants: DaffConfigurableProductVariant[] = selectMatchingConfigurableProductVariants.projector(products, appliedAttributesEntities, { id: props.id });
-			if(matchingVariants.length === 1) return matchingVariants[0].price.toString();
-			else return getMinimumPrice(matchingVariants) + '-' + getMaximumPrice(matchingVariants);
+			return selectMatchingConfigurableProductVariants.projector(products, appliedAttributesEntities, { id: props.id })
+				.map(variant => variant.price);
 		}
 	);
+
+	/**
+	 * Selector for the minimum price in the range of configurable product variant prices.
+	 */
+	const selectConfigurableProductMinimumPrice = createSelector(
+		selectProductEntities,
+		selectConfigurableProductAppliedAttributesEntitiesState,
+		(products, appliedAttributesEntities, props) => getMinimumPrice(
+			selectConfigurableProductPrices.projector(products, appliedAttributesEntities, { id: props.id })
+		)
+	)
+
+	/**
+	 * Selector for the maximum price in the range of configurable product variant prices.
+	 */
+	const selectConfigurableProductMaximumPrice = createSelector(
+		selectProductEntities,
+		selectConfigurableProductAppliedAttributesEntitiesState,
+		(products, appliedAttributesEntities, props) => getMaximumPrice(
+			selectConfigurableProductPrices.projector(products, appliedAttributesEntities, { id: props.id })
+		)
+	)
+
+	/**
+	 * Selector for whether the configurable product variant prices have been narrowed to a single price.
+	 */
+	const isConfigurablePriceRanged = createSelector(
+		selectProductEntities,
+		selectConfigurableProductAppliedAttributesEntitiesState,
+		(products, appliedAttributesEntities, props) => {
+			const minPrice = selectConfigurableProductMinimumPrice.projector(products, appliedAttributesEntities, { id: props.id });
+			const maxPrice = selectConfigurableProductMaximumPrice.projector(products, appliedAttributesEntities, { id: props.id });
+			return minPrice !== maxPrice;
+		}
+	)
 
 	const selectAllConfigurableProductAttributes = createSelector(
 		selectProductEntities,
@@ -111,7 +148,10 @@ const createConfigurableProductSelectors = (): DaffConfigurableProductMemoizedSe
 
 	return { 
 		selectAllConfigurableProductAttributes,
-		selectConfigurableProductPrice,
+		selectConfigurableProductPrices,
+		selectConfigurableProductMinimumPrice,
+		selectConfigurableProductMaximumPrice,
+		isConfigurablePriceRanged,
 		selectMatchingConfigurableProductVariants,
 		selectSelectableConfigurableProductAttributes
 	}
@@ -146,24 +186,22 @@ function isVariantAvailable(
 	)
 }
 
-function getMinimumPrice(variants: DaffConfigurableProductVariant[]): string {
-	return variants.reduce(
-		(acc, variant) => {
-			const price = variant.price;
+function getMinimumPrice(prices: number[]): number {
+	return prices.reduce(
+		(acc, price) => {
 			return price < acc ? price : acc;
 		},
-		variants[0].price
-	).toString();
+		prices[0]
+	);
 }
 
-function getMaximumPrice(variants: DaffConfigurableProductVariant[]): string {
-	return variants.reduce(
-		(acc, variant) => {
-			const price = variant.price
+function getMaximumPrice(prices: number[]): number {
+	return prices.reduce(
+		(acc, price) => {
 			return price > acc ? price : acc;
 		},
-		variants[0].price
-	).toString();
+		prices[0]
+	);
 }
 
 function initializeSelectableAttributes(attributes: DaffConfigurableProductAttribute[]): Dictionary<string[]> {

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.unit.spec.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.unit.spec.ts
@@ -20,7 +20,10 @@ describe('Configurable Product Selectors | unit tests', () => {
   const configurableProductFactory: DaffConfigurableProductFactory = new DaffConfigurableProductFactory();
 	let stubConfigurableProduct: DaffConfigurableProduct;
 	const {
-		selectConfigurableProductPrice,
+		selectConfigurableProductPrices,
+		selectConfigurableProductMinimumPrice,
+		selectConfigurableProductMaximumPrice,
+		isConfigurablePriceRanged,
 		selectMatchingConfigurableProductVariants,
 		selectSelectableConfigurableProductAttributes
 	} = getDaffConfigurableProductSelectors();
@@ -38,11 +41,11 @@ describe('Configurable Product Selectors | unit tests', () => {
     store = TestBed.get(Store);
   });
 
-	describe('selectConfigurableProductPrice', () => {
+	describe('selectConfigurableProductPrices', () => {
 
 		describe('when many variants are possible', () => {
 			
-			it('should return a ranged price', () => {
+			it('should return an array of prices', () => {
 				stubConfigurableProduct.variants[0].price = 2;
 				stubConfigurableProduct.variants[1].price = 1;
 				stubConfigurableProduct.variants[2].price = 3;
@@ -53,37 +56,90 @@ describe('Configurable Product Selectors | unit tests', () => {
 					stubConfigurableProduct.configurableAttributes[0].code,
 					stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[0].code]
 				));
-				const selector = store.pipe(select(selectConfigurableProductPrice, { id: stubConfigurableProduct.id }));
-				const expected = cold('a', { a: '1-4' });
+				const selector = store.pipe(select(selectConfigurableProductPrices, { id: stubConfigurableProduct.id }));
+				const expected = cold('a', { a: [2, 1, 3, 4] });
 
 				expect(selector).toBeObservable(expected);
 			});
 		});
+	});
 
-		describe('when only one variant is possible', () => {
-			
-			it('should return a single price', () => {
-				store.dispatch(new DaffProductLoadSuccess(stubConfigurableProduct));
-				store.dispatch(new DaffConfigurableProductApplyAttribute(
-					stubConfigurableProduct.id,
-					stubConfigurableProduct.configurableAttributes[0].code,
-					stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[0].code]
-				));
-				store.dispatch(new DaffConfigurableProductApplyAttribute(
-					stubConfigurableProduct.id,
-					stubConfigurableProduct.configurableAttributes[1].code,
-					stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[1].code]
-				));
-				store.dispatch(new DaffConfigurableProductApplyAttribute(
-					stubConfigurableProduct.id,
-					stubConfigurableProduct.configurableAttributes[2].code,
-					stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[2].code]
-				));
-				const selector = store.pipe(select(selectConfigurableProductPrice, { id: stubConfigurableProduct.id }));
-				const expected = cold('a', { a: stubConfigurableProduct.variants[0].price.toString() });
+	describe('selectConfigurableProductMinimumPrice', () => {
+		
+		it('should return the minimum price of the range of variant prices', () => {
+			stubConfigurableProduct.variants[0].price = 2;
+			stubConfigurableProduct.variants[1].price = 1;
+			stubConfigurableProduct.variants[2].price = 3;
+			stubConfigurableProduct.variants[3].price = 4;
+			store.dispatch(new DaffProductGridLoadSuccess([stubConfigurableProduct]));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				stubConfigurableProduct.configurableAttributes[0].code,
+				stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[0].code]
+			));
+			const selector = store.pipe(select(selectConfigurableProductMinimumPrice, { id: stubConfigurableProduct.id }));
+			const expected = cold('a', { a: 1 });
 
-				expect(selector).toBeObservable(expected);
-			});
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectConfigurableProductMaximumPrice', () => {
+		
+		it('should return the maximum price of the range of variant prices', () => {
+			stubConfigurableProduct.variants[0].price = 2;
+			stubConfigurableProduct.variants[1].price = 1;
+			stubConfigurableProduct.variants[2].price = 3;
+			stubConfigurableProduct.variants[3].price = 4;
+			store.dispatch(new DaffProductGridLoadSuccess([stubConfigurableProduct]));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				stubConfigurableProduct.configurableAttributes[0].code,
+				stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[0].code]
+			));
+			const selector = store.pipe(select(selectConfigurableProductMaximumPrice, { id: stubConfigurableProduct.id }));
+			const expected = cold('a', { a: 4 });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('isConfigurablePriceRanged', () => {
+		
+		it('should return true when more than one price is possible', () => {
+			store.dispatch(new DaffProductLoadSuccess(stubConfigurableProduct));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				stubConfigurableProduct.configurableAttributes[0].code,
+				stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[0].code]
+			));
+			const selector = store.pipe(select(isConfigurablePriceRanged, { id: stubConfigurableProduct.id }));
+			const expected = cold('a', { a: true });
+
+			expect(selector).toBeObservable(expected);
+		});
+		
+		it('should return false when only one price is possible', () => {
+			store.dispatch(new DaffProductLoadSuccess(stubConfigurableProduct));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				stubConfigurableProduct.configurableAttributes[0].code,
+				stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[0].code]
+			));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				stubConfigurableProduct.configurableAttributes[1].code,
+				stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[1].code]
+			));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				stubConfigurableProduct.configurableAttributes[2].code,
+				stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[2].code]
+			));
+			const selector = store.pipe(select(isConfigurablePriceRanged, { id: stubConfigurableProduct.id }));
+			const expected = cold('a', { a: false });
+
+			expect(selector).toBeObservable(expected);
 		});
 	});
 

--- a/libs/product/testing/src/helpers/mock-configurable-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-configurable-product-facade.ts
@@ -10,7 +10,13 @@ export class MockDaffConfigurableProductFacade implements DaffConfigurableProduc
 	getAppliedAttributes(id: string): BehaviorSubject<Dictionary<string>> {
 		return new BehaviorSubject({});
 	};
-	getPrice(id: string): BehaviorSubject<string> {
+	getMinimumPrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	getMaximumPrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	isPriceRanged(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(null);
 	};
 	getSelectableAttributes(id: string): BehaviorSubject<Dictionary<string[]>> {


### PR DESCRIPTION
BREAKING CHANGE: the getPrice function on the DaffConfigurableProductFacade is now split into getMinimumPrice, getMaximumPrice, and isPriceRanged.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `getPrice` function forces the app dev to perform transformations on ranged prices to get it to render correctly in the UI.

## What is the new behavior?
Now the app dev is given more elementary pieces of the ranged configurable price, which should simplify logic they would need to write.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```