### PR TITLE
fix(cart): driver failures cause effect obsevables to complete

### DIFF
--- a/libs/cart/src/effects/cart-address.effects.spec.ts
+++ b/libs/cart/src/effects/cart-address.effects.spec.ts
@@ -116,7 +116,7 @@ describe('Daffodil | Cart | CartAddressEffects', () => {
         daffAddressDriverSpy.update.and.returnValue(response);
         const cartAddressUpdateFailureAction = new DaffCartAddressUpdateFailure(error);
         actions$ = hot('--a', { a: cartAddressUpdateAction });
-        expected = cold('--(b|)', { b: cartAddressUpdateFailureAction });
+        expected = cold('--b', { b: cartAddressUpdateFailureAction });
       });
 
       it('should dispatch a CartAddressUpdateFailure action', () => {

--- a/libs/cart/src/effects/cart-address.effects.spec.ts
+++ b/libs/cart/src/effects/cart-address.effects.spec.ts
@@ -88,7 +88,7 @@ describe('Daffodil | Cart | CartAddressEffects', () => {
         daffCartStorageSpy.getCartId.and.callFake(throwStorageError)
 
         actions$ = hot('--a', { a: cartAddressUpdateAction });
-        expected = cold('--(b|)', { b: cartStorageFailureAction });
+        expected = cold('--b', { b: cartStorageFailureAction });
       });
 
       it('should return a DaffCartStorageFailure', () => {

--- a/libs/cart/src/effects/cart-address.effects.ts
+++ b/libs/cart/src/effects/cart-address.effects.ts
@@ -28,9 +28,11 @@ export class DaffCartAddressEffects<T extends DaffCartAddress, V extends DaffCar
   update$ = this.actions$.pipe(
     ofType(DaffCartAddressActionTypes.CartAddressUpdateAction),
     switchMap((action: DaffCartAddressUpdate<T>) =>
-      this.driver.update(this.storage.getCartId(), action.payload)
+      this.driver.update(this.storage.getCartId(), action.payload).pipe(
+        map((resp: V) => new DaffCartAddressUpdateSuccess(resp)),
+        catchError(error => of(new DaffCartAddressUpdateFailure('Failed to update cart address')))
+      )
     ),
-    map((resp: V) => new DaffCartAddressUpdateSuccess(resp)),
     catchError(error => of(error instanceof DaffStorageServiceError
       ? new DaffCartStorageFailure('Cart Storage Failed')
       : new DaffCartAddressUpdateFailure('Failed to update cart address')

--- a/libs/cart/src/effects/cart-coupon.effects.spec.ts
+++ b/libs/cart/src/effects/cart-coupon.effects.spec.ts
@@ -121,7 +121,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         daffCartStorageSpy.getCartId.and.callFake(throwStorageError)
 
         actions$ = hot('--a', { a: cartCouponApplyAction });
-        expected = cold('--(b|)', { b: cartStorageFailureAction });
+        expected = cold('--b', { b: cartStorageFailureAction });
       });
 
       it('should return a DaffCartStorageFailure', () => {
@@ -167,7 +167,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         daffCartStorageSpy.getCartId.and.callFake(throwStorageError)
 
         actions$ = hot('--a', { a: cartCouponListAction });
-        expected = cold('--(b|)', { b: cartStorageFailureAction });
+        expected = cold('--b', { b: cartStorageFailureAction });
       });
 
       it('should return a DaffCartStorageFailure', () => {
@@ -213,7 +213,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         daffCartStorageSpy.getCartId.and.callFake(throwStorageError)
 
         actions$ = hot('--a', { a: cartCouponRemoveAction });
-        expected = cold('--(b|)', { b: cartStorageFailureAction });
+        expected = cold('--b', { b: cartStorageFailureAction });
       });
 
       it('should return a DaffCartStorageFailure', () => {
@@ -259,7 +259,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         daffCartStorageSpy.getCartId.and.callFake(throwStorageError)
 
         actions$ = hot('--a', { a: cartCouponRemoveAllAction });
-        expected = cold('--(b|)', { b: cartStorageFailureAction });
+        expected = cold('--b', { b: cartStorageFailureAction });
       });
 
       it('should return a DaffCartStorageFailure', () => {

--- a/libs/cart/src/effects/cart-coupon.effects.spec.ts
+++ b/libs/cart/src/effects/cart-coupon.effects.spec.ts
@@ -108,7 +108,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         daffDriverSpy.apply.and.returnValue(response);
         const cartCouponApplyFailureAction = new DaffCartCouponApplyFailure(error);
         actions$ = hot('--a', { a: cartCouponApplyAction });
-        expected = cold('--(b|)', { b: cartCouponApplyFailureAction });
+        expected = cold('--b', { b: cartCouponApplyFailureAction });
       });
 
       it('should dispatch a CartCouponApplyFailure action', () => {
@@ -154,7 +154,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         daffDriverSpy.list.and.returnValue(response);
         const cartCouponListFailureAction = new DaffCartCouponListFailure(error);
         actions$ = hot('--a', { a: cartCouponListAction });
-        expected = cold('--(b|)', { b: cartCouponListFailureAction });
+        expected = cold('--b', { b: cartCouponListFailureAction });
       });
 
       it('should dispatch a CartCouponListFailure action', () => {
@@ -200,7 +200,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         daffDriverSpy.remove.and.returnValue(response);
         const cartCouponRemoveFailureAction = new DaffCartCouponRemoveFailure(error);
         actions$ = hot('--a', { a: cartCouponRemoveAction });
-        expected = cold('--(b|)', { b: cartCouponRemoveFailureAction });
+        expected = cold('--b', { b: cartCouponRemoveFailureAction });
       });
 
       it('should dispatch a CartCouponApplyFailure action', () => {
@@ -239,14 +239,14 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
       });
     });
 
-    describe('and the clear call to driver fails', () => {
+    describe('and the call to CartCouponService fails', () => {
       beforeEach(() => {
         const error = 'Failed to remove all coupons from the cart';
         const response = cold('#', {}, error);
         daffDriverSpy.removeAll.and.returnValue(response);
         const cartCouponRemoveAllFailureAction = new DaffCartCouponRemoveAllFailure(error);
         actions$ = hot('--a', { a: cartCouponRemoveAllAction });
-        expected = cold('--(b|)', { b: cartCouponRemoveAllFailureAction });
+        expected = cold('--b', { b: cartCouponRemoveAllFailureAction });
       });
 
       it('should return a DaffCartCouponRemoveAllFailure action', () => {

--- a/libs/cart/src/effects/cart-coupon.effects.ts
+++ b/libs/cart/src/effects/cart-coupon.effects.ts
@@ -41,62 +41,57 @@ export class DaffCartCouponEffects<
 
   @Effect()
   apply$ = this.actions$.pipe(
-    tap(action => console.log('coupon', action)),
     ofType(DaffCartCouponActionTypes.CartCouponApplyAction),
-    switchMap((action: DaffCartCouponApply<V>) =>
-      this.driver.apply(this.storage.getCartId(), action.payload).pipe(
-        map(resp => new DaffCartCouponApplySuccess(resp)),
-        catchError(error => of(new DaffCartCouponApplyFailure('Failed to apply coupon to cart')))
-      )
-    ),
-    catchError(error => of(error instanceof DaffStorageServiceError
-      ? new DaffCartStorageFailure('Cart Storage Failed')
-      : new DaffCartCouponApplyFailure('Failed to apply coupon to cart')
+    switchMap((action: DaffCartCouponApply<V>) => of(null).pipe(
+      map(() => this.storage.getCartId()),
+      switchMap(cartId => this.driver.apply(cartId, action.payload)),
+      map(resp => new DaffCartCouponApplySuccess(resp)),
+      catchError(error => of(error.name === DaffStorageServiceError.name
+        ? new DaffCartStorageFailure('Cart Storage Failed')
+        : new DaffCartCouponApplyFailure('Failed to apply coupon to cart')
+      )),
     )),
   )
 
   @Effect()
   list$ = this.actions$.pipe(
     ofType(DaffCartCouponActionTypes.CartCouponListAction),
-    switchMap((action: DaffCartCouponList) =>
-      this.driver.list(this.storage.getCartId()).pipe(
-        map(resp => new DaffCartCouponListSuccess<V>(resp)),
-        catchError(error => of(new DaffCartCouponListFailure('Failed to list coupons')))
-      )
-    ),
-    catchError(error => of(error instanceof DaffStorageServiceError
-      ? new DaffCartStorageFailure('Cart Storage Failed')
-      : new DaffCartCouponListFailure('Failed to list coupons')
-    ))
+    switchMap((action: DaffCartCouponList) => of(null).pipe(
+      map(() => this.storage.getCartId()),
+      switchMap(cartId => this.driver.list(cartId)),
+      map(resp => new DaffCartCouponListSuccess<V>(resp)),
+      catchError(error => of(error.name === DaffStorageServiceError.name
+        ? new DaffCartStorageFailure('Cart Storage Failed')
+        : new DaffCartCouponListFailure('Failed to list coupons')
+      )),
+    )),
   )
 
   @Effect()
   remove$ = this.actions$.pipe(
     ofType(DaffCartCouponActionTypes.CartCouponRemoveAction),
-    switchMap((action: DaffCartCouponRemove<V>) =>
-      this.driver.remove(this.storage.getCartId(), action.payload).pipe(
-        map(resp => new DaffCartCouponRemoveSuccess(resp)),
-        catchError(error => of(new DaffCartCouponRemoveFailure('Failed to remove a coupon from the cart')))
-      )
-    ),
-    catchError(error => of(error instanceof DaffStorageServiceError
-      ? new DaffCartStorageFailure('Cart Storage Failed')
-      : new DaffCartCouponRemoveFailure('Failed to remove a coupon from the cart')
-    ))
+    switchMap((action: DaffCartCouponRemove<V>) => of(null).pipe(
+      map(() => this.storage.getCartId()),
+      switchMap(cartId => this.driver.remove(cartId, action.payload)),
+      map(resp => new DaffCartCouponRemoveSuccess(resp)),
+      catchError(error => of(error.name === DaffStorageServiceError.name
+        ? new DaffCartStorageFailure('Cart Storage Failed')
+        : new DaffCartCouponRemoveFailure('Failed to remove a coupon from the cart')
+      )),
+    )),
   )
 
   @Effect()
   removeAll$ = this.actions$.pipe(
     ofType(DaffCartCouponActionTypes.CartCouponRemoveAllAction),
-    switchMap((action: DaffCartCouponRemoveAll) =>
-      this.driver.removeAll(this.storage.getCartId()).pipe(
-        map(resp => new DaffCartCouponRemoveAllSuccess(resp)),
-        catchError(error => of(new DaffCartCouponRemoveAllFailure('Failed to remove all coupons from the cart')))
-      )
-    ),
-    catchError(error => of(error instanceof DaffStorageServiceError
-      ? new DaffCartStorageFailure('Cart Storage Failed')
-      : new DaffCartCouponRemoveAllFailure('Failed to remove all coupons from the cart')
-    ))
+    switchMap((action: DaffCartCouponRemoveAll) => of(null).pipe(
+      map(() => this.storage.getCartId()),
+      switchMap(cartId => this.driver.removeAll(cartId)),
+      map(resp => new DaffCartCouponRemoveAllSuccess(resp)),
+      catchError(error => of(error.name === DaffStorageServiceError.name
+        ? new DaffCartStorageFailure('Cart Storage Failed')
+        : new DaffCartCouponRemoveAllFailure('Failed to remove all coupons from the cart')
+      )),
+    )),
   )
 }

--- a/libs/cart/src/effects/cart-coupon.effects.ts
+++ b/libs/cart/src/effects/cart-coupon.effects.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from '@angular/core';
-import { switchMap, map, catchError } from 'rxjs/operators';
+import { switchMap, map, catchError, tap, take } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 
@@ -41,16 +41,18 @@ export class DaffCartCouponEffects<
 
   @Effect()
   apply$ = this.actions$.pipe(
+    tap(action => console.log('coupon', action)),
     ofType(DaffCartCouponActionTypes.CartCouponApplyAction),
     switchMap((action: DaffCartCouponApply<V>) =>
       this.driver.apply(this.storage.getCartId(), action.payload).pipe(
         map(resp => new DaffCartCouponApplySuccess(resp)),
+        catchError(error => of(new DaffCartCouponApplyFailure('Failed to apply coupon to cart')))
       )
     ),
     catchError(error => of(error instanceof DaffStorageServiceError
       ? new DaffCartStorageFailure('Cart Storage Failed')
       : new DaffCartCouponApplyFailure('Failed to apply coupon to cart')
-    ))
+    )),
   )
 
   @Effect()
@@ -59,6 +61,7 @@ export class DaffCartCouponEffects<
     switchMap((action: DaffCartCouponList) =>
       this.driver.list(this.storage.getCartId()).pipe(
         map(resp => new DaffCartCouponListSuccess<V>(resp)),
+        catchError(error => of(new DaffCartCouponListFailure('Failed to list coupons')))
       )
     ),
     catchError(error => of(error instanceof DaffStorageServiceError
@@ -73,6 +76,7 @@ export class DaffCartCouponEffects<
     switchMap((action: DaffCartCouponRemove<V>) =>
       this.driver.remove(this.storage.getCartId(), action.payload).pipe(
         map(resp => new DaffCartCouponRemoveSuccess(resp)),
+        catchError(error => of(new DaffCartCouponRemoveFailure('Failed to remove a coupon from the cart')))
       )
     ),
     catchError(error => of(error instanceof DaffStorageServiceError
@@ -87,6 +91,7 @@ export class DaffCartCouponEffects<
     switchMap((action: DaffCartCouponRemoveAll) =>
       this.driver.removeAll(this.storage.getCartId()).pipe(
         map(resp => new DaffCartCouponRemoveAllSuccess(resp)),
+        catchError(error => of(new DaffCartCouponRemoveAllFailure('Failed to remove all coupons from the cart')))
       )
     ),
     catchError(error => of(error instanceof DaffStorageServiceError

--- a/libs/cart/src/effects/cart-order.effects.spec.ts
+++ b/libs/cart/src/effects/cart-order.effects.spec.ts
@@ -107,7 +107,7 @@ describe('Cart | Effect | CartOrderEffects', () => {
 
         cartOrderDriverSpy.placeOrder.and.returnValue(response);
         actions$ = hot('--a', { a: cartPlaceOrderAction });
-        expected = cold('--(b|)', { b: cartPlaceOrderFailureAction });
+        expected = cold('--b', { b: cartPlaceOrderFailureAction });
       });
 
       it('should dispatch a CartPlaceOrderFailure action', () => {

--- a/libs/cart/src/effects/cart-order.effects.spec.ts
+++ b/libs/cart/src/effects/cart-order.effects.spec.ts
@@ -120,7 +120,7 @@ describe('Cart | Effect | CartOrderEffects', () => {
         daffCartStorageSpy.getCartId.and.callFake(throwStorageError)
 
         actions$ = hot('--a', { a: cartPlaceOrderAction });
-        expected = cold('--(b|)', { b: cartStorageFailureAction });
+        expected = cold('--b', { b: cartStorageFailureAction });
       });
 
       it('should return a DaffCartStorageFailure', () => {

--- a/libs/cart/src/effects/cart-order.effects.ts
+++ b/libs/cart/src/effects/cart-order.effects.ts
@@ -36,14 +36,15 @@ export class DaffCartOrderEffects<
   @Effect()
   placeOrder$ = this.actions$.pipe(
     ofType(DaffCartOrderActionTypes.CartPlaceOrderAction),
-    switchMap((action: DaffCartPlaceOrder<V>) => this.driver.placeOrder(this.storage.getCartId(), action.payload).pipe(
+    switchMap((action: DaffCartPlaceOrder<V>) => of(null).pipe(
+      map(() => this.storage.getCartId()),
+      switchMap(cartId => this.driver.placeOrder(cartId, action.payload)),
       map((resp: R) => new DaffCartPlaceOrderSuccess<R>(resp)),
-      catchError(error => of(new DaffCartPlaceOrderFailure('Failed to place order')))
+      catchError(error => of(error.name === DaffStorageServiceError.name
+        ? new DaffCartStorageFailure('Cart Storage Failed')
+        : new DaffCartPlaceOrderFailure('Failed to place order')
+      )),
     )),
-    catchError(error => of(error instanceof DaffStorageServiceError
-      ? new DaffCartStorageFailure('Cart Storage Failed')
-      : new DaffCartPlaceOrderFailure('Failed to place order')
-    ))
   )
 
   @Effect()

--- a/libs/cart/src/effects/cart-order.effects.ts
+++ b/libs/cart/src/effects/cart-order.effects.ts
@@ -38,6 +38,7 @@ export class DaffCartOrderEffects<
     ofType(DaffCartOrderActionTypes.CartPlaceOrderAction),
     switchMap((action: DaffCartPlaceOrder<V>) => this.driver.placeOrder(this.storage.getCartId(), action.payload).pipe(
       map((resp: R) => new DaffCartPlaceOrderSuccess<R>(resp)),
+      catchError(error => of(new DaffCartPlaceOrderFailure('Failed to place order')))
     )),
     catchError(error => of(error instanceof DaffStorageServiceError
       ? new DaffCartStorageFailure('Cart Storage Failed')

--- a/libs/cart/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.spec.ts
@@ -11,11 +11,11 @@ import { DaffCartResolverEffects } from './cart-resolver.effects';
 import { DaffCartDriver, DaffCartServiceInterface } from '../drivers/public_api';
 import { DaffCart } from '../models/cart';
 import { DaffCartStorageService } from '../storage/cart-storage.service';
-import { 
-	DaffResolveCart, 
-	DaffCartLoadFailure, 
-	DaffCartLoadSuccess, 
-	DaffCartCreate, 
+import {
+	DaffResolveCart,
+	DaffCartLoadFailure,
+	DaffCartLoadSuccess,
+	DaffCartCreate,
 	DaffCartStorageFailure
 } from '../actions/public_api';
 import { DaffCartNotFoundError } from '../errors/not-found';
@@ -87,7 +87,7 @@ describe('DaffCartResolverEffects', () => {
 			const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
 
 			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--(b)', {
+			const expected = cold('--b', {
 				b: loadCartSuccessAction,
 			});
 
@@ -99,7 +99,7 @@ describe('DaffCartResolverEffects', () => {
 			const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
 
 			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--(b)', {
+			const expected = cold('--b', {
 				b: loadCartSuccessAction
 			});
 
@@ -117,7 +117,7 @@ describe('DaffCartResolverEffects', () => {
 			);
 
 			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--(b|)', {
+			const expected = cold('--b', {
 				b: loadCartFailureAction
 			});
 
@@ -136,7 +136,7 @@ describe('DaffCartResolverEffects', () => {
 			);
 
 			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--(b|)', {
+			const expected = cold('--b', {
 				b: loadCartFailureAction
 			});
 
@@ -153,7 +153,7 @@ describe('DaffCartResolverEffects', () => {
 			const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
 
 			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--(b)', {
+			const expected = cold('--b', {
 				b: loadCartSuccessAction
 			});
 
@@ -169,7 +169,7 @@ describe('DaffCartResolverEffects', () => {
 			const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
 
 			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--(b)', {
+			const expected = cold('--b', {
 				b: loadCartSuccessAction
 			});
 
@@ -188,7 +188,7 @@ describe('DaffCartResolverEffects', () => {
 			const cartCreateAction = new DaffCartCreate();
 
 			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--(b|)', {
+			const expected = cold('--b', {
 				b: cartCreateAction,
 			});
 
@@ -206,7 +206,7 @@ describe('DaffCartResolverEffects', () => {
 			const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
 
 			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--(b|)', {
+			const expected = cold('--b', {
 				b: cartStorageFailureAction
 			});
 

--- a/libs/cart/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.spec.ts
@@ -67,7 +67,7 @@ describe('DaffCartResolverEffects', () => {
 			);
 
 			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--(b|)', {
+			const expected = cold('--b', {
 				b: loadCartFailureAction
 			});
 

--- a/libs/cart/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.ts
@@ -18,14 +18,7 @@ import { DaffCartNotFoundError } from '../errors/not-found';
 import { DaffStorageServiceError } from '@daffodil/core';
 
 function catchResolveErrors(error: Error) {
-  switch(error.name) {
-    case DaffStorageServiceError.name:
-      return of(new DaffCartStorageFailure('Cart Storage Failed'))
-    case DaffCartNotFoundError.name:
-      return of(new DaffCartCreate());
-    default:
-      return of(new DaffCartLoadFailure('Cart loading has failed'));
-  }
+
 }
 
 /**
@@ -42,16 +35,25 @@ export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
 
 	@Effect()
 	onResolveCart$: Observable<Action> = this.actions$.pipe(
-		ofType(DaffCartActionTypes.ResolveCartAction),
-		map(() => this.cartStorage.getCartId()),
-		switchMap(cartId => (cartId ? of({ id: cartId }) : this.driver.create()).pipe(
+    ofType(DaffCartActionTypes.ResolveCartAction),
+    switchMap(() => of(null).pipe(
+      map(() => this.cartStorage.getCartId()),
+      switchMap(cartId => cartId ? of({ id: cartId }) : this.driver.create()),
       switchMap(({ id }) => this.driver.get(id)),
       switchMap(resp => {
         this.cartStorage.setCartId(String(resp.id))
         return [new DaffCartLoadSuccess(resp)]
       }),
-      catchError(catchResolveErrors),
-    )),
-		catchError(catchResolveErrors),
+      catchError(error => {
+        switch(error.name) {
+          case DaffStorageServiceError.name:
+            return of(new DaffCartStorageFailure('Cart Storage Failed'))
+          case DaffCartNotFoundError.name:
+            return of(new DaffCartCreate());
+          default:
+            return of(new DaffCartLoadFailure('Cart loading has failed'));
+        }
+      }),
+    ))
 	);
 }

--- a/libs/cart/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.ts
@@ -17,10 +17,6 @@ import { DaffCart } from '../models/cart';
 import { DaffCartNotFoundError } from '../errors/not-found';
 import { DaffStorageServiceError } from '@daffodil/core';
 
-function catchResolveErrors(error: Error) {
-
-}
-
 /**
  * An effect for resolving the Cart. It will check local state for a cart id, and retrieve the cart if it exists. If a cart
  * of that id does not exist, it will create a new cart.

--- a/libs/cart/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.ts
@@ -4,11 +4,11 @@ import { Action } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 import { switchMap, catchError, map } from 'rxjs/operators';
 
-import { 
+import {
 	DaffCartActionTypes,
-	DaffCartLoadSuccess, 
-	DaffCartCreate, 
-	DaffCartLoadFailure, 
+	DaffCartLoadSuccess,
+	DaffCartCreate,
+	DaffCartLoadFailure,
 	DaffCartStorageFailure
 } from '../actions/public_api';
 import { DaffCartStorageService } from '../storage/cart-storage.service';
@@ -16,6 +16,17 @@ import { DaffCartDriver, DaffCartServiceInterface } from '../drivers/public_api'
 import { DaffCart } from '../models/cart';
 import { DaffCartNotFoundError } from '../errors/not-found';
 import { DaffStorageServiceError } from '@daffodil/core';
+
+function catchResolveErrors(error: Error) {
+  switch(error.name) {
+    case DaffStorageServiceError.name:
+      return of(new DaffCartStorageFailure('Cart Storage Failed'))
+    case DaffCartNotFoundError.name:
+      return of(new DaffCartCreate());
+    default:
+      return of(new DaffCartLoadFailure('Cart loading has failed'));
+  }
+}
 
 /**
  * An effect for resolving the Cart. It will check local state for a cart id, and retrieve the cart if it exists. If a cart
@@ -33,21 +44,14 @@ export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
 	onResolveCart$: Observable<Action> = this.actions$.pipe(
 		ofType(DaffCartActionTypes.ResolveCartAction),
 		map(() => this.cartStorage.getCartId()),
-		switchMap(id => id ? of({ id }) : this.driver.create()),
-		switchMap(({ id }) => this.driver.get(id)),
-		switchMap(resp => {
-			this.cartStorage.setCartId(String(resp.id))
-			return [new DaffCartLoadSuccess(resp)]
-		}),
-		catchError(error => {
-			switch(error.name) {
-				case DaffStorageServiceError.name:
-					return of(new DaffCartStorageFailure('Cart Storage Failed'))
-				case DaffCartNotFoundError.name:
-					return of(new DaffCartCreate());
-				default:
-					return of(new DaffCartLoadFailure('Cart loading has failed'));
-			}
-		}),
+		switchMap(cartId => (cartId ? of({ id: cartId }) : this.driver.create()).pipe(
+      switchMap(({ id }) => this.driver.get(id)),
+      switchMap(resp => {
+        this.cartStorage.setCartId(String(resp.id))
+        return [new DaffCartLoadSuccess(resp)]
+      }),
+      catchError(catchResolveErrors),
+    )),
+		catchError(catchResolveErrors),
 	);
 }

--- a/libs/cart/src/effects/cart.effects.spec.ts
+++ b/libs/cart/src/effects/cart.effects.spec.ts
@@ -113,7 +113,7 @@ describe('Daffodil | Cart | CartEffects', () => {
         daffCartStorageSpy.getCartId.and.callFake(throwStorageError)
 
         actions$ = hot('--a', { a: cartLoadAction });
-        expected = cold('--(b|)', { b: cartStorageFailureAction });
+        expected = cold('--b', { b: cartStorageFailureAction });
       });
 
       it('should return a DaffCartStorageFailure', () => {
@@ -175,7 +175,7 @@ describe('Daffodil | Cart | CartEffects', () => {
         daffCartStorageSpy.setCartId.and.callFake(throwStorageError)
 
         actions$ = hot('--a', { a: cartCreateSuccessAction });
-        expected = cold('--(b|)', { b: cartStorageFailureAction });
+        expected = cold('--b', { b: cartStorageFailureAction });
       });
 
       it('should return a DaffCartStorageFailure', () => {

--- a/libs/cart/src/effects/cart.effects.spec.ts
+++ b/libs/cart/src/effects/cart.effects.spec.ts
@@ -100,7 +100,7 @@ describe('Daffodil | Cart | CartEffects', () => {
         daffDriverSpy.get.and.returnValue(response);
         const cartLoadFailureAction = new DaffCartLoadFailure(error);
         actions$ = hot('--a', { a: cartLoadAction });
-        expected = cold('--(b|)', { b: cartLoadFailureAction });
+        expected = cold('--b', { b: cartLoadFailureAction });
       });
 
       it('should dispatch a CartLoadFailure action', () => {

--- a/libs/cart/src/effects/cart.effects.ts
+++ b/libs/cart/src/effects/cart.effects.ts
@@ -61,6 +61,7 @@ export class DaffCartEffects<T extends DaffCart> {
     ofType(DaffCartActionTypes.CartLoadAction),
     switchMap((action: DaffCartLoad) => this.driver.get(this.storage.getCartId()).pipe(
       map((resp: T) => new DaffCartLoadSuccess(resp)),
+      catchError(error => of(new DaffCartLoadFailure('Failed to load cart')))
     )),
     catchError(error => of(error instanceof DaffStorageServiceError
       ? new DaffCartStorageFailure('Cart Storage Failed')


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When a driver call fails, certain effects handle those errors and then complete. This causes the effects to never run again.


## What is the new behavior?
Effects will not complete as a result of driver or storage failures.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information