### PR TITLE
feat(product): make composite product items have a default option if …

### DIFF
--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
@@ -188,17 +188,17 @@ describe('Product | Composite Product Entities Reducer', () => {
 
 		describe('when the default item option is not defined', () => {
 			
-			it(`should set the default option to the first option when the item is required 
-					and the first option is in stock`, () => {
+			it(`should set the default option to the first option that is in stock`, () => {
 				compositeProduct.items[0].options[0].is_default = false;
 				compositeProduct.items[0].options[1].is_default = false;
-				compositeProduct.items[0].options[0].stock_status = DaffProductStockEnum.InStock;
+				compositeProduct.items[0].options[0].stock_status = DaffProductStockEnum.OutOfStock;
+				compositeProduct.items[0].options[1].stock_status = DaffProductStockEnum.InStock;
 				compositeProduct.items[0].required = true;
 				const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
 				result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
 
 				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({
-					value: compositeProduct.items[0].options[0].id,
+					value: compositeProduct.items[0].options[1].id,
 					qty: 1
 				});
 			});
@@ -214,10 +214,11 @@ describe('Product | Composite Product Entities Reducer', () => {
 			});
 
 			it(`should set the default option to null when the item is required
-					and the first option is out of stock`, () => {
+					and all options are out of stock`, () => {
 				compositeProduct.items[0].options[0].is_default = false;
 				compositeProduct.items[0].options[1].is_default = false;
 				compositeProduct.items[0].options[0].stock_status = DaffProductStockEnum.OutOfStock;
+				compositeProduct.items[0].options[1].stock_status = DaffProductStockEnum.OutOfStock;
 				compositeProduct.items[0].required = true;
 				const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
 				result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -69,13 +69,11 @@ function buildCompositeProductAppliedOptionsEntity(product: DaffCompositeProduct
 
 /**
  * Sets the default item option to the specified default option unless that option is out of stock.
- * Sets the default item option to the first option if the specified default option is out of stock.
- * Does not set a default option if both the specified default option and the first option are out of stock.
- * Sets the default item option to the first option if no default option is specified, the first option
- * 	is in stock, and the item is required.
+ * Sets the default item option to the first in stock option if the specified default option is out of stock and
+ * 	the item is required.
+ * Does not set a default option if no options are in stock.
+ * Sets the default item option to the first in stock option if no default option is specified and the item is required.
  * Does not set a default option if a default is not specified and not required.
- * Does not set a default option if a default is not specified, is required, but has a first option that is 
- * 	out of stock.
  * @param item a DaffCompositeProductItem
  */
 function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductEntityItem {

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -87,12 +87,16 @@ function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductE
 			qty: 1
 		}
 	} else {
-		return item.required && isOptionInStock(item.options[0]) ? 
-			{ value: item.options[0].id, qty: 1 } :
+		return item.required && getFirstInStockOptionIndex(item) > -1 ? 
+			{ value: item.options[getFirstInStockOptionIndex(item)].id, qty: 1 } :
 			{ value: null, qty: null }
 	}
 }
 
 function isOptionInStock(option: DaffCompositeProductItemOption): boolean {
 	return option.stock_status === DaffProductStockEnum.InStock;
+}
+
+function getFirstInStockOptionIndex(item: DaffCompositeProductItem): number {
+	return item.options.findIndex(option => option.stock_status === DaffProductStockEnum.InStock);
 }

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -85,8 +85,9 @@ function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductE
 			qty: 1
 		}
 	} else {
-		return item.required && getFirstInStockOptionIndex(item) > -1 ? 
-			{ value: item.options[getFirstInStockOptionIndex(item)].id, qty: 1 } :
+		const firstInStockOptionIndex = getFirstInStockOptionIndex(item);
+		return item.required && firstInStockOptionIndex > -1 ? 
+			{ value: item.options[firstInStockOptionIndex].id, qty: 1 } :
 			{ value: null, qty: null }
 	}
 }

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -85,7 +85,7 @@ function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductE
 			qty: 1
 		}
 	} else {
-		const firstInStockOptionIndex = getFirstInStockOptionIndex(item);
+		const firstInStockOptionIndex = item.options.findIndex(option => option.stock_status === DaffProductStockEnum.InStock);
 		return item.required && firstInStockOptionIndex > -1 ? 
 			{ value: item.options[firstInStockOptionIndex].id, qty: 1 } :
 			{ value: null, qty: null }
@@ -94,8 +94,4 @@ function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductE
 
 function isOptionInStock(option: DaffCompositeProductItemOption): boolean {
 	return option.stock_status === DaffProductStockEnum.InStock;
-}
-
-function getFirstInStockOptionIndex(item: DaffCompositeProductItem): number {
-	return item.options.findIndex(option => option.stock_status === DaffProductStockEnum.InStock);
 }


### PR DESCRIPTION
…any are in stock

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The default option will be set to the first option if it is in stock, but will set it to null otherwise.

## What is the new behavior?
A default option will be set on any required composite product item if any of the options are in stock.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```