### PR TITLE
fix(cart): not all available shipping methods returned by update

### DIFF
--- a/libs/cart/src/drivers/magento/cart-shipping-information.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-information.service.spec.ts
@@ -230,7 +230,7 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
         data: mockSetSelectedShippingMethodResponse
       });
 
-      // set timeout because the requests here are made in serial
+      // set timeout because the requests here are made in series
       setTimeout(() => {
         const listShippingMethodsOp = controller.expectOne(addTypenameToDocument(listShippingMethods([daffMagentoNoopCartFragment])));
 

--- a/libs/cart/src/drivers/magento/cart-shipping-information.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-information.service.spec.ts
@@ -23,11 +23,12 @@ import { MagentoCartShippingMethod } from './models/outputs/cart-shipping-method
 import { DaffMagentoCartTransformer } from './transforms/outputs/cart.service';
 import { MagentoGetSelectedShippingMethodResponse } from './models/responses/get-selected-shipping-method';
 import { MagentoSetSelectedShippingMethodResponse } from './models/responses/set-selected-shipping-method';
-import { getSelectedShippingMethod, setSelectedShippingMethod } from './queries/public_api';
+import { getSelectedShippingMethod, setSelectedShippingMethod, listShippingMethods } from './queries/public_api';
 import { DaffMagentoCartShippingRateTransformer } from './transforms/outputs/cart-shipping-rate.service';
 import { DaffMagentoShippingMethodInputTransformer } from './transforms/inputs/shipping-method.service';
 import { MagentoShippingAddress } from './models/outputs/shipping-address';
 import { DaffMagentoExtraCartFragments } from './injection-tokens/public_api';
+import { MagentoListShippingMethodsResponse } from './models/responses/public_api';
 
 interface MagentoCartSelectedShippingMethod extends MagentoCartShippingMethod {
 	__typename: string;
@@ -55,6 +56,7 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
   let mockDaffCartShippingInformation: DaffCartShippingInformation;
   let mockSetSelectedShippingMethodResponse: MagentoSetSelectedShippingMethodResponse;
   let mockGetSelectedShippingMethodResponse: MagentoGetSelectedShippingMethodResponse;
+  let mockListCartShippingMethodsResponse: MagentoListShippingMethodsResponse;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -136,6 +138,16 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
         cart: mockMagentoCart
       }
     };
+    mockListCartShippingMethodsResponse = {
+      cart: {
+        __typename: 'Cart',
+        id: cartId,
+        shipping_addresses: [{
+					__typename: 'AvailableShippingAddresses',
+          available_shipping_methods: [mockMagentoShippingMethod]
+        }]
+      }
+    };
 
     magentoCartTransformerSpy.transform.and.returnValue(mockDaffCart);
     magentoShippingRateTransformerSpy.transform.and.returnValue(mockDaffCartShippingInformation)
@@ -212,11 +224,40 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
         done();
       });
 
-      const op = controller.expectOne(addTypenameToDocument(setSelectedShippingMethod([daffMagentoNoopCartFragment])));
+      const setSelectedShippingMethodOp = controller.expectOne(addTypenameToDocument(setSelectedShippingMethod([daffMagentoNoopCartFragment])));
 
-      op.flush({
+      setSelectedShippingMethodOp.flush({
         data: mockSetSelectedShippingMethodResponse
       });
+
+      // set timeout because the requests here are made in serial
+      setTimeout(() => {
+        const listShippingMethodsOp = controller.expectOne(addTypenameToDocument(listShippingMethods([daffMagentoNoopCartFragment])));
+
+        listShippingMethodsOp.flush({
+          data: mockListCartShippingMethodsResponse
+        });
+      })
+    });
+
+    it('should manually refetch the shipping methods and force cache bypass', () => {
+      service.update(cartId, mockDaffCartShippingInformation).subscribe();
+
+      const setSelectedShippingMethodOp = controller.expectOne(addTypenameToDocument(setSelectedShippingMethod([daffMagentoNoopCartFragment])));
+
+      setSelectedShippingMethodOp.flush({
+        data: mockSetSelectedShippingMethodResponse
+      });
+
+      // set timeout because the requests here are made in serial
+      setTimeout(() => {
+        const listShippingMethodsOp = controller.expectOne(addTypenameToDocument(listShippingMethods([daffMagentoNoopCartFragment])));
+
+        listShippingMethodsOp.flush({
+          data: mockListCartShippingMethodsResponse
+        });
+        console.log(listShippingMethodsOp);
+      })
     });
 
     afterEach(() => {

--- a/libs/cart/src/drivers/magento/cart-shipping-information.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-information.service.spec.ts
@@ -218,7 +218,7 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
       mockDaffCartShippingInformation.carrier = carrier;
     });
 
-    it('should return the correct value', done => {
+    it('should return the correct value and manually refetch the shipping methods', done => {
       service.update(cartId, mockDaffCartShippingInformation).subscribe(result => {
         expect(result.shipping_information.carrier).toEqual(carrier);
         done();
@@ -237,26 +237,6 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
         listShippingMethodsOp.flush({
           data: mockListCartShippingMethodsResponse
         });
-      })
-    });
-
-    it('should manually refetch the shipping methods and force cache bypass', () => {
-      service.update(cartId, mockDaffCartShippingInformation).subscribe();
-
-      const setSelectedShippingMethodOp = controller.expectOne(addTypenameToDocument(setSelectedShippingMethod([daffMagentoNoopCartFragment])));
-
-      setSelectedShippingMethodOp.flush({
-        data: mockSetSelectedShippingMethodResponse
-      });
-
-      // set timeout because the requests here are made in serial
-      setTimeout(() => {
-        const listShippingMethodsOp = controller.expectOne(addTypenameToDocument(listShippingMethods([daffMagentoNoopCartFragment])));
-
-        listShippingMethodsOp.flush({
-          data: mockListCartShippingMethodsResponse
-        });
-        console.log(listShippingMethodsOp);
       })
     });
 

--- a/libs/cart/src/drivers/magento/cart-shipping-methods.service.spec.ts
+++ b/libs/cart/src/drivers/magento/cart-shipping-methods.service.spec.ts
@@ -83,6 +83,7 @@ describe('Driver | Magento | Cart | CartShippingMethodsService', () => {
     mockListCartShippingMethodsResponse = {
       cart: {
 				__typename: 'Cart',
+        id: cartId,
         shipping_addresses: [{
 					__typename: 'AvailableShippingAddresses',
           available_shipping_methods: [mockMagentoShippingMethod]

--- a/libs/cart/src/drivers/magento/models/responses/list-shipping-methods.ts
+++ b/libs/cart/src/drivers/magento/models/responses/list-shipping-methods.ts
@@ -1,8 +1,10 @@
 import { MagentoCartShippingMethod } from '../outputs/cart-shipping-method';
+import { MagentoCart } from '../outputs/cart';
 
 export interface MagentoListShippingMethodsResponse {
   cart: {
-		__typename: string;
+    __typename: string;
+    id: MagentoCart['id'];
     shipping_addresses: {
 			__typename: string;
       available_shipping_methods: MagentoCartShippingMethod[];

--- a/libs/cart/src/drivers/magento/queries/list-shipping-methods.ts
+++ b/libs/cart/src/drivers/magento/queries/list-shipping-methods.ts
@@ -8,6 +8,7 @@ import { availableShippingMethodFragment } from './fragments/public_api';
 export const listShippingMethods = (extraCartFragments: DocumentNode[] = []) => gql`
   query ListShippingMethods($cartId: String!) {
     cart(cart_id: $cartId) {
+      id
       shipping_addresses {
         available_shipping_methods {
           ...availableShippingMethod


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`DaffMagentoCartShippingInformationService#update` only returns the selected shipping method for the available shipping methods.

## What is the new behavior?
`DaffMagentoCartShippingInformationService#update` manually requests the available shipping methods while bypassing the cache after performing the update mutation. This returns all of the available shipping methods.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is a Magento specific bug and fix.