### PR TITLE
[WIP] feat(all): make the return of function properties of mock facades Obs…

### DIFF
--- a/libs/cart/testing/src/helpers/mock-cart-facade.ts
+++ b/libs/cart/testing/src/helpers/mock-cart-facade.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { Action } from '@ngrx/store';
 
 import {
@@ -48,8 +48,8 @@ export class MockDaffCartFacade implements DaffCartFacadeInterface {
 	orderResult$ = new BehaviorSubject<DaffCartOrderResult>({id: null});
 	orderResultId$ = new BehaviorSubject<DaffCartOrderResult['id']>(null);
 
-	getCartItemDiscountedTotal(itemId: string | number): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
+	getCartItemDiscountedTotal(itemId: string | number): Observable<number> {
+		return of(null);
 	}
 
   dispatch(action: Action) {};

--- a/libs/category/testing/src/helpers/mock-category-facade.ts
+++ b/libs/category/testing/src/helpers/mock-category-facade.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of, Observable } from 'rxjs';
 import { Action } from '@ngrx/store';
 
 import { DaffProduct } from '@daffodil/product';
@@ -31,14 +31,14 @@ export class MockDaffCategoryFacade implements DaffCategoryFacadeInterface {
 	errors$: BehaviorSubject<string[]> = new BehaviorSubject([]);
 	isCategoryEmpty$: BehaviorSubject<boolean> = new BehaviorSubject(true);
 	
-	getCategoryById(id: string): BehaviorSubject<DaffCategory> {
-		return new BehaviorSubject(null);
+	getCategoryById(id: string): Observable<DaffCategory> {
+		return of(null);
 	};
-	getProductsByCategory(categoryId: string): BehaviorSubject<DaffProduct[]> {
-		return new BehaviorSubject([]);
+	getProductsByCategory(categoryId: string): Observable<DaffProduct[]> {
+		return of([]);
 	};
-	getTotalProductsByCategory(categoryId: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
+	getTotalProductsByCategory(categoryId: string): Observable<number> {
+		return of(null);
 	};
   dispatch(action: Action) {};
 }

--- a/libs/geography/testing/src/helpers/mock-geography-facade.ts
+++ b/libs/geography/testing/src/helpers/mock-geography-facade.ts
@@ -1,8 +1,8 @@
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of, Observable } from 'rxjs';
 import { Action } from '@ngrx/store';
 import { Dictionary } from '@ngrx/entity';
 
-import { DaffGeographyFacadeInterface, DaffCountry } from '@daffodil/geography';
+import { DaffGeographyFacadeInterface, DaffCountry, DaffSubdivision } from '@daffodil/geography';
 
 export class MockDaffGeographyFacade implements DaffGeographyFacadeInterface {
   loading$: BehaviorSubject<boolean> = new BehaviorSubject(null);
@@ -12,16 +12,16 @@ export class MockDaffGeographyFacade implements DaffGeographyFacadeInterface {
   countryCount$: BehaviorSubject<number> = new BehaviorSubject(null);
   countryEntities$: BehaviorSubject<Dictionary<DaffCountry>> = new BehaviorSubject(null);
 
-  getCountry(id) {
-    return new BehaviorSubject(null);
+  getCountry(id): Observable<DaffCountry> {
+    return of(null);
   }
 
-  getCountrySubdivisions(id) {
-    return new BehaviorSubject([]);
+  getCountrySubdivisions(id): Observable<DaffSubdivision[]> {
+    return of([]);
   }
 
-  isCountryFullyLoaded(id) {
-    return new BehaviorSubject(false)
+  isCountryFullyLoaded(id): Observable<boolean> {
+    return of(false)
   }
 
   dispatch(action: Action) {};

--- a/libs/product/testing/src/helpers/mock-configurable-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-configurable-product-facade.ts
@@ -1,26 +1,26 @@
-import { BehaviorSubject } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { Dictionary } from '@ngrx/entity';
 
 import { DaffConfigurableProductFacadeInterface } from '@daffodil/product';
 
 export class MockDaffConfigurableProductFacade implements DaffConfigurableProductFacadeInterface {
-	getAllAttributes(id: string): BehaviorSubject<Dictionary<string[]>> {
-		return new BehaviorSubject({});
+	getAllAttributes(id: string): Observable<Dictionary<string[]>> {
+		return of({});
 	};
-	getAppliedAttributes(id: string): BehaviorSubject<Dictionary<string>> {
-		return new BehaviorSubject({});
+	getAppliedAttributes(id: string): Observable<Dictionary<string>> {
+		return of({});
 	};
-	getMinimumPrice(id: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
+	getMinimumPrice(id: string): Observable<number> {
+		return of(null);
 	};
-	getMaximumPrice(id: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
+	getMaximumPrice(id: string): Observable<number> {
+		return of(null);
 	};
-	isPriceRanged(id: string): BehaviorSubject<boolean> {
-		return new BehaviorSubject(null);
+	isPriceRanged(id: string): Observable<boolean> {
+		return of(null);
 	};
-	getSelectableAttributes(id: string): BehaviorSubject<Dictionary<string[]>> {
-		return new BehaviorSubject({});
+	getSelectableAttributes(id: string): Observable<Dictionary<string[]>> {
+		return of({});
 	};
 	dispatch(action) {};
 }

--- a/libs/product/testing/src/helpers/mock-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-product-facade.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 
 import { DaffProduct, DaffProductFacadeInterface } from '@daffodil/product';
 
@@ -8,8 +8,8 @@ export class MockDaffProductFacade implements DaffProductFacadeInterface {
 	 * @deprecated use getProduct instead.
 	 */
 	product$: BehaviorSubject<DaffProduct> = new BehaviorSubject(null);
-	getProduct(id: string): BehaviorSubject<DaffProduct> {
-		return new BehaviorSubject(null);
+	getProduct(id: string): Observable<DaffProduct> {
+		return of(null);
 	}
 	dispatch(action) {};
 }


### PR DESCRIPTION
…ervables

BREAKING CHANGE: these functions used to return BehaviorSubjects, so the types of some tests will break.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Using the MockDaffFacades to mock out facade function properties is a little bit clunky. The only options are pretty wordy: `facade.myFunctionProperty = (input) => { return new BehaviorSubject(someValue); }` or spyOn(facade, 'myFunctionProperty').and.returnValue(new BehaviorSubject(someValue);`

## What is the new behavior?
The new way is pretty straightforward: `spyOn(facade, 'myFunctionProperty').and.returnValue(of(someValue))`. So it's a little better.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```