### PR TITLE
feat(product): composite product applied options selector returns  a …

### DIFF
--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -4,7 +4,7 @@ import { Dictionary } from '@ngrx/entity';
 
 import { DaffStoreFacade } from '@daffodil/core';
 
-import { DaffCompositeProductEntityItem } from '../../reducers/composite-product-entities/composite-product-entity';
+import { DaffCompositeProductItemOption } from '../../models/composite-product-item';
 
 export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Action> {
 
@@ -76,5 +76,5 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * Returns the applied options for a composite product.
 	 * @param id the id of the composite product.
 	 */
-	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductEntityItem>>;
+	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption>>;
 }

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -130,21 +130,8 @@ describe('DaffCompositeProductFacade', () => {
     it('should return the price of the product', () => {
 			const expected = cold('a', { a: 
 				stubCompositeProduct.price + 
-				stubCompositeProduct.items[0].options[0].price +
-				stubCompositeProduct.items[1].options[0].price 
-			});
-	
-			expect(facade.getPrice(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('getPrice', () => {
-
-    it('should return the price of the product', () => {
-			const expected = cold('a', { a: 
-				stubCompositeProduct.price + 
-				stubCompositeProduct.items[0].options[0].price +
-				stubCompositeProduct.items[1].options[0].price 
+				stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity +
+				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
 			});
 	
 			expect(facade.getPrice(stubCompositeProduct.id)).toBeObservable(expected);
@@ -167,8 +154,8 @@ describe('DaffCompositeProductFacade', () => {
     it('should the discounted price for a composite product', () => {
 			const expected = cold('a', { a: 
 				stubCompositeProduct.price 
-				+ stubCompositeProduct.items[0].options[0].price 
-				+ stubCompositeProduct.items[1].options[0].price 
+				+ stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity
+				+ stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
 				- stubCompositeProduct.discount.amount
 			});
 	
@@ -189,14 +176,8 @@ describe('DaffCompositeProductFacade', () => {
 		
 		it('should return the applied option for a composite product', () => {
 			const expected = cold('a', { a: { 
-				[stubCompositeProduct.items[0].id]: {
-					value: stubCompositeProduct.items[0].options[0].id,
-					qty: 1
-				},
-				[stubCompositeProduct.items[1].id]: {
-					value: stubCompositeProduct.items[1].options[0].id,
-					qty: 1
-				}
+				[stubCompositeProduct.items[0].id]: stubCompositeProduct.items[0].options[0],
+				[stubCompositeProduct.items[1].id]: stubCompositeProduct.items[1].options[0]
 			}});
 
 			expect(facade.getAppliedOptions(stubCompositeProduct.id)).toBeObservable(expected);

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -8,7 +8,7 @@ import { DaffProductReducersState } from '../../reducers/product-reducers-state.
 import { DaffProduct } from '../../models/product';
 import { getDaffProductSelectors } from '../../selectors/public_api';
 import { DaffCompositeProductFacadeInterface } from './composite-product-facade.interface';
-import { DaffCompositeProductEntityItem } from '../../reducers/composite-product-entities/composite-product-entity';
+import { DaffCompositeProductItemOption } from '../../models/composite-product-item';
 
 /**
  * A facade for accessing composite product state from an application component.
@@ -62,7 +62,7 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 		return this.store.pipe(select(this.selectors.selectCompositeProductHasDiscount, { id }));
 	}
 
-	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductEntityItem>> {
+	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption>> {
 		return this.store.pipe(select(this.selectors.selectCompositeProductAppliedOptions, { id }));
 	}
 

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
@@ -99,11 +99,11 @@ describe('Product | Composite Product Entities Reducer', () => {
 				items: { 
 					[compositeProduct.items[0].id]: {
 						value: compositeProduct.items[0].options[0].id,
-						qty: 1
+						qty: compositeProduct.items[0].options[0].quantity
 					},
 					[compositeProduct.items[1].id]: {
 						value: compositeProduct.items[1].options[0].id,
-						qty: 1
+						qty: compositeProduct.items[1].options[0].quantity
 					}
 				} 
 			});
@@ -131,7 +131,7 @@ describe('Product | Composite Product Entities Reducer', () => {
 								...acc,
 								[item.id]: {
 									value: item.options.find(option => option.is_default).id,
-									qty: 1
+									qty: item.options.find(option => option.is_default).quantity
 								}
 							}
 						}, {})
@@ -142,7 +142,8 @@ describe('Product | Composite Product Entities Reducer', () => {
       const compositeProductApplyAttribute = new DaffCompositeProductApplyOption(
 				compositeProduct.id,
 				<string>compositeProduct.items[0].id,
-				compositeProduct.items[0].options[1].id
+				compositeProduct.items[0].options[1].id,
+				compositeProduct.items[0].options[1].quantity
 			);
       
 			result = daffCompositeProductEntitiesReducer(specInitialState, compositeProductApplyAttribute);
@@ -151,7 +152,7 @@ describe('Product | Composite Product Entities Reducer', () => {
     it('changes the option id of the given product item', () => {
       expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({
 				value: compositeProduct.items[0].options[1].id,
-				qty: 1
+				qty: compositeProduct.items[0].options[1].quantity
 			});
     });
 	});
@@ -169,7 +170,7 @@ describe('Product | Composite Product Entities Reducer', () => {
 
 			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({
 				value: compositeProduct.items[0].options[1].id,
-				qty: 1
+				qty: compositeProduct.items[0].options[1].quantity
 			});
 		});
 
@@ -182,7 +183,7 @@ describe('Product | Composite Product Entities Reducer', () => {
 
 			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).not.toEqual({
 				value: compositeProduct.items[0].options[1].id,
-				qty: 1
+				qty: compositeProduct.items[0].options[1].quantity
 			});
 		});
 
@@ -199,7 +200,7 @@ describe('Product | Composite Product Entities Reducer', () => {
 
 				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({
 					value: compositeProduct.items[0].options[1].id,
-					qty: 1
+					qty: compositeProduct.items[0].options[1].quantity
 				});
 			});
 

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -82,12 +82,12 @@ function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductE
 	if(defaultOptionIndex > -1 && isOptionInStock(item.options[defaultOptionIndex])) {
 		return {
 			value: item.options[defaultOptionIndex].id,
-			qty: 1
+			qty: item.options[defaultOptionIndex].quantity
 		}
 	} else {
 		const firstInStockOptionIndex = item.options.findIndex(option => option.stock_status === DaffProductStockEnum.InStock);
 		return item.required && firstInStockOptionIndex > -1 ? 
-			{ value: item.options[firstInStockOptionIndex].id, qty: 1 } :
+			{ value: item.options[firstInStockOptionIndex].id, qty: item.options[firstInStockOptionIndex].quantity } :
 			{ value: null, qty: null }
 	}
 }

--- a/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.spec.ts
@@ -58,11 +58,11 @@ describe('selectCompositeProductEntitiesState', () => {
 					items: {
 						[stubCompositeProduct.items[0].id]: {
 							value: stubCompositeProduct.items[0].options[0].id,
-							qty: 1
+							qty: stubCompositeProduct.items[0].options[0].quantity
 						},
 						[stubCompositeProduct.items[1].id]: {
 							value: stubCompositeProduct.items[1].options[0].id,
-							qty: 1
+							qty: stubCompositeProduct.items[1].options[0].quantity
 						}
 					}
 				}
@@ -87,18 +87,12 @@ describe('selectCompositeProductEntitiesState', () => {
 
   describe('selectCompositeProductAppliedOptions', () => {
     
-    it('selects the composite product options of the given id', () => {
+    it('selects the composite product applied options of the given id', () => {
 			const selector = store.pipe(select(selectCompositeProductAppliedOptions, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { 
 				a: {
-					[stubCompositeProduct.items[0].id]: {
-						value: stubCompositeProduct.items[0].options[0].id,
-						qty: 1
-					},
-					[stubCompositeProduct.items[1].id]: {
-						value: stubCompositeProduct.items[1].options[0].id,
-						qty: 1
-					}
+					[stubCompositeProduct.items[0].id]: stubCompositeProduct.items[0].options[0],
+					[stubCompositeProduct.items[1].id]: stubCompositeProduct.items[1].options[0]
 				}
 			});
 

--- a/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.ts
+++ b/libs/product/src/selectors/composite-product-entities/composite-product-entities.selectors.ts
@@ -3,22 +3,29 @@ import { EntityState, Dictionary } from '@ngrx/entity';
 
 import { getDaffProductFeatureSelector } from '../product-feature.selector';
 import { DaffProductReducersState } from '../../reducers/product-reducers-state.interface';
-import { DaffProduct } from '../../models/product';
+import { DaffProduct, DaffProductTypeEnum } from '../../models/product';
 import { daffCompositeProductAppliedOptionsEntitiesAdapter } from '../../reducers/composite-product-entities/composite-product-entities-reducer-adapter';
-import { DaffCompositeProductEntity, DaffCompositeProductEntityItem } from '../../reducers/composite-product-entities/composite-product-entity';
+import { DaffCompositeProductEntity } from '../../reducers/composite-product-entities/composite-product-entity';
+import { getDaffProductEntitiesSelectors } from '../product-entities/product-entities.selectors';
+import { DaffCompositeProduct } from '../../models/composite-product';
+import { DaffCompositeProductItemOption } from '../../models/composite-product-item';
 
 export interface DaffCompositeProductEntitiesMemoizedSelectors {
 	selectCompositeProductAppliedOptionsEntitiesState: MemoizedSelector<object, EntityState<DaffCompositeProductEntity>>;
 	selectCompositeProductIds: MemoizedSelector<object, EntityState<DaffCompositeProductEntity>['ids']>;
 	selectCompositeProductAppliedOptionsEntities: MemoizedSelector<object, EntityState<DaffCompositeProductEntity>['entities']>;
 	selectCompositeProductTotal: MemoizedSelector<object, number>;
-	selectCompositeProductAppliedOptions: MemoizedSelectorWithProps<object, object, Dictionary<DaffCompositeProductEntityItem>>;
+	selectCompositeProductAppliedOptions: MemoizedSelectorWithProps<object, object, Dictionary<DaffCompositeProductItemOption>>;
 }
 
 const createCompositeProductAppliedOptionsEntitiesSelectors = <T extends DaffProduct>(): DaffCompositeProductEntitiesMemoizedSelectors => {
 	const {
 		selectProductState
 	} = getDaffProductFeatureSelector<T>();
+	const {
+		selectProductEntities,
+		selectProduct,
+	} = getDaffProductEntitiesSelectors();
 	const adapterSelectors = daffCompositeProductAppliedOptionsEntitiesAdapter().getSelectors();
 	/**
 	 * Composite Product Entities State
@@ -56,8 +63,22 @@ const createCompositeProductAppliedOptionsEntitiesSelectors = <T extends DaffPro
 	 * Selector for the applied attributes of a particular composite product.
 	 */
 	const selectCompositeProductAppliedOptions = createSelector(
+		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
-		(products, props) => products.entities[props.id].items
+		(products, appliedOptions, props) => {
+			const product = selectProduct.projector(products, { id: props.id });
+			if(product.type !== DaffProductTypeEnum.Composite) {
+				return undefined;
+			}
+
+			return (<DaffCompositeProduct>product).items.reduce((acc, item) => ({
+					...acc,
+					[item.id]: appliedOptions.entities[product.id].items[item.id].value ? {
+						...item.options.find(option => option.id === appliedOptions.entities[product.id].items[item.id].value),
+						quantity: appliedOptions.entities[product.id].items[item.id].qty
+					} : null
+			}), {})
+		}
 	);
 
 	return { 

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject } from 'rxjs';
 
-import { DaffCompositeProductFacadeInterface, DaffCompositeProductEntityItem } from '@daffodil/product';
+import { DaffCompositeProductFacadeInterface, DaffCompositeProductItemOption } from '@daffodil/product';
 import { Dictionary } from '@ngrx/entity';
 
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
@@ -34,7 +34,7 @@ export class MockDaffCompositeProductFacade implements DaffCompositeProductFacad
 	hasDiscount(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	getAppliedOptions(id: string): BehaviorSubject<Dictionary<DaffCompositeProductEntityItem>> {
+	getAppliedOptions(id: string): BehaviorSubject<Dictionary<DaffCompositeProductItemOption>> {
 		return new BehaviorSubject({});
 	}
 	dispatch(action) {};


### PR DESCRIPTION
…dictionary of DaffCompositeProductItemOption instead of DaffCompositeProductEntityItem

BREAKING CHANGE: selectCompositeProductAppliedOptions selector now returns `Dictionary<DaffCompositeProductItemOption>`

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The selectCompositeProductAppliedOptions selector returns a dictionary of `DaffCompositeProductEntityItem` which doesn't include the name/label of the applied option.

## What is the new behavior?
The selector now returns a dictionary of `DaffCompositeProductItemOption`.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information
In changing this, I also learned that there was a bug with how quantity was handled for applied options, so I fixed that as well.