### PR TITLE
feat(cart): wait for cart resolution in cart guards

### DIFF
--- a/libs/cart/src/guards/billing-address/billing-address.guard.spec.ts
+++ b/libs/cart/src/guards/billing-address/billing-address.guard.spec.ts
@@ -2,19 +2,19 @@ import { TestBed } from '@angular/core/testing';
 import { StoreModule, combineReducers, Store } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 import { MockStore } from '@ngrx/store/testing';
-import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
 
-import { DaffCartFactory, DaffCartPaymentFactory } from '@daffodil/cart/testing';
+import { DaffCartFactory, DaffCartAddressFactory } from '@daffodil/cart/testing';
 import { DaffCartFacade, DaffCart, DaffCartLoadSuccess } from '@daffodil/cart';
 
-import { DaffPaymentMethodGuard } from './payment-method-guard';
+import { DaffBillingAddressGuard } from './billing-address.guard';
 import { daffCartReducers } from '../../reducers/public_api';
-import { DaffCartPaymentMethodGuardRedirectUrl } from './payment-method-guard-redirect.token';
+import { DaffCartBillingAddressGuardRedirectUrl } from './billing-address-guard-redirect.token';
 
-describe('DaffPaymentMethodGuard', () => {
+describe('DaffBillingAddressGuard', () => {
 
-	let service: DaffPaymentMethodGuard;
+	let service: DaffBillingAddressGuard;
 	let facade;
 	let store: MockStore<any>;
 	let router: Router;
@@ -23,9 +23,9 @@ describe('DaffPaymentMethodGuard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-				DaffPaymentMethodGuard,
+				DaffBillingAddressGuard,
 				DaffCartFacade,
-				{ provide: DaffCartPaymentMethodGuardRedirectUrl, useValue: stubUrl }
+				{ provide: DaffCartBillingAddressGuardRedirectUrl, useValue: stubUrl }
 			],
 			imports: [
         StoreModule.forRoot({
@@ -34,45 +34,52 @@ describe('DaffPaymentMethodGuard', () => {
 				RouterTestingModule
 			]
     });
-		service = TestBed.get(DaffPaymentMethodGuard);
+		service = TestBed.get(DaffBillingAddressGuard);
 		facade = TestBed.get(DaffCartFacade);
-		router = TestBed.get(Router);
 		store = TestBed.get(Store);
+		router = TestBed.get(Router);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
 	});
-	
+
 	describe('canActivate', () => {
-		
-		it('should allow activation when there is a payment method', () => {
+    describe('when the cart has not been resolved', () => {
+      it('should not emit', () => {
+        const expected = cold('-');
+
+        expect(service.canActivate()).toBeObservable(expected);
+      });
+    });
+
+		it('should allow activation when there is a billing address', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
-				payment: new DaffCartPaymentFactory().create(),
+				billing_address: new DaffCartAddressFactory().create(),
 			});
 			store.dispatch(new DaffCartLoadSuccess(cart));
-			const expected = cold('a', { a: true })
-			
+			const expected = cold('(a|)', { a: true })
+
 			expect(service.canActivate()).toBeObservable(expected);
 		});
 
-		describe('when there is no payment method', () => {
+		describe('when there is no billing address', () => {
 
 			beforeEach(() => {
 				spyOn(router, 'navigateByUrl');
 				const cart: DaffCart = new DaffCartFactory().create({
-					payment: null,
+					billing_address: null,
 				});
 				store.dispatch(new DaffCartLoadSuccess(cart));
 			});
-			
+
 			it('should not allow activation', () => {
-				const expected = cold('a', { a: false })
-				
+				const expected = cold('(a|)', { a: false })
+
 				expect(service.canActivate()).toBeObservable(expected);
 			});
 
-			it('should redirect to the given DaffCartPaymentMethodGuardRedirectUrl', () => {
+			it('should redirect to the given DaffCartBillingAddressGuardRedirectUrl', () => {
 				service.canActivate().subscribe();
 				expect(router.navigateByUrl).toHaveBeenCalledWith(stubUrl);
 			});

--- a/libs/cart/src/guards/billing-address/billing-address.guard.ts
+++ b/libs/cart/src/guards/billing-address/billing-address.guard.ts
@@ -9,7 +9,7 @@ import { DaffCartBillingAddressGuardRedirectUrl } from './billing-address-guard-
 /**
  * A routing guard that will redirect to a given url if the billing address on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartBillingAddressGuardRedirectUrl injection token.
- * The guard will wait until the cart has been resolved before performing the check.
+ * The guard will wait until the cart has been resolved before performing the check and emitting.
  */
 @Injectable({
 	providedIn: 'root'

--- a/libs/cart/src/guards/payment-method/payment-method.guard.spec.ts
+++ b/libs/cart/src/guards/payment-method/payment-method.guard.spec.ts
@@ -2,30 +2,30 @@ import { TestBed } from '@angular/core/testing';
 import { StoreModule, combineReducers, Store } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 import { MockStore } from '@ngrx/store/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
-import { DaffCartFactory, DaffCartAddressFactory } from '@daffodil/cart/testing';
+import { DaffCartFactory, DaffCartPaymentFactory } from '@daffodil/cart/testing';
 import { DaffCartFacade, DaffCart, DaffCartLoadSuccess } from '@daffodil/cart';
 
-import { DaffBillingAddressGuard } from './billing-address-guard';
+import { DaffPaymentMethodGuard } from './payment-method.guard';
 import { daffCartReducers } from '../../reducers/public_api';
-import { RouterTestingModule } from '@angular/router/testing';
-import { Router } from '@angular/router';
-import { DaffCartBillingAddressGuardRedirectUrl } from './billing-address-guard-redirect.token';
+import { DaffCartPaymentMethodGuardRedirectUrl } from './payment-method-guard-redirect.token';
 
-describe('DaffBillingAddressGuard', () => {
+describe('DaffPaymentMethodGuard', () => {
 
-	let service: DaffBillingAddressGuard;
+	let service: DaffPaymentMethodGuard;
 	let facade;
 	let store: MockStore<any>;
 	let router: Router;
 	const stubUrl = 'url';
-  
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-				DaffBillingAddressGuard,
+				DaffPaymentMethodGuard,
 				DaffCartFacade,
-				{ provide: DaffCartBillingAddressGuardRedirectUrl, useValue: stubUrl }
+				{ provide: DaffCartPaymentMethodGuardRedirectUrl, useValue: stubUrl }
 			],
 			imports: [
         StoreModule.forRoot({
@@ -34,45 +34,52 @@ describe('DaffBillingAddressGuard', () => {
 				RouterTestingModule
 			]
     });
-		service = TestBed.get(DaffBillingAddressGuard);
+		service = TestBed.get(DaffPaymentMethodGuard);
 		facade = TestBed.get(DaffCartFacade);
-		store = TestBed.get(Store);
 		router = TestBed.get(Router);
+		store = TestBed.get(Store);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
 	});
-	
+
 	describe('canActivate', () => {
-		
-		it('should allow activation when there is a billing address', () => {
+		describe('when the cart has not been resolved', () => {
+      it('should not emit', () => {
+        const expected = cold('-');
+
+        expect(service.canActivate()).toBeObservable(expected);
+      });
+    });
+
+		it('should allow activation when there is a payment method', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
-				billing_address: new DaffCartAddressFactory().create(),
+				payment: new DaffCartPaymentFactory().create(),
 			});
 			store.dispatch(new DaffCartLoadSuccess(cart));
-			const expected = cold('a', { a: true })
-			
+			const expected = cold('(a|)', { a: true })
+
 			expect(service.canActivate()).toBeObservable(expected);
 		});
 
-		describe('when there is no billing address', () => {
+		describe('when there is no payment method', () => {
 
 			beforeEach(() => {
 				spyOn(router, 'navigateByUrl');
 				const cart: DaffCart = new DaffCartFactory().create({
-					billing_address: null,
+					payment: null,
 				});
 				store.dispatch(new DaffCartLoadSuccess(cart));
 			});
-			
+
 			it('should not allow activation', () => {
-				const expected = cold('a', { a: false })
-				
+				const expected = cold('(a|)', { a: false })
+
 				expect(service.canActivate()).toBeObservable(expected);
 			});
 
-			it('should redirect to the given DaffCartBillingAddressGuardRedirectUrl', () => {
+			it('should redirect to the given DaffCartPaymentMethodGuardRedirectUrl', () => {
 				service.canActivate().subscribe();
 				expect(router.navigateByUrl).toHaveBeenCalledWith(stubUrl);
 			});

--- a/libs/cart/src/guards/payment-method/payment-method.guard.ts
+++ b/libs/cart/src/guards/payment-method/payment-method.guard.ts
@@ -9,7 +9,7 @@ import { DaffCartPaymentMethodGuardRedirectUrl } from './payment-method-guard-re
 /**
  * A routing guard that will redirect to a given url if the payment method on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartPaymentMethodGuardRedirectUrl injection token.
- * The guard will wait until the cart has been resolved before performing the check.
+ * The guard will wait until the cart has been resolved before performing the check and emitting.
  */
 @Injectable({
 	providedIn: 'root'

--- a/libs/cart/src/guards/payment-method/payment-method.guard.ts
+++ b/libs/cart/src/guards/payment-method/payment-method.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
-import { tap } from 'rxjs/operators';
+import { tap, filter, switchMapTo, take } from 'rxjs/operators';
 
 import { DaffCartFacade } from '../../facades/cart/cart.facade';
 import { DaffCartPaymentMethodGuardRedirectUrl } from './payment-method-guard-redirect.token';
@@ -9,6 +9,7 @@ import { DaffCartPaymentMethodGuardRedirectUrl } from './payment-method-guard-re
 /**
  * A routing guard that will redirect to a given url if the payment method on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartPaymentMethodGuardRedirectUrl injection token.
+ * The guard will wait until the cart has been resolved before performing the check.
  */
 @Injectable({
 	providedIn: 'root'
@@ -17,11 +18,14 @@ export class DaffPaymentMethodGuard implements CanActivate {
   constructor(
 		private facade: DaffCartFacade,
 		private router: Router,
-		@Inject(DaffCartPaymentMethodGuardRedirectUrl) private redirectUrl: string 
+		@Inject(DaffCartPaymentMethodGuardRedirectUrl) private redirectUrl: string
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.hasPaymentMethod$.pipe(
+    return this.facade.id$.pipe(
+      filter(cartId => !!cartId),
+      switchMapTo(this.facade.hasPaymentMethod$),
+      take(1),
 			tap(hasPaymentMethod => {
 				if(!hasPaymentMethod) {
 					this.router.navigateByUrl(this.redirectUrl)

--- a/libs/cart/src/guards/public_api.ts
+++ b/libs/cart/src/guards/public_api.ts
@@ -1,7 +1,7 @@
-export { DaffBillingAddressGuard } from './billing-address/billing-address-guard';
-export { DaffPaymentMethodGuard } from './payment-method/payment-method-guard';
-export { DaffShippingAddressGuard } from './shipping-address/shipping-address-guard';
-export { DaffShippingMethodGuard } from './shipping-method/shipping-method-guard';
+export { DaffBillingAddressGuard } from './billing-address/billing-address.guard';
+export { DaffPaymentMethodGuard } from './payment-method/payment-method.guard';
+export { DaffShippingAddressGuard } from './shipping-address/shipping-address.guard';
+export { DaffShippingMethodGuard } from './shipping-method/shipping-method.guard';
 export { DaffCartBillingAddressGuardRedirectUrl } from './billing-address/billing-address-guard-redirect.token';
 export { DaffCartPaymentMethodGuardRedirectUrl } from './payment-method/payment-method-guard-redirect.token';
 export { DaffCartShippingAddressGuardRedirectUrl } from './shipping-address/shipping-address-guard-redirect.token';

--- a/libs/cart/src/guards/shipping-address/shipping-address.guard.spec.ts
+++ b/libs/cart/src/guards/shipping-address/shipping-address.guard.spec.ts
@@ -2,15 +2,15 @@ import { TestBed } from '@angular/core/testing';
 import { StoreModule, combineReducers, Store } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 import { MockStore } from '@ngrx/store/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { DaffCartFactory, DaffCartAddressFactory } from '@daffodil/cart/testing';
 import { DaffCartFacade, DaffCart, DaffCartLoadSuccess } from '@daffodil/cart';
 
-import { DaffShippingAddressGuard } from './shipping-address-guard';
+import { DaffShippingAddressGuard } from './shipping-address.guard';
 import { daffCartReducers } from '../../reducers/public_api';
-import { Router } from '@angular/router';
 import { DaffCartShippingAddressGuardRedirectUrl } from './shipping-address-guard-redirect.token';
-import { RouterTestingModule } from '@angular/router/testing';
 
 describe('DaffShippingAddressGuard', () => {
 
@@ -19,7 +19,7 @@ describe('DaffShippingAddressGuard', () => {
 	let store: MockStore<any>;
 	let router: Router;
 	const stubUrl = 'url';
-  
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -43,16 +43,23 @@ describe('DaffShippingAddressGuard', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
 	});
-	
+
 	describe('canActivate', () => {
-		
+		describe('when the cart has not been resolved', () => {
+      it('should not emit', () => {
+        const expected = cold('-');
+
+        expect(service.canActivate()).toBeObservable(expected);
+      });
+    });
+
 		it('should allow activation when there is a shipping address', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				shipping_address: new DaffCartAddressFactory().create(),
 			});
 			store.dispatch(new DaffCartLoadSuccess(cart));
-			const expected = cold('a', { a: true })
-			
+			const expected = cold('(a|)', { a: true })
+
 			expect(service.canActivate()).toBeObservable(expected);
 		});
 
@@ -65,10 +72,10 @@ describe('DaffShippingAddressGuard', () => {
 				});
 				store.dispatch(new DaffCartLoadSuccess(cart));
 			});
-			
+
 			it('should not allow activation', () => {
-				const expected = cold('a', { a: false })
-				
+				const expected = cold('(a|)', { a: false })
+
 				expect(service.canActivate()).toBeObservable(expected);
 			});
 

--- a/libs/cart/src/guards/shipping-address/shipping-address.guard.ts
+++ b/libs/cart/src/guards/shipping-address/shipping-address.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
-import { tap } from 'rxjs/operators';
+import { tap, filter, switchMapTo, take } from 'rxjs/operators';
 
 import { DaffCartFacade } from '../../facades/cart/cart.facade';
 import { DaffCartShippingAddressGuardRedirectUrl } from './shipping-address-guard-redirect.token';
@@ -9,6 +9,7 @@ import { DaffCartShippingAddressGuardRedirectUrl } from './shipping-address-guar
 /**
  * A routing guard that will redirect to a given url if the shipping address on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartShippingAddressGuardRedirectUrl injection token.
+ * The guard will wait until the cart has been resolved before performing the check.
  */
 @Injectable({
 	providedIn: 'root'
@@ -17,11 +18,14 @@ export class DaffShippingAddressGuard implements CanActivate {
   constructor(
 		private facade: DaffCartFacade,
 		private router: Router,
-		@Inject(DaffCartShippingAddressGuardRedirectUrl) private redirectUrl: string 
+		@Inject(DaffCartShippingAddressGuardRedirectUrl) private redirectUrl: string
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.hasShippingAddress$.pipe(
+    return this.facade.id$.pipe(
+      filter(cartId => !!cartId),
+      switchMapTo(this.facade.hasShippingAddress$),
+      take(1),
 			tap(hasShippingAddress => {
 				if(!hasShippingAddress) {
 					this.router.navigateByUrl(this.redirectUrl)

--- a/libs/cart/src/guards/shipping-address/shipping-address.guard.ts
+++ b/libs/cart/src/guards/shipping-address/shipping-address.guard.ts
@@ -9,7 +9,7 @@ import { DaffCartShippingAddressGuardRedirectUrl } from './shipping-address-guar
 /**
  * A routing guard that will redirect to a given url if the shipping address on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartShippingAddressGuardRedirectUrl injection token.
- * The guard will wait until the cart has been resolved before performing the check.
+ * The guard will wait until the cart has been resolved before performing the check and emitting.
  */
 @Injectable({
 	providedIn: 'root'

--- a/libs/cart/src/guards/shipping-method/shipping-method.guard.spec.ts
+++ b/libs/cart/src/guards/shipping-method/shipping-method.guard.spec.ts
@@ -8,7 +8,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { DaffCartFactory, DaffCartShippingRateFactory } from '@daffodil/cart/testing';
 import { DaffCartFacade, DaffCart, DaffCartLoadSuccess } from '@daffodil/cart';
 
-import { DaffShippingMethodGuard } from './shipping-method-guard';
+import { DaffShippingMethodGuard } from './shipping-method.guard';
 import { daffCartReducers } from '../../reducers/public_api';
 import { DaffCartShippingMethodGuardRedirectUrl } from './shipping-method-guard-redirect.token';
 
@@ -19,7 +19,7 @@ describe('DaffShippingMethodGuard', () => {
 	let store: MockStore<any>;
 	let router: Router;
 	const stubUrl = 'url';
-  
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -43,16 +43,23 @@ describe('DaffShippingMethodGuard', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
 	});
-	
+
 	describe('canActivate', () => {
-		
+		describe('when the cart has not been resolved', () => {
+      it('should not emit', () => {
+        const expected = cold('-');
+
+        expect(service.canActivate()).toBeObservable(expected);
+      });
+    });
+
 		it('should allow activation when there is a shipping method', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				shipping_information: new DaffCartShippingRateFactory().create(),
 			});
 			store.dispatch(new DaffCartLoadSuccess(cart));
-			const expected = cold('a', { a: true })
-			
+			const expected = cold('(a|)', { a: true })
+
 			expect(service.canActivate()).toBeObservable(expected);
 		});
 
@@ -65,10 +72,10 @@ describe('DaffShippingMethodGuard', () => {
 				});
 				store.dispatch(new DaffCartLoadSuccess(cart));
 			});
-			
+
 			it('should not allow activation', () => {
-				const expected = cold('a', { a: false })
-				
+				const expected = cold('(a|)', { a: false })
+
 				expect(service.canActivate()).toBeObservable(expected);
 			});
 

--- a/libs/cart/src/guards/shipping-method/shipping-method.guard.ts
+++ b/libs/cart/src/guards/shipping-method/shipping-method.guard.ts
@@ -9,7 +9,7 @@ import { DaffCartShippingMethodGuardRedirectUrl } from './shipping-method-guard-
 /**
  * A routing guard that will redirect to a given url if the shipping method on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartShippingMethodGuardRedirectUrl injection token.
- * The guard will wait until the cart has been resolved before performing the check.
+ * The guard will wait until the cart has been resolved before performing the check and emitting.
  */
 @Injectable({
 	providedIn: 'root'

--- a/libs/cart/src/guards/shipping-method/shipping-method.guard.ts
+++ b/libs/cart/src/guards/shipping-method/shipping-method.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
-import { tap } from 'rxjs/operators';
+import { tap, filter, switchMapTo, take } from 'rxjs/operators';
 
 import { DaffCartFacade } from '../../facades/cart/cart.facade';
 import { DaffCartShippingMethodGuardRedirectUrl } from './shipping-method-guard-redirect.token';
@@ -9,6 +9,7 @@ import { DaffCartShippingMethodGuardRedirectUrl } from './shipping-method-guard-
 /**
  * A routing guard that will redirect to a given url if the shipping method on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartShippingMethodGuardRedirectUrl injection token.
+ * The guard will wait until the cart has been resolved before performing the check.
  */
 @Injectable({
 	providedIn: 'root'
@@ -17,11 +18,14 @@ export class DaffShippingMethodGuard implements CanActivate {
   constructor(
 		private facade: DaffCartFacade,
 		private router: Router,
-		@Inject(DaffCartShippingMethodGuardRedirectUrl) private redirectUrl: string 
+		@Inject(DaffCartShippingMethodGuardRedirectUrl) private redirectUrl: string
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.hasShippingMethod$.pipe(
+    return this.facade.id$.pipe(
+      filter(cartId => !!cartId),
+      switchMapTo(this.facade.hasShippingMethod$),
+      take(1),
 			tap(hasShippingMethod => {
 				if(!hasShippingMethod) {
 					this.router.navigateByUrl(this.redirectUrl)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Cart guards will emit immediately, possibly before the cart has been resolved.

## What is the new behavior?
Cart guards will wait for a defined cart ID before evaluating the prescence of the cart field and emitting.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information