### PR TITLE
feat(product): default composite product item options are completely …

### DIFF
--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
@@ -174,58 +174,24 @@ describe('Product | Composite Product Entities Reducer', () => {
 			});
 		});
 
-		it('should not set the item to the default option when that option is out of stock', () => {
+		it('should set the default option to null when the default option is out of stock', () => {
 			compositeProduct.items[0].options[0].is_default = false;
 			compositeProduct.items[0].options[1].is_default = true;
 			compositeProduct.items[0].options[1].stock_status = DaffProductStockEnum.OutOfStock;
 			const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
 			result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
 
-			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).not.toEqual({
-				value: compositeProduct.items[0].options[1].id,
-				qty: compositeProduct.items[0].options[1].quantity
-			});
+			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({ value: null, qty: null });
 		});
 
-		describe('when the default item option is not defined', () => {
-			
-			it(`should set the default option to the first option that is in stock`, () => {
-				compositeProduct.items[0].options[0].is_default = false;
-				compositeProduct.items[0].options[1].is_default = false;
-				compositeProduct.items[0].options[0].stock_status = DaffProductStockEnum.OutOfStock;
-				compositeProduct.items[0].options[1].stock_status = DaffProductStockEnum.InStock;
-				compositeProduct.items[0].required = true;
-				const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
-				result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
+		it(`should set the default option to null when the default item option is not defined`, () => {
+			compositeProduct.items[0].options[0].is_default = false;
+			compositeProduct.items[0].options[1].is_default = false;
+			compositeProduct.items[0].required = true;
+			const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
+			result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
 
-				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({
-					value: compositeProduct.items[0].options[1].id,
-					qty: compositeProduct.items[0].options[1].quantity
-				});
-			});
-
-			it('should set the default option to null when the item is not required', () => {
-				compositeProduct.items[0].options[0].is_default = false;
-				compositeProduct.items[0].options[1].is_default = false;
-				compositeProduct.items[0].required = false;
-				const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
-				result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
-
-				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({ value: null, qty: null });
-			});
-
-			it(`should set the default option to null when the item is required
-					and all options are out of stock`, () => {
-				compositeProduct.items[0].options[0].is_default = false;
-				compositeProduct.items[0].options[1].is_default = false;
-				compositeProduct.items[0].options[0].stock_status = DaffProductStockEnum.OutOfStock;
-				compositeProduct.items[0].options[1].stock_status = DaffProductStockEnum.OutOfStock;
-				compositeProduct.items[0].required = true;
-				const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
-				result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
-
-				expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({ value: null, qty: null });
-			});
+			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({ value: null, qty: null });
 		});
 	});
 });

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -68,12 +68,8 @@ function buildCompositeProductAppliedOptionsEntity(product: DaffCompositeProduct
 }
 
 /**
- * Sets the default item option to the specified default option unless that option is out of stock.
- * Sets the default item option to the first in stock option if the specified default option is out of stock and
- * 	the item is required.
- * Does not set a default option if no options are in stock.
- * Sets the default item option to the first in stock option if no default option is specified and the item is required.
- * Does not set a default option if a default is not specified and not required.
+ * Sets the default item option to the specified default option if it is in stock.
+ * Does not set a default option if a default is not specified or if the default is out of stock.
  * @param item a DaffCompositeProductItem
  */
 function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductEntityItem {
@@ -85,10 +81,7 @@ function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductE
 			qty: item.options[defaultOptionIndex].quantity
 		}
 	} else {
-		const firstInStockOptionIndex = item.options.findIndex(option => option.stock_status === DaffProductStockEnum.InStock);
-		return item.required && firstInStockOptionIndex > -1 ? 
-			{ value: item.options[firstInStockOptionIndex].id, qty: item.options[firstInStockOptionIndex].quantity } :
-			{ value: null, qty: null }
+		return { value: null, qty: null };
 	}
 }
 


### PR DESCRIPTION
…determined by the platform

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Daffodil always sets a default item option for composite products if the item is required.


## What is the new behavior?
Daffodil only sets default item options if the platform designates a default and if that default is in stock.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```