### PR TITLE
feat(product): add ranged price selectors for composite products

### DIFF
--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -9,6 +9,46 @@ import { DaffCompositeProductEntityItem } from '../../reducers/composite-product
 export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Action> {
 
 	/**
+	 * Get the minimum price possible for a composite product regardless of applied options.
+	 * @param id the id of the composite product.
+	 */
+	getMinPossiblePrice(id: string): Observable<number>;
+
+	/**
+	 * Get the maximum price possible for a composite product regardless of applied options and including optional items.
+	 * @param id the id of the composite product.
+	 */
+	getMaxPossiblePrice(id: string): Observable<number>;
+
+	/**
+	 * Returns whether the composite product has a price range regardless of applied options and including
+	 * optional items.
+	 * @param id the id of the composite product.
+	 */
+	possiblyHasPriceRange(id: string): Observable<boolean>;
+
+	/**
+	 * Get the minimum price for a composite product excluding optional items and determined by 
+	 * currently applied options.
+	 * @param id the id of the composite product.
+	 */
+	getMinPrice(id: string): Observable<number>;
+
+	/**
+	 * Get the maximum price for a composite product excluding optional items and determined by
+	 * currently applied options.
+	 * @param id the id of the composite product.
+	 */
+	getMaxPrice(id: string): Observable<number>;
+
+	/**
+	 * Returns whether the composite product has a price range depending on applied options and excluding
+	 * optional items.
+	 * @param id the id of the composite product.
+	 */
+	hasPriceRange(id: string): Observable<boolean>;
+
+	/**
 	 * Get the price of a composite product based on the applied product options.
 	 * @param id the id of the composite product.
 	 */

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -22,6 +22,30 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 	
 	constructor(private store: Store<DaffProductReducersState<T>>) {}
 	
+	getMinPossiblePrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinPossiblePrice, { id }));
+	}
+
+	getMaxPossiblePrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPossiblePrice, { id }));
+	}
+
+	possiblyHasPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasPriceRange, { id }));
+	}
+
+	getMinPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinPrice, { id }));
+	}
+
+	getMaxPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPrice, { id }));
+	}
+
+	hasPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasPriceRange, { id }));
+	}
+
 	getPrice(id: string): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectCompositeProductPrice, { id }));
 	}

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
@@ -100,6 +100,10 @@ describe('Product | Composite Product Entities Reducer', () => {
 					[compositeProduct.items[0].id]: {
 						value: compositeProduct.items[0].options[0].id,
 						qty: 1
+					},
+					[compositeProduct.items[1].id]: {
+						value: compositeProduct.items[1].options[0].id,
+						qty: 1
 					}
 				} 
 			});

--- a/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.spec.ts
@@ -59,6 +59,10 @@ describe('selectCompositeProductEntitiesState', () => {
 						[stubCompositeProduct.items[0].id]: {
 							value: stubCompositeProduct.items[0].options[0].id,
 							qty: 1
+						},
+						[stubCompositeProduct.items[1].id]: {
+							value: stubCompositeProduct.items[1].options[0].id,
+							qty: 1
 						}
 					}
 				}
@@ -89,6 +93,10 @@ describe('selectCompositeProductEntitiesState', () => {
 				a: {
 					[stubCompositeProduct.items[0].id]: {
 						value: stubCompositeProduct.items[0].options[0].id,
+						qty: 1
+					},
+					[stubCompositeProduct.items[1].id]: {
+						value: stubCompositeProduct.items[1].options[0].id,
 						qty: 1
 					}
 				}

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -101,7 +101,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 
 			return (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
 				acc, 
-				appliedOptions[item.id].value ? item.options.find(option => option.id === appliedOptions[item.id].value).price : getMinimumCompositeItemPrice(item)
+				appliedOptions[item.id].value ? findAppliedCompositeOptionPrice(item, appliedOptions) : getMinimumCompositeItemPrice(item)
 			), product.price);
 		}
 	);
@@ -123,7 +123,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			return (<DaffCompositeProduct>product).items.reduce((acc, item) => 
 				daffAdd(
 					acc, 
-					appliedOptions[item.id].value ? item.options.find(option => option.id === appliedOptions[item.id].value).price : getMaximumRequiredItemPrice(item)
+					appliedOptions[item.id].value ? findAppliedCompositeOptionPrice(item, appliedOptions) : getMaximumRequiredItemPrice(item)
 				), product.price);
 		}
 	);
@@ -154,7 +154,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 
 			return (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
 				acc, 
-				appliedOptions[item.id].value ? daffMultiply(item.options.find(option => option.id === appliedOptions[item.id].value).price, appliedOptions[item.id].qty) : 0
+				appliedOptions[item.id].value ? daffMultiply(findAppliedCompositeOptionPrice(item, appliedOptions), appliedOptions[item.id].qty) : 0
 			), product.price);
 		}
 	);
@@ -243,6 +243,10 @@ function getOptionsDiscountAmount(product: DaffCompositeProduct, appliedOptions:
 			itemOptionDiscount && itemOptionDiscount.amount > 0 ? daffMultiply(itemOptionDiscount.amount, appliedOptions[item.id].qty) : 0
 		);
 	}, 0)
+}
+
+function findAppliedCompositeOptionPrice(item: DaffCompositeProductItem, appliedOptions: Dictionary<DaffCompositeProductEntityItem>): number {
+	return item.options.find(option => option.id === appliedOptions[item.id].value).price
 }
 
 /**

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -8,8 +8,15 @@ import { getDaffCompositeProductEntitiesSelectors } from '../composite-product-e
 import { getDaffProductEntitiesSelectors } from '../product-entities/product-entities.selectors';
 import { DaffCompositeProduct } from '../../models/composite-product';
 import { DaffCompositeProductEntityItem } from '../../reducers/public_api';
+import { DaffCompositeProductItem } from '../../models/composite-product-item';
 
 export interface DaffCompositeProductMemoizedSelectors {
+	selectCompositeProductMinPossiblePrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMaxPossiblePrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductPossiblyHasPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductMinPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMaxPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductHasPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
 	selectCompositeProductPrice: MemoizedSelectorWithProps<object, object, number>;
 	selectCompositeProductDiscountAmount: MemoizedSelectorWithProps<object, object, number>;
 	selectCompositeProductDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
@@ -30,6 +37,108 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	} = getDaffProductEntitiesSelectors();
 
 	/**
+	 * Selector for the minimum price possible for a composite product, regardless of the current item option selection.
+	 * This could be useful for a quick preview of the product.
+	 */
+	const selectCompositeProductMinPossiblePrice = createSelector(
+		selectProductEntities,
+		(products, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
+			if(product.type !== DaffProductTypeEnum.Composite) {
+				return undefined;
+			}
+			
+			return (<DaffCompositeProduct>product).items.reduce((acc, item) => 
+				daffAdd(
+					acc, 
+					getMinimumCompositeItemPrice(item)
+				), product.price);
+		}
+	);
+
+	/**
+	 * Selector for the maximum price possible for a composite product, regardless of the current item option selection.
+	 * This could be useful for a quick preview of the product.
+	 */
+	const selectCompositeProductMaxPossiblePrice = createSelector(
+		selectProductEntities,
+		(products, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
+			if(product.type !== DaffProductTypeEnum.Composite) {
+				return undefined;
+			}
+			
+			return (<DaffCompositeProduct>product).items.reduce((acc, item) => 
+				daffAdd(
+					acc, 
+					Math.max(...item.options.map(option => option.price))
+				), product.price);
+		}
+	);
+
+	/**
+	 * Selector for whether the composite product could have a price range.
+	 */
+	const selectCompositeProductPossiblyHasPriceRange = createSelector(
+		selectProductEntities,
+		(products, props) => selectCompositeProductMinPossiblePrice.projector(products, { id: props.id }) 
+			!== selectCompositeProductMaxPossiblePrice.projector(products, { id: props.id })
+	)
+
+	/**
+	 * Selector for the minimum price for required items of a composite product, depending on the current selection of item options.
+	 * This would be used for a composite product that has required items without default selections.
+	 */
+	const selectCompositeProductMinPrice = createSelector(
+		selectProductEntities,
+		selectCompositeProductAppliedOptionsEntitiesState,
+		(products, appliedOptionsEntities, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
+			if(product.type !== DaffProductTypeEnum.Composite) {
+				return undefined;
+			}
+			const appliedOptions = selectCompositeProductAppliedOptions.projector(appliedOptionsEntities, { id: props.id });
+
+			return (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
+				acc, 
+				appliedOptions[item.id].value ? item.options.find(option => option.id === appliedOptions[item.id].value).price : getMinimumCompositeItemPrice(item)
+			), product.price);
+		}
+	);
+
+	/**
+	 * Selector for the maximum price for required items of a composite product, depending on the current selection of item options.
+	 * This would be used for a composite product that has required items without default selections.
+	 */
+	const selectCompositeProductMaxPrice = createSelector(
+		selectProductEntities,
+		selectCompositeProductAppliedOptionsEntitiesState,
+		(products, appliedOptionsEntities, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
+			if(product.type !== DaffProductTypeEnum.Composite) {
+				return undefined;
+			}
+			const appliedOptions = selectCompositeProductAppliedOptions.projector(appliedOptionsEntities, { id: props.id });
+
+			return (<DaffCompositeProduct>product).items.reduce((acc, item) => 
+				daffAdd(
+					acc, 
+					appliedOptions[item.id].value ? item.options.find(option => option.id === appliedOptions[item.id].value).price : getMaximumRequiredItemPrice(item)
+				), product.price);
+		}
+	);
+
+	/**
+	 * Selector for whether the composite product has a price range based on the currently applied item options.
+	 */
+	const selectCompositeProductHasPriceRange = createSelector(
+		selectProductEntities,
+		selectCompositeProductAppliedOptionsEntitiesState,
+		(products, appliedOptionsEntities, props) => selectCompositeProductMinPrice.projector(products, appliedOptionsEntities, { id: props.id }) 
+			!== selectCompositeProductMaxPrice.projector(products, appliedOptionsEntities, { id: props.id })
+	)
+
+	/**
 	 * Selector for the price for current configuration of the composite product.
 	 */
 	const selectCompositeProductPrice = createSelector(
@@ -43,12 +152,10 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			
 			const appliedOptions = selectCompositeProductAppliedOptions.projector(appliedOptionsEntities, { id: props.id });
 
-			return (<DaffCompositeProduct>product).items.reduce((acc, item) => {
-				return daffAdd(
-					acc, 
-					daffMultiply(item.options.find(option => option.id === appliedOptions[item.id].value).price, appliedOptions[item.id].qty)
-				);
-			}, product.price);
+			return (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
+				acc, 
+				appliedOptions[item.id].value ? daffMultiply(item.options.find(option => option.id === appliedOptions[item.id].value).price, appliedOptions[item.id].qty) : 0
+			), product.price);
 		}
 	);
 
@@ -107,6 +214,12 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	);
 
 	return { 
+		selectCompositeProductMinPossiblePrice,
+		selectCompositeProductMaxPossiblePrice,
+		selectCompositeProductPossiblyHasPriceRange,
+		selectCompositeProductMinPrice,
+		selectCompositeProductMaxPrice,
+		selectCompositeProductHasPriceRange,
 		selectCompositeProductPrice,
 		selectCompositeProductDiscountAmount,
 		selectCompositeProductDiscountedPrice,
@@ -123,11 +236,27 @@ export const getDaffCompositeProductSelectors = (() => {
 
 function getOptionsDiscountAmount(product: DaffCompositeProduct, appliedOptions: Dictionary<DaffCompositeProductEntityItem>): number {
 	return product.items.reduce((acc, item) => {
-		const itemOptionDiscount = item.options.find(option => option.id === appliedOptions[item.id].value).discount;
+		const itemOptionDiscount = appliedOptions[item.id].value ? item.options.find(option => option.id === appliedOptions[item.id].value).discount : null;
 
 		return daffAdd(
 			acc, 
 			itemOptionDiscount && itemOptionDiscount.amount > 0 ? daffMultiply(itemOptionDiscount.amount, appliedOptions[item.id].qty) : 0
 		);
 	}, 0)
+}
+
+/**
+ * The minimum price of an item is zero if the item is optional.
+ * @param item DaffCompositeProductItem
+ */
+function getMinimumCompositeItemPrice(item: DaffCompositeProductItem): number {
+	return item.required ? Math.min(...item.options.map(option => option.price)) : 0;
+}
+
+/**
+ * The maximum price for an item is zero if the item is optional.
+ * @param item DaffCompositeProductItem
+ */
+function getMaximumRequiredItemPrice(item: DaffCompositeProductItem): number {
+	return item.required ? Math.max(...item.options.map(option => option.price)) : 0;
 }

--- a/libs/product/testing/src/factories/composite-product.factory.ts
+++ b/libs/product/testing/src/factories/composite-product.factory.ts
@@ -30,14 +30,36 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 				{
 					id: faker.random.alphaNumeric(10),
 					name: faker.commerce.productMaterial(),
-					price: faker.random.number({min: 1, max: 100}).toString(),
+					price: faker.random.number({min: 1, max: 100}),
 					quantity: faker.random.number({min: 1, max: 9}),
 					is_default: true
 				},
 				{
 					id: faker.random.alphaNumeric(10),
 					name: faker.commerce.productMaterial(),
-					price: faker.random.number({min: 1, max: 100}).toString(),
+					price: faker.random.number({min: 1, max: 100}),
+					quantity: faker.random.number({min: 1, max: 9}),
+					is_default: false
+				}
+			]
+		},
+		{
+			id: faker.random.alphaNumeric(10),
+			required: faker.random.boolean(),
+			title: faker.commerce.productName(),
+			input_type: DaffCompositeProductItemInputEnum.select,
+			options: [
+				{
+					id: faker.random.alphaNumeric(10),
+					name: faker.commerce.productMaterial(),
+					price: faker.random.number({min: 1, max: 100}),
+					quantity: faker.random.number({min: 1, max: 9}),
+					is_default: true
+				},
+				{
+					id: faker.random.alphaNumeric(10),
+					name: faker.commerce.productMaterial(),
+					price: faker.random.number({min: 1, max: 100}),
 					quantity: faker.random.number({min: 1, max: 9}),
 					is_default: false
 				}

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -4,6 +4,24 @@ import { DaffCompositeProductFacadeInterface, DaffCompositeProductEntityItem } f
 import { Dictionary } from '@ngrx/entity';
 
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
+	getMinPossiblePrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	getMaxPossiblePrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	possiblyHasPriceRange(id: string): BehaviorSubject<boolean> {
+		return new BehaviorSubject(false);
+	};
+	getMinPrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	getMaxPrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	hasPriceRange(id: string): BehaviorSubject<boolean> {
+		return new BehaviorSubject(false);
+	};
 	getPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
Adds ranged prices for composite products. Two kinds of ranged price selectors were needed:

One represents the full possible range of prices for the composite product, regardless of what kinds of items have been chosen by default behind the scenes or by the user. This would be used in an area of the application where the customer cannot see what items and options are available, such as which a product quick-view or a product card on a category page. Think of this as the total possible range of what a user could configure for a composite product.

The other kind of ranged price is for a product page and will typically only be needed for composite products that have required items which also have no default option. This range is dependent on the applied options for the composite product. If all required items are chosen, this range will not exist, because the final price of the product can be represented by a single number. If a composite product has a required item that has no option chosen, then the final price of the product cannot be represented by a single number, because that single number cannot be known until all required items are decided.