### PR TITLE
feat(cart): change DaffCartItemAdd payload for composite products

### DIFF
--- a/libs/cart/src/drivers/magento/transforms/inputs/cart-item-input-transformers.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/cart-item-input-transformers.spec.ts
@@ -49,7 +49,7 @@ describe('Driver | Magento | Cart | Transformers | MagentoCartItemInput', () => 
 				...mockDaffCartItemInput,
 				type: DaffCartItemInputType.Composite,
 				options: [{
-					id: 1,
+					code: 1,
 					quantity: 1,
 					value: 'value'
 				}]
@@ -60,7 +60,7 @@ describe('Driver | Magento | Cart | Transformers | MagentoCartItemInput', () => 
 			transformedCartItem = transformCompositeCartItem(mockDaffCompositeCartItemInput);
       expect(transformedCartItem.input.sku).toEqual(mockDaffCompositeCartItemInput.productId);
       expect(transformedCartItem.input.quantity).toEqual(mockDaffCompositeCartItemInput.qty);
-      expect(transformedCartItem.options[0].id).toEqual(Number(mockDaffCompositeCartItemInput.options[0].id));
+      expect(transformedCartItem.options[0].id).toEqual(Number(mockDaffCompositeCartItemInput.options[0].code));
       expect(transformedCartItem.options[0].quantity).toEqual(mockDaffCompositeCartItemInput.options[0].quantity);
       expect(transformedCartItem.options[0].value).toEqual([mockDaffCompositeCartItemInput.options[0].value]);
 		});

--- a/libs/cart/src/drivers/magento/transforms/inputs/cart-item-input-transformers.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/cart-item-input-transformers.ts
@@ -27,7 +27,7 @@ export function transformConfigurableCartItem(item: DaffConfigurableCartItemInpu
 
 function transformCompositeCartItemOption(option: DaffCompositeCartItemOption): MagentoBundledCartItemOption {
 	return {
-		id: Number(option.id),
+		id: Number(option.code),
 		quantity: option.quantity,
 		value: [option.value]
 	}

--- a/libs/cart/src/models/cart-item-input.ts
+++ b/libs/cart/src/models/cart-item-input.ts
@@ -22,7 +22,7 @@ export interface DaffCompositeCartItemInput extends DaffCartItemInput {
 }
 
 export interface DaffCompositeCartItemOption {
-	id: string | number;
+	code: string | number;
 	quantity: number;
 	value: string;
 }


### PR DESCRIPTION
BREAKING CHANGE: the DaffCartItemAdd for composite products has changed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The payload for composite products in DaffCartItemAdd isn't very intuitive, because there is an item id and option id and it isn't clear which is the parent.

## What is the new behavior?
Changed it to code vs value instead, which is a pattern used throughout daffodil (like in configurable products).

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```