### PR TITLE
feat(cart): inject extra cart fragments

### DIFF
--- a/libs/cart/src/drivers/magento/cart-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-address.service.spec.ts
@@ -9,7 +9,8 @@ import { schema } from '@daffodil/driver/magento';
 import {
   DaffCart,
   DaffCartAddress,
-  MagentoShippingAddress
+  MagentoShippingAddress,
+  daffMagentoNoopCartFragment
 } from '@daffodil/cart';
 import {
   MagentoCartFactory,
@@ -32,6 +33,7 @@ import { DaffMagentoCartTransformer } from './transforms/outputs/cart.service';
 import { MagentoCart } from './models/outputs/cart';
 import { DaffMagentoCartAddressInputTransformer } from './transforms/inputs/cart-address.service';
 import { MagentoShippingAddressInput } from './models/inputs/shipping-address';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 describe('Driver | Magento | Cart | CartAddressService', () => {
   let service: DaffMagentoCartAddressService;
@@ -70,6 +72,11 @@ describe('Driver | Magento | Cart | CartAddressService', () => {
         {
           provide: DaffMagentoCartAddressInputTransformer,
           useValue: jasmine.createSpyObj('DaffMagentoCartAddressInputTransformer', ['transform'])
+        },
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
         },
 				{
 					provide: APOLLO_TESTING_CACHE,
@@ -172,7 +179,7 @@ describe('Driver | Magento | Cart | CartAddressService', () => {
             done();
           });
 
-          const op = controller.expectOne(addTypenameToDocument(updateAddressWithEmail));
+          const op = controller.expectOne(addTypenameToDocument(updateAddressWithEmail([daffMagentoNoopCartFragment])));
 
           op.flush({
             data: mockUpdateAddressWithEmailResponse
@@ -198,7 +205,7 @@ describe('Driver | Magento | Cart | CartAddressService', () => {
             done();
           });
 
-          const op = controller.expectOne(addTypenameToDocument(updateAddress));
+          const op = controller.expectOne(addTypenameToDocument(updateAddress([daffMagentoNoopCartFragment])));
 
           op.flush({
             data: mockUpdateAddressResponse
@@ -217,7 +224,7 @@ describe('Driver | Magento | Cart | CartAddressService', () => {
           })
         ).subscribe();
 
-        const op = controller.expectOne(addTypenameToDocument(updateAddressWithEmail));
+        const op = controller.expectOne(addTypenameToDocument(updateAddressWithEmail([daffMagentoNoopCartFragment])));
 
         op.graphqlErrors([new GraphQLError(
           'Can\'t find a cart with that ID.',

--- a/libs/cart/src/drivers/magento/cart-billing-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-billing-address.service.spec.ts
@@ -8,7 +8,8 @@ import { GraphQLError } from 'graphql';
 import { schema } from '@daffodil/driver/magento';
 import {
   DaffCart,
-  DaffCartAddress
+  DaffCartAddress,
+  daffMagentoNoopCartFragment
 } from '@daffodil/cart';
 import {
   MagentoCartFactory,
@@ -27,6 +28,7 @@ import { DaffMagentoBillingAddressTransformer } from './transforms/outputs/billi
 import { DaffMagentoBillingAddressInputTransformer } from './transforms/inputs/billing-address.service';
 import { MagentoCartAddress } from './models/outputs/cart-address';
 import { MagentoUpdateBillingAddressWithEmailResponse } from './models/responses/public_api';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 describe('Driver | Magento | Cart | CartBillingAddressService', () => {
   let service: DaffMagentoCartBillingAddressService;
@@ -69,6 +71,11 @@ describe('Driver | Magento | Cart | CartBillingAddressService', () => {
         {
           provide: DaffMagentoBillingAddressInputTransformer,
           useValue: jasmine.createSpyObj('DaffMagentoBillingAddressInputTransformer', ['transform'])
+        },
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
         },
 				{
 					provide: APOLLO_TESTING_CACHE,
@@ -145,7 +152,7 @@ describe('Driver | Magento | Cart | CartBillingAddressService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(getBillingAddress));
+      const op = controller.expectOne(addTypenameToDocument(getBillingAddress([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockGetBillingAddressResponse
@@ -158,7 +165,7 @@ describe('Driver | Magento | Cart | CartBillingAddressService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(getBillingAddress));
+      const op = controller.expectOne(addTypenameToDocument(getBillingAddress([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockGetBillingAddressResponse
@@ -176,7 +183,7 @@ describe('Driver | Magento | Cart | CartBillingAddressService', () => {
           done();
         });
 
-        const op = controller.expectOne(addTypenameToDocument(getBillingAddress));
+        const op = controller.expectOne(addTypenameToDocument(getBillingAddress([daffMagentoNoopCartFragment])));
 
         op.flush({
           data: mockGetBillingAddressResponse
@@ -200,7 +207,7 @@ describe('Driver | Magento | Cart | CartBillingAddressService', () => {
           })
         ).subscribe();
 
-        const op = controller.expectOne(addTypenameToDocument(updateBillingAddressWithEmail));
+        const op = controller.expectOne(addTypenameToDocument(updateBillingAddressWithEmail([daffMagentoNoopCartFragment])));
 
         op.graphqlErrors([new GraphQLError(
           'Can\'t find a cart with that ID.',
@@ -232,7 +239,7 @@ describe('Driver | Magento | Cart | CartBillingAddressService', () => {
             done();
           });
 
-          const op = controller.expectOne(addTypenameToDocument(updateBillingAddressWithEmail));
+          const op = controller.expectOne(addTypenameToDocument(updateBillingAddressWithEmail([daffMagentoNoopCartFragment])));
 
           op.flush({
             data: mockUpdateBillingAddressWithEmailResponse
@@ -257,7 +264,7 @@ describe('Driver | Magento | Cart | CartBillingAddressService', () => {
             done();
           });
 
-          const op = controller.expectOne(addTypenameToDocument(updateBillingAddress));
+          const op = controller.expectOne(addTypenameToDocument(updateBillingAddress([daffMagentoNoopCartFragment])));
 
           op.flush({
             data: mockUpdateBillingAddressResponse

--- a/libs/cart/src/drivers/magento/cart-coupon.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-coupon.service.spec.ts
@@ -6,7 +6,8 @@ import { GraphQLError } from 'graphql';
 import {
   DaffCart,
   DaffCartCoupon,
-  MagentoCart
+  MagentoCart,
+  daffMagentoNoopCartFragment
 } from '@daffodil/cart';
 import {
   DaffCartFactory,
@@ -27,6 +28,7 @@ import {
   MagentoListCartCouponsResponse,
   MagentoRemoveAllCouponsResponse
 } from './models/responses/public_api';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 describe('Driver | Magento | Cart | CartCouponService', () => {
   let service: DaffMagentoCartCouponService;
@@ -52,6 +54,11 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
       ],
       providers: [
         DaffMagentoCartCouponService,
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
+        },
       ]
     });
 
@@ -100,7 +107,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
           done();
         });
 
-        const op = controller.expectOne(applyCoupon);
+        const op = controller.expectOne(applyCoupon([daffMagentoNoopCartFragment]));
 
         op.flush({
           data: mockApplyCouponResponse
@@ -119,7 +126,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(applyCoupon);
+          const op = controller.expectOne(applyCoupon([daffMagentoNoopCartFragment]));
 
           op.graphqlErrors([new GraphQLError(
             'Can\'t find a cart with that ID.',
@@ -143,7 +150,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(applyCoupon);
+          const op = controller.expectOne(applyCoupon([daffMagentoNoopCartFragment]));
 
           op.graphqlErrors([new GraphQLError(
             'The required coupon_code argument contains an empty value.',
@@ -175,7 +182,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
           done();
         });
 
-        const op = controller.expectOne(listCartCoupons);
+        const op = controller.expectOne(listCartCoupons([daffMagentoNoopCartFragment]));
 
         op.flush({
           data: mockListCouponsResponse
@@ -194,7 +201,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(listCartCoupons);
+          const op = controller.expectOne(listCartCoupons([daffMagentoNoopCartFragment]));
 
           op.graphqlErrors([new GraphQLError(
             'Can\'t find a cart with that ID.',
@@ -218,7 +225,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(listCartCoupons);
+          const op = controller.expectOne(listCartCoupons([daffMagentoNoopCartFragment]));
 
           op.graphqlErrors([new GraphQLError(
             'The required coupon_code argument contains an empty value.',
@@ -250,7 +257,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
           done();
         });
 
-        const op = controller.expectOne(removeAllCoupons);
+        const op = controller.expectOne(removeAllCoupons([daffMagentoNoopCartFragment]));
 
         op.flush({
           data: mockRemoveAllCouponsResponse
@@ -269,7 +276,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(removeAllCoupons);
+          const op = controller.expectOne(removeAllCoupons([daffMagentoNoopCartFragment]));
 
           op.graphqlErrors([new GraphQLError(
             'Can\'t find a cart with that ID.',
@@ -293,7 +300,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(removeAllCoupons);
+          const op = controller.expectOne(removeAllCoupons([daffMagentoNoopCartFragment]));
 
           op.graphqlErrors([new GraphQLError(
             'The required coupon_code argument contains an empty value.',
@@ -325,7 +332,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
           done();
         });
 
-        const op = controller.expectOne(removeAllCoupons);
+        const op = controller.expectOne(removeAllCoupons([daffMagentoNoopCartFragment]));
 
         op.flush({
           data: mockRemoveAllCouponsResponse
@@ -344,7 +351,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(removeAllCoupons);
+          const op = controller.expectOne(removeAllCoupons([daffMagentoNoopCartFragment]));
 
           op.graphqlErrors([new GraphQLError(
             'Can\'t find a cart with that ID.',
@@ -368,7 +375,7 @@ describe('Driver | Magento | Cart | CartCouponService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(removeAllCoupons);
+          const op = controller.expectOne(removeAllCoupons([daffMagentoNoopCartFragment]));
 
           op.graphqlErrors([new GraphQLError(
             'The required cart_id argument contains an empty value.',

--- a/libs/cart/src/drivers/magento/cart-coupon.service.ts
+++ b/libs/cart/src/drivers/magento/cart-coupon.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { Apollo } from 'apollo-angular';
-
+import { DocumentNode } from 'graphql';
 import { throwError, Observable } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
@@ -20,6 +20,7 @@ import { DaffCartCouponServiceInterface } from '../interfaces/cart-coupon-servic
 import { DaffCartCoupon } from '../../models/cart-coupon';
 import { daffMagentoCouponTransform } from './transforms/outputs/cart-coupon';
 import { DaffMagentoCartCouponResponseTransformer } from './transforms/outputs/cart-coupon-response.service';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 /**
  * A service for making Magento GraphQL queries for carts.
@@ -30,12 +31,13 @@ import { DaffMagentoCartCouponResponseTransformer } from './transforms/outputs/c
 export class DaffMagentoCartCouponService implements DaffCartCouponServiceInterface {
   constructor(
     private apollo: Apollo,
+    @Inject(DaffMagentoExtraCartFragments) public extraCartFragments: DocumentNode[],
     public cartTransformer: DaffMagentoCartCouponResponseTransformer,
   ) {}
 
   apply(cartId: DaffCart['id'], coupon: DaffCartCoupon): Observable<Partial<DaffCart>> {
     return this.apollo.mutate<MagentoApplyCouponResponse>({
-      mutation: applyCoupon,
+      mutation: applyCoupon(this.extraCartFragments),
       variables: {
         cartId,
         couponCode: coupon.code
@@ -48,7 +50,7 @@ export class DaffMagentoCartCouponService implements DaffCartCouponServiceInterf
 
   list(cartId: DaffCart['id']): Observable<DaffCartCoupon[]> {
     return this.apollo.mutate<MagentoListCartCouponsResponse>({
-      mutation: listCartCoupons,
+      mutation: listCartCoupons(this.extraCartFragments),
       variables: {
         cartId
       }
@@ -64,7 +66,7 @@ export class DaffMagentoCartCouponService implements DaffCartCouponServiceInterf
 
   removeAll(cartId: DaffCart['id']): Observable<Partial<DaffCart>> {
     return this.apollo.mutate<MagentoRemoveAllCouponsResponse>({
-      mutation: removeAllCoupons,
+      mutation: removeAllCoupons(this.extraCartFragments),
       variables: {
         cartId
       }

--- a/libs/cart/src/drivers/magento/cart-driver.module.ts
+++ b/libs/cart/src/drivers/magento/cart-driver.module.ts
@@ -49,6 +49,8 @@ import { DaffMagentoBillingAddressInputTransformer } from './transforms/inputs/b
 import { DaffMagentoCartItemUpdateInputTransformer } from './transforms/inputs/cart-item-update.service';
 import { DaffMagentoPaymentMethodInputTransformer } from './transforms/inputs/payment-method.service';
 import { DaffMagentoShippingMethodInputTransformer } from './transforms/inputs/shipping-method.service';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
+import { daffMagentoNoopCartFragment } from './queries/public_api';
 
 @NgModule({
   imports: [
@@ -121,7 +123,13 @@ export class DaffCartMagentoDriverModule {
         DaffMagentoBillingAddressInputTransformer,
         DaffMagentoCartItemUpdateInputTransformer,
         DaffMagentoPaymentMethodInputTransformer,
-        DaffMagentoShippingMethodInputTransformer
+        DaffMagentoShippingMethodInputTransformer,
+
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
+        }
       ]
     };
   }

--- a/libs/cart/src/drivers/magento/cart-item.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-item.service.spec.ts
@@ -9,7 +9,8 @@ import { DaffProduct, DaffConfigurableProduct } from '@daffodil/product';
 import { DaffProductFactory, DaffConfigurableProductFactory } from '@daffodil/product/testing';
 import {
   DaffCart,
-  DaffCartItem
+  DaffCartItem,
+  daffMagentoNoopCartFragment
 } from '@daffodil/cart';
 import {
   MagentoCartFactory,
@@ -42,6 +43,7 @@ import {
 import { MagentoCartItemInput } from './models/inputs/cart-item';
 import { MagentoCartItemUpdateInput } from './models/inputs/cart-item-update';
 import { DaffCartItemInputType, DaffCompositeCartItemInput, DaffSimpleCartItemInput, DaffConfigurableCartItemInput } from '../../models/cart-item-input';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 
 describe('Driver | Magento | Cart | CartItemService', () => {
@@ -93,6 +95,11 @@ describe('Driver | Magento | Cart | CartItemService', () => {
         {
           provide: DaffMagentoCartItemUpdateInputTransformer,
           useValue: jasmine.createSpyObj('DaffMagentoCartItemUpdateInputTransformer', ['transform'])
+        },
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
         },
 				{
 					provide: APOLLO_TESTING_CACHE,
@@ -225,7 +232,7 @@ describe('Driver | Magento | Cart | CartItemService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(listCartItems));
+      const op = controller.expectOne(addTypenameToDocument(listCartItems([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockListCartItemResponse
@@ -261,9 +268,9 @@ describe('Driver | Magento | Cart | CartItemService', () => {
 					expect(result.items[0]).toEqual(jasmine.objectContaining(mockDaffCartItem));
 					done();
 				});
-	
-				const op = controller.expectOne(addTypenameToDocument(addBundleCartItem));
-	
+
+				const op = controller.expectOne(addTypenameToDocument(addBundleCartItem([daffMagentoNoopCartFragment])));
+
 				op.flush({
 					data: mockAddBundleCartItemResponse
 				});
@@ -276,9 +283,9 @@ describe('Driver | Magento | Cart | CartItemService', () => {
 					expect(result.items[0]).toEqual(jasmine.objectContaining(mockDaffCartItem));
 					done();
 				});
-	
-				const op = controller.expectOne(addTypenameToDocument(addSimpleCartItem));
-	
+
+				const op = controller.expectOne(addTypenameToDocument(addSimpleCartItem([daffMagentoNoopCartFragment])));
+
 				op.flush({
 					data: mockAddSimpleCartItemResponse
 				});
@@ -291,9 +298,9 @@ describe('Driver | Magento | Cart | CartItemService', () => {
 					expect(result.items[0]).toEqual(jasmine.objectContaining(mockDaffCartItem));
 					done();
 				});
-	
-				const op = controller.expectOne(addTypenameToDocument(addConfigurableCartItem));
-	
+
+				const op = controller.expectOne(addTypenameToDocument(addConfigurableCartItem([daffMagentoNoopCartFragment])));
+
 				op.flush({
 					data: mockAddConfigurableCartItemResponse
 				});
@@ -322,7 +329,7 @@ describe('Driver | Magento | Cart | CartItemService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(updateCartItem));
+      const op = controller.expectOne(addTypenameToDocument(updateCartItem([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockUpdateCartItemResponse
@@ -348,7 +355,7 @@ describe('Driver | Magento | Cart | CartItemService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(removeCartItem));
+      const op = controller.expectOne(addTypenameToDocument(removeCartItem([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockRemoveCartItemResponse

--- a/libs/cart/src/drivers/magento/cart-payment-methods.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-payment-methods.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { ApolloTestingController, ApolloTestingModule } from 'apollo-angular/testing';
 
 import {
-  DaffCartPaymentMethod
+  DaffCartPaymentMethod, daffMagentoNoopCartFragment
 } from '@daffodil/cart';
 import {
   DaffCartPaymentFactory,
@@ -14,6 +14,7 @@ import { DaffMagentoCartPaymentTransformer } from './transforms/outputs/cart-pay
 import { listPaymentMethods } from './queries/public_api';
 import { MagentoListPaymentMethodsResponse } from './models/responses/public_api';
 import { MagentoCartPaymentMethod } from './models/outputs/cart-payment-method';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 describe('Driver | Magento | Cart | CartPaymentMethodsService', () => {
   let service: DaffMagentoCartPaymentMethodsService;
@@ -39,7 +40,12 @@ describe('Driver | Magento | Cart | CartPaymentMethodsService', () => {
         {
           provide: DaffMagentoCartPaymentTransformer,
           useValue: jasmine.createSpyObj('DaffMagentoCartPaymentTransformer', ['transform'])
-        }
+        },
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
+        },
       ]
     });
 
@@ -62,6 +68,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodsService', () => {
     cartId = '15';
     mockListCartPaymentMethodsResponse = {
       cart: {
+        __typename: 'Cart',
         available_payment_methods: [mockMagentoPaymentMethod]
       }
     };
@@ -87,7 +94,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodsService', () => {
         done();
       });
 
-      const op = controller.expectOne(listPaymentMethods);
+      const op = controller.expectOne(listPaymentMethods([daffMagentoNoopCartFragment]));
 
       op.flush({
         data: mockListCartPaymentMethodsResponse
@@ -100,7 +107,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodsService', () => {
         done();
       });
 
-      const op = controller.expectOne(listPaymentMethods);
+      const op = controller.expectOne(listPaymentMethods([daffMagentoNoopCartFragment]));
 
       op.flush({
         data: mockListCartPaymentMethodsResponse

--- a/libs/cart/src/drivers/magento/cart-payment-methods.service.ts
+++ b/libs/cart/src/drivers/magento/cart-payment-methods.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { Apollo } from 'apollo-angular';
-
+import { DocumentNode } from 'graphql';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -9,6 +9,7 @@ import { DaffCartPaymentMethod } from '../../models/cart-payment';
 import { listPaymentMethods } from './queries/public_api';
 import { DaffMagentoCartPaymentTransformer } from './transforms/outputs/cart-payment.service';
 import { MagentoListPaymentMethodsResponse } from './models/responses/list-payment-methods';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 /**
  * A service for making Magento GraphQL queries for carts.
@@ -19,12 +20,13 @@ import { MagentoListPaymentMethodsResponse } from './models/responses/list-payme
 export class DaffMagentoCartPaymentMethodsService implements DaffCartPaymentMethodsServiceInterface {
   constructor(
     private apollo: Apollo,
+    @Inject(DaffMagentoExtraCartFragments) public extraCartFragments: DocumentNode[],
     public paymentTransformer: DaffMagentoCartPaymentTransformer
   ) {}
 
   list(cartId: string): Observable<DaffCartPaymentMethod[]> {
     return this.apollo.query<MagentoListPaymentMethodsResponse>({
-      query: listPaymentMethods,
+      query: listPaymentMethods(this.extraCartFragments),
       variables: {cartId}
     }).pipe(
       map(result => result.data.cart.available_payment_methods.map(item => this.paymentTransformer.transform(item)))

--- a/libs/cart/src/drivers/magento/cart-payment.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-payment.service.spec.ts
@@ -9,7 +9,8 @@ import { schema } from '@daffodil/driver/magento';
 import {
   DaffCart,
   DaffCartPaymentMethod,
-  DaffCartAddress
+  DaffCartAddress,
+  daffMagentoNoopCartFragment
 } from '@daffodil/cart';
 import {
   MagentoCartFactory,
@@ -44,6 +45,7 @@ import {
   MagentoSetSelectedPaymentMethodWithBillingResponse,
   MagentoSetSelectedPaymentMethodWithBillingAndEmailResponse
 } from './models/responses/public_api';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 describe('Driver | Magento | Cart | CartPaymentMethodService', () => {
   let service: DaffMagentoCartPaymentService;
@@ -101,6 +103,11 @@ describe('Driver | Magento | Cart | CartPaymentMethodService', () => {
         {
           provide: DaffMagentoBillingAddressInputTransformer,
           useValue: jasmine.createSpyObj('DaffMagentoBillingAddressInputTransformer', ['transform'])
+        },
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
         },
         {
 					provide: APOLLO_TESTING_CACHE,
@@ -202,7 +209,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(getSelectedPaymentMethod));
+      const op = controller.expectOne(addTypenameToDocument(getSelectedPaymentMethod([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockGetSelectedPaymentMethodResponse
@@ -215,7 +222,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(getSelectedPaymentMethod));
+      const op = controller.expectOne(addTypenameToDocument(getSelectedPaymentMethod([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockGetSelectedPaymentMethodResponse
@@ -243,7 +250,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(setSelectedPaymentMethod));
+      const op = controller.expectOne(addTypenameToDocument(setSelectedPaymentMethod([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockSetSelectedPaymentMethodResponse
@@ -282,7 +289,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodService', () => {
             done();
           });
 
-          const op = controller.expectOne(addTypenameToDocument(setSelectedPaymentMethodWithBillingAndEmail));
+          const op = controller.expectOne(addTypenameToDocument(setSelectedPaymentMethodWithBillingAndEmail([daffMagentoNoopCartFragment])));
 
           op.flush({
             data: mockSetSelectedPaymentMethodWithBillingAndEmailResponse
@@ -312,7 +319,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodService', () => {
             done();
           });
 
-          const op = controller.expectOne(addTypenameToDocument(setSelectedPaymentMethodWithBilling));
+          const op = controller.expectOne(addTypenameToDocument(setSelectedPaymentMethodWithBilling([daffMagentoNoopCartFragment])));
 
           op.flush({
             data: mockSetSelectedPaymentMethodWithBillingResponse
@@ -331,7 +338,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodService', () => {
           })
         ).subscribe();
 
-        const op = controller.expectOne(addTypenameToDocument(setSelectedPaymentMethodWithBillingAndEmail));
+        const op = controller.expectOne(addTypenameToDocument(setSelectedPaymentMethodWithBillingAndEmail([daffMagentoNoopCartFragment])));
 
         op.graphqlErrors([new GraphQLError(
           'Can\'t find a cart with that ID.',
@@ -362,7 +369,7 @@ describe('Driver | Magento | Cart | CartPaymentMethodService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(setSelectedPaymentMethod));
+      const op = controller.expectOne(addTypenameToDocument(setSelectedPaymentMethod([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockSetSelectedPaymentMethodResponse

--- a/libs/cart/src/drivers/magento/cart-shipping-address.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-address.service.spec.ts
@@ -8,7 +8,8 @@ import { GraphQLError } from 'graphql';
 import { schema } from '@daffodil/driver/magento';
 import {
   DaffCart,
-  DaffCartAddress
+  DaffCartAddress,
+  daffMagentoNoopCartFragment
 } from '@daffodil/cart';
 import {
   MagentoCartFactory,
@@ -22,13 +23,18 @@ import { DaffMagentoCartShippingAddressService } from './cart-shipping-address.s
 import { DaffMagentoCartTransformer } from './transforms/outputs/cart.service';
 import { MagentoCart } from './models/outputs/cart';
 import { MagentoGetShippingAddressResponse } from './models/responses/get-shipping-address';
-import { getShippingAddress, updateShippingAddress, updateShippingAddressWithEmail } from './queries/public_api';
+import {
+  getShippingAddress,
+  updateShippingAddress,
+  updateShippingAddressWithEmail
+} from './queries/public_api';
 import { MagentoUpdateShippingAddressResponse } from './models/responses/update-shipping-address';
 import { DaffMagentoShippingAddressTransformer } from './transforms/outputs/shipping-address.service';
 import { DaffMagentoShippingAddressInputTransformer } from './transforms/inputs/shipping-address.service';
 import { MagentoShippingAddress } from './models/outputs/shipping-address';
 import { MagentoShippingAddressInput } from './models/inputs/shipping-address';
 import { MagentoUpdateShippingAddressWithEmailResponse } from './models/responses/public_api';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 describe('Driver | Magento | Cart | CartShippingAddressService', () => {
   let service: DaffMagentoCartShippingAddressService;
@@ -73,6 +79,11 @@ describe('Driver | Magento | Cart | CartShippingAddressService', () => {
         {
           provide: DaffMagentoShippingAddressInputTransformer,
           useValue: jasmine.createSpyObj('DaffMagentoShippingAddressInputTransformer', ['transform'])
+        },
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
         },
 				{
 					provide: APOLLO_TESTING_CACHE,
@@ -158,7 +169,7 @@ describe('Driver | Magento | Cart | CartShippingAddressService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(getShippingAddress));
+      const op = controller.expectOne(addTypenameToDocument(getShippingAddress([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockGetShippingAddressResponse
@@ -171,7 +182,7 @@ describe('Driver | Magento | Cart | CartShippingAddressService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(getShippingAddress));
+      const op = controller.expectOne(addTypenameToDocument(getShippingAddress([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockGetShippingAddressResponse
@@ -189,7 +200,7 @@ describe('Driver | Magento | Cart | CartShippingAddressService', () => {
           done();
         });
 
-        const op = controller.expectOne(addTypenameToDocument(getShippingAddress));
+        const op = controller.expectOne(addTypenameToDocument(getShippingAddress([daffMagentoNoopCartFragment])));
 
         op.flush({
           data: mockGetShippingAddressResponse
@@ -213,7 +224,7 @@ describe('Driver | Magento | Cart | CartShippingAddressService', () => {
           })
         ).subscribe();
 
-        const op = controller.expectOne(addTypenameToDocument(updateShippingAddressWithEmail));
+        const op = controller.expectOne(addTypenameToDocument(updateShippingAddressWithEmail([daffMagentoNoopCartFragment])));
 
         op.graphqlErrors([new GraphQLError(
           'Can\'t find a cart with that ID.',
@@ -245,7 +256,7 @@ describe('Driver | Magento | Cart | CartShippingAddressService', () => {
             done();
           });
 
-          const op = controller.expectOne(addTypenameToDocument(updateShippingAddressWithEmail));
+          const op = controller.expectOne(addTypenameToDocument(updateShippingAddressWithEmail([daffMagentoNoopCartFragment])));
 
           op.flush({
             data: mockUpdateShippingAddressWithEmailResponse
@@ -270,7 +281,7 @@ describe('Driver | Magento | Cart | CartShippingAddressService', () => {
             done();
           });
 
-          const op = controller.expectOne(addTypenameToDocument(updateShippingAddress));
+          const op = controller.expectOne(addTypenameToDocument(updateShippingAddress([daffMagentoNoopCartFragment])));
 
           op.flush({
             data: mockUpdateShippingAddressResponse

--- a/libs/cart/src/drivers/magento/cart-shipping-address.service.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-address.service.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { Apollo } from 'apollo-angular';
-import { Observable, zip, throwError } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
+import { DocumentNode } from 'graphql';
 
 import { DaffCartShippingAddressServiceInterface } from '../interfaces/cart-shipping-address-service.interface';
 import { DaffCart } from '../../models/cart';
@@ -20,6 +21,7 @@ import {
   MagentoUpdateShippingAddressWithEmailResponse,
 } from './models/responses/public_api';
 import { transformCartMagentoError } from './errors/transform';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 /**
  * A service for making Magento GraphQL queries for a cart's shipping address.
@@ -30,6 +32,7 @@ import { transformCartMagentoError } from './errors/transform';
 export class DaffMagentoCartShippingAddressService implements DaffCartShippingAddressServiceInterface {
   constructor(
     private apollo: Apollo,
+    @Inject(DaffMagentoExtraCartFragments) public extraCartFragments: DocumentNode[],
     public cartTransformer: DaffMagentoCartTransformer,
     public shippingAddressTransformer: DaffMagentoShippingAddressTransformer,
     public shippingAddressInputTransformer: DaffMagentoShippingAddressInputTransformer
@@ -37,7 +40,7 @@ export class DaffMagentoCartShippingAddressService implements DaffCartShippingAd
 
   get(cartId: string): Observable<DaffCartAddress> {
     return this.apollo.query<MagentoGetShippingAddressResponse>({
-      query: getShippingAddress,
+      query: getShippingAddress(this.extraCartFragments),
       variables: {cartId}
     }).pipe(
       map(result => result.data.cart.shipping_addresses[0]
@@ -56,7 +59,7 @@ export class DaffMagentoCartShippingAddressService implements DaffCartShippingAd
 
   private updateAddress(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return this.apollo.mutate<MagentoUpdateShippingAddressResponse>({
-      mutation: updateShippingAddress,
+      mutation: updateShippingAddress(this.extraCartFragments),
       variables: {
         cartId,
         address: this.shippingAddressInputTransformer.transform(address)
@@ -69,7 +72,7 @@ export class DaffMagentoCartShippingAddressService implements DaffCartShippingAd
 
   private updateAddressWithEmail(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return this.apollo.mutate<MagentoUpdateShippingAddressWithEmailResponse>({
-      mutation: updateShippingAddressWithEmail,
+      mutation: updateShippingAddressWithEmail(this.extraCartFragments),
       variables: {
         cartId,
         email: address.email,

--- a/libs/cart/src/drivers/magento/cart-shipping-information.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-information.service.spec.ts
@@ -6,7 +6,8 @@ import { addTypenameToDocument } from 'apollo-utilities';
 import { schema } from '@daffodil/driver/magento';
 import {
   DaffCart,
-  DaffCartShippingInformation
+  DaffCartShippingInformation,
+  daffMagentoNoopCartFragment
 } from '@daffodil/cart';
 import {
   MagentoCartFactory,
@@ -26,6 +27,7 @@ import { getSelectedShippingMethod, setSelectedShippingMethod } from './queries/
 import { DaffMagentoCartShippingRateTransformer } from './transforms/outputs/cart-shipping-rate.service';
 import { DaffMagentoShippingMethodInputTransformer } from './transforms/inputs/shipping-method.service';
 import { MagentoShippingAddress } from './models/outputs/shipping-address';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 interface MagentoCartSelectedShippingMethod extends MagentoCartShippingMethod {
 	__typename: string;
@@ -72,6 +74,11 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
         {
           provide: DaffMagentoShippingMethodInputTransformer,
           useValue: jasmine.createSpyObj('DaffMagentoShippingMethodInputTransformer', ['transform'])
+        },
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
         },
 				{
 					provide: APOLLO_TESTING_CACHE,
@@ -145,7 +152,7 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(getSelectedShippingMethod));
+      const op = controller.expectOne(addTypenameToDocument(getSelectedShippingMethod([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockGetSelectedShippingMethodResponse
@@ -158,7 +165,7 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(getSelectedShippingMethod));
+      const op = controller.expectOne(addTypenameToDocument(getSelectedShippingMethod([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockGetSelectedShippingMethodResponse
@@ -176,7 +183,7 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
           done();
         });
 
-        const op = controller.expectOne(addTypenameToDocument(getSelectedShippingMethod));
+        const op = controller.expectOne(addTypenameToDocument(getSelectedShippingMethod([daffMagentoNoopCartFragment])));
 
         op.flush({
           data: mockGetSelectedShippingMethodResponse
@@ -205,7 +212,7 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(setSelectedShippingMethod));
+      const op = controller.expectOne(addTypenameToDocument(setSelectedShippingMethod([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockSetSelectedShippingMethodResponse
@@ -229,7 +236,7 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(setSelectedShippingMethod));
+      const op = controller.expectOne(addTypenameToDocument(setSelectedShippingMethod([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockSetSelectedShippingMethodResponse

--- a/libs/cart/src/drivers/magento/cart-shipping-methods.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-methods.service.spec.ts
@@ -5,7 +5,7 @@ import { addTypenameToDocument } from 'apollo-utilities';
 
 import { schema } from '@daffodil/driver/magento';
 import {
-  DaffCartShippingRate
+  DaffCartShippingRate, daffMagentoNoopCartFragment
 } from '@daffodil/cart';
 import {
   DaffCartShippingRateFactory,
@@ -17,6 +17,7 @@ import { DaffMagentoCartShippingRateTransformer } from './transforms/outputs/car
 import { listShippingMethods } from './queries/public_api';
 import { MagentoListShippingMethodsResponse } from './models/responses/public_api';
 import { MagentoCartShippingMethod } from './models/outputs/cart-shipping-method';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 interface MagentoCartAvailableShippingMethod extends MagentoCartShippingMethod {
 	__typename: string;
@@ -46,6 +47,11 @@ describe('Driver | Magento | Cart | CartShippingMethodsService', () => {
         {
           provide: DaffMagentoCartShippingRateTransformer,
           useValue: jasmine.createSpyObj('DaffMagentoCartShippingRateTransformer', ['transform'])
+        },
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
         },
 				{
 					provide: APOLLO_TESTING_CACHE,
@@ -109,7 +115,7 @@ describe('Driver | Magento | Cart | CartShippingMethodsService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(listShippingMethods));
+      const op = controller.expectOne(addTypenameToDocument(listShippingMethods([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockListCartShippingMethodsResponse
@@ -123,7 +129,7 @@ describe('Driver | Magento | Cart | CartShippingMethodsService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(listShippingMethods));
+      const op = controller.expectOne(addTypenameToDocument(listShippingMethods([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockListCartShippingMethodsResponse

--- a/libs/cart/src/drivers/magento/cart-shipping-methods.service.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-methods.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { Apollo } from 'apollo-angular';
-
+import { DocumentNode } from 'graphql';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -9,6 +9,7 @@ import { listShippingMethods } from './queries/public_api';
 import { DaffCartShippingRate } from '../../models/cart-shipping-rate';
 import { MagentoListShippingMethodsResponse } from './models/responses/list-shipping-methods';
 import { DaffMagentoCartShippingRateTransformer } from './transforms/outputs/cart-shipping-rate.service';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 /**
  * A service for making Magento GraphQL queries for carts' shipping methods.
@@ -19,12 +20,13 @@ import { DaffMagentoCartShippingRateTransformer } from './transforms/outputs/car
 export class DaffMagentoCartShippingMethodsService implements DaffCartShippingMethodsServiceInterface {
   constructor(
     private apollo: Apollo,
+    @Inject(DaffMagentoExtraCartFragments) public extraCartFragments: DocumentNode[],
     public shippingRateTransformer: DaffMagentoCartShippingRateTransformer
   ) {}
 
   list(cartId: string): Observable<DaffCartShippingRate[]> {
     return this.apollo.query<MagentoListShippingMethodsResponse>({
-      query: listShippingMethods,
+      query: listShippingMethods(this.extraCartFragments),
       variables: {cartId}
     }).pipe(
       map(result => result.data.cart.shipping_addresses[0].available_shipping_methods.map(item =>

--- a/libs/cart/src/drivers/magento/cart.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart.service.spec.ts
@@ -2,7 +2,9 @@ import { TestBed } from '@angular/core/testing';
 import { ApolloTestingController, ApolloTestingModule, APOLLO_TESTING_CACHE } from 'apollo-angular/testing';
 import { of } from 'rxjs';
 import { addTypenameToDocument } from 'apollo-utilities';
+import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory';
 
+import { DaffCart, daffMagentoNoopCartFragment } from '@daffodil/cart';
 import {
   MagentoCartFactory,
   DaffCartFactory,
@@ -13,7 +15,6 @@ import { schema } from '@daffodil/driver/magento';
 
 import { DaffMagentoCartService } from './cart.service';
 import { DaffMagentoCartTransformer } from './transforms/outputs/cart.service';
-import { DaffCart } from '@daffodil/cart';
 import { MagentoCart } from './models/outputs/cart';
 import { MagentoCreateCartResponse } from './models/responses/create-cart';
 import { getCart, createCart } from './queries/public_api';
@@ -21,7 +22,7 @@ import { DaffCartItemDriver } from '../interfaces/cart-item-service.interface';
 import { MagentoGetCartResponse } from './models/responses/get-cart';
 import { MagentoCartItem } from './models/outputs/cart-item';
 import { DaffCartItem } from '../../models/cart-item';
-import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 describe('Driver | Magento | Cart | CartService', () => {
   let service: DaffMagentoCartService;
@@ -57,6 +58,11 @@ describe('Driver | Magento | Cart | CartService', () => {
         {
           provide: DaffCartItemDriver,
           useValue: jasmine.createSpyObj('DaffCartItemDriver', ['delete', 'list'])
+        },
+        {
+          provide: DaffMagentoExtraCartFragments,
+          useValue: daffMagentoNoopCartFragment,
+          multi: true
         },
 				{
 					provide: APOLLO_TESTING_CACHE,
@@ -117,7 +123,7 @@ describe('Driver | Magento | Cart | CartService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(getCart));
+      const op = controller.expectOne(addTypenameToDocument(getCart([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockCartResponse
@@ -130,7 +136,7 @@ describe('Driver | Magento | Cart | CartService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(getCart));
+      const op = controller.expectOne(addTypenameToDocument(getCart([daffMagentoNoopCartFragment])));
 
       op.flush({
         data: mockCartResponse

--- a/libs/cart/src/drivers/magento/cart.service.ts
+++ b/libs/cart/src/drivers/magento/cart.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Inject } from '@angular/core';
 import { Apollo } from 'apollo-angular';
+import { DocumentNode } from 'graphql';
 import { Observable, throwError, forkJoin } from 'rxjs';
 import { map, switchMap, catchError } from 'rxjs/operators';
 
@@ -13,6 +14,7 @@ import { DaffCartItemInput } from '../../models/cart-item-input';
 import { MagentoGetCartResponse } from './models/responses/get-cart';
 import { MagentoCreateCartResponse } from './models/responses/create-cart';
 import { transformCartMagentoError } from './errors/transform';
+import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
 
 /**
  * A service for making Magento GraphQL queries for carts.
@@ -28,12 +30,13 @@ export class DaffMagentoCartService implements DaffCartServiceInterface<DaffCart
       DaffCartItem,
       DaffCartItemInput,
       DaffCart
-    >
+    >,
+    @Inject(DaffMagentoExtraCartFragments) public extraCartFragments: DocumentNode[],
   ) {}
 
   get(cartId: string): Observable<DaffCart> {
     return this.apollo.query<MagentoGetCartResponse>({
-      query: getCart,
+      query: getCart(this.extraCartFragments),
       variables: {cartId}
     }).pipe(
       catchError((error: Error) => throwError(transformCartMagentoError(error))),

--- a/libs/cart/src/drivers/magento/injection-tokens/fragments/cart.ts
+++ b/libs/cart/src/drivers/magento/injection-tokens/fragments/cart.ts
@@ -1,0 +1,11 @@
+import { InjectionToken } from '@angular/core';
+import { DocumentNode } from 'graphql';
+
+/**
+ * An multi-provider injection token for providing extra GraphQL fragments that will be spread into cart queries.
+ * This can be used to retrieve additional data that is not covered by the standard Daffodil interfaces.
+ * The data will appear in DaffCart#extra_attributes.
+ *
+ * Fragment structure is platform-specific and this feature should be used with care.
+ */
+export const DaffMagentoExtraCartFragments = new InjectionToken<DocumentNode>('DaffMagentoExtraCartFragments');

--- a/libs/cart/src/drivers/magento/injection-tokens/public_api.ts
+++ b/libs/cart/src/drivers/magento/injection-tokens/public_api.ts
@@ -1,0 +1,1 @@
+export { DaffMagentoExtraCartFragments } from './fragments/cart';

--- a/libs/cart/src/drivers/magento/models/responses/list-payment-methods.ts
+++ b/libs/cart/src/drivers/magento/models/responses/list-payment-methods.ts
@@ -2,6 +2,7 @@ import { MagentoCartPaymentMethod } from '../outputs/cart-payment-method';
 
 export interface MagentoListPaymentMethodsResponse {
   cart: {
+		__typename: string;
     available_payment_methods: MagentoCartPaymentMethod[];
   };
 }

--- a/libs/cart/src/drivers/magento/public_api.ts
+++ b/libs/cart/src/drivers/magento/public_api.ts
@@ -14,6 +14,7 @@ export { DaffMagentoPaymentMethodInputTransformer } from './transforms/inputs/pa
 export { DaffMagentoShippingMethodInputTransformer } from './transforms/inputs/shipping-method.service';
 
 export * from './models/outputs/public_api';
+export * from './injection-tokens/public_api';
 
 export { DaffMagentoCartService } from './cart.service';
 export { DaffMagentoCartItemService } from './cart-item.service';
@@ -33,3 +34,4 @@ export { MagentoShippingAddressInput } from './models/inputs/shipping-address';
 export { MagentoShippingMethodInput } from './models/inputs/shipping-method';
 
 export { DaffCartMagentoDriverModule } from './cart-driver.module';
+export { daffMagentoNoopCartFragment } from './queries/public_api'

--- a/libs/cart/src/drivers/magento/queries/add-cart-item.ts
+++ b/libs/cart/src/drivers/magento/queries/add-cart-item.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const addSimpleCartItem = gql`
+export const addSimpleCartItem = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation AddSimpleCartItem($cartId: String!, $input: CartItemInput!) {
     addSimpleProductsToCart(input: {
       cart_id: $cartId,
@@ -12,13 +15,15 @@ export const addSimpleCartItem = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;
 
-export const addBundleCartItem = gql`
+export const addBundleCartItem = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation AddBundleCartItem($cartId: String!, $input: CartItemInput!, $options: [BundleOptionInput]!) {
     addBundleProductsToCart(input: {
       cart_id: $cartId,
@@ -29,13 +34,15 @@ export const addBundleCartItem = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;
 
-export const addConfigurableCartItem = gql`
+export const addConfigurableCartItem = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation AddConfigurableCartItem($cartId: String!, $parentSku: String, $data: CartItemInput!) {
     addConfigurableProductsToCart(input: {
       cart_id: $cartId,
@@ -46,8 +53,10 @@ export const addConfigurableCartItem = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/apply-coupon.ts
+++ b/libs/cart/src/drivers/magento/queries/apply-coupon.ts
@@ -1,9 +1,12 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartItemFragment } from './fragments/cart-item';
 import { pricesFragment } from './fragments/prices';
 
-export const applyCoupon = gql`
+export const applyCoupon = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation ApplyCoupon($cartId: String!, $couponCode: String!) {
     applyCouponToCart(
       input: {
@@ -22,9 +25,11 @@ export const applyCoupon = gql`
         prices {
           ...prices
         }
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartItemFragment}
   ${pricesFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/fragments/noop-cart.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/noop-cart.ts
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export const daffMagentoNoopCartFragment = gql`
+  fragment daffMagentoNoopCartFragment on Cart {
+    __typename
+  }
+`;

--- a/libs/cart/src/drivers/magento/queries/fragments/public_api.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/public_api.ts
@@ -8,3 +8,4 @@ export { availableShippingMethodFragment } from './available-shipping-method';
 export { selectedShippingMethodFragment } from './selected-shipping-method';
 export { cartFragment } from './cart';
 export { pricesFragment } from './prices';
+export { daffMagentoNoopCartFragment } from './noop-cart';

--- a/libs/cart/src/drivers/magento/queries/get-billing-address.ts
+++ b/libs/cart/src/drivers/magento/queries/get-billing-address.ts
@@ -1,15 +1,20 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartAddressFragment } from './fragments/public_api';
 
-export const getBillingAddress = gql`
+export const getBillingAddress = (extraCartFragments: DocumentNode[] = []) => gql`
   query GetBillingAddress($cartId: String!) {
     cart(cart_id: $cartId) {
       billing_address {
         ...cartAddress
       }
       email
+      ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }
   }
   ${cartAddressFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/get-cart.ts
+++ b/libs/cart/src/drivers/magento/queries/get-cart.ts
@@ -1,12 +1,17 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const getCart = gql`
+export const getCart = (extraCartFragments: DocumentNode[] = []) => gql`
   query GetCart($cartId: String!) {
     cart(cart_id: $cartId) {
       ...cart
+      ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/get-selected-payment-method.ts
+++ b/libs/cart/src/drivers/magento/queries/get-selected-payment-method.ts
@@ -1,14 +1,19 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { selectedPaymentMethodFragment } from './fragments/public_api';
 
-export const getSelectedPaymentMethod = gql`
+export const getSelectedPaymentMethod = (extraCartFragments: DocumentNode[] = []) => gql`
   query GetSelectedPaymentMethod($cartId: String!) {
     cart(cart_id: $cartId) {
       selected_payment_method {
         ...selectedPaymentMethod
       }
+      ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }
   }
   ${selectedPaymentMethodFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/get-selected-shipping-method.ts
+++ b/libs/cart/src/drivers/magento/queries/get-selected-shipping-method.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { selectedShippingMethodFragment } from './fragments/public_api';
 
-export const getSelectedShippingMethod = gql`
+export const getSelectedShippingMethod = (extraCartFragments: DocumentNode[] = []) => gql`
   query GetSelectedShippingMethod($cartId: String!) {
     cart(cart_id: $cartId) {
       shipping_addresses {
@@ -10,7 +13,9 @@ export const getSelectedShippingMethod = gql`
           ...selectedShippingMethod
         }
       }
+      ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }
   }
   ${selectedShippingMethodFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/get-shipping-address.ts
+++ b/libs/cart/src/drivers/magento/queries/get-shipping-address.ts
@@ -1,15 +1,20 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartAddressFragment } from './fragments/public_api';
 
-export const getShippingAddress = gql`
+export const getShippingAddress = (extraCartFragments: DocumentNode[] = []) => gql`
   query GetShippingAddress($cartId: String!) {
     cart(cart_id: $cartId) {
       shipping_addresses {
         ...cartAddress
       }
       email
+      ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }
   }
   ${cartAddressFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/list-cart-coupons.ts
+++ b/libs/cart/src/drivers/magento/queries/list-cart-coupons.ts
@@ -1,14 +1,19 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartCouponFragment } from './fragments/public_api';
 
-export const listCartCoupons = gql`
+export const listCartCoupons = (extraCartFragments: DocumentNode[] = []) => gql`
   query listCartCoupons($cartId: String!) {
     cart(cart_id: $cartId) {
       applied_coupons {
 				...cartCoupon
 			}
+      ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }
   }
   ${cartCouponFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/list-cart-items.ts
+++ b/libs/cart/src/drivers/magento/queries/list-cart-items.ts
@@ -1,14 +1,19 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartItemFragment } from './fragments/public_api';
 
-export const listCartItems = gql`
+export const listCartItems = (extraCartFragments: DocumentNode[] = []) => gql`
   query ListCartItems($cartId: String!) {
     cart(cart_id: $cartId) {
       items {
         ...cartItem
       }
+      ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }
   }
   ${cartItemFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/list-payment-methods.ts
+++ b/libs/cart/src/drivers/magento/queries/list-payment-methods.ts
@@ -1,14 +1,19 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { availablePaymentMethodFragment } from './fragments/public_api';
 
-export const listPaymentMethods = gql`
+export const listPaymentMethods = (extraCartFragments: DocumentNode[] = []) => gql`
   query ListPaymentMethods($cartId: String!) {
     cart(cart_id: $cartId) {
       available_payment_methods {
         ...availablePaymentMethod
       }
+      ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }
   }
   ${availablePaymentMethodFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/list-shipping-methods.ts
+++ b/libs/cart/src/drivers/magento/queries/list-shipping-methods.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { availableShippingMethodFragment } from './fragments/public_api';
 
-export const listShippingMethods = gql`
+export const listShippingMethods = (extraCartFragments: DocumentNode[] = []) => gql`
   query ListShippingMethods($cartId: String!) {
     cart(cart_id: $cartId) {
       shipping_addresses {
@@ -10,7 +13,9 @@ export const listShippingMethods = gql`
           ...availableShippingMethod
         }
       }
+      ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }
   }
   ${availableShippingMethodFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/remove-all-coupons.ts
+++ b/libs/cart/src/drivers/magento/queries/remove-all-coupons.ts
@@ -1,9 +1,12 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartItemFragment } from './fragments/cart-item';
 import { pricesFragment } from './fragments/prices';
 
-export const removeAllCoupons = gql`
+export const removeAllCoupons = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation RemoveAllCoupons($cartId: String!) {
     removeCouponFromCart(
       input: {
@@ -21,9 +24,11 @@ export const removeAllCoupons = gql`
         prices {
           ...prices
         }
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartItemFragment}
   ${pricesFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/remove-cart-item.ts
+++ b/libs/cart/src/drivers/magento/queries/remove-cart-item.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const removeCartItem = gql`
+export const removeCartItem = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation RemoveCartItem($cartId: String!, $itemId: Int!) {
     removeItemFromCart(input: {
       cart_id: $cartId,
@@ -10,8 +13,10 @@ export const removeCartItem = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/set-guest-email.ts
+++ b/libs/cart/src/drivers/magento/queries/set-guest-email.ts
@@ -1,6 +1,9 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
 
-export const setGuestEmail = gql`
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
+
+export const setGuestEmail = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation SetGuestEmail($cartId: String!, $email: String!) {
     setGuestEmailOnCart(input: {
       cart_id: $cartId,
@@ -8,7 +11,9 @@ export const setGuestEmail = gql`
     }) {
       cart {
         email
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/set-selected-payment-method-with-billing-and-email.ts
+++ b/libs/cart/src/drivers/magento/queries/set-selected-payment-method-with-billing-and-email.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const setSelectedPaymentMethodWithBillingAndEmail = gql`
+export const setSelectedPaymentMethodWithBillingAndEmail = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation SetSelectedPaymentMethodWithBillingAndEmail(
     $cartId: String!,
     $payment: PaymentMethodInput!,
@@ -31,8 +34,10 @@ export const setSelectedPaymentMethodWithBillingAndEmail = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/set-selected-payment-method-with-billing.ts
+++ b/libs/cart/src/drivers/magento/queries/set-selected-payment-method-with-billing.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const setSelectedPaymentMethodWithBilling = gql`
+export const setSelectedPaymentMethodWithBilling = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation SetSelectedPaymentMethodWithBilling(
     $cartId: String!,
     $payment: PaymentMethodInput!,
@@ -22,8 +25,10 @@ export const setSelectedPaymentMethodWithBilling = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/set-selected-payment-method.ts
+++ b/libs/cart/src/drivers/magento/queries/set-selected-payment-method.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const setSelectedPaymentMethod = gql`
+export const setSelectedPaymentMethod = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation SetSelectedPaymentMethod($cartId: String!, $payment: PaymentMethodInput!) {
     setPaymentMethodOnCart(input: {
       cart_id: $cartId
@@ -10,8 +13,10 @@ export const setSelectedPaymentMethod = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/set-selected-shipping-method.ts
+++ b/libs/cart/src/drivers/magento/queries/set-selected-shipping-method.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const setSelectedShippingMethod = gql`
+export const setSelectedShippingMethod = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation SetSelectedShippingMethod($cartId: String!, $method: ShippingMethodInput!) {
     setShippingMethodsOnCart(input: {
       cart_id: $cartId
@@ -10,8 +13,10 @@ export const setSelectedShippingMethod = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/update-address-with-email.ts
+++ b/libs/cart/src/drivers/magento/queries/update-address-with-email.ts
@@ -1,4 +1,7 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
@@ -9,7 +12,7 @@ import { cartFragment } from './fragments/public_api';
  * This helps us keep query complexity down and save some server CPU cycles.
  * Driver behavior is not guaranteed if Magento no longer processes compound queries in the order they are defined.
  */
-export const updateAddressWithEmail = gql`
+export const updateAddressWithEmail = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation UpdateAddress($cartId: String!, $address: CartAddressInput!, $email: String!) {
     setBillingAddressOnCart(input: {
       cart_id: $cartId
@@ -37,8 +40,10 @@ export const updateAddressWithEmail = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/update-address.ts
+++ b/libs/cart/src/drivers/magento/queries/update-address.ts
@@ -1,4 +1,7 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
@@ -9,7 +12,7 @@ import { cartFragment } from './fragments/public_api';
  * This helps us keep query complexity down and save some server CPU cycles.
  * Driver behavior is not guaranteed if Magento no longer processes compound queries in the order they are defined.
  */
-export const updateAddress = gql`
+export const updateAddress = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation UpdateAddress($cartId: String!, $address: CartAddressInput!) {
     setBillingAddressOnCart(input: {
       cart_id: $cartId
@@ -29,8 +32,10 @@ export const updateAddress = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/update-billing-address-with-email.ts
+++ b/libs/cart/src/drivers/magento/queries/update-billing-address-with-email.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const updateBillingAddressWithEmail = gql`
+export const updateBillingAddressWithEmail = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation UpdateBillingAddress(
     $cartId: String!,
     $address: BillingAddressInput!,
@@ -14,6 +17,7 @@ export const updateBillingAddressWithEmail = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
     setGuestEmailOnCart(input: {
@@ -26,4 +30,5 @@ export const updateBillingAddressWithEmail = gql`
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/update-billing-address.ts
+++ b/libs/cart/src/drivers/magento/queries/update-billing-address.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const updateBillingAddress = gql`
+export const updateBillingAddress = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation UpdateBillingAddress(
     $cartId: String!,
     $address: BillingAddressInput!
@@ -13,8 +16,10 @@ export const updateBillingAddress = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/update-cart-item.ts
+++ b/libs/cart/src/drivers/magento/queries/update-cart-item.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const updateCartItem = gql`
+export const updateCartItem = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation UpdateCartItem($cartId: String!, $input: CartItemUpdateInput!) {
     updateCartItems(input: {
       cart_id: $cartId
@@ -10,8 +13,10 @@ export const updateCartItem = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/update-shipping-address-with-email.ts
+++ b/libs/cart/src/drivers/magento/queries/update-shipping-address-with-email.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const updateShippingAddressWithEmail = gql`
+export const updateShippingAddressWithEmail = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation UpdateShippingAddress(
     $cartId: String!,
     $address: ShippingAddressInput!,
@@ -14,6 +17,7 @@ export const updateShippingAddressWithEmail = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
     setGuestEmailOnCart(input: {
@@ -26,4 +30,5 @@ export const updateShippingAddressWithEmail = gql`
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;

--- a/libs/cart/src/drivers/magento/queries/update-shipping-address.ts
+++ b/libs/cart/src/drivers/magento/queries/update-shipping-address.ts
@@ -1,8 +1,11 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core';
 
 import { cartFragment } from './fragments/public_api';
 
-export const updateShippingAddress = gql`
+export const updateShippingAddress = (extraCartFragments: DocumentNode[] = []) => gql`
   mutation UpdateShippingAddress(
     $cartId: String!,
     $address: ShippingAddressInput!
@@ -13,8 +16,10 @@ export const updateShippingAddress = gql`
     }) {
       cart {
         ...cart
+        ${daffBuildFragmentNameSpread(...extraCartFragments)}
       }
     }
   }
   ${cartFragment}
+  ${daffBuildFragmentDefinition(...extraCartFragments)}
 `;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no way to add extra fields to cart responses.


## What is the new behavior?
- Extra fragments can be injected with the `DaffExtraCartFragments` token.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR contains a lot of changes but all of the changes are exactly the same across the respective file types.
- Queries that include the cart response (most of them) have been changed to functions that accept extra fragments and spread them into the queries.
- Cart drivers pass the injected extra fragments to the queries that use them.