### PR TITLE
feat(cart, magento): removes shipping methods from main cart fragement

### DIFF
--- a/libs/cart/src/drivers/magento/queries/fragments/cart.ts
+++ b/libs/cart/src/drivers/magento/queries/fragments/cart.ts
@@ -5,7 +5,6 @@ import { availablePaymentMethodFragment } from './available-payment-method';
 import { selectedPaymentMethodFragment } from './selected-payment-method';
 import { cartItemFragment } from './cart-item';
 import { cartCouponFragment } from './cart-coupon';
-import { availableShippingMethodFragment } from './available-shipping-method';
 import { selectedShippingMethodFragment } from './selected-shipping-method';
 import { pricesFragment } from './prices';
 
@@ -19,9 +18,6 @@ export const cartFragment = gql`
     shipping_addresses {
       ...cartAddress
       ... on ShippingCartAddress {
-        available_shipping_methods {
-          ...availableShippingMethod
-        }
         selected_shipping_method {
           ...selectedShippingMethod
         }
@@ -46,7 +42,6 @@ export const cartFragment = gql`
   ${cartAddressFragment}
   ${availablePaymentMethodFragment}
   ${selectedPaymentMethodFragment}
-  ${availableShippingMethodFragment}
   ${selectedShippingMethodFragment}
   ${cartItemFragment}
   ${pricesFragment}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Magento's GraphQl query for Shipping Methods doesn't cache the results of rate requests for providers. This means that Magento cart requests are obnoxiously slow. See https://github.com/magento/magento2/issues/28337

Fixes: N/A


## What is the new behavior?
This removes the shipping methods from a typical cart load, they must now be loaded explicitly.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information