### PR TITLE
feat(cart): listen for resolve success and failure in cart guards

### DIFF
--- a/libs/cart/src/actions/cart.actions.ts
+++ b/libs/cart/src/actions/cart.actions.ts
@@ -97,10 +97,10 @@ export class DaffResolveCart implements Action {
 	readonly type = DaffCartActionTypes.ResolveCartAction;
 }
 
-export class DaffResolveCartSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffResolveCartSuccess implements Action {
   readonly type = DaffCartActionTypes.ResolveCartSuccessAction;
 
-  constructor(public payload: Partial<T>) {}
+  constructor() {}
 }
 
 export class DaffResolveCartFailure implements Action {
@@ -124,5 +124,5 @@ export type DaffCartActions<T extends DaffCart = DaffCart> =
   | DaffCartClearSuccess<T>
   | DaffCartClearFailure
   | DaffResolveCart
-  | DaffResolveCartSuccess<T>
+  | DaffResolveCartSuccess
   | DaffResolveCartFailure;

--- a/libs/cart/src/actions/cart.actions.ts
+++ b/libs/cart/src/actions/cart.actions.ts
@@ -16,7 +16,9 @@ export enum DaffCartActionTypes {
   CartClearAction = '[DaffCart] Cart Reset Action',
   CartClearSuccessAction = '[DaffCart] Cart Reset Success Action',
   CartClearFailureAction = '[DaffCart] Cart Reset Failure Action',
-  ResolveCartAction = '[DaffCart] Resolve Cart Action'
+  ResolveCartAction = '[DaffCart] Resolve Cart Action',
+  ResolveCartSuccessAction = '[DaffCart] Resolve Cart Success Action',
+  ResolveCartFailureAction = '[DaffCart] Resolve Cart Failure Action',
 }
 
 export class DaffCartStorageFailure implements Action {
@@ -95,6 +97,18 @@ export class DaffResolveCart implements Action {
 	readonly type = DaffCartActionTypes.ResolveCartAction;
 }
 
+export class DaffResolveCartSuccess<T extends DaffCart = DaffCart> implements Action {
+  readonly type = DaffCartActionTypes.ResolveCartSuccessAction;
+
+  constructor(public payload: Partial<T>) {}
+}
+
+export class DaffResolveCartFailure implements Action {
+  readonly type = DaffCartActionTypes.ResolveCartFailureAction;
+
+  constructor(public payload: string) {}
+}
+
 export type DaffCartActions<T extends DaffCart = DaffCart> =
   | DaffCartStorageFailure
   | DaffCartLoad
@@ -109,4 +123,6 @@ export type DaffCartActions<T extends DaffCart = DaffCart> =
   | DaffCartClear
   | DaffCartClearSuccess<T>
   | DaffCartClearFailure
-  | DaffResolveCart;
+  | DaffResolveCart
+  | DaffResolveCartSuccess<T>
+  | DaffResolveCartFailure;

--- a/libs/cart/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.spec.ts
@@ -32,7 +32,9 @@ describe('DaffCartResolverEffects', () => {
 	let cartFactory: DaffCartFactory;
 	let stubCart: DaffCart;
 
-	let cartStorageService: jasmine.SpyObj<DaffCartStorageService>;
+  let cartStorageService: jasmine.SpyObj<DaffCartStorageService>;
+  const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
+  const throwStorageError = () => { throw new DaffStorageServiceError() };
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
@@ -133,7 +135,6 @@ describe('DaffCartResolverEffects', () => {
       it('should dispatch a DaffCartLoadFailure action', () => {
         const response = cold('#', {});
         driver.get.and.returnValue(response);
-        driver.create.and.returnValue(response);
 
         const loadCartFailureAction = new DaffCartLoadFailure(
           'Cart loading has failed',
@@ -203,11 +204,7 @@ describe('DaffCartResolverEffects', () => {
     describe('when the error thrown is a DaffStorageServiceError', () => {
 
       it('should indicate that the storage service has failed', () => {
-        const response = cold('#', {}, new DaffStorageServiceError());
-        driver.get.and.returnValue(response);
-        driver.create.and.returnValue(response);
-
-        const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
+        cartStorageService.getCartId.and.callFake(throwStorageError)
 
         actions$ = hot('--a', { a: new DaffResolveCart() });
         const expected = cold('--b', {
@@ -220,7 +217,7 @@ describe('DaffCartResolverEffects', () => {
   });
 
   describe('onResolveCartSuccess$', () => {
-    describe('when cart resolution is followed by a successful cart load', () => {
+    describe('when a resolve cart action is followed by a successful cart load', () => {
       beforeEach(() => {
         const resolveCartAction = new DaffResolveCart();
         const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
@@ -232,14 +229,14 @@ describe('DaffCartResolverEffects', () => {
       })
 
       it('should indicate cart resolution success', () => {
-        const resolveCartSuccessAction = new DaffResolveCartSuccess(stubCart);
+        const resolveCartSuccessAction = new DaffResolveCartSuccess();
         const expected = cold('-----a', {a: resolveCartSuccessAction});
 
         expect(effects.onResolveCartSuccess$).toBeObservable(expected);
       })
     })
 
-    describe('when cart resolution is followed by a successful cart creation', () => {
+    describe('when a resolve cart action is followed by a successful cart creation', () => {
       beforeEach(() => {
         const resolveCartAction = new DaffResolveCart();
         const createCartSuccessAction = new DaffCartCreateSuccess(stubCart);
@@ -251,14 +248,14 @@ describe('DaffCartResolverEffects', () => {
       })
 
       it('should indicate cart resolution success', () => {
-        const resolveCartSuccessAction = new DaffResolveCartSuccess(stubCart);
+        const resolveCartSuccessAction = new DaffResolveCartSuccess();
         const expected = cold('-----a', {a: resolveCartSuccessAction});
 
         expect(effects.onResolveCartSuccess$).toBeObservable(expected);
       })
     })
 
-    describe('when cart resolution is followed by a cart resolve failure', () => {
+    describe('when a resolve cart action is followed by a cart resolve failure', () => {
       beforeEach(() => {
         const resolveCartAction = new DaffResolveCart();
         const resolveCartFailureAction = new DaffResolveCartFailure('');
@@ -278,7 +275,7 @@ describe('DaffCartResolverEffects', () => {
   })
 
   describe('onResolveCartFailure$', () => {
-    describe('when cart resolution is followed by a failed cart load', () => {
+    describe('when a resolve cart action is followed by a failed cart load', () => {
       let error;
 
       beforeEach(() => {
@@ -300,7 +297,7 @@ describe('DaffCartResolverEffects', () => {
       })
     })
 
-    describe('when cart resolution is followed by a failed cart creation', () => {
+    describe('when a resolve cart action is followed by a failed cart creation', () => {
       let error;
 
       beforeEach(() => {
@@ -314,7 +311,7 @@ describe('DaffCartResolverEffects', () => {
         });
       })
 
-      it('should indicate cart resolution success', () => {
+      it('should indicate cart resolution failure', () => {
         const resolveCartFailureAction = new DaffResolveCartFailure(error);
         const expected = cold('-----a', {a: resolveCartFailureAction});
 
@@ -322,10 +319,10 @@ describe('DaffCartResolverEffects', () => {
       })
     })
 
-    describe('when cart resolution is followed by a cart resolve success', () => {
+    describe('when a resolve cart action is followed by a cart resolve success', () => {
       beforeEach(() => {
         const resolveCartAction = new DaffResolveCart();
-        const resolveCartSuccessAction = new DaffResolveCartSuccess(stubCart);
+        const resolveCartSuccessAction = new DaffResolveCartSuccess();
 
         actions$ = hot('--a--b', {
           a: resolveCartAction,
@@ -333,7 +330,7 @@ describe('DaffCartResolverEffects', () => {
         });
       })
 
-      it('should not indicate cart resolution success', () => {
+      it('should not indicate cart resolution failure', () => {
         const expected = cold('------');
 
         expect(effects.onResolveCartFailure$).toBeObservable(expected);

--- a/libs/cart/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.spec.ts
@@ -3,23 +3,26 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Observable, of } from 'rxjs';
 import { hot, cold } from 'jasmine-marbles';
 
+import { DaffStorageServiceError } from '@daffodil/core';
+import { DaffCart, DaffCartCreateFailure } from '@daffodil/cart';
 import {
 	DaffCartFactory,
 } from '@daffodil/cart/testing';
 
 import { DaffCartResolverEffects } from './cart-resolver.effects';
 import { DaffCartDriver, DaffCartServiceInterface } from '../drivers/public_api';
-import { DaffCart } from '../models/cart';
 import { DaffCartStorageService } from '../storage/cart-storage.service';
 import {
 	DaffResolveCart,
 	DaffCartLoadFailure,
 	DaffCartLoadSuccess,
 	DaffCartCreate,
-	DaffCartStorageFailure
+	DaffCartStorageFailure,
+  DaffResolveCartSuccess,
+  DaffCartCreateSuccess,
+  DaffResolveCartFailure
 } from '../actions/public_api';
 import { DaffCartNotFoundError } from '../errors/not-found';
-import { DaffStorageServiceError } from '@daffodil/core';
 
 describe('DaffCartResolverEffects', () => {
 	let actions$: Observable<any>;
@@ -56,161 +59,285 @@ describe('DaffCartResolverEffects', () => {
 
 	it('should be created', () => {
 		expect(effects).toBeTruthy();
-	});
+  });
 
-	describe('handling storage errors e.g. being in SSR', () => {
-		it('should dispatch a DaffCartLoadFailure action', () => {
-			cartStorageService.getCartId.and.throwError('Storage error');
+  describe('onResolveCart$', () => {
+    describe('handling storage errors e.g. being in SSR', () => {
+      it('should dispatch a DaffCartLoadFailure action', () => {
+        cartStorageService.getCartId.and.throwError('Storage error');
 
-			const loadCartFailureAction = new DaffCartLoadFailure(
-				'Cart loading has failed',
-			);
+        const loadCartFailureAction = new DaffCartLoadFailure(
+          'Cart loading has failed',
+        );
 
-			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--b', {
-				b: loadCartFailureAction
-			});
+        actions$ = hot('--a', { a: new DaffResolveCart() });
+        const expected = cold('--b', {
+          b: loadCartFailureAction
+        });
 
-			expect(effects.onResolveCart$).toBeObservable(expected);
-		});
-	});
+        expect(effects.onResolveCart$).toBeObservable(expected);
+      });
+    });
 
-	describe('successfully resolving a cart when theres a cart id in storage', () => {
-		beforeEach(() => {
-			cartStorageService.getCartId.and.returnValue(
-				stubCart.id.toString(),
-			);
-			driver.get.and.returnValue(of(stubCart));
-		});
+    describe('successfully resolving a cart when theres a cart id in storage', () => {
+      beforeEach(() => {
+        cartStorageService.getCartId.and.returnValue(
+          stubCart.id.toString(),
+        );
+        driver.get.and.returnValue(of(stubCart));
+      });
 
-		it('should not attempt to create a cart', () => {
-			const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
+      it('should not attempt to create a cart', () => {
+        const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
 
-			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--b', {
-				b: loadCartSuccessAction,
-			});
+        actions$ = hot('--a', { a: new DaffResolveCart() });
+        const expected = cold('--b', {
+          b: loadCartSuccessAction,
+        });
 
-			expect(effects.onResolveCart$).toBeObservable(expected);
-			expect(driver.create).not.toHaveBeenCalled();
-		});
+        expect(effects.onResolveCart$).toBeObservable(expected);
+        expect(driver.create).not.toHaveBeenCalled();
+      });
 
-		it('should indicate that a cart has loaded', () => {
-			const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
+      it('should indicate that a cart has loaded', () => {
+        const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
 
-			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--b', {
-				b: loadCartSuccessAction
-			});
+        actions$ = hot('--a', { a: new DaffResolveCart() });
+        const expected = cold('--b', {
+          b: loadCartSuccessAction
+        });
 
-			expect(effects.onResolveCart$).toBeObservable(expected);
-		});
-	});
+        expect(effects.onResolveCart$).toBeObservable(expected);
+      });
+    });
 
-	describe('handling XHR errors when creating a cart', () => {
-		it('should dispatch DaffCartLoadFailure action', () => {
-			const response = cold('#', {});
-			driver.create.and.returnValue(response);
+    describe('handling XHR errors when creating a cart', () => {
+      it('should dispatch DaffCartLoadFailure action', () => {
+        const response = cold('#', {});
+        driver.create.and.returnValue(response);
 
-			const loadCartFailureAction = new DaffCartLoadFailure(
-				'Cart loading has failed',
-			);
+        const loadCartFailureAction = new DaffCartLoadFailure(
+          'Cart loading has failed',
+        );
 
-			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--b', {
-				b: loadCartFailureAction
-			});
+        actions$ = hot('--a', { a: new DaffResolveCart() });
+        const expected = cold('--b', {
+          b: loadCartFailureAction
+        });
 
-			expect(effects.onResolveCart$).toBeObservable(expected);
-		});
-	});
+        expect(effects.onResolveCart$).toBeObservable(expected);
+      });
+    });
 
-	describe('handling XHR errors when retrieving a cart', () => {
-		it('should dispatch a DaffCartLoadFailure action', () => {
-			const response = cold('#', {});
-			driver.get.and.returnValue(response);
-			driver.create.and.returnValue(response);
+    describe('handling XHR errors when retrieving a cart', () => {
+      it('should dispatch a DaffCartLoadFailure action', () => {
+        const response = cold('#', {});
+        driver.get.and.returnValue(response);
+        driver.create.and.returnValue(response);
 
-			const loadCartFailureAction = new DaffCartLoadFailure(
-				'Cart loading has failed',
-			);
+        const loadCartFailureAction = new DaffCartLoadFailure(
+          'Cart loading has failed',
+        );
 
-			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--b', {
-				b: loadCartFailureAction
-			});
+        actions$ = hot('--a', { a: new DaffResolveCart() });
+        const expected = cold('--b', {
+          b: loadCartFailureAction
+        });
 
-			expect(effects.onResolveCart$).toBeObservable(expected);
-		});
-	});
+        expect(effects.onResolveCart$).toBeObservable(expected);
+      });
+    });
 
-	describe('creating a cart when there is no cart id in storage', () => {
-		it('should create a cart', () => {
-			cartStorageService.getCartId.and.returnValue(undefined);
-			driver.create.and.returnValue(of({ id: stubCart.id }));
-			driver.get.and.returnValue(of(stubCart));
+    describe('creating a cart when there is no cart id in storage', () => {
+      it('should create a cart', () => {
+        cartStorageService.getCartId.and.returnValue(undefined);
+        driver.create.and.returnValue(of({ id: stubCart.id }));
+        driver.get.and.returnValue(of(stubCart));
 
-			const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
+        const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
 
-			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--b', {
-				b: loadCartSuccessAction
-			});
+        actions$ = hot('--a', { a: new DaffResolveCart() });
+        const expected = cold('--b', {
+          b: loadCartSuccessAction
+        });
 
-			expect(effects.onResolveCart$).toBeObservable(expected);
-			expect(driver.create).toHaveBeenCalled();
-		});
+        expect(effects.onResolveCart$).toBeObservable(expected);
+        expect(driver.create).toHaveBeenCalled();
+      });
 
-		it('should set the cart id in local storage', () => {
-			cartStorageService.getCartId.and.returnValue(undefined);
-			driver.create.and.returnValue(of({ id: stubCart.id }));
-			driver.get.and.returnValue(of(stubCart));
+      it('should set the cart id in local storage', () => {
+        cartStorageService.getCartId.and.returnValue(undefined);
+        driver.create.and.returnValue(of({ id: stubCart.id }));
+        driver.get.and.returnValue(of(stubCart));
 
-			const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
+        const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
 
-			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--b', {
-				b: loadCartSuccessAction
-			});
+        actions$ = hot('--a', { a: new DaffResolveCart() });
+        const expected = cold('--b', {
+          b: loadCartSuccessAction
+        });
 
-			expect(effects.onResolveCart$).toBeObservable(expected);
-			expect(cartStorageService.setCartId).toHaveBeenCalledWith(String(stubCart.id));
-		});
-	});
+        expect(effects.onResolveCart$).toBeObservable(expected);
+        expect(cartStorageService.setCartId).toHaveBeenCalledWith(String(stubCart.id));
+      });
+    });
 
-	describe('when the error thrown is a DaffCartNotFoundError', () => {
+    describe('when the error thrown is a DaffCartNotFoundError', () => {
 
-		it('should create a new cart', () => {
-			cartStorageService.getCartId.and.returnValue('id');
-			const response = cold('#', {}, new DaffCartNotFoundError('error'));
-			driver.get.and.returnValue(response);
+      it('should create a new cart', () => {
+        cartStorageService.getCartId.and.returnValue('id');
+        const response = cold('#', {}, new DaffCartNotFoundError('error'));
+        driver.get.and.returnValue(response);
 
-			const cartCreateAction = new DaffCartCreate();
+        const cartCreateAction = new DaffCartCreate();
 
-			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--b', {
-				b: cartCreateAction,
-			});
+        actions$ = hot('--a', { a: new DaffResolveCart() });
+        const expected = cold('--b', {
+          b: cartCreateAction,
+        });
 
-			expect(effects.onResolveCart$).toBeObservable(expected);
-		});
-	});
+        expect(effects.onResolveCart$).toBeObservable(expected);
+      });
+    });
 
-	describe('when the error thrown is a DaffStorageServiceError', () => {
+    describe('when the error thrown is a DaffStorageServiceError', () => {
 
-		it('should indicate that the storage service has failed', () => {
-			const response = cold('#', {}, new DaffStorageServiceError());
-			driver.get.and.returnValue(response);
-			driver.create.and.returnValue(response);
+      it('should indicate that the storage service has failed', () => {
+        const response = cold('#', {}, new DaffStorageServiceError());
+        driver.get.and.returnValue(response);
+        driver.create.and.returnValue(response);
 
-			const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
+        const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
 
-			actions$ = hot('--a', { a: new DaffResolveCart() });
-			const expected = cold('--b', {
-				b: cartStorageFailureAction
-			});
+        actions$ = hot('--a', { a: new DaffResolveCart() });
+        const expected = cold('--b', {
+          b: cartStorageFailureAction
+        });
 
-			expect(effects.onResolveCart$).toBeObservable(expected);
-		});
-	});
+        expect(effects.onResolveCart$).toBeObservable(expected);
+      });
+    });
+  });
+
+  describe('onResolveCartSuccess$', () => {
+    describe('when cart resolution is followed by a successful cart load', () => {
+      beforeEach(() => {
+        const resolveCartAction = new DaffResolveCart();
+        const loadCartSuccessAction = new DaffCartLoadSuccess(stubCart);
+
+        actions$ = hot('--a--b', {
+          a: resolveCartAction,
+          b: loadCartSuccessAction
+        });
+      })
+
+      it('should indicate cart resolution success', () => {
+        const resolveCartSuccessAction = new DaffResolveCartSuccess(stubCart);
+        const expected = cold('-----a', {a: resolveCartSuccessAction});
+
+        expect(effects.onResolveCartSuccess$).toBeObservable(expected);
+      })
+    })
+
+    describe('when cart resolution is followed by a successful cart creation', () => {
+      beforeEach(() => {
+        const resolveCartAction = new DaffResolveCart();
+        const createCartSuccessAction = new DaffCartCreateSuccess(stubCart);
+
+        actions$ = hot('--a--b', {
+          a: resolveCartAction,
+          b: createCartSuccessAction
+        });
+      })
+
+      it('should indicate cart resolution success', () => {
+        const resolveCartSuccessAction = new DaffResolveCartSuccess(stubCart);
+        const expected = cold('-----a', {a: resolveCartSuccessAction});
+
+        expect(effects.onResolveCartSuccess$).toBeObservable(expected);
+      })
+    })
+
+    describe('when cart resolution is followed by a cart resolve failure', () => {
+      beforeEach(() => {
+        const resolveCartAction = new DaffResolveCart();
+        const resolveCartFailureAction = new DaffResolveCartFailure('');
+
+        actions$ = hot('--a--b', {
+          a: resolveCartAction,
+          b: resolveCartFailureAction
+        });
+      })
+
+      it('should not indicate cart resolution success', () => {
+        const expected = cold('------');
+
+        expect(effects.onResolveCartSuccess$).toBeObservable(expected);
+      })
+    })
+  })
+
+  describe('onResolveCartFailure$', () => {
+    describe('when cart resolution is followed by a failed cart load', () => {
+      let error;
+
+      beforeEach(() => {
+        error = 'error'
+        const resolveCartAction = new DaffResolveCart();
+        const loadCartSuccessAction = new DaffCartLoadFailure(error);
+
+        actions$ = hot('--a--b', {
+          a: resolveCartAction,
+          b: loadCartSuccessAction
+        });
+      })
+
+      it('should indicate cart resolution failure', () => {
+        const resolveCartFailureAction = new DaffResolveCartFailure(error);
+        const expected = cold('-----a', {a: resolveCartFailureAction});
+
+        expect(effects.onResolveCartFailure$).toBeObservable(expected);
+      })
+    })
+
+    describe('when cart resolution is followed by a failed cart creation', () => {
+      let error;
+
+      beforeEach(() => {
+        error = 'error'
+        const resolveCartAction = new DaffResolveCart();
+        const createCartFailureAction = new DaffCartCreateFailure(error);
+
+        actions$ = hot('--a--b', {
+          a: resolveCartAction,
+          b: createCartFailureAction
+        });
+      })
+
+      it('should indicate cart resolution success', () => {
+        const resolveCartFailureAction = new DaffResolveCartFailure(error);
+        const expected = cold('-----a', {a: resolveCartFailureAction});
+
+        expect(effects.onResolveCartFailure$).toBeObservable(expected);
+      })
+    })
+
+    describe('when cart resolution is followed by a cart resolve success', () => {
+      beforeEach(() => {
+        const resolveCartAction = new DaffResolveCart();
+        const resolveCartSuccessAction = new DaffResolveCartSuccess(stubCart);
+
+        actions$ = hot('--a--b', {
+          a: resolveCartAction,
+          b: resolveCartSuccessAction
+        });
+      })
+
+      it('should not indicate cart resolution success', () => {
+        const expected = cold('------');
+
+        expect(effects.onResolveCartFailure$).toBeObservable(expected);
+      })
+    })
+  })
 });

--- a/libs/cart/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.ts
@@ -2,7 +2,7 @@ import { Injectable, Inject } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Action } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
-import { switchMap, catchError, map } from 'rxjs/operators';
+import { switchMap, catchError, map, mapTo } from 'rxjs/operators';
 
 import { DaffStorageServiceError, substream } from '@daffodil/core';
 
@@ -68,13 +68,7 @@ export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
       ],
       DaffCartActionTypes.ResolveCartFailureAction
     ),
-    map(([
-      resolveCartAction,
-      cartLoadOrCreateSuccessAction
-    ]: [
-      DaffResolveCart,
-      DaffCartLoadSuccess<T> | DaffCartCreateSuccess<T>
-    ]) => new DaffResolveCartSuccess<T>(cartLoadOrCreateSuccessAction.payload as Partial<T>))
+    mapTo(new DaffResolveCartSuccess())
   );
 
   @Effect()

--- a/libs/cart/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.ts
@@ -4,18 +4,24 @@ import { Action } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 import { switchMap, catchError, map } from 'rxjs/operators';
 
+import { DaffStorageServiceError, substream } from '@daffodil/core';
+
 import {
 	DaffCartActionTypes,
 	DaffCartLoadSuccess,
 	DaffCartCreate,
 	DaffCartLoadFailure,
-	DaffCartStorageFailure
+	DaffCartStorageFailure,
+  DaffResolveCart,
+  DaffResolveCartSuccess,
+  DaffCartCreateSuccess,
+  DaffResolveCartFailure,
+  DaffCartCreateFailure
 } from '../actions/public_api';
 import { DaffCartStorageService } from '../storage/cart-storage.service';
 import { DaffCartDriver, DaffCartServiceInterface } from '../drivers/public_api';
 import { DaffCart } from '../models/cart';
 import { DaffCartNotFoundError } from '../errors/not-found';
-import { DaffStorageServiceError } from '@daffodil/core';
 
 /**
  * An effect for resolving the Cart. It will check local state for a cart id, and retrieve the cart if it exists. If a cart
@@ -38,7 +44,7 @@ export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
       switchMap(({ id }) => this.driver.get(id)),
       switchMap(resp => {
         this.cartStorage.setCartId(String(resp.id))
-        return [new DaffCartLoadSuccess(resp)]
+        return of(new DaffCartLoadSuccess(resp))
       }),
       catchError(error => {
         switch(error.name) {
@@ -51,5 +57,41 @@ export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
         }
       }),
     ))
+  );
+
+  @Effect()
+	onResolveCartSuccess$: Observable<Action> = this.actions$.pipe(
+    substream(
+      [
+        DaffCartActionTypes.ResolveCartAction,
+        [DaffCartActionTypes.CartLoadSuccessAction, DaffCartActionTypes.CartCreateSuccessAction]
+      ],
+      DaffCartActionTypes.ResolveCartFailureAction
+    ),
+    map(([
+      resolveCartAction,
+      cartLoadOrCreateSuccessAction
+    ]: [
+      DaffResolveCart,
+      DaffCartLoadSuccess<T> | DaffCartCreateSuccess<T>
+    ]) => new DaffResolveCartSuccess<T>(cartLoadOrCreateSuccessAction.payload as Partial<T>))
+  );
+
+  @Effect()
+	onResolveCartFailure$: Observable<Action> = this.actions$.pipe(
+    substream(
+      [
+        DaffCartActionTypes.ResolveCartAction,
+        [DaffCartActionTypes.CartLoadFailureAction, DaffCartActionTypes.CartCreateFailureAction]
+      ],
+      DaffCartActionTypes.ResolveCartSuccessAction
+    ),
+    map(([
+      resolveCartAction,
+      cartFailureAction
+    ]: [
+      DaffResolveCart,
+      DaffCartLoadFailure | DaffCartCreateFailure
+    ]) => new DaffResolveCartFailure(cartFailureAction.payload))
 	);
 }

--- a/libs/cart/src/facades/cart/cart-facade.interface.ts
+++ b/libs/cart/src/facades/cart/cart-facade.interface.ts
@@ -18,6 +18,7 @@ export interface DaffCartFacadeInterface<
 	U extends DaffCartItem = DaffCartItem
 > extends DaffStoreFacade<Action> {
   loading$: Observable<boolean>;
+  resolved$: Observable<boolean>;
   cart$: Observable<T>;
   errors$: Observable<DaffCartErrors>;
   cartErrors$: Observable<DaffCartErrors[DaffCartErrorType.Cart]>;

--- a/libs/cart/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/src/facades/cart/cart.facade.spec.ts
@@ -46,6 +46,7 @@ import { DaffCart } from '../../models/cart';
 import { DaffCartOrderResult } from '../../models/cart-order-result';
 import { DaffConfigurableCartItem } from '../../models/configurable-cart-item';
 import { DaffCompositeCartItem } from '../../models/composite-cart-item';
+import { DaffResolveCartSuccess } from '../../actions/public_api';
 
 describe('DaffCartFacade', () => {
   let store: MockStore<{ product: Partial<DaffCartReducersState> }>;
@@ -124,6 +125,20 @@ describe('DaffCartFacade', () => {
       const expected = cold('a', { a: true });
       store.dispatch(new DaffCartLoad());
       expect(facade.loading$).toBeObservable(expected);
+    });
+  });
+
+  describe('resolved$', () => {
+    it('should be false if the cart is not resolved', () => {
+      const expected = cold('a', { a: false });
+      expect(facade.resolved$).toBeObservable(expected);
+    });
+
+    it('should be true if the cart is resolved', () => {
+      const cart = cartFactory.create();
+      const expected = cold('a', { a: true });
+      store.dispatch(new DaffResolveCartSuccess(cart));
+      expect(facade.resolved$).toBeObservable(expected);
     });
   });
 
@@ -352,7 +367,7 @@ describe('DaffCartFacade', () => {
 
     it('should be the cart items upon a successful cart item list', () => {
       const cart = cartFactory.create();
-			const expected = cold('a', { a: 
+			const expected = cold('a', { a:
 				cart.items.reduce((acc, item) => ({
 					...acc,
 					[item.item_id]: item

--- a/libs/cart/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/src/facades/cart/cart.facade.spec.ts
@@ -135,9 +135,8 @@ describe('DaffCartFacade', () => {
     });
 
     it('should be true if the cart is resolved', () => {
-      const cart = cartFactory.create();
       const expected = cold('a', { a: true });
-      store.dispatch(new DaffResolveCartSuccess(cart));
+      store.dispatch(new DaffResolveCartSuccess());
       expect(facade.resolved$).toBeObservable(expected);
     });
   });

--- a/libs/cart/src/facades/cart/cart.facade.ts
+++ b/libs/cart/src/facades/cart/cart.facade.ts
@@ -23,6 +23,7 @@ export class DaffCartFacade<
 	U extends DaffCartItem = DaffCartItem
 > implements DaffCartFacadeInterface<T, V, U> {
   loading$: Observable<boolean>;
+  resolved$: Observable<boolean>;
   cart$: Observable<T>;
 
   errors$: Observable<DaffCartErrors>;
@@ -72,7 +73,8 @@ export class DaffCartFacade<
 
   constructor(private store: Store<DaffCartReducersState<T, V, U>>) {
 		const {
-			selectCartLoading,
+      selectCartLoading,
+      selectCartResolved,
 			selectCartValue,
 			selectCartErrorsObject,
 			selectCartErrors,
@@ -123,6 +125,7 @@ export class DaffCartFacade<
 		this._selectCartItemCompositeOptions = selectCartItemCompositeOptions;
 
     this.loading$ = this.store.pipe(select(selectCartLoading));
+    this.resolved$ = this.store.pipe(select(selectCartResolved));
 		this.cart$ = this.store.pipe(select(selectCartValue));
     this.errors$ = this.store.pipe(select(selectCartErrorsObject));
     this.cartErrors$ = this.store.pipe(select(selectCartErrors));

--- a/libs/cart/src/guards/billing-address/billing-address.guard.spec.ts
+++ b/libs/cart/src/guards/billing-address/billing-address.guard.spec.ts
@@ -9,7 +9,8 @@ import { DaffCartFactory, DaffCartAddressFactory } from '@daffodil/cart/testing'
 import {
   DaffCartFacade,
   DaffCart,
-  DaffResolveCartSuccess
+  DaffResolveCartSuccess,
+  DaffCartLoadSuccess
 } from '@daffodil/cart';
 
 import { DaffBillingAddressGuard } from './billing-address.guard';
@@ -61,7 +62,8 @@ describe('DaffBillingAddressGuard', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				billing_address: new DaffCartAddressFactory().create(),
 			});
-			store.dispatch(new DaffResolveCartSuccess(cart));
+			store.dispatch(new DaffCartLoadSuccess(cart));
+			store.dispatch(new DaffResolveCartSuccess());
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -74,7 +76,8 @@ describe('DaffBillingAddressGuard', () => {
 				const cart: DaffCart = new DaffCartFactory().create({
 					billing_address: null,
 				});
-				store.dispatch(new DaffResolveCartSuccess(cart));
+        store.dispatch(new DaffCartLoadSuccess(cart));
+        store.dispatch(new DaffResolveCartSuccess());
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/src/guards/billing-address/billing-address.guard.spec.ts
+++ b/libs/cart/src/guards/billing-address/billing-address.guard.spec.ts
@@ -6,7 +6,11 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 
 import { DaffCartFactory, DaffCartAddressFactory } from '@daffodil/cart/testing';
-import { DaffCartFacade, DaffCart, DaffCartLoadSuccess } from '@daffodil/cart';
+import {
+  DaffCartFacade,
+  DaffCart,
+  DaffResolveCartSuccess
+} from '@daffodil/cart';
 
 import { DaffBillingAddressGuard } from './billing-address.guard';
 import { daffCartReducers } from '../../reducers/public_api';
@@ -57,7 +61,7 @@ describe('DaffBillingAddressGuard', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				billing_address: new DaffCartAddressFactory().create(),
 			});
-			store.dispatch(new DaffCartLoadSuccess(cart));
+			store.dispatch(new DaffResolveCartSuccess(cart));
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -70,7 +74,7 @@ describe('DaffBillingAddressGuard', () => {
 				const cart: DaffCart = new DaffCartFactory().create({
 					billing_address: null,
 				});
-				store.dispatch(new DaffCartLoadSuccess(cart));
+				store.dispatch(new DaffResolveCartSuccess(cart));
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/src/guards/billing-address/billing-address.guard.ts
+++ b/libs/cart/src/guards/billing-address/billing-address.guard.ts
@@ -22,12 +22,12 @@ export class DaffBillingAddressGuard implements CanActivate {
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.id$.pipe(
-      filter(cartId => !!cartId),
+    return this.facade.resolved$.pipe(
+      filter(resolved => resolved),
       switchMapTo(this.facade.hasBillingAddress$),
       take(1),
 			tap(hasBillingAddress => {
-				if(!hasBillingAddress) {
+				if (!hasBillingAddress) {
 					this.router.navigateByUrl(this.redirectUrl)
 				}
 			})

--- a/libs/cart/src/guards/payment-method/payment-method.guard.spec.ts
+++ b/libs/cart/src/guards/payment-method/payment-method.guard.spec.ts
@@ -6,7 +6,11 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { DaffCartFactory, DaffCartPaymentFactory } from '@daffodil/cart/testing';
-import { DaffCartFacade, DaffCart, DaffCartLoadSuccess } from '@daffodil/cart';
+import {
+  DaffCartFacade,
+  DaffCart,
+  DaffResolveCartSuccess
+} from '@daffodil/cart';
 
 import { DaffPaymentMethodGuard } from './payment-method.guard';
 import { daffCartReducers } from '../../reducers/public_api';
@@ -57,7 +61,7 @@ describe('DaffPaymentMethodGuard', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				payment: new DaffCartPaymentFactory().create(),
 			});
-			store.dispatch(new DaffCartLoadSuccess(cart));
+			store.dispatch(new DaffResolveCartSuccess(cart));
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -70,7 +74,7 @@ describe('DaffPaymentMethodGuard', () => {
 				const cart: DaffCart = new DaffCartFactory().create({
 					payment: null,
 				});
-				store.dispatch(new DaffCartLoadSuccess(cart));
+				store.dispatch(new DaffResolveCartSuccess(cart));
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/src/guards/payment-method/payment-method.guard.spec.ts
+++ b/libs/cart/src/guards/payment-method/payment-method.guard.spec.ts
@@ -9,7 +9,8 @@ import { DaffCartFactory, DaffCartPaymentFactory } from '@daffodil/cart/testing'
 import {
   DaffCartFacade,
   DaffCart,
-  DaffResolveCartSuccess
+  DaffResolveCartSuccess,
+  DaffCartLoadSuccess
 } from '@daffodil/cart';
 
 import { DaffPaymentMethodGuard } from './payment-method.guard';
@@ -61,7 +62,8 @@ describe('DaffPaymentMethodGuard', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				payment: new DaffCartPaymentFactory().create(),
 			});
-			store.dispatch(new DaffResolveCartSuccess(cart));
+      store.dispatch(new DaffCartLoadSuccess(cart));
+      store.dispatch(new DaffResolveCartSuccess());
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -74,7 +76,8 @@ describe('DaffPaymentMethodGuard', () => {
 				const cart: DaffCart = new DaffCartFactory().create({
 					payment: null,
 				});
-				store.dispatch(new DaffResolveCartSuccess(cart));
+        store.dispatch(new DaffCartLoadSuccess(cart));
+				store.dispatch(new DaffResolveCartSuccess());
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/src/guards/payment-method/payment-method.guard.ts
+++ b/libs/cart/src/guards/payment-method/payment-method.guard.ts
@@ -22,12 +22,12 @@ export class DaffPaymentMethodGuard implements CanActivate {
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.id$.pipe(
-      filter(cartId => !!cartId),
+    return this.facade.resolved$.pipe(
+      filter(resolved => resolved),
       switchMapTo(this.facade.hasPaymentMethod$),
       take(1),
 			tap(hasPaymentMethod => {
-				if(!hasPaymentMethod) {
+				if (!hasPaymentMethod) {
 					this.router.navigateByUrl(this.redirectUrl)
 				}
 			})

--- a/libs/cart/src/guards/shipping-address/shipping-address.guard.spec.ts
+++ b/libs/cart/src/guards/shipping-address/shipping-address.guard.spec.ts
@@ -9,7 +9,8 @@ import { DaffCartFactory, DaffCartAddressFactory } from '@daffodil/cart/testing'
 import {
   DaffCartFacade,
   DaffCart,
-  DaffResolveCartSuccess
+  DaffResolveCartSuccess,
+  DaffCartLoadSuccess
 } from '@daffodil/cart';
 
 import { DaffShippingAddressGuard } from './shipping-address.guard';
@@ -61,7 +62,8 @@ describe('DaffShippingAddressGuard', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				shipping_address: new DaffCartAddressFactory().create(),
 			});
-			store.dispatch(new DaffResolveCartSuccess(cart));
+      store.dispatch(new DaffCartLoadSuccess(cart));
+      store.dispatch(new DaffResolveCartSuccess());
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -74,7 +76,8 @@ describe('DaffShippingAddressGuard', () => {
 				const cart: DaffCart = new DaffCartFactory().create({
 					shipping_address: null,
 				});
-				store.dispatch(new DaffResolveCartSuccess(cart));
+        store.dispatch(new DaffCartLoadSuccess(cart));
+				store.dispatch(new DaffResolveCartSuccess());
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/src/guards/shipping-address/shipping-address.guard.spec.ts
+++ b/libs/cart/src/guards/shipping-address/shipping-address.guard.spec.ts
@@ -6,7 +6,11 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { DaffCartFactory, DaffCartAddressFactory } from '@daffodil/cart/testing';
-import { DaffCartFacade, DaffCart, DaffCartLoadSuccess } from '@daffodil/cart';
+import {
+  DaffCartFacade,
+  DaffCart,
+  DaffResolveCartSuccess
+} from '@daffodil/cart';
 
 import { DaffShippingAddressGuard } from './shipping-address.guard';
 import { daffCartReducers } from '../../reducers/public_api';
@@ -57,7 +61,7 @@ describe('DaffShippingAddressGuard', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				shipping_address: new DaffCartAddressFactory().create(),
 			});
-			store.dispatch(new DaffCartLoadSuccess(cart));
+			store.dispatch(new DaffResolveCartSuccess(cart));
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -70,7 +74,7 @@ describe('DaffShippingAddressGuard', () => {
 				const cart: DaffCart = new DaffCartFactory().create({
 					shipping_address: null,
 				});
-				store.dispatch(new DaffCartLoadSuccess(cart));
+				store.dispatch(new DaffResolveCartSuccess(cart));
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/src/guards/shipping-address/shipping-address.guard.ts
+++ b/libs/cart/src/guards/shipping-address/shipping-address.guard.ts
@@ -22,12 +22,12 @@ export class DaffShippingAddressGuard implements CanActivate {
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.id$.pipe(
-      filter(cartId => !!cartId),
+    return this.facade.resolved$.pipe(
+      filter(resolved => resolved),
       switchMapTo(this.facade.hasShippingAddress$),
       take(1),
 			tap(hasShippingAddress => {
-				if(!hasShippingAddress) {
+				if (!hasShippingAddress) {
 					this.router.navigateByUrl(this.redirectUrl)
 				}
 			})

--- a/libs/cart/src/guards/shipping-method/shipping-method.guard.spec.ts
+++ b/libs/cart/src/guards/shipping-method/shipping-method.guard.spec.ts
@@ -6,7 +6,11 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { DaffCartFactory, DaffCartShippingRateFactory } from '@daffodil/cart/testing';
-import { DaffCartFacade, DaffCart, DaffCartLoadSuccess } from '@daffodil/cart';
+import {
+  DaffCartFacade,
+  DaffCart,
+  DaffResolveCartSuccess
+} from '@daffodil/cart';
 
 import { DaffShippingMethodGuard } from './shipping-method.guard';
 import { daffCartReducers } from '../../reducers/public_api';
@@ -57,7 +61,7 @@ describe('DaffShippingMethodGuard', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				shipping_information: new DaffCartShippingRateFactory().create(),
 			});
-			store.dispatch(new DaffCartLoadSuccess(cart));
+			store.dispatch(new DaffResolveCartSuccess(cart));
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -70,7 +74,7 @@ describe('DaffShippingMethodGuard', () => {
 				const cart: DaffCart = new DaffCartFactory().create({
 					shipping_information: null,
 				});
-				store.dispatch(new DaffCartLoadSuccess(cart));
+				store.dispatch(new DaffResolveCartSuccess(cart));
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/src/guards/shipping-method/shipping-method.guard.spec.ts
+++ b/libs/cart/src/guards/shipping-method/shipping-method.guard.spec.ts
@@ -9,7 +9,8 @@ import { DaffCartFactory, DaffCartShippingRateFactory } from '@daffodil/cart/tes
 import {
   DaffCartFacade,
   DaffCart,
-  DaffResolveCartSuccess
+  DaffResolveCartSuccess,
+  DaffCartLoadSuccess
 } from '@daffodil/cart';
 
 import { DaffShippingMethodGuard } from './shipping-method.guard';
@@ -61,7 +62,8 @@ describe('DaffShippingMethodGuard', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				shipping_information: new DaffCartShippingRateFactory().create(),
 			});
-			store.dispatch(new DaffResolveCartSuccess(cart));
+      store.dispatch(new DaffCartLoadSuccess(cart));
+      store.dispatch(new DaffResolveCartSuccess());
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -74,7 +76,8 @@ describe('DaffShippingMethodGuard', () => {
 				const cart: DaffCart = new DaffCartFactory().create({
 					shipping_information: null,
 				});
-				store.dispatch(new DaffResolveCartSuccess(cart));
+        store.dispatch(new DaffCartLoadSuccess(cart));
+				store.dispatch(new DaffResolveCartSuccess());
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/src/guards/shipping-method/shipping-method.guard.ts
+++ b/libs/cart/src/guards/shipping-method/shipping-method.guard.ts
@@ -22,12 +22,12 @@ export class DaffShippingMethodGuard implements CanActivate {
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.id$.pipe(
-      filter(cartId => !!cartId),
+    return this.facade.resolved$.pipe(
+      filter(resolved => resolved),
       switchMapTo(this.facade.hasShippingMethod$),
       take(1),
 			tap(hasShippingMethod => {
-				if(!hasShippingMethod) {
+				if (!hasShippingMethod) {
 					this.router.navigateByUrl(this.redirectUrl)
 				}
 			})

--- a/libs/cart/src/reducers/cart-initial-state.ts
+++ b/libs/cart/src/reducers/cart-initial-state.ts
@@ -27,5 +27,6 @@ export const initialState: DaffCartReducerState<any> = Object.freeze({
     [DaffCartErrorType.Payment]: [],
     [DaffCartErrorType.PaymentMethods]: [],
     [DaffCartErrorType.Coupon]: [],
-  }
+  },
+  resolved: false
 });

--- a/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
+++ b/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  DaffCartFactory,
+} from '@daffodil/cart/testing';
+
+import { initialState } from '../cart-initial-state';
+import {
+  DaffResolveCart,
+  DaffResolveCartSuccess,
+  DaffResolveCartFailure,
+} from '../../actions/public_api';
+import { DaffCart } from '../../models/cart';
+import { cartResolveReducer as reducer } from './cart-resolve.reducer';
+import { DaffCartReducerState } from '../cart-state.interface';
+
+
+describe('Cart | Reducer | cartResolveReducer', () => {
+  let cartFactory: DaffCartFactory;
+  let cart: DaffCart;
+
+  beforeEach(() => {
+    cartFactory = TestBed.get(DaffCartFactory);
+
+    cart = cartFactory.create();
+  });
+
+  describe('when an unknown action is triggered', () => {
+    it('should return the current state', () => {
+      const action = {} as any;
+
+      const result = reducer(initialState, action);
+
+      expect(result).toEqual(initialState);
+    });
+  });
+
+  describe('when ResolveCartActionAction is triggered', () => {
+    it('should set resolved state to false', () => {
+      const cartResolveAction: DaffResolveCart = new DaffResolveCart();
+
+      const result = reducer(initialState, cartResolveAction);
+
+      expect(result.resolved).toEqual(false);
+    });
+  });
+
+  describe('when ResolveCartActionSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartReducerState<DaffCart>;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        resolved: false
+      }
+
+      const cartResolveSuccess = new DaffResolveCartSuccess(cart);
+
+      result = reducer(state, cartResolveSuccess);
+    });
+
+    it('should indicate that the cart is resolved', () => {
+      expect(result.resolved).toEqual(true);
+    });
+  });
+
+  describe('when ResolveCartActionFailureAction is triggered', () => {
+    const error = 'error message';
+    let result;
+    let state: DaffCartReducerState<DaffCart>;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        resolved: false,
+      }
+
+      const cartResolveFailure = new DaffResolveCartFailure(error);
+
+      result = reducer(state, cartResolveFailure);
+    });
+
+    it('should indicate that the cart is resolved', () => {
+      expect(result.resolved).toEqual(true);
+    });
+  });
+});

--- a/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
+++ b/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
@@ -63,6 +63,10 @@ describe('Cart | Reducer | cartResolveReducer', () => {
     it('should indicate that the cart is resolved', () => {
       expect(result.resolved).toEqual(true);
     });
+
+    it('should set cart from action.payload', () => {
+      expect(result.cart).toEqual(cart)
+    });
   });
 
   describe('when ResolveCartActionFailureAction is triggered', () => {

--- a/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
+++ b/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
@@ -1,15 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 
 import {
+  DaffResolveCart,
+  DaffResolveCartSuccess,
+  DaffResolveCartFailure,
+} from '@daffodil/cart';
+import {
   DaffCartFactory,
 } from '@daffodil/cart/testing';
 
 import { initialState } from '../cart-initial-state';
-import {
-  DaffResolveCart,
-  DaffResolveCartSuccess,
-  DaffResolveCartFailure,
-} from '../../actions/public_api';
 import { DaffCart } from '../../models/cart';
 import { cartResolveReducer as reducer } from './cart-resolve.reducer';
 import { DaffCartReducerState } from '../cart-state.interface';
@@ -55,17 +55,13 @@ describe('Cart | Reducer | cartResolveReducer', () => {
         resolved: false
       }
 
-      const cartResolveSuccess = new DaffResolveCartSuccess(cart);
+      const cartResolveSuccess = new DaffResolveCartSuccess();
 
       result = reducer(state, cartResolveSuccess);
     });
 
     it('should indicate that the cart is resolved', () => {
       expect(result.resolved).toEqual(true);
-    });
-
-    it('should set cart from action.payload', () => {
-      expect(result.cart).toEqual(cart)
     });
   });
 

--- a/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.ts
+++ b/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.ts
@@ -20,6 +20,10 @@ export function cartResolveReducer<T extends DaffCart = DaffCart>(
     case DaffCartActionTypes.ResolveCartSuccessAction:
       return {
         ...state,
+        cart: {
+          ...state.cart,
+          ...action.payload
+        },
         resolved: true
       };
 

--- a/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.ts
+++ b/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.ts
@@ -1,0 +1,35 @@
+import {
+  DaffCartActionTypes,
+} from '../../actions/public_api';
+import { initialState } from '../cart-initial-state';
+import { DaffCartReducerState } from '../cart-state.interface';
+import { ActionTypes } from '../action-types.type';
+import { DaffCart } from '../../models/cart';
+
+export function cartResolveReducer<T extends DaffCart = DaffCart>(
+  state = initialState,
+  action: ActionTypes
+): DaffCartReducerState<T> {
+  switch (action.type) {
+    case DaffCartActionTypes.ResolveCartAction:
+      return {
+        ...state,
+        resolved: false
+      };
+
+    case DaffCartActionTypes.ResolveCartSuccessAction:
+      return {
+        ...state,
+        resolved: true
+      };
+
+    case DaffCartActionTypes.ResolveCartFailureAction:
+      return {
+        ...state,
+        resolved: true
+      };
+
+    default:
+      return state;
+  }
+}

--- a/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.ts
+++ b/libs/cart/src/reducers/cart-resolve/cart-resolve.reducer.ts
@@ -18,15 +18,6 @@ export function cartResolveReducer<T extends DaffCart = DaffCart>(
       };
 
     case DaffCartActionTypes.ResolveCartSuccessAction:
-      return {
-        ...state,
-        cart: {
-          ...state.cart,
-          ...action.payload
-        },
-        resolved: true
-      };
-
     case DaffCartActionTypes.ResolveCartFailureAction:
       return {
         ...state,

--- a/libs/cart/src/reducers/cart-state.interface.ts
+++ b/libs/cart/src/reducers/cart-state.interface.ts
@@ -4,5 +4,6 @@ import { DaffCartErrors } from './errors/cart-errors.type';
 export interface DaffCartReducerState<T extends DaffCart = DaffCart> {
   cart: T,
   loading: boolean,
-  errors: DaffCartErrors
+  errors: DaffCartErrors,
+  resolved: boolean
 }

--- a/libs/cart/src/reducers/cart.reducer.ts
+++ b/libs/cart/src/reducers/cart.reducer.ts
@@ -7,6 +7,7 @@ import { cartShippingInformationReducer } from './cart-shipping-information/cart
 import { cartPaymentReducer } from './cart-payment/cart-payment.reducer';
 import { cartPaymentMethodsReducer } from './cart-payment-methods/cart-payment-methods.reducer';
 import { cartCouponReducer } from './cart-coupon/cart-coupon.reducer';
+import { cartResolveReducer } from './cart-resolve/cart-resolve.reducer';
 
 import { DaffCartReducerState } from './cart-state.interface';
 import { ActionTypes } from './action-types.type';
@@ -44,7 +45,8 @@ export function daffCartReducer<T extends DaffCart = DaffCart>(
       cartShippingInformationReducer,
       cartPaymentReducer,
       cartPaymentMethodsReducer,
-      cartCouponReducer
+      cartCouponReducer,
+      cartResolveReducer
     ]
   )
 }

--- a/libs/cart/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/src/selectors/cart/cart.selector.spec.ts
@@ -2,7 +2,12 @@ import { TestBed } from '@angular/core/testing';
 import { StoreModule, combineReducers, Store, select } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 
-import { DaffCart } from '@daffodil/cart';
+import {
+  DaffCart,
+  DaffCartLoadSuccess,
+  DaffCartPlaceOrderSuccess,
+  DaffResolveCartSuccess
+} from '@daffodil/cart';
 import {
   DaffCartFactory,
   DaffCartItemFactory,
@@ -11,7 +16,6 @@ import {
   DaffCartShippingRateFactory
 } from '@daffodil/cart/testing';
 
-import { DaffCartLoadSuccess, DaffCartPlaceOrderSuccess, DaffResolveCartSuccess } from '../../actions/public_api';
 import { daffCartReducers, DaffCartReducersState } from '../../reducers/public_api';
 import { getCartSelectors } from './cart.selector';
 import { DaffCartErrorType } from '../../reducers/errors/cart-error-type.enum';
@@ -144,7 +148,7 @@ describe('Cart | Selector | Cart', () => {
     it('it should be true after cart resolution success', () => {
       const selector = store.pipe(select(selectCartResolved));
       const expected = cold('a', {a: true});
-      store.dispatch(new DaffResolveCartSuccess(cart));
+      store.dispatch(new DaffResolveCartSuccess());
 
       expect(selector).toBeObservable(expected);
     });

--- a/libs/cart/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/src/selectors/cart/cart.selector.spec.ts
@@ -11,7 +11,7 @@ import {
   DaffCartShippingRateFactory
 } from '@daffodil/cart/testing';
 
-import { DaffCartLoadSuccess, DaffCartPlaceOrderSuccess } from '../../actions/public_api';
+import { DaffCartLoadSuccess, DaffCartPlaceOrderSuccess, DaffResolveCartSuccess } from '../../actions/public_api';
 import { daffCartReducers, DaffCartReducersState } from '../../reducers/public_api';
 import { getCartSelectors } from './cart.selector';
 import { DaffCartErrorType } from '../../reducers/errors/cart-error-type.enum';
@@ -32,6 +32,7 @@ describe('Cart | Selector | Cart', () => {
 	let errors: DaffCartErrors;
 	const {
 		selectCartLoading,
+		selectCartResolved,
     selectCartValue,
 
 		selectCartErrorsObject,
@@ -127,6 +128,23 @@ describe('Cart | Selector | Cart', () => {
     it('returns loading state', () => {
       const selector = store.pipe(select(selectCartLoading));
       const expected = cold('a', {a: loading});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartResolved', () => {
+    it('should initially be false', () => {
+      const selector = store.pipe(select(selectCartResolved));
+      const expected = cold('a', {a: false});
+
+      expect(selector).toBeObservable(expected);
+    })
+
+    it('it should be true after cart resolution success', () => {
+      const selector = store.pipe(select(selectCartResolved));
+      const expected = cold('a', {a: true});
+      store.dispatch(new DaffResolveCartSuccess(cart));
 
       expect(selector).toBeObservable(expected);
     });

--- a/libs/cart/src/selectors/cart/cart.selector.ts
+++ b/libs/cart/src/selectors/cart/cart.selector.ts
@@ -20,6 +20,7 @@ export interface DaffCartStateMemoizedSelectors<
 	selectCartState: MemoizedSelector<object, DaffCartReducerState<T>>;
 	selectCartValue: MemoizedSelector<object, T>;
   selectCartLoading: MemoizedSelector<object, boolean>;
+  selectCartResolved: MemoizedSelector<object, boolean>;
 
 	selectCartErrorsObject: MemoizedSelector<object, DaffCartReducerState<T>['errors']>;
 	selectCartErrors: MemoizedSelector<object, string[]>;
@@ -77,6 +78,10 @@ const createCartSelectors = <
 	const selectCartLoading = createSelector(
 		selectCartState,
 		(state: DaffCartReducerState<T>) => state.loading
+  );
+  const selectCartResolved = createSelector(
+		selectCartState,
+		(state: DaffCartReducerState<T>) => state.resolved
   );
 
 	const selectCartErrorsObject = createSelector(
@@ -229,6 +234,7 @@ const createCartSelectors = <
 		selectCartState,
 		selectCartValue,
     selectCartLoading,
+    selectCartResolved,
 
 		selectCartErrorsObject,
 		selectCartErrors,

--- a/libs/cart/testing/src/helpers/mock-cart-facade.ts
+++ b/libs/cart/testing/src/helpers/mock-cart-facade.ts
@@ -14,7 +14,8 @@ import {
 import { Dictionary } from '@ngrx/entity';
 
 export class MockDaffCartFacade implements DaffCartFacadeInterface {
-  loading$: BehaviorSubject<boolean> = new BehaviorSubject(null);
+  loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  resolved$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   cart$: BehaviorSubject<DaffCart> = new BehaviorSubject(null);
   errors$: BehaviorSubject<DaffCartErrors> = new BehaviorSubject(null);
   cartErrors$: BehaviorSubject<DaffCartErrors[DaffCartErrorType.Cart]> = new BehaviorSubject([]);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Cart guards will proceed on resolve success, but hang indefinitely on cart resolve failure.


## What is the new behavior?
- Adds state for storing the resolved state of the cart. False initially and when `DaffResolveCart` is dispatched. True when cart resolution succeeds or fails.
- Cart guards will check the above state to determine when to proceed with the cart field check. This results in the behavior of cart guards proceeding on both cart resolution success _and_ failure.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information