### PR TITLE
feat(product): add min and max discounted price selectors for composi…

### DIFF
--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -68,6 +68,13 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	getMaxDiscountedPrice(id: string): Observable<number>;
 
 	/**
+	 * Returns whether the composite product has a discounted price range depending on applied options and excluding
+	 * optional items.
+	 * @param id the id of the composite product.
+	 */
+	hasDiscountedPriceRange(id: string): Observable<boolean>;
+
+	/**
 	 * Get the discount amount of a composite product based on the applied product options.
 	 * @param id the id of the composite product.
 	 * @deprecated

--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -56,15 +56,29 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	getPrice(id: string): Observable<number>;
 
 	/**
+	 * Get the minimum discounted price of a composite product based on the applied product options.
+	 * @param id the id of the composite product.
+	 */
+	getMinDiscountedPrice(id: string): Observable<number>;
+
+	/**
+	 * Get the maximum discounted price of a composite product based on the applied product options.
+	 * @param id the id of the composite product.
+	 */
+	getMaxDiscountedPrice(id: string): Observable<number>;
+
+	/**
 	 * Get the discount amount of a composite product based on the applied product options.
 	 * @param id the id of the composite product.
+	 * @deprecated
 	 */
 	getDiscountAmount(id: string): Observable<number>;
 
 	/**
 	 * Get the discounted price of a composite product based on the applied product options.
 	 * @param id the id of the composite product.
-	 */
+	 * @deprecated Use getMinDiscountAmount and getMaxDiscountAmount instead.
+ 	 */
 	getDiscountedPrice(id: string): Observable<number>;
 
 	/**

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -140,6 +140,32 @@ describe('DaffCompositeProductFacade', () => {
 		});
   });
 
+  describe('getMinDiscountedPrice', () => {
+
+    it('should return the discounted price of the product', () => {
+			const expected = cold('a', { a:
+				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
+				stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount +
+				stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount
+			});
+
+			expect(facade.getMinDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('getMaxDiscountedPrice', () => {
+
+    it('should return the price of the product', () => {
+			const expected = cold('a', { a:
+				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
+				stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount +
+				stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount
+			});
+
+			expect(facade.getMaxDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
   describe('getDiscountAmount', () => {
 
     it('should return the total discount amount for a composite product', () => {

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -97,8 +97,8 @@ describe('DaffCompositeProductFacade', () => {
     it('should return the minimum price for the product', () => {
 			const expected = cold('a', { a:
 				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[0].price +
-				stubCompositeProduct.items[1].options[0].price
+				stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity +
+				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
 			});
 
 			expect(facade.getMinPrice(stubCompositeProduct.id)).toBeObservable(expected);
@@ -110,8 +110,8 @@ describe('DaffCompositeProductFacade', () => {
     it('should return the maximum price for the product', () => {
 			const expected = cold('a', { a:
 				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[0].price +
-				stubCompositeProduct.items[1].options[0].price
+				stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity +
+				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
 			});
 
 			expect(facade.getMaxPrice(stubCompositeProduct.id)).toBeObservable(expected);
@@ -145,8 +145,8 @@ describe('DaffCompositeProductFacade', () => {
     it('should return the discounted price of the product', () => {
 			const expected = cold('a', { a:
 				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
-				stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount +
-				stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount
+				(stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount)*stubCompositeProduct.items[0].options[0].quantity +
+				(stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount)*stubCompositeProduct.items[1].options[0].quantity
 			});
 
 			expect(facade.getMinDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
@@ -158,11 +158,20 @@ describe('DaffCompositeProductFacade', () => {
     it('should return the price of the product', () => {
 			const expected = cold('a', { a:
 				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
-				stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount +
-				stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount
+				(stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount)*stubCompositeProduct.items[0].options[0].quantity +
+				(stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount)*stubCompositeProduct.items[1].options[0].quantity
 			});
 
 			expect(facade.getMaxDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('hasDiscountedPriceRange', () => {
+
+    it('should return whether the product currently has a discounted price range', () => {
+			const expected = cold('a', { a: false });
+
+			expect(facade.hasDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -59,6 +59,10 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 		return this.store.pipe(select(this.selectors.selectCompositeProductMaxDiscountedPrice, { id }));
 	}
 
+	hasDiscountedPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasDiscountedPriceRange, { id }));
+	}
+
 	/**
 	 * @deprecated
 	 */

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -51,10 +51,24 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 		return this.store.pipe(select(this.selectors.selectCompositeProductPrice, { id }));
 	}
 	
+	getMinDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinDiscountedPrice, { id }));
+	}
+
+	getMaxDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxDiscountedPrice, { id }));
+	}
+
+	/**
+	 * @deprecated
+	 */
 	getDiscountAmount(id: string): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectCompositeProductDiscountAmount, { id }));
 	}
 
+	/**
+	 * @deprecated Use getMinDiscountAmount and getMaxDiscountAmount instead.
+	 */
 	getDiscountedPrice(id: string): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectCompositeProductDiscountedPrice, { id }));
 	}

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -293,23 +293,31 @@ describe('Composite Product Selectors | integration tests', () => {
 	describe('selectCompositeProductMinDiscountedPrice', () => {
 
 		let newCompositeProduct;
+		const item0Option0Price = 10;
+		const item0Option1Price = 10;
+		const item0Option0DiscountAmount = 5;
+		const item0Option1DiscountAmount = 2;
+		const item1Option0Price = 20;
+		const item1Option1Price = 10;
+		const item1Option0DiscountAmount = 2;
+		const item1Option1DiscountAmount = 4;
 
 		beforeEach(() => {
 			newCompositeProduct = compositeProductFactory.create();
 			newCompositeProduct.items[0].required = true;
 			newCompositeProduct.items[0].options[0].is_default = false;
 			newCompositeProduct.items[0].options[1].is_default = false;
-			newCompositeProduct.items[0].options[0].price = 10;
-			newCompositeProduct.items[0].options[1].price = 10;
-			newCompositeProduct.items[0].options[0].discount.amount = 5;
-			newCompositeProduct.items[0].options[1].discount.amount = 2;
+			newCompositeProduct.items[0].options[0].price = item0Option0Price;
+			newCompositeProduct.items[0].options[1].price = item0Option1Price;
+			newCompositeProduct.items[0].options[0].discount.amount = item0Option0DiscountAmount;
+			newCompositeProduct.items[0].options[1].discount.amount = item0Option1DiscountAmount;
 			newCompositeProduct.items[1].required = true;
 			newCompositeProduct.items[1].options[0].is_default = false;
 			newCompositeProduct.items[1].options[1].is_default = false;
-			newCompositeProduct.items[1].options[0].price = 20;
-			newCompositeProduct.items[1].options[1].price = 10;
-			newCompositeProduct.items[1].options[0].discount.amount = 2;
-			newCompositeProduct.items[1].options[1].discount.amount = 4;
+			newCompositeProduct.items[1].options[0].price = item1Option0Price;
+			newCompositeProduct.items[1].options[1].price = item1Option1Price;
+			newCompositeProduct.items[1].options[0].discount.amount = item1Option0DiscountAmount;
+			newCompositeProduct.items[1].options[1].discount.amount = item1Option1DiscountAmount;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
 		});
 
@@ -321,21 +329,34 @@ describe('Composite Product Selectors | integration tests', () => {
 		});
 
 		it('should initialize to the expected minimum discounted price', () => {
+			const smallestItem0DiscountedPrice = item0Option0Price - item0Option0DiscountAmount;
+			const smallestItem1DiscountedPrice = item1Option1Price - item1Option1DiscountAmount;
 			const selector = store.pipe(select(selectCompositeProductMinDiscountedPrice, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 5 + 6 });
+			const expected = cold('a', { a: 
+				newCompositeProduct.price - newCompositeProduct.discount.amount + 
+				smallestItem0DiscountedPrice + 
+				smallestItem1DiscountedPrice
+			});
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should update the price when an option change occurs', () => {
+			const updatedOption01Quantity = 3;
+			const selectedItem0DiscountedPrice = (item0Option1Price - item0Option1DiscountAmount) * updatedOption01Quantity;
+			const smallestItem1DiscountedPrice = item1Option1Price - item1Option1DiscountAmount;
+
 			store.dispatch(new DaffCompositeProductApplyOption(
 				newCompositeProduct.id,
 				<string>newCompositeProduct.items[0].id,
 				newCompositeProduct.items[0].options[1].id,
-				3
+				updatedOption01Quantity
 			));
 			const selector = store.pipe(select(selectCompositeProductMinDiscountedPrice, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 8*3 + 6 });
+			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
+				selectedItem0DiscountedPrice + 
+				smallestItem1DiscountedPrice 
+			});
 
 			expect(selector).toBeObservable(expected);
 		});
@@ -344,23 +365,31 @@ describe('Composite Product Selectors | integration tests', () => {
 	describe('selectCompositeProductMaxDiscountedPrice', () => {
 
 		let newCompositeProduct;
+		const item0Option0Price = 10;
+		const item0Option1Price = 10;
+		const item0Option0DiscountAmount = 5;
+		const item0Option1DiscountAmount = 2;
+		const item1Option0Price = 20;
+		const item1Option1Price = 10;
+		const item1Option0DiscountAmount = 2;
+		const item1Option1DiscountAmount = 4;
 
 		beforeEach(() => {
 			newCompositeProduct = compositeProductFactory.create();
 			newCompositeProduct.items[0].required = true;
 			newCompositeProduct.items[0].options[0].is_default = false;
 			newCompositeProduct.items[0].options[1].is_default = false;
-			newCompositeProduct.items[0].options[0].price = 10;
-			newCompositeProduct.items[0].options[1].price = 10;
-			newCompositeProduct.items[0].options[0].discount.amount = 5;
-			newCompositeProduct.items[0].options[1].discount.amount = 2;
+			newCompositeProduct.items[0].options[0].price = item0Option0Price;
+			newCompositeProduct.items[0].options[1].price = item0Option1Price;
+			newCompositeProduct.items[0].options[0].discount.amount = item0Option0DiscountAmount;
+			newCompositeProduct.items[0].options[1].discount.amount = item0Option1DiscountAmount;
 			newCompositeProduct.items[1].required = true;
 			newCompositeProduct.items[1].options[0].is_default = false;
 			newCompositeProduct.items[1].options[1].is_default = false;
-			newCompositeProduct.items[1].options[0].price = 20;
-			newCompositeProduct.items[1].options[1].price = 10;
-			newCompositeProduct.items[1].options[0].discount.amount = 2;
-			newCompositeProduct.items[1].options[1].discount.amount = 4;
+			newCompositeProduct.items[1].options[0].price = item1Option0Price;
+			newCompositeProduct.items[1].options[1].price = item1Option1Price;
+			newCompositeProduct.items[1].options[0].discount.amount = item1Option0DiscountAmount;
+			newCompositeProduct.items[1].options[1].discount.amount = item1Option1DiscountAmount;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
 		});
 
@@ -371,22 +400,33 @@ describe('Composite Product Selectors | integration tests', () => {
 			expect(selector).toBeObservable(expected);
 		});
 
-		it('should initialize to the expected minimum discounted price', () => {
+		it('should initialize to the expected maximum discounted price', () => {
+			const largestItem0DiscountedPrice = item0Option1Price - item0Option1DiscountAmount;
+			const largestItem1DiscountedPrice = item1Option0Price - item1Option0DiscountAmount;
 			const selector = store.pipe(select(selectCompositeProductMaxDiscountedPrice, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 8 + 18 });
+			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
+				largestItem0DiscountedPrice + 
+				largestItem1DiscountedPrice
+			});
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should update the price when an option change occurs', () => {
+			const updatedOption00Quantity = 3;
+			const selectedItem0DiscountedPrice = (item0Option0Price - item0Option0DiscountAmount) * updatedOption00Quantity;
+			const largestItem1DiscountedPrice = item1Option0Price - item1Option0DiscountAmount;
 			store.dispatch(new DaffCompositeProductApplyOption(
 				newCompositeProduct.id,
 				<string>newCompositeProduct.items[0].id,
 				newCompositeProduct.items[0].options[0].id,
-				3
+				updatedOption00Quantity
 			));
 			const selector = store.pipe(select(selectCompositeProductMaxDiscountedPrice, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 5*3 + 18 });
+			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
+				selectedItem0DiscountedPrice + 
+				largestItem1DiscountedPrice
+			});
 
 			expect(selector).toBeObservable(expected);
 		});

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -30,6 +30,8 @@ describe('Composite Product Selectors | integration tests', () => {
 		selectCompositeProductMaxPrice,
 		selectCompositeProductHasPriceRange,
 		selectCompositeProductPrice,
+		selectCompositeProductMinDiscountedPrice,
+		selectCompositeProductMaxDiscountedPrice,
 		selectCompositeProductDiscountAmount,
 		selectCompositeProductDiscountedPrice,
 		selectCompositeProductHasDiscount
@@ -281,6 +283,106 @@ describe('Composite Product Selectors | integration tests', () => {
 			));
 			const selector = store.pipe(select(selectCompositeProductPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectCompositeProductMinDiscountedPrice', () => {
+
+		let newCompositeProduct;
+
+		beforeEach(() => {
+			newCompositeProduct = compositeProductFactory.create();
+			newCompositeProduct.items[0].required = true;
+			newCompositeProduct.items[0].options[0].is_default = false;
+			newCompositeProduct.items[0].options[1].is_default = false;
+			newCompositeProduct.items[0].options[0].price = 10;
+			newCompositeProduct.items[0].options[1].price = 10;
+			newCompositeProduct.items[0].options[0].discount.amount = 5;
+			newCompositeProduct.items[0].options[1].discount.amount = 2;
+			newCompositeProduct.items[1].required = true;
+			newCompositeProduct.items[1].options[0].is_default = false;
+			newCompositeProduct.items[1].options[1].is_default = false;
+			newCompositeProduct.items[1].options[0].price = 20;
+			newCompositeProduct.items[1].options[1].price = 10;
+			newCompositeProduct.items[1].options[0].discount.amount = 2;
+			newCompositeProduct.items[1].options[1].discount.amount = 4;
+			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
+		});
+
+		it('should return undefined if the given product id is not from a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductMinDiscountedPrice, { id: stubProduct.id }));
+			const expected = cold('a', { a: undefined });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should initialize to the expected minimum discounted price', () => {
+			const selector = store.pipe(select(selectCompositeProductMinDiscountedPrice, { id: newCompositeProduct.id }));
+			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 5 + 6 });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should update the price when an option change occurs', () => {
+			store.dispatch(new DaffCompositeProductApplyOption(
+				newCompositeProduct.id,
+				<string>newCompositeProduct.items[0].id,
+				newCompositeProduct.items[0].options[1].id
+			));
+			const selector = store.pipe(select(selectCompositeProductMinDiscountedPrice, { id: newCompositeProduct.id }));
+			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 8 + 6 });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectCompositeProductMaxDiscountedPrice', () => {
+
+		let newCompositeProduct;
+
+		beforeEach(() => {
+			newCompositeProduct = compositeProductFactory.create();
+			newCompositeProduct.items[0].required = true;
+			newCompositeProduct.items[0].options[0].is_default = false;
+			newCompositeProduct.items[0].options[1].is_default = false;
+			newCompositeProduct.items[0].options[0].price = 10;
+			newCompositeProduct.items[0].options[1].price = 10;
+			newCompositeProduct.items[0].options[0].discount.amount = 5;
+			newCompositeProduct.items[0].options[1].discount.amount = 2;
+			newCompositeProduct.items[1].required = true;
+			newCompositeProduct.items[1].options[0].is_default = false;
+			newCompositeProduct.items[1].options[1].is_default = false;
+			newCompositeProduct.items[1].options[0].price = 20;
+			newCompositeProduct.items[1].options[1].price = 10;
+			newCompositeProduct.items[1].options[0].discount.amount = 2;
+			newCompositeProduct.items[1].options[1].discount.amount = 4;
+			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
+		});
+
+		it('should return undefined if the given product id is not from a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductMaxDiscountedPrice, { id: stubProduct.id }));
+			const expected = cold('a', { a: undefined });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should initialize to the expected minimum discounted price', () => {
+			const selector = store.pipe(select(selectCompositeProductMaxDiscountedPrice, { id: newCompositeProduct.id }));
+			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 8 + 18 });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should update the price when an option change occurs', () => {
+			store.dispatch(new DaffCompositeProductApplyOption(
+				newCompositeProduct.id,
+				<string>newCompositeProduct.items[0].id,
+				newCompositeProduct.items[0].options[0].id
+			));
+			const selector = store.pipe(select(selectCompositeProductMaxDiscountedPrice, { id: newCompositeProduct.id }));
+			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 5 + 18 });
 
 			expect(selector).toBeObservable(expected);
 		});

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -31,6 +31,9 @@ export class MockDaffCompositeProductFacade implements DaffCompositeProductFacad
 	getMaxDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
+	hasDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
+		return new BehaviorSubject(false);
+	};
 	/**
 	 * @deprecated
 	 */

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -25,9 +25,21 @@ export class MockDaffCompositeProductFacade implements DaffCompositeProductFacad
 	getPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
+	getMinDiscountedPrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	getMaxDiscountedPrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	/**
+	 * @deprecated
+	 */
 	getDiscountAmount(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
+	/**
+	 * @deprecated Use getMinDiscountedPrice and getMaxDiscountedPrice instead
+	 */
 	getDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};


### PR DESCRIPTION
…te products

Fix discount and price related composite product selectors.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The composite product discount selector and price selectors aren't correct. Some don't take into account the discounts of each of the item options, and others don't multiply by the item option quantities. 

## What is the new behavior?
- The composite product discounted price is now separated into min and max selectors.
- Added a boolean selector for hasDiscountedPriceRange.
- Deprecated composite product selectors that don't really make sense.
- Fixed selectors that either didn't consider all item option discount amounts or didn't consider all item option applied quantities.
- I didn't add selectors for ranged discount percents, because it doesn't really make sense with composite products. Since the price of the composite product can be really different based on what options are selected, a percent discount range doesn't mean anything useful. I also didn't add a selector for final price percent discount, because there is a lot of client-side arithmetic. I think the percent discount for a composite product (with item option discounts) must be gotten from the backend, but I don't think that field is available from magento.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```