### PR TITLE
fix(order): driver errors cause effect observables to complete

### DIFF
--- a/libs/order/src/effects/order.effects.spec.ts
+++ b/libs/order/src/effects/order.effects.spec.ts
@@ -78,7 +78,7 @@ describe('Daffodil | Order | OrderEffects', () => {
         daffDriverSpy.get.and.returnValue(response);
         const orderLoadFailureAction = new DaffOrderLoadFailure(error);
         actions$ = hot('--a', { a: orderLoadAction });
-        expected = cold('--(b|)', { b: orderLoadFailureAction });
+        expected = cold('--b', { b: orderLoadFailureAction });
       });
 
       it('should dispatch a DaffOrderLoadFailure action', () => {
@@ -111,7 +111,7 @@ describe('Daffodil | Order | OrderEffects', () => {
         daffDriverSpy.list.and.returnValue(response);
         const orderListFailureAction = new DaffOrderListFailure(error);
         actions$ = hot('--a', { a: orderListAction });
-        expected = cold('--(b|)', { b: orderListFailureAction });
+        expected = cold('--b', { b: orderListFailureAction });
       });
 
       it('should return a DaffOrderListFailure action', () => {

--- a/libs/order/src/effects/order.effects.ts
+++ b/libs/order/src/effects/order.effects.ts
@@ -36,10 +36,11 @@ export class DaffOrderEffects<
   get$ = this.actions$.pipe(
     ofType(DaffOrderActionTypes.OrderLoadAction),
     switchMap((action: DaffOrderLoad<T, V>) =>
-      this.driver.get(action.orderId, action.cartId)
+      this.driver.get(action.orderId, action.cartId).pipe(
+        map(resp => new DaffOrderLoadSuccess<T>(resp)),
+        catchError(error => of(new DaffOrderLoadFailure('Failed to load order')))
+      )
     ),
-    map(resp => new DaffOrderLoadSuccess<T>(resp)),
-    catchError(error => of(new DaffOrderLoadFailure('Failed to load order')))
   )
 
   /**
@@ -49,9 +50,10 @@ export class DaffOrderEffects<
   list$ = this.actions$.pipe(
     ofType(DaffOrderActionTypes.OrderListAction),
     switchMap((action: DaffOrderList) =>
-      this.driver.list(action.payload)
+      this.driver.list(action.payload).pipe(
+        map(resp => new DaffOrderListSuccess<T>(resp)),
+        catchError(error => of(new DaffOrderListFailure('Failed to list the orders')))
+      )
     ),
-    map(resp => new DaffOrderListSuccess<T>(resp)),
-    catchError(error => of(new DaffOrderListFailure('Failed to list the orders')))
   )
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When a driver throws an error, the corresponding effects will complete and never run again.

## What is the new behavior?
Effects will not complete and always listen to the action stream.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information