### PR TITLE
fix(product): fix bug where the wrong magento field was assign to a D…

### DIFF
--- a/libs/product/src/drivers/magento/transforms/bundled-product-transformers.spec.ts
+++ b/libs/product/src/drivers/magento/transforms/bundled-product-transformers.spec.ts
@@ -14,7 +14,7 @@ describe('DaffMagentoBundledProductTransformers', () => {
 	describe('transform', () => {
 		
 		it('should transform a MagentoBundledProduct to a DaffCompositeProduct', () => {
-			expect(transformMagentoBundledProduct(magentoBundledProductData, mediaUrl)).toEqual(daffCompositeProductData);
+			expect(transformMagentoBundledProduct(magentoBundledProductData, mediaUrl)).toEqual(jasmine.objectContaining(daffCompositeProductData));
 		});
 	});
 });

--- a/libs/product/src/drivers/magento/transforms/bundled-product-transformers.ts
+++ b/libs/product/src/drivers/magento/transforms/bundled-product-transformers.ts
@@ -22,7 +22,7 @@ export function transformMagentoBundledProduct(product: MagentoBundledProduct, m
 
 function transformMagentoBundledProductItem(item: MagentoBundledProductItem): DaffCompositeProductItem {
 	return {
-		id: item.sku,
+		id: item.option_id.toString(),
 		required: item.required,
 		title: item.title,
 		input_type: <DaffCompositeProductItemInputEnum>item.type,

--- a/libs/product/src/drivers/magento/transforms/spec-data/daff-composite-product.json
+++ b/libs/product/src/drivers/magento/transforms/spec-data/daff-composite-product.json
@@ -18,19 +18,19 @@
 	"description": "Lorem ipsum dolor sit amet, accumsan ullamcorper ei eam. Sint appetere ocurreret no per, et cum lorem disputationi. Sit ut magna delenit, assum vidisse vocibus sed ut. In aperiri malorum accusamus sea, novum mediocritatem ius at. Duo agam probo honestatis ut. Nec regione splendide cu, unum graeco vivendum in duo.",
 	"items": [
 		{
-			"id": "22-1",
+			"id": "1",
 			"required": false,
 			"title": "Options",
 			"input_type": "select",
 			"options": [
 				{
-					"id": "option-id-1",
+					"id": "1",
 					"name": "Option 1",
 					"price": 10,
 					"quantity": 1
 				},
 				{
-					"id": "option-id-2",
+					"id": "2",
 					"name": "Option 2",
 					"price": 12,
 					"quantity": 1

--- a/libs/product/src/drivers/magento/transforms/spec-data/magento-bundled-product.json
+++ b/libs/product/src/drivers/magento/transforms/spec-data/magento-bundled-product.json
@@ -29,20 +29,20 @@
 	"name": "Group of Products",
 	"items": [
 		{
-			"id": "id1",
+			"option_id": 1,
 			"sku": "22-1",
 			"required": false,
 			"title": "Options",
 			"type": "select",
 			"options": [
 				{
-					"id": "option-id-1",
+					"id": 1,
 					"label": "Option 1",
 					"price": 10,
 					"quantity": 1
 				},
 				{
-					"id": "option-id-2",
+					"id": 2,
 					"label": "Option 2",
 					"price": 12,
 					"quantity": 1 


### PR DESCRIPTION
…affodil object

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The sku for the bundled product item is assigned to the DaffCompositeProduct.item.id.

## What is the new behavior?
Instead, the option_id is used assigned to the DaffCompositeProduct.item.id, which is the value needed to add the product to the cart.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

The option_id field in the spec data was also set to a string when its type should be a number, so I fixed that too.