### PR TITLE
fix(cart): cart totals transformer crashes for no shipping addresses

### DIFF
--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.spec.ts
@@ -70,7 +70,7 @@ describe('transformCartTotals', () => {
 			]
 		};
   });
-		
+
 	it('should transform cart totals', () => {
 		expect(transformCartTotals(stubMagentoCart)).toEqual(expectedTotals);
 	});
@@ -127,6 +127,62 @@ describe('transformCartTotals', () => {
 		stubMagentoCart.prices.subtotal_including_tax.value = null;
 		stubMagentoCart.prices.subtotal_with_discount_excluding_tax.value = null;
 		stubMagentoCart.shipping_addresses[0].selected_shipping_method.amount.value = null;
+
+		expect(transformCartTotals(stubMagentoCart)).toEqual(expectedTotals);
+  });
+
+  it('should transform cart totals when magento gives empty shipping addresses', () => {
+		expectedTotals = {
+			totals: [
+				{
+					name: DaffCartTotalTypeEnum.grandTotal,
+					label: 'Grand Total',
+					value: null
+				},
+				{
+					name: DaffCartTotalTypeEnum.subtotalExcludingTax,
+					label: 'Subtotal Excluding Tax',
+					value: null
+				},
+				{
+					name: DaffCartTotalTypeEnum.subtotalIncludingTax,
+					label: 'Subtotal Including Tax',
+					value: null
+				},
+				{
+					name: DaffCartTotalTypeEnum.subtotalWithDiscountExcludingTax,
+					label: 'Subtotal with Discount Excluding Tax',
+					value: null
+				},
+				{
+					name: DaffCartTotalTypeEnum.subtotalWithDiscountIncludingTax,
+					label: 'Subtotal with Discount Including Tax',
+					value: null
+				},
+				{
+					name: DaffCartTotalTypeEnum.tax,
+					label: 'Tax',
+					value: 0
+				},
+				{
+					name: DaffCartTotalTypeEnum.discount,
+					label: 'Discount',
+					value: 0
+				},
+				{
+					name: DaffCartTotalTypeEnum.shipping,
+					label: 'Shipping',
+					value: 0
+				}
+			]
+		};
+		stubMagentoCart.prices.applied_taxes = [];
+		stubMagentoCart.prices.discounts = [];
+		stubMagentoCart.prices.grand_total.value = null;
+		stubMagentoCart.prices.subtotal_excluding_tax.value = null;
+		stubMagentoCart.prices.subtotal_including_tax.value = null;
+		stubMagentoCart.prices.subtotal_with_discount_excluding_tax.value = null;
+		stubMagentoCart.shipping_addresses = null;
 
 		expect(transformCartTotals(stubMagentoCart)).toEqual(expectedTotals);
 	});

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.ts
@@ -31,7 +31,7 @@ export function transformCartTotals(cart: Partial<MagentoCart>): {totals: DaffCa
 			{
 				name: DaffCartTotalTypeEnum.subtotalWithDiscountIncludingTax,
 				label: 'Subtotal with Discount Including Tax',
-				value: cart.prices.subtotal_with_discount_excluding_tax.value ? 
+				value: cart.prices.subtotal_with_discount_excluding_tax.value ?
 								daffAdd(cart.prices.subtotal_with_discount_excluding_tax.value, totalTax) :
 								cart.prices.subtotal_with_discount_excluding_tax.value
 			},
@@ -55,6 +55,7 @@ export function transformCartTotals(cart: Partial<MagentoCart>): {totals: DaffCa
 }
 
 function validateSelectedShippingAddress(cart: Partial<MagentoCart>): boolean {
-	return !!cart.shipping_addresses[0] && !!cart.shipping_addresses[0].selected_shipping_method &&
+  // TODO: optional chaining
+	return !!cart.shipping_addresses && !!cart.shipping_addresses[0] && !!cart.shipping_addresses[0].selected_shipping_method &&
 		!!cart.shipping_addresses[0].selected_shipping_method.amount;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When the magento `cart.shipping_addresses` field is empty, the cart totals transformer would crash.


## What is the new behavior?
When the magento `cart.shipping_addresses` field is empty, the cart totals transformer does not crash and produces a value of `0` for the shipping total.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information