### PR TITLE
feat(design): add theme and theme-contrast styles to button and set t…

### DIFF
--- a/apps/design-land/src/app/button/button.component.html
+++ b/apps/design-land/src/app/button/button.component.html
@@ -41,8 +41,8 @@
   <design-land-example-viewer example="sizeable-button"></design-land-example-viewer>
 
   <h3>Theming</h3>
-  <p>The color of a button can be changed by using the <code>color</code> property. By default, the button uses the base-contrast color of the theme. This can be changed to one of the supported colors.</p>
-  <p>Supported colors: <code>primary | secondary | tertiary | black | white</code></p>
+  <p>The color of a button can be changed by using the <code>color</code> property. The default color is set to <code>theme-contrast</code>. This can be changed to one of the supported colors.</p>
+  <p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
 
   <h3>Accessibility</h3>
   <p>Daffodil uses native <code>&lt;a&gt;</code> and <code>&lt;button&gt;</code> HTML elements to ensure an accessible experience by default. The <code>&lt;button&gt;</code> element should be used when a clickable action is performed within the same page. The <code>&lt;a&gt;</code> element should be used to navigate users to a new page or to a different target on the same page.</p>

--- a/libs/design/button/examples/src/basic-button/basic-button.component.html
+++ b/libs/design/button/examples/src/basic-button/basic-button.component.html
@@ -4,6 +4,8 @@
 <button daff-button color="tertiary">Tertiary</button>
 <button daff-button color="black">Black</button>
 <button daff-button color="white">White</button>
+<button daff-button color="theme">Theme</button>
+<button daff-button color="theme-contrast">Theme Contrast</button>
 <button daff-button><fa-icon [icon]="faChevronLeft" daffPrefix></fa-icon>Button</button>
 <button daff-button><fa-icon [icon]="faChevronRight" daffSuffix></fa-icon>Button</button>
 <button daff-button disabled>Disabled</button>

--- a/libs/design/button/examples/src/icon-button/icon-button.component.html
+++ b/libs/design/button/examples/src/icon-button/icon-button.component.html
@@ -4,4 +4,6 @@
 <button daff-icon-button color="tertiary"><fa-icon [icon]="faPlus"></fa-icon></button>
 <button daff-icon-button color="black"><fa-icon [icon]="faPlus"></fa-icon></button>
 <button daff-icon-button color="white"><fa-icon [icon]="faPlus"></fa-icon></button>
+<button daff-icon-button color="theme"><fa-icon [icon]="faPlus"></fa-icon></button>
+<button daff-icon-button color="theme-contrast"><fa-icon [icon]="faPlus"></fa-icon></button>
 <button daff-icon-button disabled><fa-icon [icon]="faPlus"></fa-icon></button>

--- a/libs/design/button/examples/src/raised-button/raised-button.component.html
+++ b/libs/design/button/examples/src/raised-button/raised-button.component.html
@@ -4,6 +4,8 @@
 <button daff-raised-button color="tertiary">Tertiary</button>
 <button daff-raised-button color="black">Black</button>
 <button daff-raised-button color="white">White</button>
+<button daff-raised-button color="theme">Theme</button>
+<button daff-raised-button color="theme-contrast">Theme Contrast</button>
 <button daff-raised-button><fa-icon [icon]="faChevronLeft" daffPrefix></fa-icon>Button</button>
 <button daff-raised-button><fa-icon [icon]="faChevronRight" daffSuffix></fa-icon>Button</button>
 <button daff-raised-button disabled>Disabled</button>

--- a/libs/design/button/examples/src/stroked-button/stroked-button.component.html
+++ b/libs/design/button/examples/src/stroked-button/stroked-button.component.html
@@ -4,6 +4,8 @@
 <button daff-stroked-button color="tertiary">Tertiary</button>
 <button daff-stroked-button color="black">Black</button>
 <button daff-stroked-button color="white">White</button>
+<button daff-stroked-button color="theme">Theme</button>
+<button daff-stroked-button color="theme-contrast">Theme Contrast</button>
 <button daff-stroked-button><fa-icon [icon]="faChevronLeft" daffPrefix></fa-icon>Button</button>
 <button daff-stroked-button><fa-icon [icon]="faChevronRight" daffSuffix></fa-icon>Button</button>
 <button daff-stroked-button disabled>Disabled</button>

--- a/libs/design/button/examples/src/underline-button/underline-button.component.html
+++ b/libs/design/button/examples/src/underline-button/underline-button.component.html
@@ -4,6 +4,8 @@
 <button daff-underline-button color="tertiary">Tertiary</button>
 <button daff-underline-button color="black">Black</button>
 <button daff-underline-button color="white">White</button>
+<button daff-underline-button color="theme">Theme</button>
+<button daff-underline-button color="theme-contrast">Theme Contrast</button>
 <button daff-underline-button><fa-icon [icon]="faChevronLeft" daffPrefix></fa-icon>Button</button>
 <button daff-underline-button><fa-icon [icon]="faChevronRight" daffSuffix></fa-icon>Button</button>
 <button daff-underline-button disabled>Disabled</button>

--- a/libs/design/src/atoms/button/button-theme.scss
+++ b/libs/design/src/atoms/button/button-theme.scss
@@ -16,12 +16,6 @@
 	$gray: daff-configure-palette($daff-gray, 60);
 
 	.daff-button {
-		@include daff-button-theme-variant(
-			$base-contrast,
-			daff-illuminate($base-contrast, $daff-gray, 1),
-			daff-illuminate($base-contrast, $daff-gray, 2)
-		);
-
 		&.daff-primary {
 			@include daff-button-theme-variant(
 				daff-color($primary),
@@ -62,6 +56,22 @@
 			);
 		}
 
+		&.daff-theme {
+			@include daff-button-theme-variant(
+				$base,
+				daff-illuminate($base, $daff-gray, 1),
+				daff-illuminate($base, $daff-gray, 2)
+			);
+		}
+
+		&.daff-theme-contrast {
+			@include daff-button-theme-variant(
+				$base-contrast,
+				daff-illuminate($base-contrast, $daff-gray, 2),
+				daff-illuminate($base-contrast, $daff-gray, 3)
+			);
+		}
+
 		&[disabled] {
 			@include daff-button-theme-variant(
 				daff-color($daff-gray, 30),
@@ -73,13 +83,12 @@
 	}
 
 	.daff-raised-button {
+		@include daff-raised-button-theme-variant($base-contrast);
 		box-shadow: 0 3px 5px rgba($black, 0.12), 0 1px 3px rgba($black, 0.08);
 
 		&:hover {
 			box-shadow: 0 5px 14px rgba($black, 0.12), 0 3px 5px rgba($black, 0.08);
 		}
-
-		@include daff-raised-button-theme-variant($base-contrast);
 
 		&.daff-primary {
 			@include daff-raised-button-theme-variant(daff-color($primary));
@@ -101,6 +110,14 @@
 			@include daff-raised-button-theme-variant($white);
 		}
 
+		&.daff-theme {
+			@include daff-raised-button-theme-variant($base);
+		}
+
+		&.daff-theme-contrast {
+			@include daff-raised-button-theme-variant($base-contrast);
+		}
+
 		&[disabled] {
 			@include daff-raised-button-theme-variant(daff-color($daff-gray, 30));
 			color: daff-color($gray);
@@ -112,8 +129,6 @@
 	}
 
 	.daff-icon-button {
-		@include daff-icon-button-theme-variant();
-
 		&.daff-primary {
 			@include daff-icon-button-theme-variant(
 				daff-color($primary),
@@ -154,6 +169,18 @@
 			);
 		}
 
+		&.daff-theme {
+			@include daff-icon-button-theme-variant(
+				$base,
+				daff-illuminate($base, $daff-gray, 1),
+				daff-illuminate($base, $daff-gray, 2)
+			);
+		}
+
+		&.daff-theme-contrast {
+			@include daff-icon-button-theme-variant();
+		}
+
 		&[disabled] {
 			@include daff-icon-button-theme-variant(
 				daff-color($gray),
@@ -165,12 +192,6 @@
 	}
 
 	.daff-stroked-button {
-		@include daff-stroked-button-theme-variant(
-			currentColor,
-			0.08,
-			currentColor
-		);
-
 		&.daff-primary {
 			@include daff-stroked-button-theme-variant(
 				daff-color($primary),
@@ -211,6 +232,22 @@
 			);
 		}
 
+		&.daff-theme {
+			@include daff-stroked-button-theme-variant(
+				$base,
+				0.08,
+				$base
+			);
+		}
+
+		&.daff-theme-contrast {
+			@include daff-stroked-button-theme-variant(
+				currentColor,
+				0.08,
+				currentColor
+			);
+		}
+
 		&[disabled] {
 			@include daff-stroked-button-theme-variant(
 				daff-color($daff-gray, 30),
@@ -221,8 +258,6 @@
 	}
 
 	.daff-underline-button {
-		@include daff-underline-button-theme-variant;
-
 		&.daff-primary {
 			@include daff-underline-button-theme-variant(daff-color($primary));
 		}
@@ -243,6 +278,14 @@
 			@include daff-underline-button-theme-variant($white);
 		}
 
+		&.daff-theme {
+			@include daff-underline-button-theme-variant($base);
+		}
+
+		&.daff-theme-contrast {
+			@include daff-underline-button-theme-variant;
+		}
+
 		&[disabled] {
 			@include daff-underline-button-theme-variant(daff-color($gray));
 		}
@@ -253,8 +296,6 @@
 	.daff-stroked-button,
 	.daff-underline-button,
 	.daff-icon-button {
-		@include daff-button-focus-theme-variant($base-contrast);
-
 		&.daff-primary {
 			@include daff-button-focus-theme-variant(daff-color($primary));
 		}
@@ -273,6 +314,14 @@
 
 		&.daff-white {
 			@include daff-button-focus-theme-variant(daff-color($gray));
+		}
+
+		&.daff-theme {
+			@include daff-button-focus-theme-variant($base);
+		}
+
+		&.daff-theme-contrast {
+			@include daff-button-focus-theme-variant($base-contrast);
 		}
 	}
 }

--- a/libs/design/src/atoms/button/button.component.spec.ts
+++ b/libs/design/src/atoms/button/button.component.spec.ts
@@ -146,8 +146,11 @@ describe('DaffButtonComponent', () => {
       expect(de.nativeElement.classList.contains('daff-primary')).toEqual(true);
     });
 
-    it('should not set a default color', () => {
-      expect(wrapper.color).toBeFalsy();
+    it('should set the default color to theme-contrast', () => {
+      wrapper.color = 'theme-contrast';
+      fixture.detectChanges();
+
+      expect(de.nativeElement.classList.contains('daff-theme-contrast')).toEqual(true);
     });
   });
 

--- a/libs/design/src/atoms/button/button.component.ts
+++ b/libs/design/src/atoms/button/button.component.ts
@@ -1,6 +1,6 @@
 import {
   Component, OnInit, ViewEncapsulation, ChangeDetectionStrategy,
-  ElementRef, Input, HostBinding, Renderer2, ContentChild
+  ElementRef, Input, HostBinding, Renderer2
 } from '@angular/core';
 
 import { daffColorMixin, DaffColorable, DaffPalette } from '../../core/colorable/colorable';
@@ -16,7 +16,7 @@ import { daffSizeMixin } from '../../core/sizeable/sizeable-mixin';
 import { DaffSizeable, DaffSizeSmallType, DaffSizeMediumType, DaffSizeLargeType } from '../../core/sizeable/sizeable';
 
 /**
-* List of classes to add to Daff Button instances based on host attributes to style as different variants.
+* List of classes to add to DaffButtonComponent instances based on host attributes to style as different variants.
 */
 const BUTTON_HOST_ATTRIBUTES: DaffButtonType[] = [
   'daff-button',
@@ -27,14 +27,13 @@ const BUTTON_HOST_ATTRIBUTES: DaffButtonType[] = [
 ];
 
 /**
- * An _elementRef and an instance of renderer2 are needed for the Colorable mixin
+ * An _elementRef and an instance of renderer2 are needed for the button mixins
  */
 class DaffButtonBase{
   constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
 }
 
-const _daffButtonBase = 
-daffColorMixin(daffSuffixableMixin(daffPrefixableMixin(daffSizeMixin(DaffButtonBase, 'md')))); 
+const _daffButtonBase = daffPrefixableMixin(daffSuffixableMixin(daffColorMixin(daffSizeMixin(DaffButtonBase, 'md'),'theme-contrast')));
 
 export type DaffButtonType = 'daff-button' | 'daff-stroked-button' | 'daff-raised-button' | 'daff-icon-button' | 'daff-underline-button' | undefined;
 


### PR DESCRIPTION
…heme-contrast as default color

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There are no styles for `theme` and `theme-contrast`

Fixes: N/A


## What is the new behavior?
Add styles for `theme` and `theme-contrast`. Removed color styles on base and set `theme-contrast` as default style since they are the same styles.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information