### PR TITLE
feat(product): add qty to composite product option state

### DIFF
--- a/libs/product/src/actions/composite-product.actions.ts
+++ b/libs/product/src/actions/composite-product.actions.ts
@@ -19,7 +19,7 @@ export enum DaffCompositeProductActionTypes {
 export class DaffCompositeProductApplyOption<T extends DaffCompositeProduct> implements Action {
   readonly type = DaffCompositeProductActionTypes.CompositeProductApplyOptionAction;
 
-  constructor(public id: T['id'], public itemId: string, public optionId: string) {}
+  constructor(public id: T['id'], public itemId: string, public optionId: string, public qty?: number) {}
 }
 
 export type DaffCompositeProductActions<T extends DaffCompositeProduct = DaffCompositeProduct> = 

--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -4,7 +4,7 @@ import { Dictionary } from '@ngrx/entity';
 
 import { DaffStoreFacade } from '@daffodil/core';
 
-import { DaffCompositeProductItemOption } from '../../models/composite-product-item';
+import { DaffCompositeProductEntityItem } from '../../reducers/composite-product-entities/composite-product-entity';
 
 export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Action> {
 
@@ -36,5 +36,5 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * Returns the applied options for a composite product.
 	 * @param id the id of the composite product.
 	 */
-	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption['id']>>;
+	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductEntityItem>>;
 }

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -112,7 +112,10 @@ describe('DaffCompositeProductFacade', () => {
 		
 		it('should return the applied option for a composite product', () => {
 			const expected = cold('a', { a: { 
-				[stubCompositeProduct.items[0].id]: stubCompositeProduct.items[0].options[0].id 
+				[stubCompositeProduct.items[0].id]: {
+					value: stubCompositeProduct.items[0].options[0].id,
+					qty: 1
+				}
 			}});
 
 			expect(facade.getAppliedOptions(stubCompositeProduct.id)).toBeObservable(expected);

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -8,7 +8,7 @@ import { DaffProductReducersState } from '../../reducers/product-reducers-state.
 import { DaffProduct } from '../../models/product';
 import { getDaffProductSelectors } from '../../selectors/public_api';
 import { DaffCompositeProductFacadeInterface } from './composite-product-facade.interface';
-import { DaffCompositeProductItemOption } from '../../models/composite-product-item';
+import { DaffCompositeProductEntityItem } from '../../reducers/composite-product-entities/composite-product-entity';
 
 /**
  * A facade for accessing composite product state from an application component.
@@ -38,7 +38,7 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 		return this.store.pipe(select(this.selectors.selectCompositeProductHasDiscount, { id }));
 	}
 
-	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption['id']>> {
+	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductEntityItem>> {
 		return this.store.pipe(select(this.selectors.selectCompositeProductAppliedOptions, { id }));
 	}
 

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
@@ -94,7 +94,15 @@ describe('Product | Composite Product Entities Reducer', () => {
     it('sets a composite product entity when the given product is composite', () => {
 			const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
 			result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
-			expect(result.entities[compositeProduct.id]).toEqual({ id: compositeProduct.id, items: { [compositeProduct.items[0].id]: compositeProduct.items[0].options[0].id } });
+			expect(result.entities[compositeProduct.id]).toEqual({ 
+				id: compositeProduct.id, 
+				items: { 
+					[compositeProduct.items[0].id]: {
+						value: compositeProduct.items[0].options[0].id,
+						qty: 1
+					}
+				} 
+			});
     });
 		
     it('does not set a composite product entity when the given product is not composite', () => {
@@ -117,7 +125,10 @@ describe('Product | Composite Product Entities Reducer', () => {
 						items: compositeProduct.items.reduce((acc, item) => {
 							return {
 								...acc,
-								[item.id]: item.options.find(option => option.is_default).id
+								[item.id]: {
+									value: item.options.find(option => option.is_default).id,
+									qty: 1
+								}
 							}
 						}, {})
 					}
@@ -134,7 +145,10 @@ describe('Product | Composite Product Entities Reducer', () => {
     });
 
     it('changes the option id of the given product item', () => {
-      expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual(compositeProduct.items[0].options[1].id);
+      expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({
+				value: compositeProduct.items[0].options[1].id,
+				qty: 1
+			});
     });
 	});
 	
@@ -148,7 +162,10 @@ describe('Product | Composite Product Entities Reducer', () => {
 			const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
 			result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
 
-			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual(compositeProduct.items[0].options[1].id);
+			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({
+				value: compositeProduct.items[0].options[1].id,
+				qty: 1
+			});
 		});
 
 		describe('when the default item option is not defined', () => {
@@ -160,7 +177,10 @@ describe('Product | Composite Product Entities Reducer', () => {
 				const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
 				result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
 
-				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual(compositeProduct.items[0].options[0].id);
+				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({
+					value: compositeProduct.items[0].options[0].id,
+					qty: 1
+				});
 			});
 
 			it('should set the default option to null when the item is not required', () => {
@@ -170,7 +190,7 @@ describe('Product | Composite Product Entities Reducer', () => {
 				const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
 				result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
 
-				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual(null);
+				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({ value: null, qty: null });
 			});
 		});
 	});

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -7,7 +7,7 @@ import { daffCompositeProductAppliedOptionsEntitiesAdapter } from './composite-p
 import { DaffProduct, DaffProductTypeEnum } from '../../models/product';
 import { DaffCompositeProductActions, DaffCompositeProductActionTypes } from '../../actions/composite-product.actions';
 import { DaffCompositeProduct } from '../../models/composite-product';
-import { DaffCompositeProductEntity } from './composite-product-entity';
+import { DaffCompositeProductEntity, DaffCompositeProductEntityItem } from './composite-product-entity';
 import { DaffCompositeProductItem } from '../../models/composite-product-item';
 
 /**
@@ -44,7 +44,10 @@ export function daffCompositeProductEntitiesReducer<T extends DaffProduct, V ext
 					id: action.id,
 					items: {
 						...state.entities[action.id].items,
-						[action.itemId]: action.optionId
+						[action.itemId]: {
+							value: action.optionId,
+							qty: action.qty ? action.qty : 1
+						}
 					}
 				},
 				state
@@ -64,12 +67,17 @@ function buildCompositeProductAppliedOptionsEntity(product: DaffCompositeProduct
 	}
 }
 
-function getDefaultOption(item: DaffCompositeProductItem): string {
+function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductEntityItem {
 	const defaultOptionIndex = item.options.findIndex(option => option.is_default);
 
 	if(defaultOptionIndex > -1) {
-		return item.options[defaultOptionIndex].id;
+		return {
+			value: item.options[defaultOptionIndex].id,
+			qty: 1
+		}
 	} else {
-		return item.required ? item.options[0].id : null;
+		return item.required ? 
+			{ value: item.options[0].id, qty: 1 } :
+			{ value: null, qty: null }
 	}
 }

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
@@ -1,7 +1,5 @@
 import { Dictionary } from '@ngrx/entity';
 
-import { DaffCompositeProductItemOption } from '../../models/composite-product-item';
-
 export interface DaffCompositeProductEntity {
 	id: string;
 	items: Dictionary<DaffCompositeProductEntityItem>;

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
@@ -1,7 +1,13 @@
 import { Dictionary } from '@ngrx/entity';
+
 import { DaffCompositeProductItemOption } from '../../models/composite-product-item';
 
 export interface DaffCompositeProductEntity {
 	id: string;
-	items: Dictionary<DaffCompositeProductItemOption['id']>;
+	items: Dictionary<DaffCompositeProductEntityItem>;
+}
+
+export interface DaffCompositeProductEntityItem {
+	value: string;
+	qty: number;
 }

--- a/libs/product/src/reducers/public_api.ts
+++ b/libs/product/src/reducers/public_api.ts
@@ -8,3 +8,4 @@ export { DaffProductReducerState } from './product/product-reducer-state.interfa
 export { daffProductReducer } from './product/product.reducer';
 export { DaffBestSellersReducerState } from './best-sellers/best-sellers-reducer-state.interface';
 export { daffBestSellersReducer } from './best-sellers/best-sellers.reducer';
+export * from './composite-product-entities/composite-product-entity';

--- a/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.spec.ts
@@ -51,12 +51,15 @@ describe('selectCompositeProductEntitiesState', () => {
 
 	describe('selectCompositeProductAppliedOptionsEntities', () => {
 		
-		it('selects composite product items and the applied options as a dictionary object', () => {
+		it('selects composite product items and the applied options', () => {
 			const expectedDictionary = {
 				[stubCompositeProduct.id]: {
 					id: stubCompositeProduct.id,
 					items: {
-						[stubCompositeProduct.items[0].id]: stubCompositeProduct.items[0].options[0].id
+						[stubCompositeProduct.items[0].id]: {
+							value: stubCompositeProduct.items[0].options[0].id,
+							qty: 1
+						}
 					}
 				}
 			}
@@ -83,7 +86,12 @@ describe('selectCompositeProductEntitiesState', () => {
     it('selects the composite product options of the given id', () => {
 			const selector = store.pipe(select(selectCompositeProductAppliedOptions, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { 
-				a: {[stubCompositeProduct.items[0].id]: stubCompositeProduct.items[0].options[0].id}
+				a: {
+					[stubCompositeProduct.items[0].id]: {
+						value: stubCompositeProduct.items[0].options[0].id,
+						qty: 1
+					}
+				}
 			});
 
 			expect(selector).toBeObservable(expected);

--- a/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.ts
+++ b/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.ts
@@ -5,14 +5,14 @@ import { getDaffProductFeatureSelector } from '../product-feature.selector';
 import { DaffProductReducersState } from '../../reducers/product-reducers-state.interface';
 import { DaffProduct } from '../../models/product';
 import { daffCompositeProductAppliedOptionsEntitiesAdapter } from '../../reducers/composite-product-entities/composite-product-entities-reducer-adapter';
-import { DaffCompositeProductEntity } from '../../reducers/composite-product-entities/composite-product-entity';
+import { DaffCompositeProductEntity, DaffCompositeProductEntityItem } from '../../reducers/composite-product-entities/composite-product-entity';
 
 export interface DaffCompositeProductEntitiesMemoizedSelectors {
 	selectCompositeProductAppliedOptionsEntitiesState: MemoizedSelector<object, EntityState<DaffCompositeProductEntity>>;
 	selectCompositeProductIds: MemoizedSelector<object, EntityState<DaffCompositeProductEntity>['ids']>;
 	selectCompositeProductAppliedOptionsEntities: MemoizedSelector<object, EntityState<DaffCompositeProductEntity>['entities']>;
 	selectCompositeProductTotal: MemoizedSelector<object, number>;
-	selectCompositeProductAppliedOptions: MemoizedSelectorWithProps<object, object, Dictionary<string>>;
+	selectCompositeProductAppliedOptions: MemoizedSelectorWithProps<object, object, Dictionary<DaffCompositeProductEntityItem>>;
 }
 
 const createCompositeProductAppliedOptionsEntitiesSelectors = <T extends DaffProduct>(): DaffCompositeProductEntitiesMemoizedSelectors => {

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -28,9 +28,10 @@ describe('Composite Product Selectors | integration tests', () => {
 		selectCompositeProductHasDiscount
 	} = getDaffCompositeProductSelectors();
 	const stubDefaultPrice0 = 10;
-	const stubDiscountAmount0 = 2.4;
-	const stubDiscountAmount1 = 1.4;
+	const stubDiscountAmount0 = 2;
+	const stubDiscountAmount1 = 1;
 	const stubChangedPrice0 = 20;
+	const stubQty0 = 3;
   
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -111,10 +112,11 @@ describe('Composite Product Selectors | integration tests', () => {
 			store.dispatch(new DaffCompositeProductApplyOption(
 				stubCompositeProduct.id,
 				<string>stubCompositeProduct.items[0].id,
-				stubCompositeProduct.items[0].options[1].id
+				stubCompositeProduct.items[0].options[0].id,
+				stubQty0
 			));
 			const selector = store.pipe(select(selectCompositeProductDiscountAmount, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.discount.amount + stubDiscountAmount1 });
+			const expected = cold('a', { a: stubCompositeProduct.discount.amount + (stubDiscountAmount0*stubQty0) });
 
 			expect(selector).toBeObservable(expected);
 		});
@@ -145,14 +147,15 @@ describe('Composite Product Selectors | integration tests', () => {
 			store.dispatch(new DaffCompositeProductApplyOption(
 				stubCompositeProduct.id,
 				<string>stubCompositeProduct.items[0].id,
-				stubCompositeProduct.items[0].options[1].id
+				stubCompositeProduct.items[0].options[1].id,
+				stubQty0
 			));
 			const selector = store.pipe(select(selectCompositeProductDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: 
 				stubCompositeProduct.price 
-				+ stubCompositeProduct.items[0].options[1].price 
+				+ (stubCompositeProduct.items[0].options[1].price * stubQty0)
 				- stubCompositeProduct.discount.amount 
-				- stubCompositeProduct.items[0].options[1].discount.amount
+				- (stubCompositeProduct.items[0].options[1].discount.amount * stubQty0)
 			});
 			expect(selector).toBeObservable(expected);
 		});

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -127,7 +127,7 @@ function getOptionsDiscountAmount(product: DaffCompositeProduct, appliedOptions:
 
 		return daffAdd(
 			acc, 
-			daffMultiply((itemOptionDiscount && itemOptionDiscount.amount > 0 ? itemOptionDiscount.amount : 0), appliedOptions[item.id].qty)
+			itemOptionDiscount && itemOptionDiscount.amount > 0 ? daffMultiply(itemOptionDiscount.amount, appliedOptions[item.id].qty) : 0
 		);
 	}, 0)
 }

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject } from 'rxjs';
-import { Dictionary } from '@ngrx/entity';
 
-import { DaffCompositeProductFacadeInterface, DaffCompositeProductItemOption } from '@daffodil/product';
+import { DaffCompositeProductFacadeInterface, DaffCompositeProductEntityItem } from '@daffodil/product';
+import { Dictionary } from '@ngrx/entity';
 
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
 	getPrice(id: string): BehaviorSubject<number> {
@@ -16,7 +16,7 @@ export class MockDaffCompositeProductFacade implements DaffCompositeProductFacad
 	hasDiscount(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	getAppliedOptions(id: string): BehaviorSubject<Dictionary<DaffCompositeProductItemOption['id']>> {
+	getAppliedOptions(id: string): BehaviorSubject<Dictionary<DaffCompositeProductEntityItem>> {
 		return new BehaviorSubject({});
 	}
 	dispatch(action) {};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Composite Product Option state does not hold qty, which is a feature needed for composite products.

## What is the new behavior?
Composite Product Option state now has qty.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
I'd like to make a minor (though breaking) change to the add to cart action payload to reflect the same naming convention of this PR. I'll do it separately.