### PR TITLE
feat(cart, geography): deprecate region_id and transform region to string for cart address input

### DIFF
--- a/libs/cart/src/drivers/magento/transforms/inputs/cart-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/cart-address.service.spec.ts
@@ -36,15 +36,18 @@ describe('Driver | Magento | Cart | Transformer | MagentoCartAddress', () => {
     let street;
     let city;
     let firstname;
+    let region;
 
     beforeEach(() => {
       street = 'street';
       city = 'city';
       firstname = 'firstname';
+      region = 'region';
 
       mockDaffCartAddress.street = street;
       mockDaffCartAddress.city = city;
       mockDaffCartAddress.firstname = firstname;
+      mockDaffCartAddress.region = region;
 
       transformedCartAddress = service.transform(mockDaffCartAddress);
     });
@@ -53,6 +56,7 @@ describe('Driver | Magento | Cart | Transformer | MagentoCartAddress', () => {
       expect(transformedCartAddress.street).toEqual([street]);
       expect(transformedCartAddress.city).toEqual(city);
       expect(transformedCartAddress.firstname).toEqual(firstname);
+      expect(transformedCartAddress.region).toEqual(region);
     });
   });
 });

--- a/libs/cart/src/drivers/magento/transforms/inputs/cart-address.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/cart-address.service.ts
@@ -12,7 +12,7 @@ export class DaffMagentoCartAddressInputTransformer {
       firstname: cartAddress.firstname,
       lastname: cartAddress.lastname,
       postcode: cartAddress.postcode,
-      region: cartAddress.region,
+      region: String(cartAddress.region),
       save_in_address_book: false,
       street: [cartAddress.street],
       telephone: cartAddress.telephone,

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-address.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-address.service.ts
@@ -21,8 +21,7 @@ export class DaffMagentoCartAddressTransformer {
       // address
       street: address.street[0],
       city: address.city,
-      region: address.region.label,
-      region_id: address.region.code,
+      region: address.region.code,
       country: address.country.label,
       country_id: address.country.code,
       postcode: address.postcode,

--- a/libs/cart/testing/src/factories/cart-address.factory.ts
+++ b/libs/cart/testing/src/factories/cart-address.factory.ts
@@ -19,7 +19,6 @@ export class MockCartAddress implements DaffCartAddress {
   city = 'city';
   state = 'state';
   region = 'region';
-  region_id = faker.random.number(1000);
   postcode = 'postcode';
   country_id = 'ISO';
   telephone = '+1 (123)-123-1234';
@@ -29,7 +28,7 @@ export class MockCartAddress implements DaffCartAddress {
   providedIn: 'root'
 })
 export class DaffCartAddressFactory extends DaffModelFactory<DaffCartAddress> {
-  
+
   constructor(){
     super(MockCartAddress);
   }

--- a/libs/geography/src/models/address.ts
+++ b/libs/geography/src/models/address.ts
@@ -5,7 +5,12 @@ export interface DaffAddress {
 	street: string;
 	street2?: string;
   city: string;
-  region: string;
+  region: string | number;
+  /**
+   * Use DaffAddress#region instead.
+   *
+   * @deprecated
+   */
   region_id?: string | number;
   country?: string;
   country_id?: string | number;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?
- Deprecates `DaffAddress#region_id`
- Changes the Magento cart address input transformer to transform the region to a string.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information