### PR TITLE
feat(cart): make cart totals individually selectable

### DIFF
--- a/libs/cart/src/drivers/magento/models/outputs/cart.ts
+++ b/libs/cart/src/drivers/magento/models/outputs/cart.ts
@@ -22,6 +22,14 @@ export interface MagentoCart {
     grand_total: MagentoMoney,
     subtotal_excluding_tax: MagentoMoney,
     subtotal_including_tax: MagentoMoney,
-    subtotal_with_discount_excluding_tax: MagentoMoney,
+		subtotal_with_discount_excluding_tax: MagentoMoney,
+		applied_taxes: {
+			amount: MagentoMoney,
+			label: string
+		}[],
+		discounts: {
+			amount: MagentoMoney,
+			label: string
+		}[]
   }
 }

--- a/libs/cart/src/drivers/magento/queries/fragments/prices.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/prices.ts
@@ -15,6 +15,18 @@ export const pricesFragment = gql`
 		subtotal_with_discount_excluding_tax {
 			...money
 		}
+		applied_taxes {
+			amount {
+				...money
+			}
+			label
+		}
+		discounts {
+			amount {
+				...money
+			}
+			label
+		}
 	}
   ${moneyFragment}
 `;

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-coupon-response.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-coupon-response.service.ts
@@ -4,6 +4,7 @@ import { MagentoCart } from '../../models/outputs/cart';
 import { DaffCart } from '../../../../models/cart';
 import { daffMagentoCouponTransform } from './cart-coupon';
 import { transformMagentoCartItem } from './cart-item/cart-item-transformer';
+import { transformCartTotals } from './cart-totals-transformer';
 
 /**
  * Transforms magento carts into an object usable by daffodil.
@@ -29,33 +30,6 @@ export class DaffMagentoCartCouponResponseTransformer {
     }
   }
 
-  private transformTotalsList(cart: Partial<MagentoCart>): {totals: DaffCart['totals']} {
-    return {
-      totals: [
-        {
-          name: 'grand_total',
-          label: 'Grand Total',
-          value: cart.prices.grand_total.value
-        },
-        {
-          name: 'subtotal_excluding_tax',
-          label: 'Subtotal Excluding Tax',
-          value: cart.prices.subtotal_excluding_tax.value
-        },
-        {
-          name: 'subtotal_including_tax',
-          label: 'Subtotal Including Tax',
-          value: cart.prices.subtotal_including_tax.value
-        },
-        {
-          name: 'subtotal_with_discount_excluding_tax',
-          label: 'Subtotal with Discount Excluding Tax',
-          value: cart.prices.subtotal_with_discount_excluding_tax.value
-        },
-      ],
-    }
-  }
-
   private transformCoupons(cart: Partial<MagentoCart>): {coupons: DaffCart['coupons']} {
     return {
       coupons: cart.applied_coupons
@@ -73,7 +47,7 @@ export class DaffMagentoCartCouponResponseTransformer {
       ...this.transformCartItems(cart),
       ...this.transformCoupons(cart),
       ...this.transformTotals(cart),
-      ...this.transformTotalsList(cart),
+      ...transformCartTotals(cart),
 
       id: cart.id
     } : null

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.spec.ts
@@ -1,0 +1,62 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoCart, DaffCart, DaffCartTotalTypeEnum } from '@daffodil/cart';
+import { MagentoCartFactory } from '@daffodil/cart/testing';
+import { daffAdd } from '@daffodil/core';
+
+import { transformCartTotals } from './cart-totals-transformer';
+
+describe('transformCartTotals', () => {
+	let stubMagentoCart: MagentoCart;
+	let expectedTotals: {totals: DaffCart['totals']};
+
+	beforeEach(() => {
+    TestBed.configureTestingModule({});
+
+		stubMagentoCart = new MagentoCartFactory().create();
+		const totalTax = stubMagentoCart.prices.applied_taxes.reduce((acc, tax) => (daffAdd(acc, tax.amount.value)), 0);
+		expectedTotals = {
+			totals: [
+				{
+					name: DaffCartTotalTypeEnum.grandTotal,
+					label: 'Grand Total',
+					value: stubMagentoCart.prices.grand_total.value
+				},
+				{
+					name: DaffCartTotalTypeEnum.subtotalExcludingTax,
+					label: 'Subtotal Excluding Tax',
+					value: stubMagentoCart.prices.subtotal_excluding_tax.value
+				},
+				{
+					name: DaffCartTotalTypeEnum.subtotalIncludingTax,
+					label: 'Subtotal Including Tax',
+					value: stubMagentoCart.prices.subtotal_including_tax.value
+				},
+				{
+					name: DaffCartTotalTypeEnum.subtotalWithDiscountExcludingTax,
+					label: 'Subtotal with Discount Excluding Tax',
+					value: stubMagentoCart.prices.subtotal_with_discount_excluding_tax.value
+				},
+				{
+					name: DaffCartTotalTypeEnum.subtotalWithDiscountIncludingTax,
+					label: 'Subtotal with Discount Including Tax',
+					value: daffAdd(stubMagentoCart.prices.subtotal_with_discount_excluding_tax.value, totalTax)
+				},
+				{
+					name: DaffCartTotalTypeEnum.tax,
+					label: 'Tax',
+					value: totalTax
+				},
+				{
+					name: DaffCartTotalTypeEnum.discount,
+					label: 'Discount',
+					value: stubMagentoCart.prices.discounts.reduce((acc, discount) => (daffAdd(acc, discount.amount.value)), 0)
+				}
+			]
+		};
+  });
+		
+	it('should transform cart totals', () => {
+		expect(transformCartTotals(stubMagentoCart)).toEqual(expectedTotals);
+	});
+});

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.ts
@@ -5,7 +5,7 @@ import { DaffCart } from '../../../../models/cart';
 import { DaffCartTotalTypeEnum } from '../../../../models/cart-total';
 
 export function transformCartTotals(cart: Partial<MagentoCart>): {totals: DaffCart['totals']} {
-	const totalTax = cart.prices.applied_taxes.reduce((acc, tax) => (daffAdd(acc, tax.amount.value)), 0);
+	const totalTax = cart.prices.applied_taxes ? cart.prices.applied_taxes.reduce((acc, tax) => (daffAdd(acc, tax.amount.value)), 0) : 0;
 	return {
 		totals: [
 			{
@@ -41,7 +41,7 @@ export function transformCartTotals(cart: Partial<MagentoCart>): {totals: DaffCa
 			{
 				name: DaffCartTotalTypeEnum.discount,
 				label: 'Discount',
-				value: cart.prices.discounts.reduce((acc, discount) => (daffAdd(acc, discount.amount.value)), 0)
+				value: cart.prices.discounts ? cart.prices.discounts.reduce((acc, discount) => (daffAdd(acc, discount.amount.value)), 0) : 0
 			}
 		],
 	}

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.ts
@@ -1,0 +1,48 @@
+import { daffAdd } from '@daffodil/core';
+
+import { MagentoCart } from '../../models/outputs/cart';
+import { DaffCart } from '../../../../models/cart';
+import { DaffCartTotalTypeEnum } from '../../../../models/cart-total';
+
+export function transformCartTotals(cart: Partial<MagentoCart>): {totals: DaffCart['totals']} {
+	const totalTax = cart.prices.applied_taxes.reduce((acc, tax) => (daffAdd(acc, tax.amount.value)), 0);
+	return {
+		totals: [
+			{
+				name: DaffCartTotalTypeEnum.grandTotal,
+				label: 'Grand Total',
+				value: cart.prices.grand_total.value
+			},
+			{
+				name: DaffCartTotalTypeEnum.subtotalExcludingTax,
+				label: 'Subtotal Excluding Tax',
+				value: cart.prices.subtotal_excluding_tax.value
+			},
+			{
+				name: DaffCartTotalTypeEnum.subtotalIncludingTax,
+				label: 'Subtotal Including Tax',
+				value: cart.prices.subtotal_including_tax.value
+			},
+			{
+				name: DaffCartTotalTypeEnum.subtotalWithDiscountExcludingTax,
+				label: 'Subtotal with Discount Excluding Tax',
+				value: cart.prices.subtotal_with_discount_excluding_tax.value
+			},
+			{
+				name: DaffCartTotalTypeEnum.subtotalWithDiscountIncludingTax,
+				label: 'Subtotal with Discount Including Tax',
+				value: daffAdd(cart.prices.subtotal_with_discount_excluding_tax.value, totalTax)
+			},
+			{
+				name: DaffCartTotalTypeEnum.tax,
+				label: 'Tax',
+				value: totalTax
+			},
+			{
+				name: DaffCartTotalTypeEnum.discount,
+				label: 'Discount',
+				value: cart.prices.discounts.reduce((acc, discount) => (daffAdd(acc, discount.amount.value)), 0)
+			}
+		],
+	}
+}

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart.service.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart.service.ts
@@ -10,6 +10,7 @@ import { DaffMagentoCartShippingRateTransformer } from './cart-shipping-rate.ser
 import { daffMagentoCouponTransform } from './cart-coupon';
 import { transformMagentoCartItem } from './cart-item/cart-item-transformer';
 import { MagentoCartShippingMethod } from '../../models/outputs/public_api';
+import { transformCartTotals } from './cart-totals-transformer';
 
 /**
  * Transforms magento carts into an object usable by daffodil.
@@ -61,33 +62,6 @@ export class DaffMagentoCartTransformer {
     return {
       grand_total: cart.prices.grand_total.value,
       subtotal: cart.prices.subtotal_excluding_tax.value,
-    }
-  }
-
-  private transformTotalsList(cart: MagentoCart): {totals: DaffCart['totals']} {
-    return {
-      totals: [
-        {
-          name: 'grand_total',
-          label: 'Grand Total',
-          value: cart.prices.grand_total.value
-        },
-        {
-          name: 'subtotal_excluding_tax',
-          label: 'Subtotal Excluding Tax',
-          value: cart.prices.subtotal_excluding_tax.value
-        },
-        {
-          name: 'subtotal_including_tax',
-          label: 'Subtotal Including Tax',
-          value: cart.prices.subtotal_including_tax.value
-        },
-        {
-          name: 'subtotal_with_discount_excluding_tax',
-          label: 'Subtotal with Discount Excluding Tax',
-          value: cart.prices.subtotal_with_discount_excluding_tax.value
-        },
-      ],
     }
   }
 
@@ -165,7 +139,7 @@ export class DaffMagentoCartTransformer {
       ...this.transformCoupons(cart),
       ...this.transformPayment(cart),
       ...this.transformTotals(cart),
-      ...this.transformTotalsList(cart),
+      ...transformCartTotals(cart),
       ...this.transformShippingInformation(cart),
       ...this.transformShippingMethods(cart),
       ...this.transformPaymentMethods(cart),

--- a/libs/cart/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/src/facades/cart/cart.facade.spec.ts
@@ -26,7 +26,8 @@ import {
   DaffCartPlaceOrder,
   DaffCartPlaceOrderFailure,
   DaffCartPlaceOrderSuccess,
-  DaffCartCouponListFailure
+  DaffCartCouponListFailure,
+	DaffCartTotalTypeEnum
 } from '@daffodil/cart';
 import {
   DaffCartFactory,
@@ -311,7 +312,7 @@ describe('DaffCartFacade', () => {
 
     it('should be the cart subtotal upon a successful cart load', () => {
       const cart = cartFactory.create();
-      const expected = cold('a', { a: cart.subtotal});
+      const expected = cold('a', { a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalExcludingTax).value});
       store.dispatch(new DaffCartLoadSuccess(cart));
       expect(facade.subtotal$).toBeObservable(expected);
     });
@@ -325,9 +326,69 @@ describe('DaffCartFacade', () => {
 
     it('should be the cart grand total upon a successful cart load', () => {
       const cart = cartFactory.create();
-      const expected = cold('a', { a: cart.grand_total});
+      const expected = cold('a', { a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.grandTotal).value});
       store.dispatch(new DaffCartLoadSuccess(cart));
       expect(facade.grandTotal$).toBeObservable(expected);
+    });
+  });
+
+  describe('subtotalExcludingTax$', () => {
+
+    it('should be the cart grand total upon a successful cart load', () => {
+      const cart = cartFactory.create();
+      const expected = cold('a', { a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalExcludingTax).value});
+      store.dispatch(new DaffCartLoadSuccess(cart));
+      expect(facade.subtotalExcludingTax$).toBeObservable(expected);
+    });
+  });
+
+  describe('subtotalIncludingTax$', () => {
+
+    it('should be the cart grand total upon a successful cart load', () => {
+      const cart = cartFactory.create();
+      const expected = cold('a', { a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalIncludingTax).value});
+      store.dispatch(new DaffCartLoadSuccess(cart));
+      expect(facade.subtotalIncludingTax$).toBeObservable(expected);
+    });
+  });
+
+  describe('subtotalWithDiscountExcludingTax$', () => {
+
+    it('should be the cart grand total upon a successful cart load', () => {
+      const cart = cartFactory.create();
+      const expected = cold('a', { a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalWithDiscountExcludingTax).value});
+      store.dispatch(new DaffCartLoadSuccess(cart));
+      expect(facade.subtotalWithDiscountExcludingTax$).toBeObservable(expected);
+    });
+  });
+
+  describe('subtotalWithDiscountIncludingTax$', () => {
+
+    it('should be the cart grand total upon a successful cart load', () => {
+      const cart = cartFactory.create();
+      const expected = cold('a', { a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalWithDiscountIncludingTax).value});
+      store.dispatch(new DaffCartLoadSuccess(cart));
+      expect(facade.subtotalWithDiscountIncludingTax$).toBeObservable(expected);
+    });
+  });
+
+  describe('totalDiscount$', () => {
+
+    it('should be the cart grand total upon a successful cart load', () => {
+      const cart = cartFactory.create();
+      const expected = cold('a', { a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.discount).value});
+      store.dispatch(new DaffCartLoadSuccess(cart));
+      expect(facade.totalDiscount$).toBeObservable(expected);
+    });
+  });
+
+  describe('totalTax$', () => {
+
+    it('should be the cart grand total upon a successful cart load', () => {
+      const cart = cartFactory.create();
+      const expected = cold('a', { a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.tax).value});
+      store.dispatch(new DaffCartLoadSuccess(cart));
+      expect(facade.totalTax$).toBeObservable(expected);
     });
   });
 

--- a/libs/cart/src/facades/cart/cart.facade.ts
+++ b/libs/cart/src/facades/cart/cart.facade.ts
@@ -13,6 +13,7 @@ import { DaffCartOrderResult } from '../../models/cart-order-result';
 import { DaffCartItem } from '../../models/cart-item';
 import { DaffConfigurableCartItemAttribute } from '../../models/configurable-cart-item';
 import { DaffCompositeCartItemOption } from '../../models/composite-cart-item';
+import { DaffCartTotal } from '../../models/cart-total';
 
 @Injectable({
   providedIn: 'root'
@@ -38,8 +39,14 @@ export class DaffCartFacade<
   couponErrors$: Observable<DaffCartErrors[DaffCartErrorType.Coupon]>;
 
   id$: Observable<DaffCart['id']>;
-  subtotal$: Observable<DaffCart['subtotal']>;
-  grandTotal$: Observable<DaffCart['grand_total']>;
+  subtotal$: Observable<DaffCartTotal['value']>;
+  grandTotal$: Observable<DaffCartTotal['value']>;
+  subtotalExcludingTax$: Observable<DaffCartTotal['value']>;
+  subtotalIncludingTax$: Observable<DaffCartTotal['value']>;
+  subtotalWithDiscountExcludingTax$: Observable<DaffCartTotal['value']>;
+  subtotalWithDiscountIncludingTax$: Observable<DaffCartTotal['value']>;
+  totalDiscount$: Observable<DaffCartTotal['value']>;
+  totalTax$: Observable<DaffCartTotal['value']>;
   coupons$: Observable<DaffCart['coupons']>;
   items$: Observable<DaffCart['items']>;
   itemDictionary$: Observable<Dictionary<U>>;
@@ -91,6 +98,12 @@ export class DaffCartFacade<
 			selectCartId,
 			selectCartSubtotal,
 			selectCartGrandTotal,
+			selectCartSubtotalExcludingTax,
+			selectCartSubtotalIncludingTax,
+			selectCartSubtotalWithDiscountExcludingTax,
+			selectCartSubtotalWithDiscountIncludingTax,
+			selectCartTotalDiscount,
+			selectCartTotalTax,
 			selectCartCoupons,
 			selectCartItems,
 			selectCartItemEntities,
@@ -144,6 +157,12 @@ export class DaffCartFacade<
     this.id$ = this.store.pipe(select(selectCartId));
     this.subtotal$ = this.store.pipe(select(selectCartSubtotal));
     this.grandTotal$ = this.store.pipe(select(selectCartGrandTotal));
+    this.subtotalExcludingTax$ = this.store.pipe(select(selectCartSubtotalExcludingTax));
+    this.subtotalIncludingTax$ = this.store.pipe(select(selectCartSubtotalIncludingTax));
+    this.subtotalWithDiscountExcludingTax$ = this.store.pipe(select(selectCartSubtotalWithDiscountExcludingTax));
+    this.subtotalWithDiscountIncludingTax$ = this.store.pipe(select(selectCartSubtotalWithDiscountIncludingTax));
+    this.totalDiscount$ = this.store.pipe(select(selectCartTotalDiscount));
+    this.totalTax$ = this.store.pipe(select(selectCartTotalTax));
     this.coupons$ = this.store.pipe(select(selectCartCoupons));
     this.items$ = this.store.pipe(select(selectCartItems));
     this.itemDictionary$ = this.store.pipe(select(selectCartItemEntities));

--- a/libs/cart/src/index.ts
+++ b/libs/cart/src/index.ts
@@ -1,4 +1,4 @@
-export { DaffCart } from './models/cart';
+export * from './models/cart';
 export * from './models/cart-item';
 export * from './models/composite-cart-item';
 export * from './models/configurable-cart-item';
@@ -7,7 +7,7 @@ export { DaffCartAddress } from './models/cart-address';
 export { DaffCartPaymentMethod } from './models/cart-payment';
 export { DaffCartShippingRate } from './models/cart-shipping-rate';
 export { DaffCartShippingInformation } from './models/cart-shipping-info';
-export { DaffCartTotal } from './models/cart-total';
+export * from './models/cart-total';
 export { DaffCartCoupon } from './models/cart-coupon';
 export { DaffCartOrderResult } from './models/cart-order-result';
 

--- a/libs/cart/src/models/cart-total.ts
+++ b/libs/cart/src/models/cart-total.ts
@@ -1,5 +1,15 @@
+export enum DaffCartTotalTypeEnum {
+	grandTotal = 'grand_total',
+	subtotalExcludingTax = 'subtotal_excluding_tax',
+	subtotalIncludingTax = 'subtotal_including_tax',
+	subtotalWithDiscountExcludingTax = 'subtotal_with_discount_excluding_tax',
+	subtotalWithDiscountIncludingTax = 'subtotal_with_discount_including_tax',
+	discount = 'discount',
+	tax = 'tax'
+}
+
 export interface DaffCartTotal {
   value: number;
   label: string;
-  name: string;
+  name: DaffCartTotalTypeEnum;
 }

--- a/libs/cart/src/models/cart.ts
+++ b/libs/cart/src/models/cart.ts
@@ -7,8 +7,14 @@ import { DaffCartTotal } from './cart-total';
 import { DaffCartShippingRate } from './cart-shipping-rate';
 
 export interface DaffCart {
-  id: number | string;
-  subtotal: number;
+	id: number | string;
+	/**
+	 * @deprecated use totals instead
+	 */
+	subtotal: number;
+	/**
+	 * @deprecated use totals instead
+	 */
   grand_total: number;
   coupons: DaffCartCoupon[];
   items?: DaffCartItem[];

--- a/libs/cart/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/src/selectors/cart/cart.selector.spec.ts
@@ -6,7 +6,8 @@ import {
   DaffCart,
   DaffCartLoadSuccess,
   DaffCartPlaceOrderSuccess,
-  DaffResolveCartSuccess
+  DaffResolveCartSuccess,
+	DaffCartTotalTypeEnum
 } from '@daffodil/cart';
 import {
   DaffCartFactory,
@@ -53,6 +54,12 @@ describe('Cart | Selector | Cart', () => {
 		selectCartId,
 		selectCartSubtotal,
 		selectCartGrandTotal,
+		selectCartSubtotalExcludingTax,
+		selectCartSubtotalIncludingTax,
+		selectCartSubtotalWithDiscountExcludingTax,
+		selectCartSubtotalWithDiscountIncludingTax,
+		selectCartTotalTax,
+		selectCartTotalDiscount,
 		selectCartCoupons,
 		selectCartItems,
 		selectCartBillingAddress,
@@ -256,7 +263,7 @@ describe('Cart | Selector | Cart', () => {
   describe('selectCartSubtotal', () => {
     it('returns cart subtotal', () => {
       const selector = store.pipe(select(selectCartSubtotal));
-      const expected = cold('a', {a: cart.subtotal});
+      const expected = cold('a', {a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalExcludingTax).value});
 
       expect(selector).toBeObservable(expected);
     });
@@ -265,7 +272,61 @@ describe('Cart | Selector | Cart', () => {
   describe('selectCartGrandTotal', () => {
     it('returns cart grand total', () => {
       const selector = store.pipe(select(selectCartGrandTotal));
-      const expected = cold('a', {a: cart.grand_total});
+      const expected = cold('a', {a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.grandTotal).value});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartSubtotalExcludingTax', () => {
+    it('returns cart subtotal excluding tax', () => {
+      const selector = store.pipe(select(selectCartSubtotalExcludingTax));
+      const expected = cold('a', {a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalExcludingTax).value});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartSubtotalIncludingTax', () => {
+    it('returns cart subtotal including tax', () => {
+      const selector = store.pipe(select(selectCartSubtotalIncludingTax));
+      const expected = cold('a', {a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalIncludingTax).value});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartSubtotalWithDiscountExcludingTax', () => {
+    it('returns cart subtotal with discount excluding tax', () => {
+      const selector = store.pipe(select(selectCartSubtotalWithDiscountExcludingTax));
+      const expected = cold('a', {a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalWithDiscountExcludingTax).value});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartSubtotalWithDiscountIncludingTax', () => {
+    it('returns cart subtotal with discount including tax', () => {
+      const selector = store.pipe(select(selectCartSubtotalWithDiscountIncludingTax));
+      const expected = cold('a', {a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalWithDiscountIncludingTax).value});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartTotalTax', () => {
+    it('returns cart total tax', () => {
+      const selector = store.pipe(select(selectCartTotalTax));
+      const expected = cold('a', {a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.tax).value});
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartTotalDiscount', () => {
+    it('returns cart total discount', () => {
+      const selector = store.pipe(select(selectCartTotalDiscount));
+      const expected = cold('a', {a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.discount).value});
 
       expect(selector).toBeObservable(expected);
     });

--- a/libs/cart/src/selectors/cart/cart.selector.ts
+++ b/libs/cart/src/selectors/cart/cart.selector.ts
@@ -13,6 +13,7 @@ import { DaffCart } from '../../models/cart';
 import { DaffCartReducerState, DaffCartReducersState, DaffCartErrorType } from '../../reducers/public_api';
 import { DaffCartOrderResult } from '../../models/cart-order-result';
 import { DaffCartItem } from '../../models/cart-item';
+import { DaffCartTotalTypeEnum, DaffCartTotal } from '../../models/cart-total';
 
 export interface DaffCartStateMemoizedSelectors<
   T extends DaffCart = DaffCart
@@ -34,8 +35,14 @@ export interface DaffCartStateMemoizedSelectors<
 
 	selectItemErrors: MemoizedSelector<object, string[]>;
 	selectCartId: MemoizedSelector<object, T['id']>;
-	selectCartSubtotal: MemoizedSelector<object, T['subtotal']>;
-	selectCartGrandTotal: MemoizedSelector<object, T['grand_total']>;
+	selectCartSubtotal: MemoizedSelector<object, DaffCartTotal['value']>;
+	selectCartGrandTotal: MemoizedSelector<object, DaffCartTotal['value']>;
+	selectCartSubtotalExcludingTax: MemoizedSelector<object, DaffCartTotal['value']>;
+	selectCartSubtotalIncludingTax: MemoizedSelector<object, DaffCartTotal['value']>;
+	selectCartSubtotalWithDiscountExcludingTax: MemoizedSelector<object, DaffCartTotal['value']>;
+	selectCartSubtotalWithDiscountIncludingTax: MemoizedSelector<object, DaffCartTotal['value']>;
+	selectCartTotalTax: MemoizedSelector<object, DaffCartTotal['value']>;
+	selectCartTotalDiscount: MemoizedSelector<object, DaffCartTotal['value']>;
 	selectCartCoupons: MemoizedSelector<object, T['coupons']>;
 	selectCartItems: MemoizedSelector<object, T['items']>;
 	selectCartBillingAddress: MemoizedSelector<object, T['billing_address']>;
@@ -129,13 +136,64 @@ const createCartSelectors = <
 		selectCartValue,
 		(state: DaffCartReducerState<T>['cart']) => state.id
 	);
+	/**
+	 * @deprecated use selectCartSubtotalExcludingTax selector instead.
+	 */
 	const selectCartSubtotal = createSelector(
 		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.subtotal
+		(state: DaffCartReducerState<T>['cart']) => {
+			const subtotalObject = state.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalExcludingTax);
+			return subtotalObject ? subtotalObject.value : null;
+		}
 	);
 	const selectCartGrandTotal = createSelector(
 		selectCartValue,
-		(state: DaffCartReducerState<T>['cart']) => state.grand_total
+		(state: DaffCartReducerState<T>['cart']) => {
+			const grandTotalObject = state.totals.find(total => total.name === DaffCartTotalTypeEnum.grandTotal);
+			return grandTotalObject ? grandTotalObject.value : null;
+		}
+	);
+	const selectCartSubtotalExcludingTax = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => {
+			const subtotalExcludingTaxObject = state.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalExcludingTax);
+			return subtotalExcludingTaxObject ? subtotalExcludingTaxObject.value : null;
+		}
+	);
+	const selectCartSubtotalIncludingTax = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => {
+			const subtotalIncludingTaxObject = state.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalIncludingTax);
+			return subtotalIncludingTaxObject ? subtotalIncludingTaxObject.value : null;
+		}
+	);
+	const selectCartSubtotalWithDiscountExcludingTax = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => {
+			const subtotalWithDiscountExcludingTaxObject = state.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalWithDiscountExcludingTax);
+			return subtotalWithDiscountExcludingTaxObject ? subtotalWithDiscountExcludingTaxObject.value : null;
+		}
+	);
+	const selectCartSubtotalWithDiscountIncludingTax = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => {
+			const subtotalWithDiscountIncludingTaxObject = state.totals.find(total => total.name === DaffCartTotalTypeEnum.subtotalWithDiscountIncludingTax);
+			return subtotalWithDiscountIncludingTaxObject ? subtotalWithDiscountIncludingTaxObject.value : null;
+		}
+	);
+	const selectCartTotalTax = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => {
+			const taxObject = state.totals.find(total => total.name === DaffCartTotalTypeEnum.tax);
+			return taxObject ? taxObject.value : null;
+		}
+	);
+	const selectCartTotalDiscount = createSelector(
+		selectCartValue,
+		(state: DaffCartReducerState<T>['cart']) => {
+			const discountObject = state.totals.find(total => total.name === DaffCartTotalTypeEnum.discount);
+			return discountObject ? discountObject.value : null;
+		}
 	);
 	const selectCartCoupons = createSelector(
 		selectCartValue,
@@ -250,6 +308,12 @@ const createCartSelectors = <
 		selectCartId,
 		selectCartSubtotal,
 		selectCartGrandTotal,
+		selectCartSubtotalExcludingTax,
+		selectCartSubtotalIncludingTax,
+		selectCartSubtotalWithDiscountExcludingTax,
+		selectCartSubtotalWithDiscountIncludingTax,
+		selectCartTotalDiscount,
+		selectCartTotalTax,
 		selectCartCoupons,
 		selectCartItems,
 		selectCartBillingAddress,

--- a/libs/cart/testing/src/factories/cart.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart.factory.spec.ts
@@ -47,7 +47,11 @@ describe('Cart | Testing | Factories | DaffCartFactory', () => {
 
       it('should not have a payment', () => {
         expect(result.payment).toEqual(null);
-      });
+			});
+			
+			it('should have cart totals', () => {
+				expect(result.totals.length).toBeGreaterThan(0);
+			});
     });
   });
 

--- a/libs/cart/testing/src/factories/cart.factory.ts
+++ b/libs/cart/testing/src/factories/cart.factory.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import * as faker from 'faker/locale/en_US';
 
-import { DaffCart } from '@daffodil/cart';
+import { DaffCart, DaffCartTotalTypeEnum } from '@daffodil/cart';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockCart implements DaffCart {
@@ -13,7 +13,43 @@ export class MockCart implements DaffCart {
   billing_address = null;
   shipping_address = null;
   shipping_information = null;
-  totals = [];
+  totals = [
+		{
+			name: DaffCartTotalTypeEnum.grandTotal,
+			value: 1000,
+			label: 'Grand Total'
+		},
+		{
+			name: DaffCartTotalTypeEnum.subtotalExcludingTax,
+			value: 900,
+			label: 'Subtotal Excluding Tax'
+		},
+		{
+			name: DaffCartTotalTypeEnum.subtotalIncludingTax,
+			value: 950,
+			label: 'Subtotal Including Tax'
+		},
+		{
+			name: DaffCartTotalTypeEnum.subtotalWithDiscountExcludingTax,
+			value: 850,
+			label: ''
+		},
+		{
+			name: DaffCartTotalTypeEnum.subtotalWithDiscountIncludingTax,
+			value: 900,
+			label: ''
+		},
+		{
+			name: DaffCartTotalTypeEnum.tax,
+			value: 50,
+			label: ''
+		},
+		{
+			name: DaffCartTotalTypeEnum.discount,
+			value: 50,
+			label: ''
+		}
+	];
   payment = null;
   available_shipping_methods = [];
   available_payment_methods = [];

--- a/libs/cart/testing/src/factories/magento/cart.factory.spec.ts
+++ b/libs/cart/testing/src/factories/magento/cart.factory.spec.ts
@@ -37,6 +37,8 @@ describe('Cart | Testing | Factories | CartFactory', () => {
       expect(result.prices.grand_total).toBeDefined();
       expect(result.prices.subtotal_including_tax).toBeDefined();
       expect(result.prices.subtotal_with_discount_excluding_tax).toBeDefined();
+      expect(result.prices.applied_taxes).toBeDefined();
+      expect(result.prices.discounts).toBeDefined();
       expect(result.email).toBeDefined();
     });
   });

--- a/libs/cart/testing/src/factories/magento/cart.factory.ts
+++ b/libs/cart/testing/src/factories/magento/cart.factory.ts
@@ -15,6 +15,16 @@ export class MockMagentoCart implements MagentoCart {
     grand_total: this.money(),
     subtotal_including_tax: this.money(),
     subtotal_with_discount_excluding_tax: this.money(),
+    applied_taxes: [{
+			__typename: 'AppliedTax',
+			amount: this.money(),
+			label: 'tax'
+		}],
+		discounts: [{
+			__typename: 'Discount',
+			amount: this.money(),
+			label: 'discount'
+		}]
   };
   applied_coupons = [];
   items = [];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Cart totals are returned as an array, and it isn't easy to get particular totals. Cart grand total and subtotal are repeated in two places unnecessarily too.

## What is the new behavior?
Selectors for each individual total exist, and the extra references in the cart object are deprecated.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```