### PR TITLE
feat(cart): update the cart payment with the payment package-specific…

### DIFF
--- a/libs/cart/src/drivers/magento/transforms/inputs/payment-method.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/payment-method.service.spec.ts
@@ -38,13 +38,19 @@ describe('Driver | Magento | Cart | Transformer | MagentoPaymentMethodInput', ()
     beforeEach(() => {
       method = 'method';
 
-      mockDaffPayment.method = method;
+			mockDaffPayment.method = method;
+			mockDaffPayment.payment_info = {
+				field: 1,
+				field2: {
+					someField: 'test'
+				}
+			}
 
       transformedPaymentMethod = service.transform(mockDaffPayment);
     });
 
-    it('should return an object with the correct values', () => {
-      expect(transformedPaymentMethod.code).toEqual(method);
+    it('should return the payment_info object', () => {
+      expect(transformedPaymentMethod).toEqual(mockDaffPayment.payment_info);
     });
   });
 });

--- a/libs/cart/src/drivers/magento/transforms/inputs/payment-method.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/payment-method.service.ts
@@ -7,7 +7,7 @@ import { DaffCartPaymentMethod } from '../../../../models/cart-payment';
 export class DaffMagentoPaymentMethodInputTransformer {
   transform(payment: Partial<DaffCartPaymentMethod>): MagentoPaymentMethodInput {
     return {
-      code: payment.method
+			...payment.payment_info
     }
   }
 }


### PR DESCRIPTION
… info object

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The cart payment update mutation is called with the wrong object.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

Notes:
This change goes back to conversations we've had about passing the platform-specific payment model directly from the daffodil payment package to the cart payment update call. This is to avoid needing payment-specific transformers in the cart package.