### PR TITLE
feat(product): add state for composite products

### DIFF
--- a/libs/product/src/actions/composite-product.actions.ts
+++ b/libs/product/src/actions/composite-product.actions.ts
@@ -1,0 +1,26 @@
+import { Action } from '@ngrx/store';
+
+import { DaffCompositeProduct } from '../models/composite-product';
+
+/**
+ * Action types for Composite Product Actions.
+ */
+export enum DaffCompositeProductActionTypes {
+	CompositeProductApplyOptionAction = '[Composite Product] Composite Product Apply Option Action'
+}
+
+/**
+ * Applies a product option to a particular composite product.
+ * 
+ * @param id - Id of the Composite Product
+ * @param itemId - Id of the product item.
+ * @param optionId - Id of the option of the product item that is chosen.
+ */
+export class DaffCompositeProductApplyOption<T extends DaffCompositeProduct> implements Action {
+  readonly type = DaffCompositeProductActionTypes.CompositeProductApplyOptionAction;
+
+  constructor(public id: T['id'], public itemId: string, public optionId: string) {}
+}
+
+export type DaffCompositeProductActions<T extends DaffCompositeProduct = DaffCompositeProduct> = 
+	| DaffCompositeProductApplyOption<T>;

--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -1,7 +1,10 @@
 import { Observable } from 'rxjs';
 import { Action } from '@ngrx/store';
+import { Dictionary } from '@ngrx/entity';
 
 import { DaffStoreFacade } from '@daffodil/core';
+
+import { DaffCompositeProductItemOption } from '../../models/composite-product-item';
 
 export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Action> {
 
@@ -28,4 +31,10 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * @param id the id of the composite product.
 	 */
 	hasDiscount(id: string): Observable<boolean>;
+
+	/**
+	 * Returns the applied options for a composite product.
+	 * @param id the id of the composite product.
+	 */
+	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption['id']>>;
 }

--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -1,0 +1,31 @@
+import { Observable } from 'rxjs';
+import { Action } from '@ngrx/store';
+
+import { DaffStoreFacade } from '@daffodil/core';
+
+export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Action> {
+
+	/**
+	 * Get the price of a composite product based on the applied product options.
+	 * @param id the id of the composite product.
+	 */
+	getPrice(id: string): Observable<number>;
+
+	/**
+	 * Get the discount amount of a composite product based on the applied product options.
+	 * @param id the id of the composite product.
+	 */
+	getDiscountAmount(id: string): Observable<number>;
+
+	/**
+	 * Get the discounted price of a composite product based on the applied product options.
+	 * @param id the id of the composite product.
+	 */
+	getDiscountedPrice(id: string): Observable<number>;
+
+	/**
+	 * Returns whether the composite product has a discount based on the applied product options.
+	 * @param id the id of the composite product.
+	 */
+	hasDiscount(id: string): Observable<boolean>;
+}

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -106,5 +106,16 @@ describe('DaffCompositeProductFacade', () => {
 	
 			expect(facade.hasDiscount(stubCompositeProduct.id)).toBeObservable(expected);
 		});
-  });
+	});
+	
+	describe('getAppliedOptions', () => {
+		
+		it('should return the applied option for a composite product', () => {
+			const expected = cold('a', { a: { 
+				[stubCompositeProduct.items[0].id]: stubCompositeProduct.items[0].options[0].id 
+			}});
+
+			expect(facade.getAppliedOptions(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+	});
 });

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -1,0 +1,110 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore } from '@ngrx/store/testing';
+import { Store, StoreModule, combineReducers } from '@ngrx/store';
+import { cold } from 'jasmine-marbles';
+
+import { 
+	DaffCompositeProduct, 
+	DaffProductLoadSuccess,
+	daffProductReducers,
+	DaffProductReducersState
+} from '@daffodil/product';
+import { DaffCompositeProductFactory } from '@daffodil/product/testing';
+
+import { DaffCompositeProductFacade } from './composite-product.facade';
+
+describe('DaffCompositeProductFacade', () => {
+  let store: MockStore<Partial<DaffProductReducersState>>;
+	let facade: DaffCompositeProductFacade;
+	let stubCompositeProduct: DaffCompositeProduct;
+	stubCompositeProduct = new DaffCompositeProductFactory().create();
+	const stubDefaultPrice0 = 10;
+	const stubDiscountAmount0 = 2.4;
+	const stubDiscountAmount1 = 1.4;
+	const stubChangedPrice0 = 20;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports:[
+        StoreModule.forRoot({
+          product: combineReducers(daffProductReducers),
+        })
+      ],
+      providers: [
+        DaffCompositeProductFacade,
+      ]
+		})
+		// setup: set items to required, set a default option on each item, and set prices/discounts.
+		stubCompositeProduct.items[0].required = true;
+		stubCompositeProduct.items[0].options[0].is_default = true;
+		stubCompositeProduct.items[0].options[0].price = stubDefaultPrice0;
+		stubCompositeProduct.items[0].options[1].price = stubChangedPrice0;
+		stubCompositeProduct.items[0].options[0].discount = {
+			amount: stubDiscountAmount0,
+			percent: null
+		}
+		stubCompositeProduct.items[0].options[1].discount = {
+			amount: stubDiscountAmount1,
+			percent: null
+		}
+
+    store = TestBed.get(Store);
+		facade = TestBed.get(DaffCompositeProductFacade);
+		store.dispatch(new DaffProductLoadSuccess(stubCompositeProduct));
+	});
+
+  it('should be created', () => {
+    expect(facade).toBeTruthy();
+  });
+
+  it('should be able to dispatch an action to the store', () => {
+    spyOn(store, 'dispatch');
+    const action = {type: 'SOME_TYPE'};
+
+    facade.dispatch(action);
+    expect(store.dispatch).toHaveBeenCalledWith(action);
+    expect(store.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  describe('getPrice', () => {
+
+    it('should return the price of the product', () => {
+			console.log(stubCompositeProduct);
+			const expected = cold('a', { a: stubCompositeProduct.price + stubDefaultPrice0 });
+	
+			expect(facade.getPrice(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('getDiscountAmount', () => {
+
+    it('should return the total discount amount for a composite product', () => {
+			const expected = cold('a', { a: stubCompositeProduct.discount.amount + stubDiscountAmount0 });
+	
+			expect(facade.getDiscountAmount(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('getDiscountedPrice', () => {
+
+    it('should the discounted price for a composite product', () => {
+			const expected = cold('a', { a: 
+				stubCompositeProduct.price 
+				+ stubCompositeProduct.items[0].options[0].price 
+				- stubCompositeProduct.discount.amount 
+				- stubCompositeProduct.items[0].options[0].discount.amount
+			});
+	
+			expect(facade.getDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('hasDiscount', () => {
+
+    it('should return whether the product has a discount', () => {
+			const expected = cold('a', { a: true });
+	
+			expect(facade.hasDiscount(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+});

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Store, select, Action } from '@ngrx/store';
+
+import { DaffProductModule } from '../../product.module';
+import { DaffProductReducersState } from '../../reducers/product-reducers-state.interface';
+import { DaffProduct } from '../../models/product';
+import { getDaffProductSelectors } from '../../selectors/public_api';
+import { DaffCompositeProductFacadeInterface } from './composite-product-facade.interface';
+
+/**
+ * A facade for accessing composite product state from an application component.
+ */
+@Injectable({
+  providedIn: DaffProductModule
+})
+export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> implements DaffCompositeProductFacadeInterface {
+
+	selectors = getDaffProductSelectors<T>();
+	
+	constructor(private store: Store<DaffProductReducersState<T>>) {}
+	
+	getPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPrice, { id }));
+	}
+	
+	getDiscountAmount(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductDiscountAmount, { id }));
+	}
+
+	getDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductDiscountedPrice, { id }));
+	}
+	
+	hasDiscount(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasDiscount, { id }));
+	}
+
+  /**
+   * Dispatches an action to the rxjs action stream.
+   */
+  dispatch(action: Action) {
+    this.store.dispatch(action);
+  }
+}

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -1,12 +1,14 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Store, select, Action } from '@ngrx/store';
+import { Dictionary } from '@ngrx/entity';
 
 import { DaffProductModule } from '../../product.module';
 import { DaffProductReducersState } from '../../reducers/product-reducers-state.interface';
 import { DaffProduct } from '../../models/product';
 import { getDaffProductSelectors } from '../../selectors/public_api';
 import { DaffCompositeProductFacadeInterface } from './composite-product-facade.interface';
+import { DaffCompositeProductItemOption } from '../../models/composite-product-item';
 
 /**
  * A facade for accessing composite product state from an application component.
@@ -34,6 +36,10 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 	
 	hasDiscount(id: string): Observable<boolean> {
 		return this.store.pipe(select(this.selectors.selectCompositeProductHasDiscount, { id }));
+	}
+
+	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption['id']>> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductAppliedOptions, { id }));
 	}
 
   /**

--- a/libs/product/src/index.ts
+++ b/libs/product/src/index.ts
@@ -4,6 +4,7 @@ export * from './actions/product.actions';
 export * from './actions/product-grid.actions';
 export * from './actions/best-sellers.actions';
 export * from './actions/configurable-product.actions';
+export * from './actions/composite-product.actions';
 export { DaffProductImage } from './models/product-image';
 export * from './models/composite-product';
 export * from './models/composite-product-item';
@@ -25,6 +26,8 @@ export { DaffProductFacade } from './facades/product/product.facade';
 export { DaffProductFacadeInterface } from './facades/product/product-facade.interface';
 export { DaffConfigurableProductFacade } from './facades/configurable-product/configurable-product.facade';
 export { DaffConfigurableProductFacadeInterface } from './facades/configurable-product/configurable-product-facade.interface';
+export { DaffCompositeProductFacade } from './facades/composite-product/composite-product.facade';
+export { DaffCompositeProductFacadeInterface } from './facades/composite-product/composite-product-facade.interface';
 export { DaffBestSellersFacade } from './facades/best-sellers/best-sellers.facade';
 
 export * from './drivers/magento/public_api';

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities-reducer-adapter.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities-reducer-adapter.ts
@@ -1,0 +1,12 @@
+import { EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+
+import { DaffCompositeProductEntity } from './composite-product-entity';
+
+/**
+ * Composite Product Item Options Adapter for changing/overwriting entity state.
+ */
+export const daffCompositeProductAppliedOptionsEntitiesAdapter = (() => {
+	let cache;
+  return (): EntityAdapter<DaffCompositeProductEntity> =>
+    cache = cache || createEntityAdapter<DaffCompositeProductEntity>();
+})();

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
@@ -136,5 +136,42 @@ describe('Product | Composite Product Entities Reducer', () => {
     it('changes the option id of the given product item', () => {
       expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual(compositeProduct.items[0].options[1].id);
     });
-  });
+	});
+	
+	describe('setting the default item option', () => {
+		
+		let result;
+
+		it('should set the item to the default option when it is provided', () => {
+			compositeProduct.items[0].options[0].is_default = false;
+			compositeProduct.items[0].options[1].is_default = true;
+			const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
+			result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
+
+			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual(compositeProduct.items[0].options[1].id);
+		});
+
+		describe('when the default item option is not defined', () => {
+			
+			it('should set the default option to the first option when the item is required', () => {
+				compositeProduct.items[0].options[0].is_default = false;
+				compositeProduct.items[0].options[1].is_default = false;
+				compositeProduct.items[0].required = true;
+				const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
+				result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
+
+				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual(compositeProduct.items[0].options[0].id);
+			});
+
+			it('should set the default option to null when the item is not required', () => {
+				compositeProduct.items[0].options[0].is_default = false;
+				compositeProduct.items[0].options[1].is_default = false;
+				compositeProduct.items[0].required = false;
+				const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
+				result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
+
+				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual(null);
+			});
+		});
+	});
 });

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
@@ -1,0 +1,140 @@
+import { DaffProductFactory, DaffCompositeProductFactory } from '@daffodil/product/testing';
+
+import { DaffProductLoadSuccess } from '../../actions/product.actions';
+import { DaffProductGridLoadSuccess } from '../../actions/product-grid.actions';
+import { daffCompositeProductEntitiesReducer } from './composite-product-entities.reducer';
+import { DaffBestSellersLoadSuccess } from '../../actions/best-sellers.actions';
+import { DaffProduct } from '../../models/product';
+import { daffCompositeProductAppliedOptionsEntitiesAdapter } from './composite-product-entities-reducer-adapter';
+import { DaffCompositeProduct } from '../../models/composite-product';
+import { DaffCompositeProductApplyOption } from '../../actions/composite-product.actions';
+
+describe('Product | Composite Product Entities Reducer', () => {
+
+	let productFactory: DaffProductFactory;
+	let compositeProductFactory: DaffCompositeProductFactory;
+	const initialState = daffCompositeProductAppliedOptionsEntitiesAdapter().getInitialState();
+	let compositeProduct: DaffCompositeProduct;
+
+  beforeEach(() => {
+		productFactory = new DaffProductFactory();
+		compositeProductFactory = new DaffCompositeProductFactory();
+		compositeProduct = compositeProductFactory.create()
+  });
+
+  describe('when an unknown action is triggered', () => {
+
+    it('should return the current state', () => {
+      const action = {} as any;
+
+      const result = daffCompositeProductEntitiesReducer(initialState, action);
+
+      expect(result).toEqual(initialState);
+    });
+  });
+
+  describe('when ProductGridLoadSuccessAction is triggered', () => {
+
+    let products: DaffProduct[];
+    let compositeProducts: DaffCompositeProduct[];
+    let result;
+
+    beforeEach(() => {
+			products = productFactory.createMany(2);
+			compositeProducts = compositeProductFactory.createMany(2);
+
+			products = [
+				...products,
+				...compositeProducts
+			];
+      const productGridLoadSuccess = new DaffProductGridLoadSuccess(products);
+      
+      result = daffCompositeProductEntitiesReducer(initialState, productGridLoadSuccess);
+    });
+
+    it('sets a composite product entity for each composite product', () => {
+      expect(result.ids.length).toEqual(compositeProducts.length);
+    });
+  });
+
+  describe('when BestSellersLoadSuccessAction is triggered', () => {
+
+    let products: DaffProduct[];
+    let compositeProducts: DaffCompositeProduct[];
+    let result;
+
+    beforeEach(() => {
+			products = productFactory.createMany(2);
+			compositeProducts = compositeProductFactory.createMany(2);
+
+			products = [
+				...products,
+				...compositeProducts
+			];
+      
+      const bestSellersLoadSuccess = new DaffBestSellersLoadSuccess(products);
+      
+      result = daffCompositeProductEntitiesReducer(initialState, bestSellersLoadSuccess);
+    });
+
+    it('sets a composite product entity for each composite product', () => {
+      expect(result.ids.length).toEqual(compositeProducts.length);
+    });
+  });
+
+  describe('when ProductLoadSuccessAction is triggered', () => {
+    
+    let product: DaffProduct;
+		let result;
+
+    beforeEach(() => {
+      product = productFactory.create();
+    });
+		
+    it('sets a composite product entity when the given product is composite', () => {
+			const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
+			result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
+			expect(result.entities[compositeProduct.id]).toEqual({ id: compositeProduct.id, items: { [compositeProduct.items[0].id]: compositeProduct.items[0].options[0].id } });
+    });
+		
+    it('does not set a composite product entity when the given product is not composite', () => {
+			const productLoadSuccess = new DaffProductLoadSuccess(product);
+			result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
+      expect(result.entities[product.id]).toBeUndefined();
+    });
+  });
+
+  describe('when DaffCompositeProductApplyOption is triggered', () => {
+    
+		let result;
+
+    beforeEach(() => {
+			const specInitialState = {
+				ids: [compositeProduct.id],
+				entities: {
+					[compositeProduct.id]: {
+						id: compositeProduct.id,
+						items: compositeProduct.items.reduce((acc, item) => {
+							return {
+								...acc,
+								[item.id]: item.options.find(option => option.is_default).id
+							}
+						}, {})
+					}
+				}
+			}
+
+      const compositeProductApplyAttribute = new DaffCompositeProductApplyOption(
+				compositeProduct.id,
+				<string>compositeProduct.items[0].id,
+				compositeProduct.items[0].options[1].id
+			);
+      
+			result = daffCompositeProductEntitiesReducer(specInitialState, compositeProductApplyAttribute);
+    });
+
+    it('changes the option id of the given product item', () => {
+      expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual(compositeProduct.items[0].options[1].id);
+    });
+  });
+});

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -1,0 +1,73 @@
+import { EntityState } from '@ngrx/entity';
+
+import { DaffProductGridActionTypes, DaffProductGridActions } from '../../actions/product-grid.actions';
+import { DaffProductActionTypes, DaffProductActions } from '../../actions/product.actions';
+import { DaffBestSellersActionTypes, DaffBestSellersActions } from '../../actions/best-sellers.actions';
+import { daffCompositeProductAppliedOptionsEntitiesAdapter } from './composite-product-entities-reducer-adapter';
+import { DaffProduct, DaffProductTypeEnum } from '../../models/product';
+import { DaffCompositeProductActions, DaffCompositeProductActionTypes } from '../../actions/composite-product.actions';
+import { DaffCompositeProduct } from '../../models/composite-product';
+import { DaffCompositeProductEntity } from './composite-product-entity';
+import { DaffCompositeProductItem } from '../../models/composite-product-item';
+
+/**
+ * Reducer function that catches actions and changes/overwrites composite product entities state.
+ * 
+ * @param state current State of the redux store
+ * @param action ProductGrid, BestSellers, Product, or Composite Product actions
+ * @returns Product entities state
+ */
+export function daffCompositeProductEntitiesReducer<T extends DaffProduct, V extends DaffCompositeProduct>(
+  state = daffCompositeProductAppliedOptionsEntitiesAdapter().getInitialState(), 
+  action: DaffProductGridActions<T> | DaffBestSellersActions<T> | DaffProductActions<T> | DaffCompositeProductActions<V>): EntityState<DaffCompositeProductEntity> {
+	const adapter = daffCompositeProductAppliedOptionsEntitiesAdapter();
+  switch (action.type) {
+    case DaffProductGridActionTypes.ProductGridLoadSuccessAction:
+		case DaffBestSellersActionTypes.BestSellersLoadSuccessAction:
+			return adapter.upsertMany(
+				action.payload
+					.filter(product => product.type === DaffProductTypeEnum.Composite)
+					.map(product => buildCompositeProductAppliedOptionsEntity(<V><unknown>product)), 
+				state
+			);
+    case DaffProductActionTypes.ProductLoadSuccessAction:
+			if(action.payload.type === DaffProductTypeEnum.Composite) {
+				return adapter.upsertOne(
+					buildCompositeProductAppliedOptionsEntity(<V><unknown>action.payload),
+					state
+				);
+			};
+			return state;
+		case DaffCompositeProductActionTypes.CompositeProductApplyOptionAction:
+			return adapter.upsertOne(
+				{
+					id: action.id,
+					items: {
+						...state.entities[action.id].items,
+						[action.itemId]: action.optionId
+					}
+				},
+				state
+			);
+    default:
+      return state;
+  }
+}
+
+function buildCompositeProductAppliedOptionsEntity(product: DaffCompositeProduct): DaffCompositeProductEntity {
+	return {
+		id: product.id,
+		items: product.items.reduce((acc, item) => ({
+			...acc,
+			[item.id]: getDefaultOption(item)
+		}), {})
+	}
+
+	function getDefaultOption(item: DaffCompositeProductItem): string {
+		const defaultOptionIndex = item.options.findIndex(option => option.is_default);
+
+		return defaultOptionIndex < 0 && item.required ?
+			item.options[0].id :
+			item.options[defaultOptionIndex].id;
+	}
+}

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -62,12 +62,14 @@ function buildCompositeProductAppliedOptionsEntity(product: DaffCompositeProduct
 			[item.id]: getDefaultOption(item)
 		}), {})
 	}
+}
 
-	function getDefaultOption(item: DaffCompositeProductItem): string {
-		const defaultOptionIndex = item.options.findIndex(option => option.is_default);
+function getDefaultOption(item: DaffCompositeProductItem): string {
+	const defaultOptionIndex = item.options.findIndex(option => option.is_default);
 
-		return defaultOptionIndex < 0 && item.required ?
-			item.options[0].id :
-			item.options[defaultOptionIndex].id;
+	if(defaultOptionIndex > -1) {
+		return item.options[defaultOptionIndex].id;
+	} else {
+		return item.required ? item.options[0].id : null;
 	}
 }

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
@@ -1,0 +1,6 @@
+import { Dictionary } from '@ngrx/entity';
+
+export interface DaffCompositeProductEntity {
+	id: string;
+	items: Dictionary<string>;
+}

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
@@ -1,6 +1,7 @@
 import { Dictionary } from '@ngrx/entity';
+import { DaffCompositeProductItemOption } from '../../models/composite-product-item';
 
 export interface DaffCompositeProductEntity {
 	id: string;
-	items: Dictionary<string>;
+	items: Dictionary<DaffCompositeProductItemOption['id']>;
 }

--- a/libs/product/src/reducers/product-reducers-state.interface.ts
+++ b/libs/product/src/reducers/product-reducers-state.interface.ts
@@ -5,6 +5,7 @@ import { DaffProductGridReducerState } from './product-grid/product-grid-reducer
 import { DaffProductReducerState } from './product/product-reducer-state.interface';
 import { DaffBestSellersReducerState } from './best-sellers/best-sellers-reducer-state.interface';
 import { DaffConfigurableProductEntity } from './configurable-product-entities/configurable-product-entity';
+import { DaffCompositeProductEntity } from './composite-product-entities/composite-product-entity';
 
 /**
  * Interface for product redux store.
@@ -15,4 +16,5 @@ export interface DaffProductReducersState<T extends DaffProduct = DaffProduct> {
   product: DaffProductReducerState;
 	bestSellers: DaffBestSellersReducerState;
 	configurableProductAttributes: EntityState<DaffConfigurableProductEntity>;
+	compositeProductOptions: EntityState<DaffCompositeProductEntity>;
 }

--- a/libs/product/src/reducers/product-reducers.ts
+++ b/libs/product/src/reducers/product-reducers.ts
@@ -3,6 +3,7 @@ import { daffProductReducer } from './product/product.reducer';
 import { daffBestSellersReducer } from './best-sellers/best-sellers.reducer';
 import { daffProductEntitiesReducer } from './product-entities/product-entities.reducer';
 import { daffConfigurableProductEntitiesReducer } from './configurable-product-entities/configurable-product-entities.reducer';
+import { daffCompositeProductEntitiesReducer } from './composite-product-entities/composite-product-entities.reducer';
 
 /**
  * Returns state values from all product related reducers.
@@ -12,5 +13,6 @@ export const daffProductReducers = {
 	productGrid: daffProductGridReducer,
 	product: daffProductReducer,
 	bestSellers: daffBestSellersReducer,
-	configurableProductAttributes: daffConfigurableProductEntitiesReducer
+	configurableProductAttributes: daffConfigurableProductEntitiesReducer,
+	compositeProductOptions: daffCompositeProductEntitiesReducer
 }

--- a/libs/product/src/selectors/all-selectors.selectors.ts
+++ b/libs/product/src/selectors/all-selectors.selectors.ts
@@ -6,6 +6,8 @@ import { DaffProductGridMemoizedSelectors, getDaffProductGridSelectors } from '.
 import { DaffProductFeatureMemoizedSelector, getDaffProductFeatureSelector } from './product-feature.selector';
 import { DaffConfigurableProductEntitiesMemoizedSelectors, getDaffConfigurableProductEntitiesSelectors } from './configurable-product-entities/configurable-product-entities.selectors';
 import { DaffConfigurableProductMemoizedSelectors, getDaffConfigurableProductSelectors } from './configurable-product/configurable-product.selectors';
+import { DaffCompositeProductEntitiesMemoizedSelectors, getDaffCompositeProductEntitiesSelectors } from './composite-product-entities/composite-product-entities.selectors';
+import { DaffCompositeProductMemoizedSelectors, getDaffCompositeProductSelectors } from './composite-product/composite-product.selectors';
 
 export interface DaffProductAllSelectors<T extends DaffProduct = DaffProduct> extends 
 	DaffProductPageMemoizedSelectors<T>, 
@@ -14,7 +16,9 @@ export interface DaffProductAllSelectors<T extends DaffProduct = DaffProduct> ex
 	DaffProductGridMemoizedSelectors<T>,
 	DaffProductFeatureMemoizedSelector<T>,
 	DaffConfigurableProductEntitiesMemoizedSelectors,
-	DaffConfigurableProductMemoizedSelectors { }
+	DaffConfigurableProductMemoizedSelectors,
+	DaffCompositeProductEntitiesMemoizedSelectors,
+	DaffCompositeProductMemoizedSelectors { }
 
 export const getDaffProductSelectors = <T extends DaffProduct = DaffProduct>(): DaffProductAllSelectors<T> => {
 	return {
@@ -24,6 +28,8 @@ export const getDaffProductSelectors = <T extends DaffProduct = DaffProduct>(): 
 		...getDaffProductEntitiesSelectors<T>(),
 		...getDaffProductFeatureSelector<T>(),
 		...getDaffConfigurableProductEntitiesSelectors(),
-		...getDaffConfigurableProductSelectors()
+		...getDaffConfigurableProductSelectors(),
+		...getDaffCompositeProductEntitiesSelectors(),
+		...getDaffCompositeProductSelectors()
 	}
 };

--- a/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.spec.ts
@@ -1,0 +1,92 @@
+import { TestBed } from '@angular/core/testing';
+import { StoreModule, combineReducers, Store, select } from '@ngrx/store';
+import { cold } from 'jasmine-marbles';
+
+import { DaffCompositeProductFactory } from '@daffodil/product/testing';
+import { 
+	DaffProductGridLoadSuccess,
+	DaffProductReducersState,
+	daffProductReducers,
+	DaffCompositeProduct
+} from '@daffodil/product';
+
+import { getDaffCompositeProductEntitiesSelectors } from './composite-product-entities.selectors';
+
+describe('selectCompositeProductEntitiesState', () => {
+
+  let store: Store<DaffProductReducersState>;
+  const compositeProductFactory: DaffCompositeProductFactory = new DaffCompositeProductFactory();
+	let stubCompositeProduct: DaffCompositeProduct;
+	const {
+		selectCompositeProductIds,
+		selectCompositeProductAppliedOptionsEntities,
+		selectCompositeProductTotal,
+		selectCompositeProductAppliedOptions
+	} = getDaffCompositeProductEntitiesSelectors();
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          product: combineReducers(daffProductReducers),
+        })
+      ]
+    });
+
+		stubCompositeProduct = compositeProductFactory.create();
+    store = TestBed.get(Store);
+
+    store.dispatch(new DaffProductGridLoadSuccess(new Array(stubCompositeProduct)));
+  });
+    
+	describe('selectCompositeProductIds', () => {
+	
+		it('selects product ids', () => {
+			const selector = store.pipe(select(selectCompositeProductIds));
+			const expected = cold('a', { a: [stubCompositeProduct.id] });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectCompositeProductAppliedOptionsEntities', () => {
+		
+		it('selects composite product items and the applied options as a dictionary object', () => {
+			const expectedDictionary = {
+				[stubCompositeProduct.id]: {
+					id: stubCompositeProduct.id,
+					items: {
+						[stubCompositeProduct.items[0].id]: stubCompositeProduct.items[0].options[0].id
+					}
+				}
+			}
+
+			const selector = store.pipe(select(selectCompositeProductAppliedOptionsEntities));
+			const expected = cold('a', { a: expectedDictionary });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectCompositeProductTotal', () => {
+		
+		it('selects the total number of composite products', () => {
+			const selector = store.pipe(select(selectCompositeProductTotal));
+			const expected = cold('a', { a: 1 });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+  describe('selectCompositeProductAppliedOptions', () => {
+    
+    it('selects the composite product options of the given id', () => {
+			const selector = store.pipe(select(selectCompositeProductAppliedOptions, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { 
+				a: {[stubCompositeProduct.items[0].id]: stubCompositeProduct.items[0].options[0].id}
+			});
+
+			expect(selector).toBeObservable(expected);
+    });
+  });
+});

--- a/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.ts
+++ b/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.ts
@@ -1,0 +1,77 @@
+import { createSelector, MemoizedSelector, MemoizedSelectorWithProps } from '@ngrx/store';
+import { EntityState, Dictionary } from '@ngrx/entity';
+
+import { getDaffProductFeatureSelector } from '../product-feature.selector';
+import { DaffProductReducersState } from '../../reducers/product-reducers-state.interface';
+import { DaffProduct } from '../../models/product';
+import { daffCompositeProductAppliedOptionsEntitiesAdapter } from '../../reducers/composite-product-entities/composite-product-entities-reducer-adapter';
+import { DaffCompositeProductEntity } from '../../reducers/composite-product-entities/composite-product-entity';
+
+export interface DaffCompositeProductEntitiesMemoizedSelectors {
+	selectCompositeProductAppliedOptionsEntitiesState: MemoizedSelector<object, EntityState<DaffCompositeProductEntity>>;
+	selectCompositeProductIds: MemoizedSelector<object, EntityState<DaffCompositeProductEntity>['ids']>;
+	selectCompositeProductAppliedOptionsEntities: MemoizedSelector<object, EntityState<DaffCompositeProductEntity>['entities']>;
+	selectCompositeProductTotal: MemoizedSelector<object, number>;
+	selectCompositeProductAppliedOptions: MemoizedSelectorWithProps<object, object, Dictionary<string>>;
+}
+
+const createCompositeProductAppliedOptionsEntitiesSelectors = <T extends DaffProduct>(): DaffCompositeProductEntitiesMemoizedSelectors => {
+	const {
+		selectProductState
+	} = getDaffProductFeatureSelector<T>();
+	const adapterSelectors = daffCompositeProductAppliedOptionsEntitiesAdapter().getSelectors();
+	/**
+	 * Composite Product Entities State
+	 */
+	const selectCompositeProductAppliedOptionsEntitiesState = createSelector(
+		selectProductState,
+		(state: DaffProductReducersState<T>) => state.compositeProductOptions
+	);
+
+	/**
+	 * Selector for composite product IDs.
+	 */
+	const selectCompositeProductIds = createSelector(
+		selectCompositeProductAppliedOptionsEntitiesState,
+		adapterSelectors.selectIds
+	);
+
+	/**
+	 * Selector for all composite product applied attributes as entities (see ngrx/entity).
+	 */
+	const selectCompositeProductAppliedOptionsEntities = createSelector(
+		selectCompositeProductAppliedOptionsEntitiesState,
+		adapterSelectors.selectEntities
+	);
+
+	/**
+	 * Selector for the total number of composite products.
+	 */
+	const selectCompositeProductTotal = createSelector(
+		selectCompositeProductAppliedOptionsEntitiesState,
+		adapterSelectors.selectTotal
+	);
+
+	/**
+	 * Selector for the applied attributes of a particular composite product.
+	 */
+	const selectCompositeProductAppliedOptions = createSelector(
+		selectCompositeProductAppliedOptionsEntitiesState,
+		(products, props) => products.entities[props.id].items
+	);
+
+	return { 
+		selectCompositeProductAppliedOptionsEntitiesState,
+		selectCompositeProductIds,
+		selectCompositeProductAppliedOptionsEntities,
+		selectCompositeProductTotal,
+		selectCompositeProductAppliedOptions
+	}
+}
+
+export const getDaffCompositeProductEntitiesSelectors = (() => {
+	let cache;
+	return <T extends DaffProduct>(): DaffCompositeProductEntitiesMemoizedSelectors => cache = cache 
+		? cache 
+		: createCompositeProductAppliedOptionsEntitiesSelectors<T>();
+})()

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -1,0 +1,196 @@
+import { TestBed } from '@angular/core/testing';
+import { StoreModule, combineReducers, Store, select } from '@ngrx/store';
+import { cold } from 'jasmine-marbles';
+
+import { DaffCompositeProductFactory, DaffProductFactory } from '@daffodil/product/testing';
+import { 
+	DaffCompositeProduct, 
+	DaffProductLoadSuccess,
+	daffProductReducers,
+	DaffProductReducersState,
+	DaffCompositeProductApplyOption,
+	DaffProduct,
+} from '@daffodil/product';
+
+import { getDaffCompositeProductSelectors } from './composite-product.selectors';
+
+describe('Composite Product Selectors | integration tests', () => {
+
+  let store: Store<DaffProductReducersState>;
+  const compositeProductFactory: DaffCompositeProductFactory = new DaffCompositeProductFactory();
+  const productFactory: DaffProductFactory = new DaffProductFactory();
+	let stubCompositeProduct: DaffCompositeProduct;
+	let stubProduct: DaffProduct;
+	const {
+		selectCompositeProductPrice,
+		selectCompositeProductDiscountAmount,
+		selectCompositeProductDiscountedPrice,
+		selectCompositeProductHasDiscount
+	} = getDaffCompositeProductSelectors();
+	const stubDefaultPrice0 = 10;
+	const stubDiscountAmount0 = 2.4;
+	const stubDiscountAmount1 = 1.4;
+	const stubChangedPrice0 = 20;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          product: combineReducers(daffProductReducers),
+        })
+      ]
+    });
+
+		stubCompositeProduct = compositeProductFactory.create();
+		stubProduct = productFactory.create();
+
+		// setup: set items to required, set a default option on each item, and set prices/discounts.
+		stubCompositeProduct.items[0].required = true;
+		stubCompositeProduct.items[0].options[0].is_default = true;
+		stubCompositeProduct.items[0].options[0].price = stubDefaultPrice0;
+		stubCompositeProduct.items[0].options[1].price = stubChangedPrice0;
+		stubCompositeProduct.items[0].options[0].discount = {
+			amount: stubDiscountAmount0,
+			percent: null
+		}
+		stubCompositeProduct.items[0].options[1].discount = {
+			amount: stubDiscountAmount1,
+			percent: null
+		}
+		store = TestBed.get(Store);
+		store.dispatch(new DaffProductLoadSuccess(stubCompositeProduct));
+		store.dispatch(new DaffProductLoadSuccess(stubProduct));
+	});
+
+	describe('selectCompositeProductPrice', () => {
+
+		it('should return undefined if the given product id is not from a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductPrice, { id: stubProduct.id }));
+			const expected = cold('a', { a: undefined });
+	
+			expect(selector).toBeObservable(expected);
+		});
+		
+		it('should initialize to the expected price', () => {
+			const selector = store.pipe(select(selectCompositeProductPrice, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: stubCompositeProduct.price + stubDefaultPrice0 });
+	
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should update the price when an option change occurs', () => {
+			store.dispatch(new DaffCompositeProductApplyOption(
+				stubCompositeProduct.id,
+				<string>stubCompositeProduct.items[0].id,
+				stubCompositeProduct.items[0].options[1].id
+			));
+			const selector = store.pipe(select(selectCompositeProductPrice, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: stubCompositeProduct.price + stubChangedPrice0 });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectCompositeProductDiscountAmount', () => {
+		
+		it('should return undefined if the given product id is not from a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductDiscountAmount, { id: stubProduct.id }));
+			const expected = cold('a', { a: undefined });
+	
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should initialize to the expected discount amount', () => {
+			const selector = store.pipe(select(selectCompositeProductDiscountAmount, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: stubCompositeProduct.discount.amount + stubDiscountAmount0 });
+	
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should update the discount amount when an option change occurs', () => {
+			store.dispatch(new DaffCompositeProductApplyOption(
+				stubCompositeProduct.id,
+				<string>stubCompositeProduct.items[0].id,
+				stubCompositeProduct.items[0].options[1].id
+			));
+			const selector = store.pipe(select(selectCompositeProductDiscountAmount, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: stubCompositeProduct.discount.amount + stubDiscountAmount1 });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+	
+	describe('selectCompositeProductDiscountedPrice', () => {
+		
+		it('should return undefined if the given product id is not from a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductDiscountedPrice, { id: stubProduct.id }));
+			const expected = cold('a', { a: undefined });
+	
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should initialize to the expected discounted price', () => {
+			const selector = store.pipe(select(selectCompositeProductDiscountedPrice, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: 
+				stubCompositeProduct.price 
+				+ stubCompositeProduct.items[0].options[0].price 
+				- stubCompositeProduct.discount.amount 
+				- stubCompositeProduct.items[0].options[0].discount.amount
+			});
+	
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should update the discounted price when an option change occurs', () => {
+			store.dispatch(new DaffCompositeProductApplyOption(
+				stubCompositeProduct.id,
+				<string>stubCompositeProduct.items[0].id,
+				stubCompositeProduct.items[0].options[1].id
+			));
+			const selector = store.pipe(select(selectCompositeProductDiscountedPrice, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: 
+				stubCompositeProduct.price 
+				+ stubCompositeProduct.items[0].options[1].price 
+				- stubCompositeProduct.discount.amount 
+				- stubCompositeProduct.items[0].options[1].discount.amount
+			});
+			expect(selector).toBeObservable(expected);
+		});
+
+		describe('when the price or discount are long decimal values', () => {
+			
+			it('should return the expected discounted price to two decimals', () => {
+				const newCompositeProduct = compositeProductFactory.create();
+				newCompositeProduct.price = 70.53578;
+				newCompositeProduct.discount.amount = 20.3243;
+				newCompositeProduct.items[0].options[0].price = 10.3287;
+				newCompositeProduct.items[0].options[0].is_default = true;
+				newCompositeProduct.items[0].options[0].discount = { 
+					amount: 1.53518,
+					percent: null
+				};
+				store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
+				const selector = store.pipe(select(selectCompositeProductDiscountedPrice, { id: newCompositeProduct.id }));
+				const expected = cold('a', { a: 59.01 });
+				expect(selector).toBeObservable(expected);
+			});
+		});
+	});
+
+	describe('selectCompositeProductHasDiscount', () => {
+
+		it('should return undefined if the given product id is not from a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductHasDiscount, { id: stubProduct.id }));
+			const expected = cold('a', { a: undefined });
+	
+			expect(selector).toBeObservable(expected);
+		});
+		
+		it('should return whether the composite product has a discount', () => {
+			const selector = store.pipe(select(selectCompositeProductHasDiscount, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: true });
+	
+			expect(selector).toBeObservable(expected);
+		});
+	});
+});

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -171,7 +171,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				};
 				store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
 				const selector = store.pipe(select(selectCompositeProductDiscountedPrice, { id: newCompositeProduct.id }));
-				const expected = cold('a', { a: 59.01 });
+				const expected = cold('a', { a: 59.005 });
 				expect(selector).toBeObservable(expected);
 			});
 		});

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -159,7 +159,7 @@ describe('Composite Product Selectors | integration tests', () => {
 
 		describe('when the price or discount are long decimal values', () => {
 			
-			it('should return the expected discounted price to two decimals', () => {
+			it('should return the expected discounted price', () => {
 				const newCompositeProduct = compositeProductFactory.create();
 				newCompositeProduct.price = 70.53578;
 				newCompositeProduct.discount.amount = 20.3243;

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -1,0 +1,123 @@
+import { createSelector, MemoizedSelectorWithProps } from '@ngrx/store';
+
+import { DaffProductTypeEnum } from '../../models/product';
+import { getDaffCompositeProductEntitiesSelectors } from '../composite-product-entities/composite-product-entities.selectors';
+import { getDaffProductEntitiesSelectors } from '../product-entities/product-entities.selectors';
+import { DaffCompositeProduct } from '../../models/composite-product';
+import { Dictionary } from '@ngrx/entity';
+
+export interface DaffCompositeProductMemoizedSelectors {
+	selectCompositeProductPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductDiscountAmount: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductHasDiscount: MemoizedSelectorWithProps<object, object, boolean>;
+}
+
+const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelectors => {
+
+	const {
+		selectCompositeProductAppliedOptions,
+		selectCompositeProductAppliedOptionsEntitiesState
+	} = getDaffCompositeProductEntitiesSelectors();
+
+	const {
+		selectProductEntities,
+		selectProduct,
+		selectProductDiscountAmount
+	} = getDaffProductEntitiesSelectors();
+
+	/**
+	 * Selector for the price for current configuration of the composite product.
+	 */
+	const selectCompositeProductPrice = createSelector(
+		selectProductEntities,
+		selectCompositeProductAppliedOptionsEntitiesState,
+		(products, appliedOptionsEntities, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
+			if(product.type !== DaffProductTypeEnum.Composite) {
+				return undefined;
+			}
+			
+			const appliedOptions = selectCompositeProductAppliedOptions.projector(appliedOptionsEntities, { id: props.id });
+
+			return (<DaffCompositeProduct>product).items.reduce((acc, item) => {
+				return acc + item.options.find(option => option.id === appliedOptions[item.id]).price;
+			}, product.price);
+		}
+	);
+
+
+	/**
+	 * Selector for the discount amount for current configuration of the composite product.
+	 */
+	const selectCompositeProductDiscountAmount = createSelector(
+		selectProductEntities,
+		selectCompositeProductAppliedOptionsEntitiesState,
+		(products, appliedOptionsEntities, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
+			if(product.type !== DaffProductTypeEnum.Composite) {
+				return undefined;
+			}
+			const appliedOptions = selectCompositeProductAppliedOptions.projector(appliedOptionsEntities, { id: props.id });
+			const productDiscountAmount = selectProductDiscountAmount.projector(products, { id: props.id });
+
+			return productDiscountAmount + getOptionsDiscountAmount(<DaffCompositeProduct>product, appliedOptions);
+		}
+	);
+
+	/**
+	 * Selector for the discounted price for current configuration of the composite product.
+	 */
+	const selectCompositeProductDiscountedPrice = createSelector(
+		selectProductEntities,
+		selectCompositeProductAppliedOptionsEntitiesState,
+		(products, appliedOptionsEntities, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
+			if(product.type !== DaffProductTypeEnum.Composite) {
+				return undefined;
+			}
+
+			return Math.round(100*
+				(selectCompositeProductPrice.projector(products, appliedOptionsEntities, { id: props.id }) - selectCompositeProductDiscountAmount.projector(products, appliedOptionsEntities, { id: props.id }))
+			)/100;
+		}
+	);
+
+	/**
+	 * Selector for whether the composite product has a discount.
+	 */
+	const selectCompositeProductHasDiscount = createSelector(
+		selectProductEntities,
+		selectCompositeProductAppliedOptionsEntitiesState,
+		(products, appliedOptionsEntities, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
+			if(product.type !== DaffProductTypeEnum.Composite) {
+				return undefined;
+			}
+
+			return selectCompositeProductDiscountAmount.projector(products, appliedOptionsEntities, { id: props.id }) > 0;
+		}
+	);
+
+	return { 
+		selectCompositeProductPrice,
+		selectCompositeProductDiscountAmount,
+		selectCompositeProductDiscountedPrice,
+		selectCompositeProductHasDiscount
+	}
+}
+
+export const getDaffCompositeProductSelectors = (() => {
+	let cache;
+	return (): DaffCompositeProductMemoizedSelectors => cache = cache 
+		? cache 
+		: createCompositeProductSelectors();
+})();
+
+function getOptionsDiscountAmount(product: DaffCompositeProduct, appliedOptions: Dictionary<string>): number {
+	return product.items.reduce((acc, item) => {
+		const itemOptionDiscount = item.options.find(option => option.id === appliedOptions[item.id]).discount;
+
+		return acc + (itemOptionDiscount && itemOptionDiscount.amount > 0 ? itemOptionDiscount.amount : 0);
+	}, 0)
+}

--- a/libs/product/src/selectors/product-entities/product-entities.selectors.spec.ts
+++ b/libs/product/src/selectors/product-entities/product-entities.selectors.spec.ts
@@ -19,7 +19,8 @@ describe('selectProductEntitiesState', () => {
 		selectProductEntities,
 		selectAllProducts,
 		selectProductTotal,
-		selectProduct
+		selectProduct,
+		selectProductDiscountAmount
 	} = getDaffProductEntitiesSelectors();
   
   beforeEach(() => {
@@ -88,6 +89,16 @@ describe('selectProductEntitiesState', () => {
     it('should select the product of the given id', () => {
 			const selector = store.pipe(select(selectProduct, { id: mockProduct.id }));
 			const expected = cold('a', { a: mockProduct });
+
+			expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectProductDiscountAmount', () => {
+    
+    it('should select the product discount amount of the given id', () => {
+			const selector = store.pipe(select(selectProductDiscountAmount, { id: mockProduct.id }));
+			const expected = cold('a', { a: mockProduct.discount.amount });
 
 			expect(selector).toBeObservable(expected);
     });

--- a/libs/product/src/selectors/product-entities/product-entities.selectors.ts
+++ b/libs/product/src/selectors/product-entities/product-entities.selectors.ts
@@ -79,8 +79,7 @@ const createProductEntitiesSelectors = <T extends DaffProduct>(): DaffProductEnt
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
 
-			return !!(product.discount && product.discount.amount) ?
-				product.discount.amount : 0;
+			return (product.discount && product.discount.amount) || 0;
 		}
 	)
 

--- a/libs/product/src/selectors/product-entities/product-entities.selectors.ts
+++ b/libs/product/src/selectors/product-entities/product-entities.selectors.ts
@@ -13,6 +13,7 @@ export interface DaffProductEntitiesMemoizedSelectors<T extends DaffProduct = Da
 	selectAllProducts: MemoizedSelector<object, T[]>;
 	selectProductTotal: MemoizedSelector<object, number>;
 	selectProduct: MemoizedSelectorWithProps<object, object, T>;
+	selectProductDiscountAmount: MemoizedSelectorWithProps<object, object, number>;
 }
 
 const createProductEntitiesSelectors = <T extends DaffProduct>(): DaffProductEntitiesMemoizedSelectors<T> => {
@@ -73,13 +74,24 @@ const createProductEntitiesSelectors = <T extends DaffProduct>(): DaffProductEnt
 		(products, props) => products[props.id]
 	);
 
+	const selectProductDiscountAmount = createSelector(
+		selectProductEntities,
+		(products, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
+
+			return !!(product.discount && product.discount.amount) ?
+				product.discount.amount : 0;
+		}
+	)
+
 	return { 
 		selectProductEntitiesState,
 		selectProductIds,
 		selectProductEntities,
 		selectAllProducts,
 		selectProductTotal,
-		selectProduct
+		selectProduct,
+		selectProductDiscountAmount
 	}
 }
 

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -1,0 +1,19 @@
+import { BehaviorSubject } from 'rxjs';
+
+import { DaffCompositeProductFacadeInterface } from '@daffodil/product';
+
+export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
+	getPrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	getDiscountAmount(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	getDiscountedPrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	hasDiscount(id: string): BehaviorSubject<boolean> {
+		return new BehaviorSubject(false);
+	};
+	dispatch(action) {};
+}

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -1,6 +1,7 @@
 import { BehaviorSubject } from 'rxjs';
+import { Dictionary } from '@ngrx/entity';
 
-import { DaffCompositeProductFacadeInterface } from '@daffodil/product';
+import { DaffCompositeProductFacadeInterface, DaffCompositeProductItemOption } from '@daffodil/product';
 
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
 	getPrice(id: string): BehaviorSubject<number> {
@@ -15,5 +16,8 @@ export class MockDaffCompositeProductFacade implements DaffCompositeProductFacad
 	hasDiscount(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
+	getAppliedOptions(id: string): BehaviorSubject<Dictionary<DaffCompositeProductItemOption['id']>> {
+		return new BehaviorSubject({});
+	}
 	dispatch(action) {};
 }

--- a/libs/product/testing/src/helpers/product-testing.module.ts
+++ b/libs/product/testing/src/helpers/product-testing.module.ts
@@ -1,15 +1,17 @@
 import { NgModule } from '@angular/core';
-import { DaffProductFacade, DaffProductGridFacade, DaffConfigurableProductFacade } from '@daffodil/product';
+import { DaffProductFacade, DaffProductGridFacade, DaffConfigurableProductFacade, DaffCompositeProductFacade } from '@daffodil/product';
 
 import { MockDaffProductFacade } from './mock-product-facade';
 import { MockDaffProductGridFacade } from './mock-product-grid-facade';
 import { MockDaffConfigurableProductFacade } from './mock-configurable-product-facade';
+import { MockDaffCompositeProductFacade } from './mock-composite-product-facade';
 
 @NgModule({
 	providers: [
 		{ provide: DaffProductFacade, useClass: MockDaffProductFacade },
 		{ provide: DaffProductGridFacade, useClass: MockDaffProductGridFacade },
 		{ provide: DaffConfigurableProductFacade, useClass: MockDaffConfigurableProductFacade },
+		{ provide: DaffCompositeProductFacade, useClass: MockDaffCompositeProductFacade },
 	]
 })
 export class DaffProductTestingModule { }

--- a/libs/product/testing/src/index.ts
+++ b/libs/product/testing/src/index.ts
@@ -11,5 +11,6 @@ export { MockDaffProductFacade } from './helpers/mock-product-facade';
 export { DaffProductTestingModule } from './helpers/product-testing.module';
 export { MockDaffProductGridFacade } from './helpers/mock-product-grid-facade';
 export { MockDaffConfigurableProductFacade } from './helpers/mock-configurable-product-facade';
+export { MockDaffCompositeProductFacade } from './helpers/mock-composite-product-facade';
 
 export * from './factories/magento/public_api';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

- A composite product has a discount if the primary product or any of the applied options of the product items have a discount.
- The price is determined by adding up the primary product price and the applied option prices.
- The default option (from the backend) will be set as the initially applied option for each item of the composite product. If no default is chosen by the backend, daffodil will set the first option as the default if the item is required. If the item is not required, and there is no default option, there will be no option set.