### PR TITLE
feat(authorizenet): remove name as type from DaffAuthorizeNetCreditCard Interface

### DIFF
--- a/libs/authorizenet/src/drivers/magento/transformers/authorize-net-transformer.spec.ts
+++ b/libs/authorizenet/src/drivers/magento/transformers/authorize-net-transformer.spec.ts
@@ -6,7 +6,6 @@ import { AuthorizeNetResponse } from 'libs/authorizenet/src/models/response/auth
 
 describe('AuthorizeNet | Drivers | Magento | Transformers', () => {
 	const stubCreditCard: DaffAuthorizeNetCreditCard = {
-		name: 'name',
 		cardnumber: 'cardnumber',
 		month: 'month',
 		year: 'year',

--- a/libs/authorizenet/src/effects/authorize-net.effects.spec.ts
+++ b/libs/authorizenet/src/effects/authorize-net.effects.spec.ts
@@ -36,7 +36,6 @@ describe('DaffAuthorizeNetEffects', () => {
   let effects: DaffAuthorizeNetEffects;
 	const paymentTokenRequest: DaffAuthorizeNetTokenRequest = {
 		creditCard: {
-			name: 'name',
 			cardnumber: '1234123412341234',
 			month: 'month',
 			year: 'year',

--- a/libs/authorizenet/src/models/request/credit-card.ts
+++ b/libs/authorizenet/src/models/request/credit-card.ts
@@ -1,5 +1,4 @@
 export interface DaffAuthorizeNetCreditCard {
-	name: string;
 	cardnumber: string;
 	month: string;
 	year: string;

--- a/libs/authorizenet/src/reducers/authorize-net/authorize-net.reducer.spec.ts
+++ b/libs/authorizenet/src/reducers/authorize-net/authorize-net.reducer.spec.ts
@@ -38,7 +38,6 @@ describe('AuthorizeNet | AuthorizeNet Reducer', () => {
     beforeEach(() => {
       const tokenLoad: DaffAuthorizeNetUpdatePayment = new DaffAuthorizeNetUpdatePayment({
 				creditCard: {
-					name: 'name',
 					cardnumber: '1234123412341234',
 					month: 'month',
 					year: 'year',

--- a/libs/authorizenet/testing/src/drivers/in-memory/authorize-net.service.spec.ts
+++ b/libs/authorizenet/testing/src/drivers/in-memory/authorize-net.service.spec.ts
@@ -46,7 +46,6 @@ describe('Driver | In Memory | AuthorizeNet | AuthorizeNetService', () => {
       it('should send a post request to `api/authorizenet/generateToken` and return a response', done => {
 				const paymentTokenRequest: DaffAuthorizeNetTokenRequest = {
 					creditCard: {
-						name: 'name',
 						cardnumber: '5555555555554444', 
 						month: 'month', 
 						year: 'year', 

--- a/libs/authorizenet/testing/src/drivers/testing/authorize-net.service.spec.ts
+++ b/libs/authorizenet/testing/src/drivers/testing/authorize-net.service.spec.ts
@@ -25,7 +25,6 @@ describe('Driver | Testing | AuthorizeNet | AuthorizeNetService', () => {
       const expected = cold('(a|)', {a: jasmine.any(Object)});
       expect(service.generateToken({
 				creditCard: {
-					name: 'name',
 					cardnumber: '1234123412341234',
 					month: 'month',
 					year: 'year',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?
Cardholder name is not a required field for authorizenet or other modern payment processors. It's extra data that doesn't need to be retrieved or stored.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information