### PR TITLE
fix(cart): Magento cart address query fails from parameter type and complexity

### DIFF
--- a/libs/cart/README.md
+++ b/libs/cart/README.md
@@ -9,3 +9,11 @@ provides clear interfaces, models, and factories for the frontend of an ecommerc
 ```
 npm install @daffodil/cart
 ```
+
+## Magento
+
+### Query Complexity Limit
+
+The Magento cart address driver uses a query that has a high complexity of 481. This exceeds the default limit of 300. Users of the Magento cart drivers should raise the query complexity limit above 481 to prevent the cart address operations from failing.
+
+Graycore maintains a Magento 2 module that will modify limits to accomodate Daffodil queries. Refer to [the module repository](https://github.com/graycoreio/magento2-graphql-query-complexity-limiter-module) for installation procedures.

--- a/libs/cart/README.md
+++ b/libs/cart/README.md
@@ -9,11 +9,3 @@ provides clear interfaces, models, and factories for the frontend of an ecommerc
 ```
 npm install @daffodil/cart
 ```
-
-## Magento
-
-### Query Complexity Limit
-
-The Magento cart address driver uses a query that has a high complexity of 481. This exceeds the default limit of 300. Users of the Magento cart drivers should raise the query complexity limit above 481 to prevent the cart address operations from failing.
-
-Graycore maintains a Magento 2 module that will modify limits to accomodate Daffodil queries. Refer to [the module repository](https://github.com/graycoreio/magento2-graphql-query-complexity-limiter-module) for installation procedures.

--- a/libs/cart/src/drivers/magento/cart-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-address.service.spec.ts
@@ -20,15 +20,17 @@ import {
 } from '@daffodil/cart/testing';
 
 import {
-  updateAddress, updateAddressWithEmail
+  updateAddress,
+  updateAddressWithEmail
 } from './queries/public_api';
 import {
-  MagentoUpdateAddressResponse, MagentoUpdateAddressWithEmailResponse,
+  MagentoUpdateAddressResponse,
+  MagentoUpdateAddressWithEmailResponse,
 } from './models/responses/public_api';
 import { DaffMagentoCartAddressService } from './cart-address.service';
 import { DaffMagentoCartTransformer } from './transforms/outputs/cart.service';
 import { MagentoCart } from './models/outputs/cart';
-import { DaffMagentoShippingAddressInputTransformer } from './transforms/inputs/shipping-address.service';
+import { DaffMagentoCartAddressInputTransformer } from './transforms/inputs/cart-address.service';
 import { MagentoShippingAddressInput } from './models/inputs/shipping-address';
 
 describe('Driver | Magento | Cart | CartAddressService', () => {
@@ -42,7 +44,7 @@ describe('Driver | Magento | Cart | CartAddressService', () => {
   let magentoCartAddressInputFactory: MagentoCartAddressInputFactory;
 
   let magentoCartTransformerSpy;
-  let magentoShippingAddressInputTransformerSpy;
+  let magentoCartAddressInputTransformerSpy;
 
   let cartId;
   let email;
@@ -66,8 +68,8 @@ describe('Driver | Magento | Cart | CartAddressService', () => {
           useValue: jasmine.createSpyObj('DaffMagentoCartTransformer', ['transform'])
         },
         {
-          provide: DaffMagentoShippingAddressInputTransformer,
-          useValue: jasmine.createSpyObj('DaffMagentoShippingAddressInputTransformer', ['transform'])
+          provide: DaffMagentoCartAddressInputTransformer,
+          useValue: jasmine.createSpyObj('DaffMagentoCartAddressInputTransformer', ['transform'])
         },
 				{
 					provide: APOLLO_TESTING_CACHE,
@@ -85,7 +87,7 @@ describe('Driver | Magento | Cart | CartAddressService', () => {
     controller = TestBed.get(ApolloTestingController);
 
     magentoCartTransformerSpy = TestBed.get(DaffMagentoCartTransformer);
-    magentoShippingAddressInputTransformerSpy = TestBed.get(DaffMagentoShippingAddressInputTransformer);
+    magentoCartAddressInputTransformerSpy = TestBed.get(DaffMagentoCartAddressInputTransformer);
 
     daffCartFactory = TestBed.get(DaffCartFactory);
     magentoCartFactory = TestBed.get(MagentoCartFactory);
@@ -137,7 +139,7 @@ describe('Driver | Magento | Cart | CartAddressService', () => {
     };
 
     magentoCartTransformerSpy.transform.and.returnValue(mockDaffCart);
-    magentoShippingAddressInputTransformerSpy.transform.withArgs(mockDaffCartAddress).and.returnValue(mockMagentoShippingAddressInput);
+    magentoCartAddressInputTransformerSpy.transform.withArgs(mockDaffCartAddress).and.returnValue(mockMagentoShippingAddressInput);
   });
 
   it('should be created', () => {

--- a/libs/cart/src/drivers/magento/cart-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-address.service.spec.ts
@@ -115,7 +115,9 @@ describe('Driver | Magento | Cart | CartAddressService', () => {
     mockUpdateAddressResponse = {
       setBillingAddressOnCart: {
 				__typename: 'SetBillingAddressOnCart',
-        cart: mockMagentoCart
+        cart: {
+          id: cartId
+        }
       },
       setShippingAddressesOnCart: {
         __typename: 'SetShippingAddresses',
@@ -125,16 +127,19 @@ describe('Driver | Magento | Cart | CartAddressService', () => {
     mockUpdateAddressWithEmailResponse = {
       setBillingAddressOnCart: {
 				__typename: 'SetBillingAddressOnCart',
-        cart: mockMagentoCart
+        cart: {
+          id: cartId
+        }
       },
       setShippingAddressesOnCart: {
         __typename: 'SetShippingAddresses',
-        cart: mockMagentoCart
+        cart: {
+          id: cartId
+        }
       },
       setGuestEmailOnCart: {
-        cart: {
-          email
-        }
+        __typename: 'setGuestEmailOnCart',
+        cart: mockMagentoCart
       }
     };
 

--- a/libs/cart/src/drivers/magento/cart-address.service.ts
+++ b/libs/cart/src/drivers/magento/cart-address.service.ts
@@ -45,12 +45,7 @@ export class DaffMagentoCartAddressService implements DaffCartAddressServiceInte
         address: this.cartAddressInputTransformer.transform(address)
       }
     }).pipe(
-      map(resp => this.cartTransformer.transform({
-        ...resp.data.setBillingAddressOnCart.cart,
-        ...resp.data.setShippingAddressesOnCart.cart,
-        billing_address: resp.data.setBillingAddressOnCart.cart.billing_address,
-        shipping_addresses: resp.data.setShippingAddressesOnCart.cart.shipping_addresses,
-      })),
+      map(resp => this.cartTransformer.transform(resp.data.setShippingAddressesOnCart.cart)),
       catchError(error => throwError(transformCartMagentoError(error))),
     )
   }
@@ -64,13 +59,7 @@ export class DaffMagentoCartAddressService implements DaffCartAddressServiceInte
         address: this.cartAddressInputTransformer.transform(address)
       }
     }).pipe(
-      map(resp => this.cartTransformer.transform({
-        ...resp.data.setBillingAddressOnCart.cart,
-        ...resp.data.setShippingAddressesOnCart.cart,
-        billing_address: resp.data.setBillingAddressOnCart.cart.billing_address,
-        shipping_addresses: resp.data.setShippingAddressesOnCart.cart.shipping_addresses,
-        email: resp.data.setGuestEmailOnCart.cart.email
-      })),
+      map(resp => this.cartTransformer.transform(resp.data.setGuestEmailOnCart.cart)),
       catchError(error => throwError(transformCartMagentoError(error))),
     )
   }

--- a/libs/cart/src/drivers/magento/cart-address.service.ts
+++ b/libs/cart/src/drivers/magento/cart-address.service.ts
@@ -7,15 +7,17 @@ import { DaffCartAddressServiceInterface } from '../interfaces/cart-address-serv
 import { DaffCart } from '../../models/cart';
 import { DaffCartAddress } from '../../models/cart-address';
 import {
-  updateAddress, updateAddressWithEmail,
+  updateAddress,
+  updateAddressWithEmail,
 } from './queries/public_api';
 import {
-  MagentoUpdateAddressResponse, MagentoUpdateAddressWithEmailResponse,
+  MagentoUpdateAddressResponse,
+  MagentoUpdateAddressWithEmailResponse,
 } from './models/responses/public_api';
-import { DaffMagentoShippingAddressInputTransformer } from './transforms/inputs/shipping-address.service';
 import { DaffMagentoCartTransformer } from './transforms/outputs/cart.service';
 import { DaffMagentoShippingAddressTransformer } from './transforms/outputs/shipping-address.service';
 import { transformCartMagentoError } from './errors/transform';
+import { DaffMagentoCartAddressInputTransformer } from './transforms/inputs/cart-address.service';
 
 /**
  * A service for making Magento GraphQL queries for carts.
@@ -28,7 +30,7 @@ export class DaffMagentoCartAddressService implements DaffCartAddressServiceInte
     private apollo: Apollo,
     public cartTransformer: DaffMagentoCartTransformer,
     public cartAddressTransformer: DaffMagentoShippingAddressTransformer,
-    public cartAddressInputTransformer: DaffMagentoShippingAddressInputTransformer,
+    public cartAddressInputTransformer: DaffMagentoCartAddressInputTransformer,
   ) {}
 
   update(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {

--- a/libs/cart/src/drivers/magento/models/responses/update-address-with-email.ts
+++ b/libs/cart/src/drivers/magento/models/responses/update-address-with-email.ts
@@ -1,11 +1,17 @@
 import { MagentoGetCartResponse } from './get-cart';
 
 export interface MagentoUpdateAddressWithEmailResponse {
-  setBillingAddressOnCart: MagentoGetCartResponse;
-  setShippingAddressesOnCart: MagentoGetCartResponse;
-  setGuestEmailOnCart: {
+  setBillingAddressOnCart: {
+    __typename: string;
     cart: {
-      email: MagentoGetCartResponse['cart']['email']
+      id: MagentoGetCartResponse['cart']['id']
     }
   };
+  setShippingAddressesOnCart: {
+    __typename: string;
+    cart: {
+      id: MagentoGetCartResponse['cart']['id']
+    }
+  };
+  setGuestEmailOnCart: MagentoGetCartResponse;
 }

--- a/libs/cart/src/drivers/magento/models/responses/update-address.ts
+++ b/libs/cart/src/drivers/magento/models/responses/update-address.ts
@@ -1,6 +1,11 @@
 import { MagentoGetCartResponse } from './get-cart';
 
 export interface MagentoUpdateAddressResponse {
-  setBillingAddressOnCart: MagentoGetCartResponse;
+  setBillingAddressOnCart: {
+    __typename: string;
+    cart: {
+      id: MagentoGetCartResponse['cart']['id']
+    }
+  };
   setShippingAddressesOnCart: MagentoGetCartResponse;
 }

--- a/libs/cart/src/drivers/magento/queries/update-address-with-email.ts
+++ b/libs/cart/src/drivers/magento/queries/update-address-with-email.ts
@@ -11,7 +11,7 @@ export const updateAddressWithEmail = gql`
       }
     }) {
       cart {
-        ...cart
+        id
       }
     }
     setShippingAddressesOnCart(input: {
@@ -21,7 +21,7 @@ export const updateAddressWithEmail = gql`
       }]
     }) {
       cart {
-        ...cart
+        id
       }
     }
     setGuestEmailOnCart(input: {
@@ -29,7 +29,7 @@ export const updateAddressWithEmail = gql`
       email: $email
     }) {
       cart {
-        email
+        ...cart
       }
     }
   }

--- a/libs/cart/src/drivers/magento/queries/update-address-with-email.ts
+++ b/libs/cart/src/drivers/magento/queries/update-address-with-email.ts
@@ -3,10 +3,12 @@ import gql from 'graphql-tag';
 import { cartFragment } from './fragments/public_api';
 
 export const updateAddressWithEmail = gql`
-  mutation UpdateAddress($cartId: String!, $address: AddressInput!, $email: String!) {
+  mutation UpdateAddress($cartId: String!, $address: CartAddressInput!, $email: String!) {
     setBillingAddressOnCart(input: {
       cart_id: $cartId
-      billing_address: $address
+      billing_address: {
+        address: $address
+      }
     }) {
       cart {
         ...cart
@@ -14,7 +16,9 @@ export const updateAddressWithEmail = gql`
     }
     setShippingAddressesOnCart(input: {
       cart_id: $cartId
-      shipping_addresses: [$address]
+      shipping_addresses: [{
+        address: $address
+      }]
     }) {
       cart {
         ...cart

--- a/libs/cart/src/drivers/magento/queries/update-address-with-email.ts
+++ b/libs/cart/src/drivers/magento/queries/update-address-with-email.ts
@@ -2,6 +2,13 @@ import gql from 'graphql-tag';
 
 import { cartFragment } from './fragments/public_api';
 
+/**
+ * Update the shipping and billing address of the cart.
+ * At the time of writing, Magento 2 processes compound queries in the order they are defined.
+ * We rely on this fact and only use the return of the last query.
+ * This helps us keep query complexity down and save some server CPU cycles.
+ * Driver behavior is not guaranteed if Magento no longer processes compound queries in the order they are defined.
+ */
 export const updateAddressWithEmail = gql`
   mutation UpdateAddress($cartId: String!, $address: CartAddressInput!, $email: String!) {
     setBillingAddressOnCart(input: {

--- a/libs/cart/src/drivers/magento/queries/update-address.ts
+++ b/libs/cart/src/drivers/magento/queries/update-address.ts
@@ -11,7 +11,7 @@ export const updateAddress = gql`
       }
     }) {
       cart {
-        ...cart
+        id
       }
     }
     setShippingAddressesOnCart(input: {

--- a/libs/cart/src/drivers/magento/queries/update-address.ts
+++ b/libs/cart/src/drivers/magento/queries/update-address.ts
@@ -3,10 +3,12 @@ import gql from 'graphql-tag';
 import { cartFragment } from './fragments/public_api';
 
 export const updateAddress = gql`
-  mutation UpdateAddress($cartId: String!, $address: AddressInput!) {
+  mutation UpdateAddress($cartId: String!, $address: CartAddressInput!) {
     setBillingAddressOnCart(input: {
       cart_id: $cartId
-      billing_address: $address
+      billing_address: {
+        address: $address
+      }
     }) {
       cart {
         ...cart
@@ -14,7 +16,9 @@ export const updateAddress = gql`
     }
     setShippingAddressesOnCart(input: {
       cart_id: $cartId
-      shipping_addresses: [$address]
+      shipping_addresses: [{
+        address: $address
+      }]
     }) {
       cart {
         ...cart

--- a/libs/cart/src/drivers/magento/queries/update-address.ts
+++ b/libs/cart/src/drivers/magento/queries/update-address.ts
@@ -2,6 +2,13 @@ import gql from 'graphql-tag';
 
 import { cartFragment } from './fragments/public_api';
 
+/**
+ * Update the shipping and billing address of the cart.
+ * At the time of writing, Magento 2 processes compound queries in the order they are defined.
+ * We rely on this fact and only use the return of the last query.
+ * This helps us keep query complexity down and save some server CPU cycles.
+ * Driver behavior is not guaranteed if Magento no longer processes compound queries in the order they are defined.
+ */
 export const updateAddress = gql`
   mutation UpdateAddress($cartId: String!, $address: CartAddressInput!) {
     setBillingAddressOnCart(input: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Magento cart address queries fail complaining about the input type.

Magento cart address queries will also fail due to a high query complexity.

## What is the new behavior?
Magento cart address queries will complete as expected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information