### PR TITLE
feat(product): add out_of_stock state for products

### DIFF
--- a/libs/product/src/facades/product/product-facade.interface.ts
+++ b/libs/product/src/facades/product/product-facade.interface.ts
@@ -14,4 +14,5 @@ export interface DaffProductFacadeInterface<T extends DaffProduct = DaffProduct>
 
 	getProduct(id: string): Observable<T>;
 	hasDiscount(id: string): Observable<boolean>;
+	isOutOfStock(id: string): Observable<boolean>;
 }

--- a/libs/product/src/facades/product/product.facade.spec.ts
+++ b/libs/product/src/facades/product/product.facade.spec.ts
@@ -12,6 +12,7 @@ import {
 
 import { DaffProductFacade } from './product.facade';
 import { DaffProductFactory } from '@daffodil/product/testing';
+import { DaffProductStockEnum } from '../../models/product';
 
 describe('DaffProductFacade', () => {
   let store: MockStore<Partial<DaffProductReducersState>>;
@@ -91,6 +92,16 @@ describe('DaffProductFacade', () => {
       store.dispatch(new DaffProductLoad(product.id));
       store.dispatch(new DaffProductLoadSuccess(product));
       expect(facade.hasDiscount(product.id)).toBeObservable(expected);
+		});
+	});
+	
+	describe('isOutOfStock()', () => {
+		it('should be an observable of whether the given product is out of stock', () => {
+			const product = {id: '1', name: 'Some Name', discount: { amount: 20, percent: 10 }, stock_status: DaffProductStockEnum.OutOfStock};
+      const expected = cold('a', { a: true });
+      store.dispatch(new DaffProductLoad(product.id));
+      store.dispatch(new DaffProductLoadSuccess(product));
+      expect(facade.isOutOfStock(product.id)).toBeObservable(expected);
 		});
 	});
 });

--- a/libs/product/src/facades/product/product.facade.ts
+++ b/libs/product/src/facades/product/product.facade.ts
@@ -42,6 +42,10 @@ export class DaffProductFacade<T extends DaffProduct = DaffProduct> implements D
 		return this.store.pipe(select(this.selectors.selectProductHasDiscount, { id }));
 	}
 
+	isOutOfStock(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectProductOutOfStock, { id }));
+	}
+
   /**
    * Dispatches an action to the rxjs action stream.
    */

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
@@ -2,7 +2,7 @@ import { createSelector, MemoizedSelectorWithProps } from '@ngrx/store';
 
 import { daffSubtract } from '@daffodil/core';
 
-import { DaffProductTypeEnum } from '../../models/product';
+import { DaffProductTypeEnum, DaffProductStockEnum } from '../../models/product';
 import { Dictionary } from '@ngrx/entity';
 import { getDaffConfigurableProductEntitiesSelectors } from '../configurable-product-entities/configurable-product-entities.selectors';
 import { getDaffProductEntitiesSelectors } from '../product-entities/product-entities.selectors';
@@ -236,10 +236,11 @@ function isVariantAvailable(
 	appliedAttributes: DaffConfigurableProductEntityAttribute[], 
 	variant: DaffConfigurableProductVariant
 ): boolean {
-	return appliedAttributes.reduce((acc, attribute) => 
-		acc && attribute.value === variant.appliedAttributes[attribute.code],
-		true
-	)
+	return variant.stock_status === DaffProductStockEnum.InStock && 
+		appliedAttributes.reduce((acc, attribute) => 
+			acc && attribute.value === variant.appliedAttributes[attribute.code],
+			true
+		)
 }
 
 function getMinimumPrice(prices: number[]): number {

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.unit.spec.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.unit.spec.ts
@@ -13,6 +13,7 @@ import {
 } from '@daffodil/product';
 
 import { getDaffConfigurableProductSelectors } from './configurable-product.selectors';
+import { DaffProductStockEnum } from '../../models/product';
 
 describe('Configurable Product Selectors | unit tests', () => {
 
@@ -265,6 +266,23 @@ describe('Configurable Product Selectors | unit tests', () => {
 			const selector = store.pipe(select(selectMatchingConfigurableProductVariants, { id: stubConfigurableProduct.id }));
 			const expected = cold('a', { a:
 				stubConfigurableProduct.variants.slice(0, 4)
+			});
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('only returns variants that are in stock', () => {
+			stubConfigurableProduct.variants[0].stock_status = DaffProductStockEnum.OutOfStock;
+
+			store.dispatch(new DaffProductLoadSuccess(stubConfigurableProduct));
+			store.dispatch(new DaffConfigurableProductApplyAttribute(
+				stubConfigurableProduct.id,
+				stubConfigurableProduct.configurableAttributes[0].code,
+				stubConfigurableProduct.variants[0].appliedAttributes[stubConfigurableProduct.configurableAttributes[0].code]
+			));
+			const selector = store.pipe(select(selectMatchingConfigurableProductVariants, { id: stubConfigurableProduct.id }));
+			const expected = cold('a', { a:
+				stubConfigurableProduct.variants.slice(1, 4)
 			});
 
 			expect(selector).toBeObservable(expected);

--- a/libs/product/src/selectors/product-entities/product-entities.selectors.spec.ts
+++ b/libs/product/src/selectors/product-entities/product-entities.selectors.spec.ts
@@ -4,7 +4,7 @@ import { cold } from 'jasmine-marbles';
 
 import { DaffProductFactory } from '@daffodil/product/testing';
 import { DaffProductGridLoadSuccess } from '../../actions/product-grid.actions';
-import { DaffProduct } from '../../models/product';
+import { DaffProduct, DaffProductStockEnum } from '../../models/product';
 import { DaffProductReducersState } from '../../reducers/product-reducers-state.interface';
 import { daffProductReducers } from '../../reducers/product-reducers';
 import { getDaffProductEntitiesSelectors } from './product-entities.selectors';
@@ -21,7 +21,8 @@ describe('selectProductEntitiesState', () => {
 		selectProductTotal,
 		selectProduct,
 		selectProductDiscountAmount,
-		selectProductHasDiscount
+		selectProductHasDiscount,
+		selectProductOutOfStock
 	} = getDaffProductEntitiesSelectors();
   
   beforeEach(() => {
@@ -110,6 +111,16 @@ describe('selectProductEntitiesState', () => {
     it('should select whether the product has a discount', () => {
 			const selector = store.pipe(select(selectProductHasDiscount, { id: mockProduct.id }));
 			const expected = cold('a', { a: !!mockProduct.discount.amount });
+
+			expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectProductOutOfStock', () => {
+    
+    it('should select whether the product has a discount', () => {
+			const selector = store.pipe(select(selectProductOutOfStock, { id: mockProduct.id }));
+			const expected = cold('a', { a: mockProduct.stock_status === DaffProductStockEnum.OutOfStock });
 
 			expect(selector).toBeObservable(expected);
     });

--- a/libs/product/src/selectors/product-entities/product-entities.selectors.ts
+++ b/libs/product/src/selectors/product-entities/product-entities.selectors.ts
@@ -4,7 +4,7 @@ import { EntityState } from '@ngrx/entity';
 import { daffProductEntitiesAdapter } from '../../reducers/product-entities/product-entities-reducer-adapter';
 import { getDaffProductFeatureSelector } from '../product-feature.selector';
 import { DaffProductReducersState } from '../../reducers/product-reducers-state.interface';
-import { DaffProduct } from '../../models/product';
+import { DaffProduct, DaffProductStockEnum } from '../../models/product';
 
 export interface DaffProductEntitiesMemoizedSelectors<T extends DaffProduct = DaffProduct> {
 	selectProductEntitiesState: MemoizedSelector<object, EntityState<T>>;
@@ -15,6 +15,7 @@ export interface DaffProductEntitiesMemoizedSelectors<T extends DaffProduct = Da
 	selectProduct: MemoizedSelectorWithProps<object, object, T>;
 	selectProductDiscountAmount: MemoizedSelectorWithProps<object, object, number>;
 	selectProductHasDiscount: MemoizedSelectorWithProps<object, object, boolean>;
+	selectProductOutOfStock: MemoizedSelectorWithProps<object, object, boolean>;
 }
 
 const createProductEntitiesSelectors = <T extends DaffProduct>(): DaffProductEntitiesMemoizedSelectors<T> => {
@@ -82,7 +83,7 @@ const createProductEntitiesSelectors = <T extends DaffProduct>(): DaffProductEnt
 
 			return (product.discount && product.discount.amount) || 0;
 		}
-	)
+	);
 
 	const selectProductHasDiscount = createSelector(
 		selectProductEntities,
@@ -91,7 +92,15 @@ const createProductEntitiesSelectors = <T extends DaffProduct>(): DaffProductEnt
 
 			return !!discountAmount;
 		}
-	)
+	);
+
+	const selectProductOutOfStock = createSelector(
+		selectProductEntities,
+		(products, props) => {
+			return selectProduct.projector(products, { id: props.id })
+				.stock_status === DaffProductStockEnum.OutOfStock;
+		}
+	);
 
 	return { 
 		selectProductEntitiesState,
@@ -101,7 +110,8 @@ const createProductEntitiesSelectors = <T extends DaffProduct>(): DaffProductEnt
 		selectProductTotal,
 		selectProduct,
 		selectProductDiscountAmount,
-		selectProductHasDiscount
+		selectProductHasDiscount,
+		selectProductOutOfStock
 	}
 }
 

--- a/libs/product/testing/src/helpers/mock-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-product-facade.ts
@@ -14,5 +14,8 @@ export class MockDaffProductFacade implements DaffProductFacadeInterface {
 	hasDiscount(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	}
+	isOutOfStock(id: string): BehaviorSubject<boolean> {
+		return new BehaviorSubject(false);
+	}
 	dispatch(action) {};
 }


### PR DESCRIPTION
integrate stock_status for variants into configurable product state

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
- Adds a selector for out of stock state for an individual product.
- Integrates out of stock state for configurable product variants, so that if a particular variant is out of stock it won't be included in determining the available attributes for a configurable product.