### PR TITLE
feat(cart): change the DaffCompositeCartItemOption model to DaffCompo…

### DIFF
--- a/libs/cart/src/drivers/magento/transforms/inputs/cart-item-input-transformers.ts
+++ b/libs/cart/src/drivers/magento/transforms/inputs/cart-item-input-transformers.ts
@@ -1,5 +1,5 @@
 import { MagentoCartItemInput, MagentoBundledCartItemInput, MagentoBundledCartItemOption, MagentoConfigurableCartItemInput } from '../../models/inputs/cart-item';
-import { DaffCartItemInput, DaffCompositeCartItemInput, DaffCompositeCartItemOption, DaffConfigurableCartItemInput } from '../../../../models/cart-item-input';
+import { DaffCartItemInput, DaffCompositeCartItemInput, DaffCompositeCartItemInputOption, DaffConfigurableCartItemInput } from '../../../../models/cart-item-input';
 
 export function transformCompositeCartItem(item: DaffCompositeCartItemInput): MagentoBundledCartItemInput {
 	return {
@@ -25,7 +25,7 @@ export function transformConfigurableCartItem(item: DaffConfigurableCartItemInpu
 	}
 }
 
-function transformCompositeCartItemOption(option: DaffCompositeCartItemOption): MagentoBundledCartItemOption {
+function transformCompositeCartItemOption(option: DaffCompositeCartItemInputOption): MagentoBundledCartItemOption {
 	return {
 		id: Number(option.code),
 		quantity: option.quantity,

--- a/libs/cart/src/index.ts
+++ b/libs/cart/src/index.ts
@@ -6,7 +6,7 @@ export {
 	DaffCartItemInput,
 	DaffCartItemInputType,
 	DaffCompositeCartItemInput,
-	DaffCompositeCartItemOption
+	DaffCompositeCartItemInputOption
 } from './models/cart-item-input';
 export { DaffCartAddress } from './models/cart-address';
 export { DaffCartPaymentMethod } from './models/cart-payment';

--- a/libs/cart/src/models/cart-item-input.ts
+++ b/libs/cart/src/models/cart-item-input.ts
@@ -18,10 +18,10 @@ export interface DaffSimpleCartItemInput extends DaffCartItemInput {
 
 export interface DaffCompositeCartItemInput extends DaffCartItemInput {
 	type: DaffCartItemInputType.Composite;
-	options: DaffCompositeCartItemOption[];
+	options: DaffCompositeCartItemInputOption[];
 }
 
-export interface DaffCompositeCartItemOption {
+export interface DaffCompositeCartItemInputOption {
 	code: string | number;
 	quantity: number;
 	value: string;


### PR DESCRIPTION
…siteCartItemInputOption

BREAKING CHANGE: DaffCompositeCartItemOption model has changed to DaffCompositeCartItemInputOption to avoid a naming collision

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `DaffCompositeCartItemOption` name is needed for the DaffCompositeCartItem. Right now, it is being used for the DaffCompositeCartItemInput.

## What is the new behavior?
DaffCompositeCartItemOption is renamed to DaffCompositeCartItemInputOption.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```