### PR TITLE
feat(order): add optional cartId parameters to support guest orders

### DIFF
--- a/libs/order/package.json
+++ b/libs/order/package.json
@@ -21,11 +21,13 @@
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
+    "@daffodil/cart": "0.0.0-PLACEHOLDER",
     "@daffodil/core": "0.0.0-PLACEHOLDER",
     "@daffodil/geography": "0.0.0-PLACEHOLDER",
     "@daffodil/product": "0.0.0-PLACEHOLDER"
   },
   "devDependencies": {
+    "@daffodil/cart": "0.0.0-PLACEHOLDER",
     "@daffodil/core": "0.0.0-PLACEHOLDER",
     "@daffodil/geography": "0.0.0-PLACEHOLDER",
     "@daffodil/product": "0.0.0-PLACEHOLDER"

--- a/libs/order/src/drivers/interfaces/order-service.interface.ts
+++ b/libs/order/src/drivers/interfaces/order-service.interface.ts
@@ -1,6 +1,8 @@
 import { InjectionToken } from '@angular/core';
 import { Observable } from 'rxjs';
 
+import { DaffCart } from '@daffodil/cart';
+
 import { DaffOrder } from '../../models/public_api';
 
 export const DaffOrderDriver = new InjectionToken<DaffOrderServiceInterface>('DaffOrderDriver');
@@ -8,14 +10,17 @@ export const DaffOrderDriver = new InjectionToken<DaffOrderServiceInterface>('Da
 /**
  * Query order objects accessible by the logged-in user.
  */
-export interface DaffOrderServiceInterface<T extends DaffOrder = DaffOrder> {
+export interface DaffOrderServiceInterface<
+  T extends DaffOrder = DaffOrder,
+  V extends DaffCart = DaffCart
+> {
   /**
    * Get an order object with the specified order ID.
    */
-  get(orderId: T['id']): Observable<T>;
+  get(orderId: T['id'], cartId?: V['id']): Observable<T>;
 
   /**
    * List all order objects for the logged-in user.
    */
-  list(): Observable<T[]>;
+  list(cartId?: V['id']): Observable<T[]>;
 }

--- a/libs/order/src/errors/invalid-api-response.ts
+++ b/libs/order/src/errors/invalid-api-response.ts
@@ -1,0 +1,8 @@
+export class DaffInvalidAPIResponseError extends Error {
+	readonly name = 'DaffInvalidAPIResponseError';
+  readonly code: string = 'INVALID_API_RESPONSE';
+
+	constructor(public message: string) {
+		super(message);
+	}
+}

--- a/libs/order/src/errors/public_api.ts
+++ b/libs/order/src/errors/public_api.ts
@@ -1,0 +1,1 @@
+export { DaffInvalidAPIResponseError } from './invalid-api-response';

--- a/libs/order/src/index.ts
+++ b/libs/order/src/index.ts
@@ -7,3 +7,4 @@ export * from './actions/order.actions';
 export * from './reducers/public_api';
 export * from './selectors/public_api';
 export * from './facades/public_api';
+export * from './errors/public_api';

--- a/libs/order/src/models/order-item.ts
+++ b/libs/order/src/models/order-item.ts
@@ -8,8 +8,8 @@ export interface DaffOrderItem {
   qty_fulfilled: number;
   image: DaffProductImage;
   order_id: DaffOrder['id'];
-  created_at: Date;
-  updated_at: Date;
+  created_at: string;
+  updated_at: string;
   product_id: number;
   parent_item_id: number;
   sku: string;

--- a/libs/order/testing/src/factories/order-item.factory.ts
+++ b/libs/order/testing/src/factories/order-item.factory.ts
@@ -18,7 +18,6 @@ export class MockOrderItem implements DaffOrderItem {
   parent_item_id = faker.random.number(1000);
   sku = 'sku';
   name = 'Product Name';
-  description = 'description';
   weight = faker.random.number(1000);
   qty = faker.random.number({min:1, max:100});
   price = faker.random.number(1000);

--- a/libs/order/testing/src/factories/order-payment.factory.ts
+++ b/libs/order/testing/src/factories/order-payment.factory.ts
@@ -8,8 +8,8 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 export class MockOrderPayment implements DaffOrderPayment {
     payment_id = faker.random.number(1000);
     order_id = faker.random.number(1000);
-    created_at = faker.date.past();
-    updated_at = faker.date.past();
+    created_at = faker.date.past().toString();
+    updated_at = faker.date.past().toString();
     method = 'card';
     cc_type = 'visa';
     cc_last4 = faker.random.number(1000).toString();

--- a/libs/order/testing/src/factories/order-shipping-rate.factory.ts
+++ b/libs/order/testing/src/factories/order-shipping-rate.factory.ts
@@ -8,8 +8,8 @@ export class MockOrderShippingMethod implements DaffOrderShippingMethod {
   rate_id = faker.random.number(1000);
   address_id = faker.random.number(1000);
   order_id = faker.random.number(1000);
-  created_at = faker.date.past();
-  updated_at = faker.date.past();
+  created_at = faker.date.past().toString();
+  updated_at = faker.date.past().toString();
   carrier = 'Birds Inc.';
   carrier_title = 'laden';
   code = 'code';

--- a/libs/order/testing/src/factories/order.factory.ts
+++ b/libs/order/testing/src/factories/order.factory.ts
@@ -6,21 +6,18 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockOrder implements DaffOrder {
   id = faker.random.number(1000);
-  created_at = faker.date.past();
-  updated_at = faker.date.past();
-  store_to_base_rate = faker.random.number(1000);
-  grand_total = faker.random.number(1000);
-  checkout_method = 'card';
   customer_id = faker.random.number(1000);
-  coupon_code = faker.random.number(100000).toString();
-  subtotal = faker.random.number(1000);
-  subtotal_with_discount = faker.random.number(1000);
-  items = [];
-  addresses = [];
+  created_at = faker.date.past().toString();
+  updated_at = faker.date.past().toString();
   status = faker.random.word();
   totals = [];
   applied_codes = [];
+  items = [];
+  addresses = [];
+  shipments = [];
   payment = null;
+  invoices = [];
+  credits = [];
 };
 
 

--- a/libs/order/testing/src/factories/public_api.ts
+++ b/libs/order/testing/src/factories/public_api.ts
@@ -1,5 +1,11 @@
 export { DaffOrderAddressFactory } from './order-address.factory';
-export { DaffOrderItemFactory } from './order-item.factory';
+export { DaffOrderCouponFactory } from './order-coupon.factory';
+export { DaffOrderInvoiceFactory } from './order-invoice.factory';
 export { DaffOrderPaymentFactory } from './order-payment.factory';
+export { DaffOrderItemFactory } from './order-item.factory';
+export { DaffOrderShipmentItemFactory } from './order-shipment-item.factory';
+export { DaffOrderShipmentTrackingFactory } from './order-shipment-tracking.factory';
+export { DaffOrderShipmentFactory } from './order-shipment.factory';
 export { DaffOrderShippingMethodFactory } from './order-shipping-rate.factory';
+export { DaffOrderTotalFactory } from './order-total.factory';
 export { DaffOrderFactory } from './order.factory';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?
- Changes order item date field types from `Date` to `string`.
- Updates factories to align more closely with the new order models.
- Adds the invalid API response error.
- Changes the order service interface to accept an optional `cartId` which will enable support for guest orders.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Adds `@daffodil/cart` as a peer dep. Just install this package to satisfy the dep.

## Other information