### PR TITLE
feat(order): use order_number for order ID

### DIFF
--- a/libs/order/driver/src/magento/models/responses/order.ts
+++ b/libs/order/driver/src/magento/models/responses/order.ts
@@ -6,7 +6,7 @@ import { MagentoGraycoreOrderInvoice } from './order-invoice';
 
 export interface MagentoGraycoreOrder {
   id: number;
-  order_number: string;
+  order_number: string | number;
   customer_id: number;
   created_at: string;
   updated_at: string;

--- a/libs/order/driver/src/magento/order.service.spec.ts
+++ b/libs/order/driver/src/magento/order.service.spec.ts
@@ -249,7 +249,7 @@ describe('Driver | Magento | Order | OrderService', () => {
     };
     mockMagentoOrder = {
       id: Number(mockDaffOrder.id),
-      order_number: null,
+      order_number: mockDaffOrder.id,
       customer_id: Number(mockDaffOrder.customer_id),
       created_at: mockDaffOrder.created_at,
       updated_at: mockDaffOrder.updated_at,

--- a/libs/order/driver/src/magento/transforms/responses/order.spec.ts
+++ b/libs/order/driver/src/magento/transforms/responses/order.spec.ts
@@ -218,7 +218,7 @@ describe('Driver | Magento | Order | Transformer | Order', () => {
     };
     mockMagentoOrder = {
       id: Number(mockDaffOrder.id),
-      order_number: null,
+      order_number: mockDaffOrder.id,
       customer_id: Number(mockDaffOrder.customer_id),
       created_at: mockDaffOrder.created_at,
       updated_at: mockDaffOrder.updated_at,

--- a/libs/order/driver/src/magento/transforms/responses/order.ts
+++ b/libs/order/driver/src/magento/transforms/responses/order.ts
@@ -149,7 +149,7 @@ function transformInvoice(invoice: MagentoGraycoreOrderInvoice): DaffOrderInvoic
  */
 export function daffMagentoTransformOrder(order: MagentoGraycoreOrder): DaffOrder {
   return {
-    id: order.id,
+    id: order.order_number,
     customer_id: order.customer_id,
     created_at: order.created_at,
     updated_at: order.updated_at,

--- a/libs/order/src/selectors/order-entities.selector.ts
+++ b/libs/order/src/selectors/order-entities.selector.ts
@@ -46,7 +46,7 @@ const createOrderEntitySelectors = <T extends DaffOrder = DaffOrder>() => {
 
   const selectOrder = createSelector(
     selectEntities,
-    (orders, props) => orders[Number(props.id)] || null
+    (orders, props) => orders[props.id] || null
   )
 
   const selectPlacedOrder = createSelector(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The Magento driver uses the Magento order ID for the Daffodil order ID. The placed order lookup is done with the Magento order number since this is the _only_ piece of identifying info that `placeOrder` returns.

Looking up the placed order will therefore fail due to the mismatch between the order number and order ID.

## What is the new behavior?
The Magento order number is used for the Daffodil order ID which allows Daffodil to correctly look it up using the info returned by `placeOrder`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information