### PR TITLE
fix(cart): a null shipping total should be null instead of zero

### DIFF
--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.spec.ts
@@ -172,7 +172,7 @@ describe('transformCartTotals', () => {
 				{
 					name: DaffCartTotalTypeEnum.shipping,
 					label: 'Shipping',
-					value: 0
+					value: null
 				}
 			]
 		};

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.ts
@@ -48,7 +48,7 @@ export function transformCartTotals(cart: Partial<MagentoCart>): {totals: DaffCa
 			{
 				name: DaffCartTotalTypeEnum.shipping,
 				label: 'Shipping',
-				value: validateSelectedShippingAddress(cart) ? cart.shipping_addresses[0].selected_shipping_method.amount.value : 0
+				value: validateSelectedShippingAddress(cart) ? cart.shipping_addresses[0].selected_shipping_method.amount.value : null
 			}
 		],
 	}

--- a/libs/cart/src/models/cart-total.ts
+++ b/libs/cart/src/models/cart-total.ts
@@ -9,6 +9,12 @@ export enum DaffCartTotalTypeEnum {
 	shipping = 'shipping'
 }
 
+/**
+ * Since some cart totals might not have a value defined at all times, like shipping, the values of these totals
+ * can be null. Allowing their values to be null differentiates a non-existent value from a zero value. In the case of
+ * shipping, this would mean the difference between a cart with no selected shipping method and a cart with a selected shipping
+ * method that costs zero.
+ */
 export interface DaffCartTotal {
   value: number;
   label: string;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The shipping total in daffodil is set to zero even if the total from magento is null. This is a problem, because the shipping total needs to be shown as "FREE" when the shipping total is zero. So the shipping will be shown as "FREE" even though a shipping method hasn't been chosen yet.

## What is the new behavior?
The shipping total will be null when the shipping method hasn't been chosen yet.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```