### PR TITLE
feat(product): stock_status data is now available for composite produ…

### DIFF
--- a/libs/product/src/drivers/magento/queries/fragments/bundled-product.ts
+++ b/libs/product/src/drivers/magento/queries/fragments/bundled-product.ts
@@ -22,6 +22,7 @@ export const magentoBundledProductFragment = gql`
 					id
 					name
 					sku
+					stock_status
 				}
 			}
 		}

--- a/libs/product/src/drivers/magento/transforms/bundled-product-transformers.spec.ts
+++ b/libs/product/src/drivers/magento/transforms/bundled-product-transformers.spec.ts
@@ -1,9 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 
+import { MagentoProductFactory } from '@daffodil/product/testing';
+
 import { transformMagentoBundledProduct } from './bundled-product-transformers';
 import daffCompositeProductData from './spec-data/daff-composite-product.json';
 import magentoBundledProductData from './spec-data/magento-bundled-product.json';
 import { MagentoProductStockStatusEnum } from '../models/magento-product';
+import { MagentoBundledProduct } from '../models/bundled-product';
 
 describe('DaffMagentoBundledProductTransformers', () => {
 	const mediaUrl = 'media url';
@@ -13,8 +16,17 @@ describe('DaffMagentoBundledProductTransformers', () => {
   });
 
 	describe('transform', () => {
-		const magentoBundledProduct = {
+		const stubSimpleProduct = new MagentoProductFactory().create();
+		const magentoBundledProduct: MagentoBundledProduct = {
 			...magentoBundledProductData,
+			stock_status: MagentoProductStockStatusEnum.InStock,
+		}
+		magentoBundledProduct.items[0].options[0].product = {
+			...stubSimpleProduct,
+			stock_status: MagentoProductStockStatusEnum.InStock
+		}
+		magentoBundledProduct.items[0].options[1].product = {
+			...stubSimpleProduct,
 			stock_status: MagentoProductStockStatusEnum.InStock
 		}
 		

--- a/libs/product/src/drivers/magento/transforms/bundled-product-transformers.ts
+++ b/libs/product/src/drivers/magento/transforms/bundled-product-transformers.ts
@@ -1,5 +1,5 @@
 import { MagentoBundledProduct, MagentoBundledProductItem, MagentoBundledProductItemOption } from '../models/bundled-product';
-import { DaffProductTypeEnum } from '../../../models/product';
+import { DaffProductTypeEnum, DaffProductStockEnum } from '../../../models/product';
 import { DaffCompositeProduct } from '../../../models/composite-product';
 import { 
 	DaffCompositeProductItemOption, 
@@ -7,6 +7,7 @@ import {
 	DaffCompositeProductItemInputEnum 
 } from '../../../models/composite-product-item';
 import { transformMagentoSimpleProduct } from './simple-product-transformers';
+import { MagentoProductStockStatusEnum } from '../models/magento-product';
 
 /**
  * Transforms the magento MagentoProduct from the magento product query into a DaffProduct. 
@@ -36,6 +37,18 @@ function transformMagentoBundledProductItemOption(option: MagentoBundledProductI
 		name: option.label,
 		price: option.price,
 		quantity: option.quantity,
-		is_default: option.is_default
+		is_default: option.is_default,
+		stock_status: getStockStatus(option.product.stock_status)
+	}
+}
+
+function getStockStatus(magentoStatus: string): DaffProductStockEnum {
+	switch(magentoStatus) {
+		case MagentoProductStockStatusEnum.InStock:
+			return DaffProductStockEnum.InStock;
+		case MagentoProductStockStatusEnum.OutOfStock:
+			return DaffProductStockEnum.OutOfStock;
+		default:
+			return DaffProductStockEnum.InStock;
 	}
 }

--- a/libs/product/src/drivers/magento/transforms/spec-data/daff-composite-product.json
+++ b/libs/product/src/drivers/magento/transforms/spec-data/daff-composite-product.json
@@ -29,14 +29,16 @@
 					"name": "Option 1",
 					"price": 10,
 					"quantity": 1,
-					"is_default": true
+					"is_default": true,
+					"stock_status": "IN_STOCK"
 				},
 				{
 					"id": "2",
 					"name": "Option 2",
 					"price": 12,
 					"quantity": 1,
-					"is_default": false
+					"is_default": false,
+					"stock_status": "IN_STOCK"
 				}
 			]
 		}

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -4,11 +4,11 @@ import { DaffProductGridActionTypes, DaffProductGridActions } from '../../action
 import { DaffProductActionTypes, DaffProductActions } from '../../actions/product.actions';
 import { DaffBestSellersActionTypes, DaffBestSellersActions } from '../../actions/best-sellers.actions';
 import { daffCompositeProductAppliedOptionsEntitiesAdapter } from './composite-product-entities-reducer-adapter';
-import { DaffProduct, DaffProductTypeEnum } from '../../models/product';
+import { DaffProduct, DaffProductTypeEnum, DaffProductStockEnum } from '../../models/product';
 import { DaffCompositeProductActions, DaffCompositeProductActionTypes } from '../../actions/composite-product.actions';
 import { DaffCompositeProduct } from '../../models/composite-product';
 import { DaffCompositeProductEntity, DaffCompositeProductEntityItem } from './composite-product-entity';
-import { DaffCompositeProductItem } from '../../models/composite-product-item';
+import { DaffCompositeProductItem, DaffCompositeProductItemOption } from '../../models/composite-product-item';
 
 /**
  * Reducer function that catches actions and changes/overwrites composite product entities state.
@@ -67,17 +67,32 @@ function buildCompositeProductAppliedOptionsEntity(product: DaffCompositeProduct
 	}
 }
 
+/**
+ * Sets the default item option to the specified default option unless that option is out of stock.
+ * Sets the default item option to the first option if the specified default option is out of stock.
+ * Does not set a default option if both the specified default option and the first option are out of stock.
+ * Sets the default item option to the first option if no default option is specified, the first option
+ * 	is in stock, and the item is required.
+ * Does not set a default option if a default is not specified and not required.
+ * Does not set a default option if a default is not specified, is required, but has a first option that is 
+ * 	out of stock.
+ * @param item a DaffCompositeProductItem
+ */
 function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductEntityItem {
 	const defaultOptionIndex = item.options.findIndex(option => option.is_default);
 
-	if(defaultOptionIndex > -1) {
+	if(defaultOptionIndex > -1 && isOptionInStock(item.options[defaultOptionIndex])) {
 		return {
 			value: item.options[defaultOptionIndex].id,
 			qty: 1
 		}
 	} else {
-		return item.required ? 
+		return item.required && isOptionInStock(item.options[0]) ? 
 			{ value: item.options[0].id, qty: 1 } :
 			{ value: null, qty: null }
 	}
+}
+
+function isOptionInStock(option: DaffCompositeProductItemOption): boolean {
+	return option.stock_status === DaffProductStockEnum.InStock;
 }


### PR DESCRIPTION
…ct item options

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
I didn't think that we could get data for stock_status for composite product item options, but I was wrong.

## What is the new behavior?
Composite product item option stock_status is now available in product state.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```