### PR TITLE
feat(cart): store cartId in order result

### DIFF
--- a/libs/cart/src/drivers/magento/cart-order.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-order.service.spec.ts
@@ -64,9 +64,10 @@ describe('Driver | Magento | Cart | CartOrderService', () => {
 
   describe('placeOrder | placing an order for the specified cart', () => {
     describe('when the call to the Magento API is successful', () => {
-      it('should return the order ID', done => {
+      it('should return the order and cart ID', done => {
         service.placeOrder(cartId, mockDaffCartPayment).subscribe(result => {
-          expect(String(result.id)).toEqual(String(orderNumber));
+          expect(String(result.orderId)).toEqual(String(orderNumber));
+          expect(String(result.cartId)).toEqual(String(cartId));
           done();
         });
 

--- a/libs/cart/src/drivers/magento/cart-order.service.ts
+++ b/libs/cart/src/drivers/magento/cart-order.service.ts
@@ -31,7 +31,11 @@ export class DaffMagentoCartOrderService implements DaffCartOrderServiceInterfac
         cartId
       }
     }).pipe(
-      map(result => ({id: result.data.placeOrder.order.order_number})),
+      map(result => ({
+        id: result.data.placeOrder.order.order_number,
+        orderId: result.data.placeOrder.order.order_number,
+        cartId
+      })),
       catchError(err => throwError(transformCartMagentoError(err))),
     )
   }

--- a/libs/cart/src/effects/cart-order.effects.spec.ts
+++ b/libs/cart/src/effects/cart-order.effects.spec.ts
@@ -8,7 +8,8 @@ import {
 } from '@daffodil/core'
 import {
   DaffCart,
-  DaffCartPaymentMethod
+  DaffCartPaymentMethod,
+  DaffCartOrderResult
 } from '@daffodil/cart';
 import {
   DaffCartFactory,
@@ -81,7 +82,10 @@ describe('Cart | Effect | CartOrderEffects', () => {
 
     describe('when the call to CartOrderService is successful', () => {
       beforeEach(() => {
-        const response = {id: orderId};
+        const response: DaffCartOrderResult = {
+          orderId,
+          cartId: mockCart.id,
+        };
         const cartPlaceOrderSuccessAction = new DaffCartPlaceOrderSuccess(response);
 
         cartOrderDriverSpy.placeOrder.and.returnValue(of(response));

--- a/libs/cart/src/facades/cart/cart-facade.interface.ts
+++ b/libs/cart/src/facades/cart/cart-facade.interface.ts
@@ -48,7 +48,8 @@ export interface DaffCartFacadeInterface<
   orderResultLoading$: Observable<boolean>;
 	orderResultErrors$: Observable<string[]>;
 	orderResult$: Observable<V>;
-	orderResultId$: Observable<V['id']>;
+	orderResultId$: Observable<V['orderId']>;
+	orderResultCartId$: Observable<V['cartId']>;
 
 	getCartItemDiscountedTotal(itemId: string | number): Observable<number>;
 }

--- a/libs/cart/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/src/facades/cart/cart.facade.spec.ts
@@ -87,7 +87,8 @@ describe('DaffCartFacade', () => {
       [DaffCartErrorType.Coupon]: [],
     };
     mockCartOrderResult = {
-      id: 'id'
+      orderId: 'orderId',
+      cartId: 'cartId',
     };
   });
 
@@ -485,7 +486,7 @@ describe('DaffCartFacade', () => {
 
   describe('orderResult$', () => {
     it('should initially be a cart order result object with a null ID', () => {
-      const expected = cold('a', { a: {id: null} });
+      const expected = cold('a', { a: jasmine.objectContaining({orderId: null, cartId: null}) });
       expect(facade.orderResult$).toBeObservable(expected);
     });
 
@@ -513,8 +514,26 @@ describe('DaffCartFacade', () => {
       });
 
       it('should be the cart order result ID', () => {
-        const expected = cold('a', { a: mockCartOrderResult.id });
+        const expected = cold('a', { a: mockCartOrderResult.orderId });
         expect(facade.orderResultId$).toBeObservable(expected);
+      });
+    });
+  });
+
+  describe('orderResultCartId$', () => {
+    it('should initially be null', () => {
+      const expected = cold('a', { a: null});
+      expect(facade.orderResultCartId$).toBeObservable(expected);
+    });
+
+    describe('when a place order request has succeeded', () => {
+      beforeEach(() => {
+        store.dispatch(new DaffCartPlaceOrderSuccess(mockCartOrderResult));
+      });
+
+      it('should be the cart ID', () => {
+        const expected = cold('a', { a: mockCartOrderResult.cartId });
+        expect(facade.orderResultCartId$).toBeObservable(expected);
       });
     });
   });

--- a/libs/cart/src/facades/cart/cart.facade.ts
+++ b/libs/cart/src/facades/cart/cart.facade.ts
@@ -55,6 +55,7 @@ export class DaffCartFacade<
 	orderResultErrors$: Observable<string[]>;
 	orderResult$: Observable<V>;
 	orderResultId$: Observable<V['id']>;
+	orderResultCartId$: Observable<V['cartId']>;
 
 	private _selectCartItemDiscountedRowTotal;
 
@@ -91,6 +92,7 @@ export class DaffCartFacade<
       selectCartOrderErrors,
       selectCartOrderValue,
 			selectCartOrderId,
+			selectCartOrderCartId,
       selectCartItemDiscountedRowTotal,
 
       selectHasBillingAddress,
@@ -138,6 +140,7 @@ export class DaffCartFacade<
     this.orderResultErrors$ = this.store.pipe(select(selectCartOrderErrors));
     this.orderResult$ = this.store.pipe(select(selectCartOrderValue));
     this.orderResultId$ = this.store.pipe(select(selectCartOrderId));
+    this.orderResultCartId$ = this.store.pipe(select(selectCartOrderCartId));
 	}
 
 	getCartItemDiscountedTotal(itemId: string | number): Observable<number> {

--- a/libs/cart/src/models/cart-order-result.ts
+++ b/libs/cart/src/models/cart-order-result.ts
@@ -1,7 +1,12 @@
 /**
  * The result of placing an order for a cart.
- * Stores a reference to an order object.
+ * Stores a reference to a cart and order object.
  */
 export interface DaffCartOrderResult {
+  cartId: string | number;
+  orderId: string | number;
+  /**
+   * @deprecated Use DaffCartOrderResult#orderId instead.
+   */
   id: string | number;
 }

--- a/libs/cart/src/models/cart-order-result.ts
+++ b/libs/cart/src/models/cart-order-result.ts
@@ -8,5 +8,5 @@ export interface DaffCartOrderResult {
   /**
    * @deprecated Use DaffCartOrderResult#orderId instead.
    */
-  id: string | number;
+  id?: string | number;
 }

--- a/libs/cart/src/reducers/cart-order/cart-order-initial-state.ts
+++ b/libs/cart/src/reducers/cart-order/cart-order-initial-state.ts
@@ -2,7 +2,9 @@ import { DaffCartOrderReducerState } from './cart-order-state.interface';
 
 export const daffCartOrderInitialState: DaffCartOrderReducerState<any> = {
   cartOrderResult: {
-    id: null
+    id: null,
+    orderId: null,
+    cartId: null
   },
   loading: false,
   errors: []

--- a/libs/cart/src/reducers/cart-order/cart-order.reducer.spec.ts
+++ b/libs/cart/src/reducers/cart-order/cart-order.reducer.spec.ts
@@ -31,9 +31,11 @@ describe('Cart | Reducer | CartOrder', () => {
     let result;
     let state: DaffCartOrderReducerState;
     let orderId;
+    let cartId;
 
     beforeEach(() => {
-      orderId = 'id';
+      orderId = 'orderId';
+      cartId = 'cartId';
       state = {
         ...initialState,
         loading: true
@@ -41,14 +43,15 @@ describe('Cart | Reducer | CartOrder', () => {
 
       const cartPlaceOrderSuccess = new DaffCartPlaceOrderSuccess({
         orderId,
-        cartId: 'cartId',
+        cartId,
       });
 
       result = reducer(state, cartPlaceOrderSuccess);
     });
 
-    it('should set the order ID from action.payload', () => {
+    it('should set the order result from action.payload', () => {
       expect(result.cartOrderResult.orderId).toEqual(orderId)
+      expect(result.cartOrderResult.cartId).toEqual(cartId)
     });
 
     it('should indicate that the place order operation is not in progress', () => {

--- a/libs/cart/src/reducers/cart-order/cart-order.reducer.spec.ts
+++ b/libs/cart/src/reducers/cart-order/cart-order.reducer.spec.ts
@@ -39,13 +39,16 @@ describe('Cart | Reducer | CartOrder', () => {
         loading: true
       }
 
-      const cartPlaceOrderSuccess = new DaffCartPlaceOrderSuccess({id: orderId});
+      const cartPlaceOrderSuccess = new DaffCartPlaceOrderSuccess({
+        orderId,
+        cartId: 'cartId',
+      });
 
       result = reducer(state, cartPlaceOrderSuccess);
     });
 
     it('should set the order ID from action.payload', () => {
-      expect(result.cartOrderResult.id).toEqual(orderId)
+      expect(result.cartOrderResult.orderId).toEqual(orderId)
     });
 
     it('should indicate that the place order operation is not in progress', () => {

--- a/libs/cart/src/selectors/cart-order/cart-order.selector.spec.ts
+++ b/libs/cart/src/selectors/cart-order/cart-order.selector.spec.ts
@@ -22,7 +22,8 @@ describe('Cart | Selector | CartOrder', () => {
     selectCartOrderLoading,
     selectCartOrderErrors,
     selectCartOrderValue,
-    selectCartOrderId
+    selectCartOrderId,
+    selectCartOrderCartId
 	} = getCartOrderSelectors();
 
   beforeEach(() => {
@@ -43,13 +44,19 @@ describe('Cart | Selector | CartOrder', () => {
     loading = false;
 
     store.dispatch(new DaffCartLoadSuccess(cart));
-    store.dispatch(new DaffCartPlaceOrderSuccess({id: orderId}));
+    store.dispatch(new DaffCartPlaceOrderSuccess({
+      orderId,
+      cartId: cart.id,
+    }));
   });
 
   describe('selectCartOrderState', () => {
     it('selects whether the place order operation is in progress', () => {
 			const expectedOrderState: DaffCartOrderReducerState = {
-				cartOrderResult: { id: orderId },
+				cartOrderResult: {
+          orderId,
+          cartId: cart.id,
+        },
 				loading: false,
 				errors: []
 			};
@@ -81,7 +88,10 @@ describe('Cart | Selector | CartOrder', () => {
   describe('selectCartOrderValue', () => {
     it('selects the order object', () => {
       const selector = store.pipe(select(selectCartOrderValue));
-      const expected = cold('a', {a: {id: orderId}});
+      const expected = cold('a', {a: jasmine.objectContaining({
+        orderId,
+        cartId: cart.id,
+      })});
 
       expect(selector).toBeObservable(expected);
     });
@@ -91,6 +101,15 @@ describe('Cart | Selector | CartOrder', () => {
     it('selects the ID of the order object', () => {
       const selector = store.pipe(select(selectCartOrderId));
       const expected = cold('a', {a: orderId});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartOrderCartId', () => {
+    it('selects the cart ID of the order object', () => {
+      const selector = store.pipe(select(selectCartOrderCartId));
+      const expected = cold('a', {a: cart.id});
 
       expect(selector).toBeObservable(expected);
     });

--- a/libs/cart/src/selectors/cart-order/cart-order.selector.ts
+++ b/libs/cart/src/selectors/cart-order/cart-order.selector.ts
@@ -15,7 +15,8 @@ export interface DaffCartOrderMemoizedSelectors<
   selectCartOrderLoading: MemoizedSelector<object, boolean>;
 	selectCartOrderErrors: MemoizedSelector<object, DaffCartOrderReducerState<T>['errors']>;
 	selectCartOrderValue: MemoizedSelector<object, DaffCartOrderReducerState<T>['cartOrderResult']>;
-	selectCartOrderId: MemoizedSelector<object, DaffCartOrderReducerState<T>['cartOrderResult']['id']>;
+	selectCartOrderId: MemoizedSelector<object, DaffCartOrderReducerState<T>['cartOrderResult']['orderId']>;
+	selectCartOrderCartId: MemoizedSelector<object, DaffCartOrderReducerState<T>['cartOrderResult']['cartId']>;
 }
 
 const createCartOrderSelectors = <
@@ -34,7 +35,11 @@ const createCartOrderSelectors = <
   );
   const selectCartOrderId = createSelector(
 		selectCartOrderValue,
-		(state: DaffCartOrderReducerState<V>['cartOrderResult']) => state.id
+		(state: DaffCartOrderReducerState<V>['cartOrderResult']) => state.orderId
+  );
+  const selectCartOrderCartId = createSelector(
+		selectCartOrderValue,
+		(state: DaffCartOrderReducerState<V>['cartOrderResult']) => state.cartId
   );
   const selectCartOrderLoading = createSelector(
 		selectCartOrderState,
@@ -50,7 +55,8 @@ const createCartOrderSelectors = <
     selectCartOrderLoading,
     selectCartOrderErrors,
     selectCartOrderValue,
-    selectCartOrderId
+    selectCartOrderId,
+    selectCartOrderCartId
 	}
 }
 

--- a/libs/cart/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/src/selectors/cart/cart.selector.spec.ts
@@ -106,7 +106,10 @@ describe('Cart | Selector | Cart', () => {
     };
 
     store.dispatch(new DaffCartLoadSuccess(cart));
-    store.dispatch(new DaffCartPlaceOrderSuccess({id: orderId}));
+    store.dispatch(new DaffCartPlaceOrderSuccess({
+      orderId,
+      cartId: cart.id,
+    }));
   });
 
   describe('selectCartValue', () => {

--- a/libs/cart/testing/src/drivers/in-memory/cart-order/cart-order.service.spec.ts
+++ b/libs/cart/testing/src/drivers/in-memory/cart-order/cart-order.service.spec.ts
@@ -43,7 +43,9 @@ describe('Driver | In Memory | Cart | CartOrderService', () => {
     mockCart = cartFactory.create();
     mockCartPayment = cartPaymentFactory.create();
     mockCartOrderResult = {
-      id: 'id'
+      id: 'orderId',
+      orderId: 'orderId',
+      cartId: 'cartId',
     };
     cartId = mockCart.id;
   });

--- a/libs/cart/testing/src/drivers/testing/cart-order/cart-order.service.spec.ts
+++ b/libs/cart/testing/src/drivers/testing/cart-order/cart-order.service.spec.ts
@@ -38,7 +38,9 @@ describe('Driver | Testing | Cart | CartOrderService', () => {
     mockCart = cartFactory.create();
     mockCartPayment = cartPaymentFactory.create();
     mockCartOrderResult = {
-      id: 'id'
+      id: 'orderId',
+      orderId: 'orderId',
+      cartId: 'cartId',
     };
     cartId = mockCart.id;
   });

--- a/libs/cart/testing/src/drivers/testing/cart-order/cart-order.service.spec.ts
+++ b/libs/cart/testing/src/drivers/testing/cart-order/cart-order.service.spec.ts
@@ -50,7 +50,9 @@ describe('Driver | Testing | Cart | CartOrderService', () => {
   describe('placeOrder | placing an order and getting an order result', () => {
     it('should return the order ID and not throw an error', () => {
       const expected = cold('(a|)', {a: jasmine.objectContaining({
-        id: jasmine.any(Number)
+        id: jasmine.any(Number),
+        orderId: jasmine.any(Number),
+        cartId: jasmine.any(Number),
       })});
       expect(service.placeOrder(cartId, mockCartPayment)).toBeObservable(expected);
     });

--- a/libs/cart/testing/src/drivers/testing/cart-order/cart-order.service.ts
+++ b/libs/cart/testing/src/drivers/testing/cart-order/cart-order.service.ts
@@ -14,6 +14,10 @@ import {
 })
 export class DaffTestingCartOrderService implements DaffCartOrderServiceInterface {
   placeOrder(cartId: DaffCart['id'], payment?: DaffCartPaymentMethod): Observable<DaffCartOrderResult> {
-    return of({id: faker.random.number(999999)});
+    return of({
+      id: faker.random.number(999999),
+      orderId: faker.random.number(999999),
+      cartId,
+    });
   }
 }

--- a/libs/cart/testing/src/helpers/mock-cart-facade.ts
+++ b/libs/cart/testing/src/helpers/mock-cart-facade.ts
@@ -45,7 +45,11 @@ export class MockDaffCartFacade implements DaffCartFacadeInterface {
 
   orderResultLoading$ = new BehaviorSubject<boolean>(false);
 	orderResultErrors$ = new BehaviorSubject<string[]>([]);
-	orderResult$ = new BehaviorSubject<DaffCartOrderResult>({id: null});
+	orderResult$ = new BehaviorSubject<DaffCartOrderResult>({
+    id: null,
+    orderId: null,
+    cartId: null,
+  });
 	orderResultId$ = new BehaviorSubject<DaffCartOrderResult['id']>(null);
 
 	getCartItemDiscountedTotal(itemId: string | number): BehaviorSubject<number> {

--- a/libs/cart/testing/src/helpers/mock-cart-facade.ts
+++ b/libs/cart/testing/src/helpers/mock-cart-facade.ts
@@ -50,7 +50,8 @@ export class MockDaffCartFacade implements DaffCartFacadeInterface {
     orderId: null,
     cartId: null,
   });
-	orderResultId$ = new BehaviorSubject<DaffCartOrderResult['id']>(null);
+	orderResultId$ = new BehaviorSubject<DaffCartOrderResult['orderId']>(null);
+	orderResultCartId$ = new BehaviorSubject<DaffCartOrderResult['cartId']>(null);
 
 	getCartItemDiscountedTotal(itemId: string | number): BehaviorSubject<number> {
 		return new BehaviorSubject(null);

--- a/libs/cart/testing/src/in-memory-backend/cart-order/cart-order.service.ts
+++ b/libs/cart/testing/src/in-memory-backend/cart-order/cart-order.service.ts
@@ -19,7 +19,9 @@ export class DaffInMemoryBackendCartOrderService implements DaffInMemoryDataServ
 
   private placeOrder(reqInfo): DaffCartOrderResult {
     return {
-      id: '8235422034'
+      id: '8235422034',
+      cartId: '89fdsa8sadf',
+      orderId: '8235422034',
     };
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The cart ID corresponding to the order result will be lost when a new cart is created.

## What is the new behavior?
Stores the cart ID used to place the order in the order result object, which allows the cart ID to be used for order fetching even after a new cart is created.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Deprecates `DaffCartOrderResult#id` in favor of `DaffCartOrderResult#orderId`.

## Other information