### PR TITLE
feat(product): finalize the composite product price selectors and fac…

### DIFF
--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -10,89 +10,112 @@ import { DaffCompositeProduct } from '../../models/composite-product';
 export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Action> {
 
 	/**
-	 * Get the minimum price possible for a composite product regardless of applied options.
+	 * Get the minimum price for a composite product, including optional items and regardless of applied options.
+	 * This would be useful for a quick preview of a product.
 	 * @param id the id of the composite product.
 	 */
-	getMinPossiblePrice(id: string): Observable<number>;
+	getMinOptionalPrice(id: string): Observable<number>;
 
 	/**
-	 * Get the maximum price possible for a composite product regardless of applied options and including optional items.
+   * Get the maximum price for a composite product, including optional items and regardless of applied options.
+	 * This would be useful for a quick preview of a product.	 
 	 * @param id the id of the composite product.
 	 */
-	getMaxPossiblePrice(id: string): Observable<number>;
+	getMaxOptionalPrice(id: string): Observable<number>;
 
 	/**
-	 * Returns whether the composite product has a price range regardless of applied options and including
-	 * optional items.
+	 * Returns whether the composite product could have a price range in any configuration,
+	 * including the optional items and regardless of the current item option selection.
+	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	possiblyHasPriceRange(id: string): Observable<boolean>;
+	hasOptionalPriceRange(id: string): Observable<boolean>;
 
 	/**
-	 * Get the minimum price for a composite product excluding optional items and determined by 
-	 * currently applied options.
+	 * Get the minimum discounted price for a composite product, including optional items and regardless of the current selection of item options.
+	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	getMinPrice(id: string): Observable<number>;
+	getMinOptionalDiscountedPrice(id: string): Observable<number>;
 
 	/**
-	 * Get the maximum price for a composite product excluding optional items and determined by
-	 * currently applied options.
+	 * Get the maximum discounted price for a composite product, including optional items and regardless of the current selection of item options.
+	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	getMaxPrice(id: string): Observable<number>;
+	getMaxOptionalDiscountedPrice(id: string): Observable<number>;
 
 	/**
-	 * Returns whether the composite product has a price range depending on applied options and excluding
-	 * optional items.
+	 * Selector for whether the composite product could have a discounted price range in any configuration,
+	 * including the optional items and regardless of the current item option selection.
+	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	hasPriceRange(id: string): Observable<boolean>;
+	hasOptionalDiscountedPriceRange(id: string): Observable<boolean>;
 
 	/**
-	 * Get the price of a composite product based on the applied product options.
+	 * Returns whether the minimum and maximum composite product discounted prices equal the minimum and maximum
+	 * pre discount prices, including optional items. Note: this intentionally misses a usecase where there is a discount
+	 * in between the minimum and maximum prices. This is because the resulting UI would be non-sensical to the customer for
+	 * this usecase. For example, if we have a set of item options' prices: (price, discount), (10, 0), (20, 0), (15, 4).
+	 * While it is true that there is a discounted price (15, 4), the user would see the original price range (10-20) followed
+	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
+	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
 	 * @param id the id of the composite product.
 	 */
-	getPrice(id: string): Observable<number>;
+	hasOptionalDiscount(id: string): Observable<boolean>;
 
 	/**
-	 * Get the minimum discounted price of a composite product based on the applied product options.
+	 * Get the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
+	 * This would be used for a composite product that has required items without default selections.
 	 * @param id the id of the composite product.
 	 */
-	getMinDiscountedPrice(id: string): Observable<number>;
+	getMinRequiredPrice(id: string): Observable<number>;
 
 	/**
-	 * Get the maximum discounted price of a composite product based on the applied product options.
+	 * Get the maximum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
+	 * This would be used for a composite product that has required items without default selections.
 	 * @param id the id of the composite product.
 	 */
-	getMaxDiscountedPrice(id: string): Observable<number>;
+	getMaxRequiredPrice(id: string): Observable<number>;
 
 	/**
-	 * Returns whether the composite product has a discounted price range depending on applied options and excluding
-	 * optional items.
+	 * Selector for whether the composite product has a price range, excluding unselected optional items and based on the currently applied item options.
 	 * @param id the id of the composite product.
 	 */
-	hasDiscountedPriceRange(id: string): Observable<boolean>;
+	hasRequiredPriceRange(id: string): Observable<boolean>;
 
 	/**
-	 * Get the discount amount of a composite product based on the applied product options.
-	 * @param id the id of the composite product.
-	 * @deprecated
-	 */
-	getDiscountAmount(id: string): Observable<number>;
-
-	/**
-	 * Get the discounted price of a composite product based on the applied product options.
-	 * @param id the id of the composite product.
-	 * @deprecated Use getMinDiscountAmount and getMaxDiscountAmount instead.
- 	 */
-	getDiscountedPrice(id: string): Observable<number>;
-
-	/**
-	 * Returns whether the composite product has a discount based on the applied product options.
+	 * Get the minimum discounted price for a composite product, excluding unselected optional items and depending on the current selection of item options.
+	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
 	 * @param id the id of the composite product.
 	 */
-	hasDiscount(id: string): Observable<boolean>;
+	getMinRequiredDiscountedPrice(id: string): Observable<number>;
+
+	/**
+	 * Get the maximum discounted price for a composite product, excluding unselected optional items and depending on the current selection of item options.
+	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
+	 * @param id the id of the composite product.
+	 */
+	getMaxRequiredDiscountedPrice(id: string): Observable<number>;
+
+	/**
+	 * Returns whether the composite product has a discounted price range, excluding unselected optional items and based on the currently applied item options.
+	 * @param id the id of the composite product.
+	 */
+	hasRequiredDiscountedPriceRange(id: string): Observable<boolean>;
+
+	/**
+	 * Returns whether the minimum and maximum composite product discounted prices equal the minimum and maximum
+	 * pre discount prices, excluding unselected optional items. Note: this intentionally misses a usecase where there is a discount
+	 * in between the minimum and maximum prices. This is because the resulting UI would be non-sensical to the customer for
+	 * this usecase. For example, if we have a set of item options' prices: (price, discount), (10, 0), (20, 0), (15, 4).
+	 * While it is true that there is technically a discounted price, the user would see the original price range (10-20) followed
+	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
+	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
+	 * @param id the id of the composite product.
+	 */
+	hasRequiredDiscount(id: string): Observable<boolean>;
 
 	/**
 	 * Returns the applied options for a composite product.

--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -14,14 +14,14 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * This would be useful for a quick preview of a product.
 	 * @param id the id of the composite product.
 	 */
-	getMinOptionalItemPrice(id: string): Observable<number>;
+	getMinPossibleItemPrice(id: string): Observable<number>;
 
 	/**
    * Get the maximum price for a composite product, including optional items and regardless of applied options.
 	 * This would be useful for a quick preview of a product.	 
 	 * @param id the id of the composite product.
 	 */
-	getMaxOptionalItemPrice(id: string): Observable<number>;
+	getMaxPossibleItemPrice(id: string): Observable<number>;
 
 	/**
 	 * Returns whether the composite product could have a price range in any configuration,
@@ -29,21 +29,21 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	hasOptionalItemPriceRange(id: string): Observable<boolean>;
+	possiblyHasItemPriceRange(id: string): Observable<boolean>;
 
 	/**
 	 * Get the minimum discounted price for a composite product, including optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	getMinOptionalItemDiscountedPrice(id: string): Observable<number>;
+	getMinPossibleItemDiscountedPrice(id: string): Observable<number>;
 
 	/**
 	 * Get the maximum discounted price for a composite product, including optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	getMaxOptionalItemDiscountedPrice(id: string): Observable<number>;
+	getMaxPossibleItemDiscountedPrice(id: string): Observable<number>;
 
 	/**
 	 * Selector for whether the composite product could have a discounted price range in any configuration,
@@ -51,7 +51,7 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	hasOptionalItemDiscountedPriceRange(id: string): Observable<boolean>;
+	possiblyHasItemDiscountedPriceRange(id: string): Observable<boolean>;
 
 	/**
 	 * Returns whether the minimum and maximum composite product discounted prices equal the minimum and maximum
@@ -63,7 +63,7 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
 	 * @param id the id of the composite product.
 	 */
-	hasOptionalItemDiscount(id: string): Observable<boolean>;
+	possiblyHasItemDiscount(id: string): Observable<boolean>;
 
 	/**
 	 * Get the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.

--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -14,14 +14,14 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * This would be useful for a quick preview of a product.
 	 * @param id the id of the composite product.
 	 */
-	getMinOptionalPrice(id: string): Observable<number>;
+	getMinOptionalItemPrice(id: string): Observable<number>;
 
 	/**
    * Get the maximum price for a composite product, including optional items and regardless of applied options.
 	 * This would be useful for a quick preview of a product.	 
 	 * @param id the id of the composite product.
 	 */
-	getMaxOptionalPrice(id: string): Observable<number>;
+	getMaxOptionalItemPrice(id: string): Observable<number>;
 
 	/**
 	 * Returns whether the composite product could have a price range in any configuration,
@@ -29,21 +29,21 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	hasOptionalPriceRange(id: string): Observable<boolean>;
+	hasOptionalItemPriceRange(id: string): Observable<boolean>;
 
 	/**
 	 * Get the minimum discounted price for a composite product, including optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	getMinOptionalDiscountedPrice(id: string): Observable<number>;
+	getMinOptionalItemDiscountedPrice(id: string): Observable<number>;
 
 	/**
 	 * Get the maximum discounted price for a composite product, including optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	getMaxOptionalDiscountedPrice(id: string): Observable<number>;
+	getMaxOptionalItemDiscountedPrice(id: string): Observable<number>;
 
 	/**
 	 * Selector for whether the composite product could have a discounted price range in any configuration,
@@ -51,7 +51,7 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	hasOptionalDiscountedPriceRange(id: string): Observable<boolean>;
+	hasOptionalItemDiscountedPriceRange(id: string): Observable<boolean>;
 
 	/**
 	 * Returns whether the minimum and maximum composite product discounted prices equal the minimum and maximum
@@ -63,47 +63,47 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
 	 * @param id the id of the composite product.
 	 */
-	hasOptionalDiscount(id: string): Observable<boolean>;
+	hasOptionalItemDiscount(id: string): Observable<boolean>;
 
 	/**
 	 * Get the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
 	 * This would be used for a composite product that has required items without default selections.
 	 * @param id the id of the composite product.
 	 */
-	getMinRequiredPrice(id: string): Observable<number>;
+	getMinRequiredItemPrice(id: string): Observable<number>;
 
 	/**
 	 * Get the maximum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
 	 * This would be used for a composite product that has required items without default selections.
 	 * @param id the id of the composite product.
 	 */
-	getMaxRequiredPrice(id: string): Observable<number>;
+	getMaxRequiredItemPrice(id: string): Observable<number>;
 
 	/**
 	 * Selector for whether the composite product has a price range, excluding unselected optional items and based on the currently applied item options.
 	 * @param id the id of the composite product.
 	 */
-	hasRequiredPriceRange(id: string): Observable<boolean>;
+	hasRequiredItemPriceRange(id: string): Observable<boolean>;
 
 	/**
 	 * Get the minimum discounted price for a composite product, excluding unselected optional items and depending on the current selection of item options.
 	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
 	 * @param id the id of the composite product.
 	 */
-	getMinRequiredDiscountedPrice(id: string): Observable<number>;
+	getMinRequiredItemDiscountedPrice(id: string): Observable<number>;
 
 	/**
 	 * Get the maximum discounted price for a composite product, excluding unselected optional items and depending on the current selection of item options.
 	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
 	 * @param id the id of the composite product.
 	 */
-	getMaxRequiredDiscountedPrice(id: string): Observable<number>;
+	getMaxRequiredItemDiscountedPrice(id: string): Observable<number>;
 
 	/**
 	 * Returns whether the composite product has a discounted price range, excluding unselected optional items and based on the currently applied item options.
 	 * @param id the id of the composite product.
 	 */
-	hasRequiredDiscountedPriceRange(id: string): Observable<boolean>;
+	hasRequiredItemDiscountedPriceRange(id: string): Observable<boolean>;
 
 	/**
 	 * Returns whether the minimum and maximum composite product discounted prices equal the minimum and maximum
@@ -115,7 +115,7 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
 	 * @param id the id of the composite product.
 	 */
-	hasRequiredDiscount(id: string): Observable<boolean>;
+	hasRequiredItemDiscount(id: string): Observable<boolean>;
 
 	/**
 	 * Returns the applied options for a composite product.

--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -67,14 +67,14 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 
 	/**
 	 * Get the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
-	 * This would be used for a composite product that has required items without default selections.
+	 * This will be equal to getMaxRequiredItemPrice when all required items already have default selections.
 	 * @param id the id of the composite product.
 	 */
 	getMinRequiredItemPrice(id: string): Observable<number>;
 
 	/**
 	 * Get the maximum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
-	 * This would be used for a composite product that has required items without default selections.
+	 * This will be equal to getMinRequiredItemPrice when all required items already have default selections.
 	 * @param id the id of the composite product.
 	 */
 	getMaxRequiredItemPrice(id: string): Observable<number>;

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -58,7 +58,7 @@ describe('DaffCompositeProductFacade', () => {
     expect(store.dispatch).toHaveBeenCalledTimes(1);
   });
 
-  describe('getMinOptionalPrice', () => {
+  describe('getMinOptionalItemPrice', () => {
 
     it('should return the minimum price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -67,11 +67,11 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[0].price
 			});
 
-			expect(facade.getMinOptionalPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMinOptionalItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxOptionalPrice', () => {
+  describe('getMaxOptionalItemPrice', () => {
 
     it('should return the maximum price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -80,20 +80,20 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[1].price
 			});
 
-			expect(facade.getMaxOptionalPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMaxOptionalItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('hasOptionalPriceRange', () => {
+  describe('hasOptionalItemPriceRange', () => {
 
     it('should return whether the product could have a price range', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.hasOptionalPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.hasOptionalItemPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
 	});
 
-  describe('getMinOptionalDiscountedPrice', () => {
+  describe('getMinOptionalItemDiscountedPrice', () => {
 
     it('should return the minimum discounted price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -102,11 +102,11 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[0].price
 			});
 
-			expect(facade.getMinOptionalDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMinOptionalItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxOptionalDiscountedPrice', () => {
+  describe('getMaxOptionalItemDiscountedPrice', () => {
 
     it('should return the maximum discounted price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -115,20 +115,20 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[1].price
 			});
 
-			expect(facade.getMaxOptionalDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMaxOptionalItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('hasOptionalDiscountedPriceRange', () => {
+  describe('hasOptionalItemDiscountedPriceRange', () => {
 
     it('should return whether the product could have a discounted price range', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.hasOptionalDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.hasOptionalItemDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
 	});
 
-  describe('hasOptionalDiscount', () => {
+  describe('hasOptionalItemDiscount', () => {
     let productWithDiscount;
 
     beforeEach(() => {
@@ -144,11 +144,11 @@ describe('DaffCompositeProductFacade', () => {
     it('should return whether the product has a discount including optional items', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.hasOptionalDiscount(productWithDiscount.id)).toBeObservable(expected);
+			expect(facade.hasOptionalItemDiscount(productWithDiscount.id)).toBeObservable(expected);
 		});
 	});
 
-  describe('getMinRequiredPrice', () => {
+  describe('getMinRequiredItemPrice', () => {
 
     it('should return the minimum price for the product', () => {
 			const expected = cold('a', { a:
@@ -157,11 +157,11 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
 			});
 
-			expect(facade.getMinRequiredPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMinRequiredItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxRequiredPrice', () => {
+  describe('getMaxRequiredItemPrice', () => {
 
     it('should return the maximum price for the product', () => {
 			const expected = cold('a', { a:
@@ -170,20 +170,20 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
 			});
 
-			expect(facade.getMaxRequiredPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMaxRequiredItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('hasRequiredPriceRange', () => {
+  describe('hasRequiredItemPriceRange', () => {
 
     it('should return whether the product currently has a price range', () => {
 			const expected = cold('a', { a: false });
 
-			expect(facade.hasRequiredPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.hasRequiredItemPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
 	});
 
-  describe('getMinRequiredDiscountedPrice', () => {
+  describe('getMinRequiredItemDiscountedPrice', () => {
 
     it('should return the discounted price of the product', () => {
 			const expected = cold('a', { a:
@@ -192,11 +192,11 @@ describe('DaffCompositeProductFacade', () => {
 				(stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount)*stubCompositeProduct.items[1].options[0].quantity
 			});
 
-			expect(facade.getMinRequiredDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMinRequiredItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxRequiredDiscountedPrice', () => {
+  describe('getMaxRequiredItemDiscountedPrice', () => {
 
     it('should return the price of the product', () => {
 			const expected = cold('a', { a:
@@ -205,20 +205,20 @@ describe('DaffCompositeProductFacade', () => {
 				(stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount)*stubCompositeProduct.items[1].options[0].quantity
 			});
 
-			expect(facade.getMaxRequiredDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMaxRequiredItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('hasRequiredDiscountedPriceRange', () => {
+  describe('hasRequiredItemDiscountedPriceRange', () => {
 
     it('should return whether the product currently has a discounted price range', () => {
 			const expected = cold('a', { a: false });
 
-			expect(facade.hasRequiredDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.hasRequiredItemDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('hasRequiredDiscount', () => {
+  describe('hasRequiredItemDiscount', () => {
     let productWithDiscount;
 
     beforeEach(() => {
@@ -234,7 +234,7 @@ describe('DaffCompositeProductFacade', () => {
     it('should return whether the product has a discount excluding optional items', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.hasRequiredDiscount(productWithDiscount.id)).toBeObservable(expected);
+			expect(facade.hasRequiredItemDiscount(productWithDiscount.id)).toBeObservable(expected);
 		});
 	});
 

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -58,19 +58,20 @@ describe('DaffCompositeProductFacade', () => {
     expect(store.dispatch).toHaveBeenCalledTimes(1);
   });
 
-  describe('getMinPossiblePrice', () => {
+  describe('getMinOptionalPrice', () => {
 
     it('should return the minimum price possible for the product', () => {
 			const expected = cold('a', { a:
 				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[0].price
+				stubCompositeProduct.items[0].options[0].price +
+				stubCompositeProduct.items[1].options[0].price
 			});
 
-			expect(facade.getMinPossiblePrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMinOptionalPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxPossiblePrice', () => {
+  describe('getMaxOptionalPrice', () => {
 
     it('should return the maximum price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -79,128 +80,55 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[1].price
 			});
 
-			expect(facade.getMaxPossiblePrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMaxOptionalPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('possiblyHasPriceRange', () => {
+  describe('hasOptionalPriceRange', () => {
 
     it('should return whether the product could have a price range', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.possiblyHasPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.hasOptionalPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
 	});
 
-  describe('getMinPrice', () => {
+  describe('getMinOptionalDiscountedPrice', () => {
 
-    it('should return the minimum price for the product', () => {
+    it('should return the minimum discounted price possible for the product', () => {
 			const expected = cold('a', { a:
-				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity +
-				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
+				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
+				stubCompositeProduct.items[0].options[0].price +
+				stubCompositeProduct.items[1].options[0].price
 			});
 
-			expect(facade.getMinPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMinOptionalDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxPrice', () => {
+  describe('getMaxOptionalDiscountedPrice', () => {
 
-    it('should return the maximum price for the product', () => {
+    it('should return the maximum discounted price possible for the product', () => {
 			const expected = cold('a', { a:
-				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity +
-				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
+				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
+				stubCompositeProduct.items[0].options[1].price +
+				stubCompositeProduct.items[1].options[1].price
 			});
 
-			expect(facade.getMaxPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMaxOptionalDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('hasPriceRange', () => {
+  describe('hasOptionalDiscountedPriceRange', () => {
 
-    it('should return whether the product currently has a price range', () => {
-			const expected = cold('a', { a: false });
+    it('should return whether the product could have a discounted price range', () => {
+			const expected = cold('a', { a: true });
 
-			expect(facade.hasPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.hasOptionalDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
 	});
 
-  describe('getPrice', () => {
-
-    it('should return the price of the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity +
-				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
-			});
-
-			expect(facade.getPrice(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('getMinDiscountedPrice', () => {
-
-    it('should return the discounted price of the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
-				(stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount)*stubCompositeProduct.items[0].options[0].quantity +
-				(stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount)*stubCompositeProduct.items[1].options[0].quantity
-			});
-
-			expect(facade.getMinDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('getMaxDiscountedPrice', () => {
-
-    it('should return the price of the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
-				(stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount)*stubCompositeProduct.items[0].options[0].quantity +
-				(stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount)*stubCompositeProduct.items[1].options[0].quantity
-			});
-
-			expect(facade.getMaxDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('hasDiscountedPriceRange', () => {
-
-    it('should return whether the product currently has a discounted price range', () => {
-			const expected = cold('a', { a: false });
-
-			expect(facade.hasDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('getDiscountAmount', () => {
-
-    it('should return the total discount amount for a composite product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.discount.amount
-			});
-
-			expect(facade.getDiscountAmount(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('getDiscountedPrice', () => {
-
-    it('should the discounted price for a composite product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price
-				+ stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity
-				+ stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
-				- stubCompositeProduct.discount.amount
-			});
-
-			expect(facade.getDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('hasDiscount', () => {
+  describe('hasOptionalDiscount', () => {
     let productWithDiscount;
 
     beforeEach(() => {
@@ -213,10 +141,100 @@ describe('DaffCompositeProductFacade', () => {
       store.dispatch(new DaffProductLoadSuccess(productWithDiscount));
     })
 
-    it('should return whether the product has a discount', () => {
+    it('should return whether the product has a discount including optional items', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.hasDiscount(productWithDiscount.id)).toBeObservable(expected);
+			expect(facade.hasOptionalDiscount(productWithDiscount.id)).toBeObservable(expected);
+		});
+	});
+
+  describe('getMinRequiredPrice', () => {
+
+    it('should return the minimum price for the product', () => {
+			const expected = cold('a', { a:
+				stubCompositeProduct.price +
+				stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity +
+				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
+			});
+
+			expect(facade.getMinRequiredPrice(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('getMaxRequiredPrice', () => {
+
+    it('should return the maximum price for the product', () => {
+			const expected = cold('a', { a:
+				stubCompositeProduct.price +
+				stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity +
+				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
+			});
+
+			expect(facade.getMaxRequiredPrice(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('hasRequiredPriceRange', () => {
+
+    it('should return whether the product currently has a price range', () => {
+			const expected = cold('a', { a: false });
+
+			expect(facade.hasRequiredPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+	});
+
+  describe('getMinRequiredDiscountedPrice', () => {
+
+    it('should return the discounted price of the product', () => {
+			const expected = cold('a', { a:
+				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
+				(stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount)*stubCompositeProduct.items[0].options[0].quantity +
+				(stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount)*stubCompositeProduct.items[1].options[0].quantity
+			});
+
+			expect(facade.getMinRequiredDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('getMaxRequiredDiscountedPrice', () => {
+
+    it('should return the price of the product', () => {
+			const expected = cold('a', { a:
+				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
+				(stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount)*stubCompositeProduct.items[0].options[0].quantity +
+				(stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount)*stubCompositeProduct.items[1].options[0].quantity
+			});
+
+			expect(facade.getMaxRequiredDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('hasRequiredDiscountedPriceRange', () => {
+
+    it('should return whether the product currently has a discounted price range', () => {
+			const expected = cold('a', { a: false });
+
+			expect(facade.hasRequiredDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+		});
+  });
+
+  describe('hasRequiredDiscount', () => {
+    let productWithDiscount;
+
+    beforeEach(() => {
+      productWithDiscount = compositeProductFactory.create({
+        discount: {
+          amount: 10,
+          percent: 10
+        }
+      })
+      store.dispatch(new DaffProductLoadSuccess(productWithDiscount));
+    })
+
+    it('should return whether the product has a discount excluding optional items', () => {
+			const expected = cold('a', { a: true });
+
+			expect(facade.hasRequiredDiscount(productWithDiscount.id)).toBeObservable(expected);
 		});
 	});
 

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -58,7 +58,7 @@ describe('DaffCompositeProductFacade', () => {
     expect(store.dispatch).toHaveBeenCalledTimes(1);
   });
 
-  describe('getMinOptionalItemPrice', () => {
+  describe('getMinPossibleItemPrice', () => {
 
     it('should return the minimum price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -67,11 +67,11 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[0].price
 			});
 
-			expect(facade.getMinOptionalItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMinPossibleItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxOptionalItemPrice', () => {
+  describe('getMaxPossibleItemPrice', () => {
 
     it('should return the maximum price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -80,20 +80,20 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[1].price
 			});
 
-			expect(facade.getMaxOptionalItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMaxPossibleItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('hasOptionalItemPriceRange', () => {
+  describe('possiblyHasItemPriceRange', () => {
 
     it('should return whether the product could have a price range', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.hasOptionalItemPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.possiblyHasItemPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
 	});
 
-  describe('getMinOptionalItemDiscountedPrice', () => {
+  describe('getMinPossibleItemDiscountedPrice', () => {
 
     it('should return the minimum discounted price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -102,11 +102,11 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[0].price
 			});
 
-			expect(facade.getMinOptionalItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMinPossibleItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxOptionalItemDiscountedPrice', () => {
+  describe('getMaxPossibleItemDiscountedPrice', () => {
 
     it('should return the maximum discounted price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -115,20 +115,20 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[1].price
 			});
 
-			expect(facade.getMaxOptionalItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMaxPossibleItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('hasOptionalItemDiscountedPriceRange', () => {
+  describe('possiblyHasItemDiscountedPriceRange', () => {
 
     it('should return whether the product could have a discounted price range', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.hasOptionalItemDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.possiblyHasItemDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
 	});
 
-  describe('hasOptionalItemDiscount', () => {
+  describe('possiblyHasItemDiscount', () => {
     let productWithDiscount;
 
     beforeEach(() => {
@@ -144,7 +144,7 @@ describe('DaffCompositeProductFacade', () => {
     it('should return whether the product has a discount including optional items', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.hasOptionalItemDiscount(productWithDiscount.id)).toBeObservable(expected);
+			expect(facade.possiblyHasItemDiscount(productWithDiscount.id)).toBeObservable(expected);
 		});
 	});
 

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -23,60 +23,60 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 	
 	constructor(private store: Store<DaffProductReducersState<T>>) {}
 	
-	getMinOptionalPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinOptionalPrice, { id }));
+	getMinOptionalItemPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinOptionalItemPrice, { id }));
 	}
 
-	getMaxOptionalPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxOptionalPrice, { id }));
+	getMaxOptionalItemPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxOptionalItemPrice, { id }));
 	}
 
-	hasOptionalPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalPriceRange, { id }));
+	hasOptionalItemPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalItemPriceRange, { id }));
 	}
 
-	getMinOptionalDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinOptionalDiscountedPrice, { id }));
+	getMinOptionalItemDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinOptionalItemDiscountedPrice, { id }));
 	}
 
-	getMaxOptionalDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxOptionalDiscountedPrice, { id }));
+	getMaxOptionalItemDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxOptionalItemDiscountedPrice, { id }));
 	}
 
-	hasOptionalDiscountedPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalDiscountedPriceRange, { id }));
+	hasOptionalItemDiscountedPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalItemDiscountedPriceRange, { id }));
 	}
 
-	hasOptionalDiscount(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalDiscount, { id }));
+	hasOptionalItemDiscount(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalItemDiscount, { id }));
 	}
 
-	getMinRequiredPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinRequiredPrice, { id }));
+	getMinRequiredItemPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinRequiredItemPrice, { id }));
 	}
 
-	getMaxRequiredPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxRequiredPrice, { id }));
+	getMaxRequiredItemPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxRequiredItemPrice, { id }));
 	}
 
-	hasRequiredPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredPriceRange, { id }));
+	hasRequiredItemPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredItemPriceRange, { id }));
 	}
 	
-	getMinRequiredDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinRequiredDiscountedPrice, { id }));
+	getMinRequiredItemDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinRequiredItemDiscountedPrice, { id }));
 	}
 
-	getMaxRequiredDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxRequiredDiscountedPrice, { id }));
+	getMaxRequiredItemDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxRequiredItemDiscountedPrice, { id }));
 	}
 
-	hasRequiredDiscountedPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredDiscountedPriceRange, { id }));
+	hasRequiredItemDiscountedPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredItemDiscountedPriceRange, { id }));
 	}
 	
-	hasRequiredDiscount(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredDiscount, { id }));
+	hasRequiredItemDiscount(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredItemDiscount, { id }));
 	}
 
 	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption>> {

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -23,62 +23,60 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 	
 	constructor(private store: Store<DaffProductReducersState<T>>) {}
 	
-	getMinPossiblePrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinPossiblePrice, { id }));
+	getMinOptionalPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinOptionalPrice, { id }));
 	}
 
-	getMaxPossiblePrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPossiblePrice, { id }));
+	getMaxOptionalPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxOptionalPrice, { id }));
 	}
 
-	possiblyHasPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasPriceRange, { id }));
+	hasOptionalPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalPriceRange, { id }));
 	}
 
-	getMinPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinPrice, { id }));
+	getMinOptionalDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinOptionalDiscountedPrice, { id }));
 	}
 
-	getMaxPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPrice, { id }));
+	getMaxOptionalDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxOptionalDiscountedPrice, { id }));
 	}
 
-	hasPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasPriceRange, { id }));
+	hasOptionalDiscountedPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalDiscountedPriceRange, { id }));
 	}
 
-	getPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductPrice, { id }));
+	hasOptionalDiscount(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalDiscount, { id }));
+	}
+
+	getMinRequiredPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinRequiredPrice, { id }));
+	}
+
+	getMaxRequiredPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxRequiredPrice, { id }));
+	}
+
+	hasRequiredPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredPriceRange, { id }));
 	}
 	
-	getMinDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinDiscountedPrice, { id }));
+	getMinRequiredDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinRequiredDiscountedPrice, { id }));
 	}
 
-	getMaxDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxDiscountedPrice, { id }));
+	getMaxRequiredDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxRequiredDiscountedPrice, { id }));
 	}
 
-	hasDiscountedPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasDiscountedPriceRange, { id }));
-	}
-
-	/**
-	 * @deprecated
-	 */
-	getDiscountAmount(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductDiscountAmount, { id }));
-	}
-
-	/**
-	 * @deprecated Use getMinDiscountAmount and getMaxDiscountAmount instead.
-	 */
-	getDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductDiscountedPrice, { id }));
+	hasRequiredDiscountedPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredDiscountedPriceRange, { id }));
 	}
 	
-	hasDiscount(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasDiscount, { id }));
+	hasRequiredDiscount(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredDiscount, { id }));
 	}
 
 	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption>> {

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -23,32 +23,32 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 	
 	constructor(private store: Store<DaffProductReducersState<T>>) {}
 	
-	getMinOptionalItemPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinOptionalItemPrice, { id }));
+	getMinPossibleItemPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinPossibleItemPrice, { id }));
 	}
 
-	getMaxOptionalItemPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxOptionalItemPrice, { id }));
+	getMaxPossibleItemPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPossibleItemPrice, { id }));
 	}
 
-	hasOptionalItemPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalItemPriceRange, { id }));
+	possiblyHasItemPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasItemPriceRange, { id }));
 	}
 
-	getMinOptionalItemDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinOptionalItemDiscountedPrice, { id }));
+	getMinPossibleItemDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinPossibleItemDiscountedPrice, { id }));
 	}
 
-	getMaxOptionalItemDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxOptionalItemDiscountedPrice, { id }));
+	getMaxPossibleItemDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPossibleItemDiscountedPrice, { id }));
 	}
 
-	hasOptionalItemDiscountedPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalItemDiscountedPriceRange, { id }));
+	possiblyHasItemDiscountedPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasItemDiscountedPriceRange, { id }));
 	}
 
-	hasOptionalItemDiscount(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasOptionalItemDiscount, { id }));
+	possiblyHasItemDiscount(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasItemDiscount, { id }));
 	}
 
 	getMinRequiredItemPrice(id: string): Observable<number> {

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -22,20 +22,20 @@ describe('Composite Product Selectors | integration tests', () => {
 	let stubCompositeProduct: DaffCompositeProduct;
 	let stubProduct: DaffProduct;
 	const {
-		selectCompositeProductMinOptionalPrice,
-		selectCompositeProductMaxOptionalPrice,
-		selectCompositeProductHasOptionalPriceRange,
-		selectCompositeProductMinOptionalDiscountedPrice,
-		selectCompositeProductMaxOptionalDiscountedPrice,
-		selectCompositeProductHasOptionalDiscountedPriceRange,
-		selectCompositeProductHasOptionalDiscount,
-		selectCompositeProductMinRequiredPrice,
-		selectCompositeProductMaxRequiredPrice,
-		selectCompositeProductHasRequiredPriceRange,
-		selectCompositeProductMinRequiredDiscountedPrice,
-		selectCompositeProductMaxRequiredDiscountedPrice,
-		selectCompositeProductHasRequiredDiscountedPriceRange,
-		selectCompositeProductHasRequiredDiscount
+		selectCompositeProductMinOptionalItemPrice,
+		selectCompositeProductMaxOptionalItemPrice,
+		selectCompositeProductHasOptionalItemPriceRange,
+		selectCompositeProductMinOptionalItemDiscountedPrice,
+		selectCompositeProductMaxOptionalItemDiscountedPrice,
+		selectCompositeProductHasOptionalItemDiscountedPriceRange,
+		selectCompositeProductHasOptionalItemDiscount,
+		selectCompositeProductMinRequiredItemPrice,
+		selectCompositeProductMaxRequiredItemPrice,
+		selectCompositeProductHasRequiredItemPriceRange,
+		selectCompositeProductMinRequiredItemDiscountedPrice,
+		selectCompositeProductMaxRequiredItemDiscountedPrice,
+		selectCompositeProductHasRequiredItemDiscountedPriceRange,
+		selectCompositeProductHasRequiredItemDiscount
 	} = getDaffCompositeProductSelectors();
 	const stubPrice00 = 10;
 	const stubDiscountAmount0 = 2;
@@ -80,17 +80,17 @@ describe('Composite Product Selectors | integration tests', () => {
 		store.dispatch(new DaffProductLoadSuccess(stubProduct));
 	});
 
-	describe('selectCompositeProductMinOptionalPrice', () => {
+	describe('selectCompositeProductMinOptionalItemPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinOptionalPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinOptionalItemPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the minimum price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMinOptionalPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinOptionalItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
@@ -102,24 +102,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMinOptionalPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinOptionalItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMaxOptionalPrice', () => {
+	describe('selectCompositeProductMaxOptionalItemPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the maximum price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
@@ -131,24 +131,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductHasOptionalPriceRange', () => {
+	describe('selectCompositeProductHasOptionalItemPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalItemPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return true if the possible min and max prices are not equal', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalItemPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -161,24 +161,24 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].price = 0;
 			newCompositeProduct.items[1].options[1].price = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasOptionalPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalItemPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMinOptionalDiscountedPrice', () => {
+	describe('selectCompositeProductMinOptionalItemDiscountedPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinOptionalDiscountedPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinOptionalItemDiscountedPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the minimum discounted price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMinOptionalDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinOptionalItemDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
@@ -190,24 +190,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMinOptionalDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinOptionalItemDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMaxOptionalDiscountedPrice', () => {
+	describe('selectCompositeProductMaxOptionalItemDiscountedPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalDiscountedPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemDiscountedPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the maximum discounted price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice01 - stubDiscountAmount1 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
@@ -219,24 +219,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice01 - stubDiscountAmount1 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductHasOptionalDiscountedPriceRange', () => {
+	describe('selectCompositeProductHasOptionalItemDiscountedPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscountedPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscountedPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return true if the min and max prices including optional items are not equal', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscountedPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscountedPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -249,24 +249,24 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].price = 0;
 			newCompositeProduct.items[1].options[1].price = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscountedPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscountedPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductHasOptionalDiscount', () => {
+	describe('selectCompositeProductHasOptionalItemDiscount', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscount, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscount, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return true if the product, including optional items, has a discount', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscount, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscount, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -284,7 +284,7 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].discount.amount = 0;
 			newCompositeProduct.items[1].options[1].discount.amount = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscount, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscount, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
@@ -314,24 +314,24 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].discount.amount = 0;
 			newCompositeProduct.items[1].options[1].discount.amount = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscount, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscount, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMinRequiredPrice', () => {
+	describe('selectCompositeProductMinRequiredItemPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinRequiredPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredItemPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the current minimum price', () => {
-			const selector = store.pipe(select(selectCompositeProductMinRequiredPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00*stubQty0 });
 
 			expect(selector).toBeObservable(expected);
@@ -343,24 +343,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMinRequiredPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMaxRequiredPrice', () => {
+	describe('selectCompositeProductMaxRequiredItemPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the current maximum price', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00*stubQty0 });
 
 			expect(selector).toBeObservable(expected);
@@ -372,17 +372,17 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductHasRequiredPriceRange', () => {
+	describe('selectCompositeProductHasRequiredItemPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasRequiredPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredItemPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
@@ -394,7 +394,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				null
 			));
-			const selector = store.pipe(select(selectCompositeProductHasRequiredPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredItemPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -407,14 +407,14 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].price = 0;
 			newCompositeProduct.items[1].options[1].price = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasRequiredPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredItemPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMinRequiredDiscountedPrice', () => {
+	describe('selectCompositeProductMinRequiredItemDiscountedPrice', () => {
 
 		let newCompositeProduct;
 		const item0Option0Price = 10;
@@ -446,7 +446,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		});
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinRequiredDiscountedPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredItemDiscountedPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
@@ -455,7 +455,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		it('should initialize to the expected minimum discounted price', () => {
 			const smallestItem0DiscountedPrice = item0Option0Price - item0Option0DiscountAmount;
 			const smallestItem1DiscountedPrice = item1Option1Price - item1Option1DiscountAmount;
-			const selector = store.pipe(select(selectCompositeProductMinRequiredDiscountedPrice, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredItemDiscountedPrice, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: 
 				newCompositeProduct.price - newCompositeProduct.discount.amount + 
 				smallestItem0DiscountedPrice + 
@@ -476,7 +476,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				newCompositeProduct.items[0].options[1].id,
 				updatedOption01Quantity
 			));
-			const selector = store.pipe(select(selectCompositeProductMinRequiredDiscountedPrice, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredItemDiscountedPrice, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
 				selectedItem0DiscountedPrice + 
 				smallestItem1DiscountedPrice 
@@ -486,7 +486,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		});
 	});
 
-	describe('selectCompositeProductMaxRequiredDiscountedPrice', () => {
+	describe('selectCompositeProductMaxRequiredItemDiscountedPrice', () => {
 
 		let newCompositeProduct;
 		const item0Option0Price = 10;
@@ -518,7 +518,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		});
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredDiscountedPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemDiscountedPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
@@ -527,7 +527,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		it('should initialize to the expected maximum discounted price', () => {
 			const largestItem0DiscountedPrice = item0Option1Price - item0Option1DiscountAmount;
 			const largestItem1DiscountedPrice = item1Option0Price - item1Option0DiscountAmount;
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredDiscountedPrice, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemDiscountedPrice, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
 				largestItem0DiscountedPrice + 
 				largestItem1DiscountedPrice
@@ -546,7 +546,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				newCompositeProduct.items[0].options[0].id,
 				updatedOption00Quantity
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredDiscountedPrice, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemDiscountedPrice, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
 				selectedItem0DiscountedPrice + 
 				largestItem1DiscountedPrice
@@ -556,10 +556,10 @@ describe('Composite Product Selectors | integration tests', () => {
 		});
 	});
 
-	describe('selectCompositeProductHasRequiredDiscountedPriceRange', () => {
+	describe('selectCompositeProductHasRequiredItemDiscountedPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasRequiredDiscountedPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscountedPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
@@ -571,7 +571,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				null
 			));
-			const selector = store.pipe(select(selectCompositeProductHasRequiredDiscountedPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscountedPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -588,17 +588,17 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[1].discount.amount = 0;
 			newCompositeProduct.items[1].options[1].discount.amount = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasRequiredDiscountedPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscountedPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductHasRequiredDiscount', () => {
+	describe('selectCompositeProductHasRequiredItemDiscount', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasRequiredDiscount, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscount, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
@@ -618,7 +618,7 @@ describe('Composite Product Selectors | integration tests', () => {
       });
 
       it('should return true', () => {
-        const selector = store.pipe(select(selectCompositeProductHasRequiredDiscount, { id: mockProduct.id }));
+        const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscount, { id: mockProduct.id }));
         const expected = cold('a', { a: true });
 
         expect(selector).toBeObservable(expected);
@@ -639,7 +639,7 @@ describe('Composite Product Selectors | integration tests', () => {
       });
 
       it('should return false', () => {
-        const selector = store.pipe(select(selectCompositeProductHasRequiredDiscount, { id: mockProduct.id }));
+        const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscount, { id: mockProduct.id }));
         const expected = cold('a', { a: false });
 
         expect(selector).toBeObservable(expected);
@@ -671,7 +671,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				}
 			})
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasRequiredDiscount, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscount, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -13,7 +13,6 @@ import {
 } from '@daffodil/product';
 
 import { getDaffCompositeProductSelectors } from './composite-product.selectors';
-import { daffMultiply, daffAdd, daffSubtract } from '@daffodil/core';
 
 describe('Composite Product Selectors | integration tests', () => {
 
@@ -23,19 +22,20 @@ describe('Composite Product Selectors | integration tests', () => {
 	let stubCompositeProduct: DaffCompositeProduct;
 	let stubProduct: DaffProduct;
 	const {
-		selectCompositeProductMinPossiblePrice,
-		selectCompositeProductMaxPossiblePrice,
-		selectCompositeProductPossiblyHasPriceRange,
-		selectCompositeProductMinPrice,
-		selectCompositeProductMaxPrice,
-		selectCompositeProductHasPriceRange,
-		selectCompositeProductPrice,
-		selectCompositeProductMinDiscountedPrice,
-		selectCompositeProductMaxDiscountedPrice,
-		selectCompositeProductHasDiscountedPriceRange,
-		selectCompositeProductDiscountAmount,
-		selectCompositeProductDiscountedPrice,
-		selectCompositeProductHasDiscount
+		selectCompositeProductMinOptionalPrice,
+		selectCompositeProductMaxOptionalPrice,
+		selectCompositeProductHasOptionalPriceRange,
+		selectCompositeProductMinOptionalDiscountedPrice,
+		selectCompositeProductMaxOptionalDiscountedPrice,
+		selectCompositeProductHasOptionalDiscountedPriceRange,
+		selectCompositeProductHasOptionalDiscount,
+		selectCompositeProductMinRequiredPrice,
+		selectCompositeProductMaxRequiredPrice,
+		selectCompositeProductHasRequiredPriceRange,
+		selectCompositeProductMinRequiredDiscountedPrice,
+		selectCompositeProductMaxRequiredDiscountedPrice,
+		selectCompositeProductHasRequiredDiscountedPriceRange,
+		selectCompositeProductHasRequiredDiscount
 	} = getDaffCompositeProductSelectors();
 	const stubPrice00 = 10;
 	const stubDiscountAmount0 = 2;
@@ -80,18 +80,18 @@ describe('Composite Product Selectors | integration tests', () => {
 		store.dispatch(new DaffProductLoadSuccess(stubProduct));
 	});
 
-	describe('selectCompositeProductMinPossiblePrice', () => {
+	describe('selectCompositeProductMinOptionalPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinOptionalPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
-		it('should initialize to the minimum possible price for the composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 });
+		it('should initialize to the minimum price for the composite product including optional items', () => {
+			const selector = store.pipe(select(selectCompositeProductMinOptionalPrice, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
 		});
@@ -102,24 +102,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 });
+			const selector = store.pipe(select(selectCompositeProductMinOptionalPrice, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMaxPossiblePrice', () => {
+	describe('selectCompositeProductMaxOptionalPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPossiblePrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
-		it('should initialize to the maximum possible price for the composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPossiblePrice, { id: stubCompositeProduct.id }));
+		it('should initialize to the maximum price for the composite product including optional items', () => {
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
@@ -131,24 +131,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxPossiblePrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductPossiblyHasPriceRange', () => {
+	describe('selectCompositeProductHasOptionalPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return true if the possible min and max prices are not equal', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -161,24 +161,177 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].price = 0;
 			newCompositeProduct.items[1].options[1].price = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMinPrice', () => {
+	describe('selectCompositeProductMinOptionalDiscountedPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinOptionalDiscountedPrice, { id: stubProduct.id }));
+			const expected = cold('a', { a: undefined });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should initialize to the minimum discounted price for the composite product including optional items', () => {
+			const selector = store.pipe(select(selectCompositeProductMinOptionalDiscountedPrice, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 + stubPrice10 });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should not update the price when an option change occurs', () => {
+			store.dispatch(new DaffCompositeProductApplyOption(
+				stubCompositeProduct.id,
+				<string>stubCompositeProduct.items[0].id,
+				stubCompositeProduct.items[0].options[1].id
+			));
+			const selector = store.pipe(select(selectCompositeProductMinOptionalDiscountedPrice, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 + stubPrice10 });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectCompositeProductMaxOptionalDiscountedPrice', () => {
+
+		it('should return undefined if the given product id is not from a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalDiscountedPrice, { id: stubProduct.id }));
+			const expected = cold('a', { a: undefined });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should initialize to the maximum discounted price for the composite product including optional items', () => {
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalDiscountedPrice, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice01 - stubDiscountAmount1 + stubPrice11 });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should not update the price when an option change occurs', () => {
+			store.dispatch(new DaffCompositeProductApplyOption(
+				stubCompositeProduct.id,
+				<string>stubCompositeProduct.items[0].id,
+				stubCompositeProduct.items[0].options[1].id
+			));
+			const selector = store.pipe(select(selectCompositeProductMaxOptionalDiscountedPrice, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice01 - stubDiscountAmount1 + stubPrice11 });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectCompositeProductHasOptionalDiscountedPriceRange', () => {
+
+		it('should return false if the given product id is not from a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscountedPriceRange, { id: stubProduct.id }));
+			const expected = cold('a', { a: false });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should return true if the min and max prices including optional items are not equal', () => {
+			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscountedPriceRange, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: true });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should return false if the possible min and max prices including optional items are equal', () => {
+			const newCompositeProduct = compositeProductFactory.create();
+			newCompositeProduct.items[0].options[0].price = 0;
+			newCompositeProduct.items[0].options[1].price = 0;
+			newCompositeProduct.items[1].options[0].price = 0;
+			newCompositeProduct.items[1].options[1].price = 0;
+			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscountedPriceRange, { id: newCompositeProduct.id }));
+			const expected = cold('a', { a: false });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectCompositeProductHasOptionalDiscount', () => {
+
+		it('should return undefined if the given product id is not from a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscount, { id: stubProduct.id }));
+			const expected = cold('a', { a: undefined });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should return true if the product, including optional items, has a discount', () => {
+			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscount, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: true });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should return false if the product, including optional items, does not have a discount', () => {
+			const newCompositeProduct = compositeProductFactory.create();
+			newCompositeProduct.discount.amount = 0;
+			newCompositeProduct.items[0].options[0].price = 10;
+			newCompositeProduct.items[0].options[1].price = 20;
+			newCompositeProduct.items[1].options[0].price = 30;
+			newCompositeProduct.items[1].options[1].price = 40;
+			newCompositeProduct.items[0].options[0].discount.amount = 0;
+			newCompositeProduct.items[0].options[1].discount.amount = 0;
+			newCompositeProduct.items[1].options[0].discount.amount = 0;
+			newCompositeProduct.items[1].options[1].discount.amount = 0;
+			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscount, { id: newCompositeProduct.id }));
+			const expected = cold('a', { a: false });
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it(`should return false if the product\'s min and max discount amounts are zero, 
+				but there is a discount in between those extremes`, () => {
+			const newCompositeProduct = compositeProductFactory.create();
+			newCompositeProduct.discount.amount = 0;
+			newCompositeProduct.items[0].options[0].price = 10;
+			newCompositeProduct.items[0].options[1].price = 20;
+			newCompositeProduct.items[0].options.push({
+				id: 'id',
+				name: 'inbetween option with discount',
+				price: 15,
+				is_default: false,
+				quantity: 1,
+				discount: {
+					amount: 4,
+					percent: 10
+				}
+			})
+			newCompositeProduct.items[1].options[0].price = 0;
+			newCompositeProduct.items[1].options[1].price = 0;
+			newCompositeProduct.items[0].options[0].discount.amount = 0;
+			newCompositeProduct.items[0].options[1].discount.amount = 0;
+			newCompositeProduct.items[1].options[0].discount.amount = 0;
+			newCompositeProduct.items[1].options[1].discount.amount = 0;
+			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
+			const selector = store.pipe(select(selectCompositeProductHasOptionalDiscount, { id: newCompositeProduct.id }));
+			const expected = cold('a', { a: false });
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectCompositeProductMinRequiredPrice', () => {
+
+		it('should return undefined if the given product id is not from a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductMinRequiredPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the current minimum price', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00*stubQty0 });
 
 			expect(selector).toBeObservable(expected);
@@ -190,24 +343,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMinPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMaxPrice', () => {
+	describe('selectCompositeProductMaxRequiredPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the current maximum price', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00*stubQty0 });
 
 			expect(selector).toBeObservable(expected);
@@ -219,17 +372,17 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductHasPriceRange', () => {
+	describe('selectCompositeProductHasRequiredPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
@@ -241,7 +394,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				null
 			));
-			const selector = store.pipe(select(selectCompositeProductHasPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -254,43 +407,14 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].price = 0;
 			newCompositeProduct.items[1].options[1].price = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductPrice', () => {
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductPrice, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should initialize to the expected price', () => {
-			const selector = store.pipe(select(selectCompositeProductPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + (stubPrice00*stubCompositeProduct.items[0].options[0].quantity) });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should update the price when an option change occurs', () => {
-			store.dispatch(new DaffCompositeProductApplyOption(
-				stubCompositeProduct.id,
-				<string>stubCompositeProduct.items[0].id,
-				stubCompositeProduct.items[0].options[1].id
-			));
-			const selector = store.pipe(select(selectCompositeProductPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductMinDiscountedPrice', () => {
+	describe('selectCompositeProductMinRequiredDiscountedPrice', () => {
 
 		let newCompositeProduct;
 		const item0Option0Price = 10;
@@ -322,7 +446,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		});
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinDiscountedPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredDiscountedPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
@@ -331,7 +455,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		it('should initialize to the expected minimum discounted price', () => {
 			const smallestItem0DiscountedPrice = item0Option0Price - item0Option0DiscountAmount;
 			const smallestItem1DiscountedPrice = item1Option1Price - item1Option1DiscountAmount;
-			const selector = store.pipe(select(selectCompositeProductMinDiscountedPrice, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredDiscountedPrice, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: 
 				newCompositeProduct.price - newCompositeProduct.discount.amount + 
 				smallestItem0DiscountedPrice + 
@@ -352,7 +476,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				newCompositeProduct.items[0].options[1].id,
 				updatedOption01Quantity
 			));
-			const selector = store.pipe(select(selectCompositeProductMinDiscountedPrice, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinRequiredDiscountedPrice, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
 				selectedItem0DiscountedPrice + 
 				smallestItem1DiscountedPrice 
@@ -362,7 +486,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		});
 	});
 
-	describe('selectCompositeProductMaxDiscountedPrice', () => {
+	describe('selectCompositeProductMaxRequiredDiscountedPrice', () => {
 
 		let newCompositeProduct;
 		const item0Option0Price = 10;
@@ -394,7 +518,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		});
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxDiscountedPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredDiscountedPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
@@ -403,7 +527,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		it('should initialize to the expected maximum discounted price', () => {
 			const largestItem0DiscountedPrice = item0Option1Price - item0Option1DiscountAmount;
 			const largestItem1DiscountedPrice = item1Option0Price - item1Option0DiscountAmount;
-			const selector = store.pipe(select(selectCompositeProductMaxDiscountedPrice, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredDiscountedPrice, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
 				largestItem0DiscountedPrice + 
 				largestItem1DiscountedPrice
@@ -422,7 +546,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				newCompositeProduct.items[0].options[0].id,
 				updatedOption00Quantity
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxDiscountedPrice, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxRequiredDiscountedPrice, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
 				selectedItem0DiscountedPrice + 
 				largestItem1DiscountedPrice
@@ -432,10 +556,10 @@ describe('Composite Product Selectors | integration tests', () => {
 		});
 	});
 
-	describe('selectCompositeProductHasDiscountedPriceRange', () => {
+	describe('selectCompositeProductHasRequiredDiscountedPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasDiscountedPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredDiscountedPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
@@ -447,7 +571,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				null
 			));
-			const selector = store.pipe(select(selectCompositeProductHasDiscountedPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredDiscountedPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -464,107 +588,17 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[1].discount.amount = 0;
 			newCompositeProduct.items[1].options[1].discount.amount = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasDiscountedPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredDiscountedPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductDiscountAmount', () => {
+	describe('selectCompositeProductHasRequiredDiscount', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductDiscountAmount, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should initialize to the expected discount amount', () => {
-			const selector = store.pipe(select(selectCompositeProductDiscountAmount, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.discount.amount + (stubDiscountAmount0*stubCompositeProduct.items[0].options[0].quantity) });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should update the discount amount when an option change occurs', () => {
-			stubCompositeProduct.items[0].options[0].quantity = stubQty0;
-			store.dispatch(new DaffProductLoadSuccess(stubCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductDiscountAmount, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.discount.amount + (stubDiscountAmount0*stubQty0) });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductDiscountedPrice', () => {
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductDiscountedPrice, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should initialize to the expected discounted price', () => {
-			const selector = store.pipe(select(selectCompositeProductDiscountedPrice, { id: stubCompositeProduct.id }));
-			const price = daffAdd(
-				stubCompositeProduct.price,
-				daffMultiply(stubCompositeProduct.items[0].options[0].price, stubCompositeProduct.items[0].options[0].quantity),
-			);
-			const discount = daffAdd(
-				stubCompositeProduct.discount.amount,
-				daffMultiply(stubCompositeProduct.items[0].options[0].discount.amount, stubCompositeProduct.items[0].options[0].quantity)
-			)
-			const expected = cold('a', { a: daffSubtract(price, discount) });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should update the discounted price when an option change occurs', () => {
-			store.dispatch(new DaffCompositeProductApplyOption(
-				stubCompositeProduct.id,
-				<string>stubCompositeProduct.items[0].id,
-				stubCompositeProduct.items[0].options[1].id,
-				stubQty0
-			));
-			const selector = store.pipe(select(selectCompositeProductDiscountedPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a:
-				stubCompositeProduct.price
-				+ (stubCompositeProduct.items[0].options[1].price * stubQty0)
-				- stubCompositeProduct.discount.amount
-				- (stubCompositeProduct.items[0].options[1].discount.amount * stubQty0)
-			});
-			expect(selector).toBeObservable(expected);
-		});
-
-		describe('when the price or discount are long decimal values', () => {
-
-			it('should return the expected discounted price', () => {
-				const newCompositeProduct = compositeProductFactory.create();
-				newCompositeProduct.price = 70.53578;
-				newCompositeProduct.discount.amount = 20.3243;
-				newCompositeProduct.items[0].options[0].price = 10.3287;
-				newCompositeProduct.items[0].options[0].quantity = 1;
-				newCompositeProduct.items[0].options[0].is_default = true;
-				newCompositeProduct.items[1].required = false;
-				newCompositeProduct.items[1].options[0].is_default = false;
-				newCompositeProduct.items[0].options[0].discount = {
-					amount: 1.53518,
-					percent: null
-				};
-				store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-				const selector = store.pipe(select(selectCompositeProductDiscountedPrice, { id: newCompositeProduct.id }));
-				const expected = cold('a', { a: 59.005 });
-				expect(selector).toBeObservable(expected);
-			});
-		});
-	});
-
-	describe('selectCompositeProductHasDiscount', () => {
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasDiscount, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredDiscount, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
@@ -584,7 +618,7 @@ describe('Composite Product Selectors | integration tests', () => {
       });
 
       it('should return true', () => {
-        const selector = store.pipe(select(selectCompositeProductHasDiscount, { id: mockProduct.id }));
+        const selector = store.pipe(select(selectCompositeProductHasRequiredDiscount, { id: mockProduct.id }));
         const expected = cold('a', { a: true });
 
         expect(selector).toBeObservable(expected);
@@ -605,11 +639,42 @@ describe('Composite Product Selectors | integration tests', () => {
       });
 
       it('should return false', () => {
-        const selector = store.pipe(select(selectCompositeProductHasDiscount, { id: mockProduct.id }));
+        const selector = store.pipe(select(selectCompositeProductHasRequiredDiscount, { id: mockProduct.id }));
         const expected = cold('a', { a: false });
 
         expect(selector).toBeObservable(expected);
       });
-    });
+		});
+		
+		it(`should return false if the product\'s min and max discount amounts are zero, 
+				but there is a discount in between those extremes`, () => {
+			const newCompositeProduct = compositeProductFactory.create();
+			newCompositeProduct.discount.amount = 0;
+			newCompositeProduct.items[0].options[0].price = 10;
+			newCompositeProduct.items[0].options[1].price = 20;
+			newCompositeProduct.items[1].options[0].price = 0;
+			newCompositeProduct.items[1].options[1].price = 0;
+			newCompositeProduct.items[0].options[0].discount.amount = 0;
+			newCompositeProduct.items[0].options[1].discount.amount = 0;
+			newCompositeProduct.items[1].options[0].discount.amount = 0;
+			newCompositeProduct.items[1].options[1].discount.amount = 0;
+			newCompositeProduct.items[0].required = true;
+			newCompositeProduct.items[0].options.push({
+				id: 'id',
+				name: 'inbetween option with discount',
+				price: 15,
+				is_default: false,
+				quantity: 1,
+				discount: {
+					amount: 4,
+					percent: 10
+				}
+			})
+			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
+			const selector = store.pipe(select(selectCompositeProductHasRequiredDiscount, { id: newCompositeProduct.id }));
+			const expected = cold('a', { a: false });
+
+			expect(selector).toBeObservable(expected);
+		});
 	});
 });

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -22,13 +22,13 @@ describe('Composite Product Selectors | integration tests', () => {
 	let stubCompositeProduct: DaffCompositeProduct;
 	let stubProduct: DaffProduct;
 	const {
-		selectCompositeProductMinOptionalItemPrice,
-		selectCompositeProductMaxOptionalItemPrice,
-		selectCompositeProductHasOptionalItemPriceRange,
-		selectCompositeProductMinOptionalItemDiscountedPrice,
-		selectCompositeProductMaxOptionalItemDiscountedPrice,
-		selectCompositeProductHasOptionalItemDiscountedPriceRange,
-		selectCompositeProductHasOptionalItemDiscount,
+		selectCompositeProductMinPossibleItemPrice,
+		selectCompositeProductMaxPossibleItemPrice,
+		selectCompositeProductPossiblyHasItemPriceRange,
+		selectCompositeProductMinPossibleItemDiscountedPrice,
+		selectCompositeProductMaxPossibleItemDiscountedPrice,
+		selectCompositeProductPossiblyHasItemDiscountedPriceRange,
+		selectCompositeProductPossiblyHasItemDiscount,
 		selectCompositeProductMinRequiredItemPrice,
 		selectCompositeProductMaxRequiredItemPrice,
 		selectCompositeProductHasRequiredItemPriceRange,
@@ -80,17 +80,17 @@ describe('Composite Product Selectors | integration tests', () => {
 		store.dispatch(new DaffProductLoadSuccess(stubProduct));
 	});
 
-	describe('selectCompositeProductMinOptionalItemPrice', () => {
+	describe('selectCompositeProductMinPossibleItemPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinOptionalItemPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossibleItemPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the minimum price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMinOptionalItemPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossibleItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
@@ -102,24 +102,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMinOptionalItemPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossibleItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMaxOptionalItemPrice', () => {
+	describe('selectCompositeProductMaxPossibleItemPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the maximum price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
@@ -131,24 +131,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductHasOptionalItemPriceRange', () => {
+	describe('selectCompositeProductPossiblyHasItemPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalItemPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return true if the possible min and max prices are not equal', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalItemPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -161,24 +161,24 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].price = 0;
 			newCompositeProduct.items[1].options[1].price = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasOptionalItemPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMinOptionalItemDiscountedPrice', () => {
+	describe('selectCompositeProductMinPossibleItemDiscountedPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinOptionalItemDiscountedPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossibleItemDiscountedPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the minimum discounted price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMinOptionalItemDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossibleItemDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
@@ -190,24 +190,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMinOptionalItemDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossibleItemDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMaxOptionalItemDiscountedPrice', () => {
+	describe('selectCompositeProductMaxPossibleItemDiscountedPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemDiscountedPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemDiscountedPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the maximum discounted price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice01 - stubDiscountAmount1 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
@@ -219,24 +219,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxOptionalItemDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice01 - stubDiscountAmount1 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductHasOptionalItemDiscountedPriceRange', () => {
+	describe('selectCompositeProductPossiblyHasItemDiscountedPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscountedPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscountedPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return true if the min and max prices including optional items are not equal', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscountedPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscountedPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -249,24 +249,24 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].price = 0;
 			newCompositeProduct.items[1].options[1].price = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscountedPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscountedPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductHasOptionalItemDiscount', () => {
+	describe('selectCompositeProductPossiblyHasItemDiscount', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscount, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscount, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return true if the product, including optional items, has a discount', () => {
-			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscount, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscount, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -284,7 +284,7 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].discount.amount = 0;
 			newCompositeProduct.items[1].options[1].discount.amount = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscount, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscount, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
@@ -314,7 +314,7 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].discount.amount = 0;
 			newCompositeProduct.items[1].options[1].discount.amount = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasOptionalItemDiscount, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscount, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -9,20 +9,20 @@ import { DaffCompositeProduct } from '../../models/composite-product';
 import { DaffCompositeProductItem } from '../../models/composite-product-item';
 
 export interface DaffCompositeProductMemoizedSelectors {
-	selectCompositeProductMinOptionalPrice: MemoizedSelectorWithProps<object, object, number>;
-	selectCompositeProductMaxOptionalPrice: MemoizedSelectorWithProps<object, object, number>;
-	selectCompositeProductHasOptionalPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
-	selectCompositeProductMinOptionalDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
-	selectCompositeProductMaxOptionalDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
-	selectCompositeProductHasOptionalDiscountedPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
-	selectCompositeProductHasOptionalDiscount: MemoizedSelectorWithProps<object, object, boolean>;
-	selectCompositeProductMinRequiredPrice: MemoizedSelectorWithProps<object, object, number>;
-	selectCompositeProductMaxRequiredPrice: MemoizedSelectorWithProps<object, object, number>;
-	selectCompositeProductHasRequiredPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
-	selectCompositeProductMinRequiredDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
-	selectCompositeProductMaxRequiredDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
-	selectCompositeProductHasRequiredDiscountedPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
-	selectCompositeProductHasRequiredDiscount: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductMinOptionalItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMaxOptionalItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductHasOptionalItemPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductMinOptionalItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMaxOptionalItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductHasOptionalItemDiscountedPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductHasOptionalItemDiscount: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductMinRequiredItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMaxRequiredItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductHasRequiredItemPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductMinRequiredItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMaxRequiredItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductHasRequiredItemDiscountedPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductHasRequiredItemDiscount: MemoizedSelectorWithProps<object, object, boolean>;
 }
 
 const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelectors => {
@@ -41,7 +41,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * Selector for the minimum price for a composite product, including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	const selectCompositeProductMinOptionalPrice = createSelector(
+	const selectCompositeProductMinOptionalItemPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -61,7 +61,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * Selector for the maximum price for a composite product, including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	const selectCompositeProductMaxOptionalPrice = createSelector(
+	const selectCompositeProductMaxOptionalItemPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -82,10 +82,10 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	const selectCompositeProductHasOptionalPriceRange = createSelector(
+	const selectCompositeProductHasOptionalItemPriceRange = createSelector(
 		selectProductEntities,
-		(products, props) => selectCompositeProductMinOptionalPrice.projector(products, { id: props.id }) 
-			!== selectCompositeProductMaxOptionalPrice.projector(products, { id: props.id })
+		(products, props) => selectCompositeProductMinOptionalItemPrice.projector(products, { id: props.id }) 
+			!== selectCompositeProductMaxOptionalItemPrice.projector(products, { id: props.id })
 	)
 
 	/**
@@ -93,7 +93,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * This could be useful for a quick preview of the product.
 	 */
 	//todo use optional chaining where possible.
-	const selectCompositeProductMinOptionalDiscountedPrice = createSelector(
+	const selectCompositeProductMinOptionalItemDiscountedPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -112,7 +112,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * This could be useful for a quick preview of the product.
 	 */
 	//todo use optional chaining where possible.
-	const selectCompositeProductMaxOptionalDiscountedPrice = createSelector(
+	const selectCompositeProductMaxOptionalItemDiscountedPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -131,10 +131,10 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	const selectCompositeProductHasOptionalDiscountedPriceRange = createSelector(
+	const selectCompositeProductHasOptionalItemDiscountedPriceRange = createSelector(
 		selectProductEntities,
-		(products, props) => selectCompositeProductMinOptionalDiscountedPrice.projector(products, { id: props.id }) 
-			!== selectCompositeProductMaxOptionalDiscountedPrice.projector(products, { id: props.id })
+		(products, props) => selectCompositeProductMinOptionalItemDiscountedPrice.projector(products, { id: props.id }) 
+			!== selectCompositeProductMaxOptionalItemDiscountedPrice.projector(products, { id: props.id })
 	)
 
 	/**
@@ -146,7 +146,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
 	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
 	 */
-	const selectCompositeProductHasOptionalDiscount = createSelector(
+	const selectCompositeProductHasOptionalItemDiscount = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -155,11 +155,11 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			}
 
 			return daffSubtract(
-				selectCompositeProductMinOptionalPrice.projector(products, { id: props.id }), 
-				selectCompositeProductMinOptionalDiscountedPrice.projector(products, { id: props.id })
+				selectCompositeProductMinOptionalItemPrice.projector(products, { id: props.id }), 
+				selectCompositeProductMinOptionalItemDiscountedPrice.projector(products, { id: props.id })
 			) > 0 || daffSubtract(
-				selectCompositeProductMaxOptionalPrice.projector(products, { id: props.id }), 
-				selectCompositeProductMaxOptionalDiscountedPrice.projector(products, { id: props.id })
+				selectCompositeProductMaxOptionalItemPrice.projector(products, { id: props.id }), 
+				selectCompositeProductMaxOptionalItemDiscountedPrice.projector(products, { id: props.id })
 			) > 0;
 		}
 	);
@@ -168,7 +168,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * Selector for the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
 	 * This would be used for a composite product that has required items without default selections.
 	 */
-	const selectCompositeProductMinRequiredPrice = createSelector(
+	const selectCompositeProductMinRequiredItemPrice = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
 		(products, appliedOptionsEntities, props) => {
@@ -188,7 +188,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * Selector for the maximum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
 	 * This would be used for a composite product that has required items without default selections.
 	 */
-	const selectCompositeProductMaxRequiredPrice = createSelector(
+	const selectCompositeProductMaxRequiredItemPrice = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
 		(products, appliedOptionsEntities, props) => {
@@ -209,11 +209,11 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	/**
 	 * Selector for whether the composite product has a price range, excluding unselected optional items and based on the currently applied item options.
 	 */
-	const selectCompositeProductHasRequiredPriceRange = createSelector(
+	const selectCompositeProductHasRequiredItemPriceRange = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
-		(products, appliedOptionsEntities, props) => selectCompositeProductMinRequiredPrice.projector(products, appliedOptionsEntities, { id: props.id }) 
-			!== selectCompositeProductMaxRequiredPrice.projector(products, appliedOptionsEntities, { id: props.id })
+		(products, appliedOptionsEntities, props) => selectCompositeProductMinRequiredItemPrice.projector(products, appliedOptionsEntities, { id: props.id }) 
+			!== selectCompositeProductMaxRequiredItemPrice.projector(products, appliedOptionsEntities, { id: props.id })
 	)
 
 	/**
@@ -221,7 +221,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
 	 */
 	//todo use optional chaining where possible.
-	const selectCompositeProductMinRequiredDiscountedPrice = createSelector(
+	const selectCompositeProductMinRequiredItemDiscountedPrice = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
 		(products, appliedOptionsEntities, props) => {
@@ -247,7 +247,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
 	 */
 	//todo use optional chaining where possible.
-	const selectCompositeProductMaxRequiredDiscountedPrice = createSelector(
+	const selectCompositeProductMaxRequiredItemDiscountedPrice = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
 		(products, appliedOptionsEntities, props) => {
@@ -271,11 +271,11 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	/**
 	 * Selector for whether the composite product has a discounted price range, excluding unselected optional items and based on the currently applied item options.
 	 */
-	const selectCompositeProductHasRequiredDiscountedPriceRange = createSelector(
+	const selectCompositeProductHasRequiredItemDiscountedPriceRange = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
-		(products, appliedOptionsEntities, props) => selectCompositeProductMinRequiredDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id }) 
-			!== selectCompositeProductMaxRequiredDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id })
+		(products, appliedOptionsEntities, props) => selectCompositeProductMinRequiredItemDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id }) 
+			!== selectCompositeProductMaxRequiredItemDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id })
 	)
 
 	/**
@@ -287,7 +287,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
 	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
 	 */
-	const selectCompositeProductHasRequiredDiscount = createSelector(
+	const selectCompositeProductHasRequiredItemDiscount = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
 		(products, appliedOptionsEntities, props) => {
@@ -297,30 +297,30 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			}
 
 			return daffSubtract(
-				selectCompositeProductMinRequiredPrice.projector(products, appliedOptionsEntities, { id: props.id }), 
-				selectCompositeProductMinRequiredDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id })
+				selectCompositeProductMinRequiredItemPrice.projector(products, appliedOptionsEntities, { id: props.id }), 
+				selectCompositeProductMinRequiredItemDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id })
 			) > 0 || daffSubtract(
-				selectCompositeProductMaxRequiredPrice.projector(products, appliedOptionsEntities, { id: props.id }), 
-				selectCompositeProductMaxRequiredDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id })
+				selectCompositeProductMaxRequiredItemPrice.projector(products, appliedOptionsEntities, { id: props.id }), 
+				selectCompositeProductMaxRequiredItemDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id })
 			) > 0;
 		}
 	);
 
 	return { 
-		selectCompositeProductMinOptionalPrice,
-		selectCompositeProductMaxOptionalPrice,
-		selectCompositeProductHasOptionalPriceRange,
-		selectCompositeProductMinOptionalDiscountedPrice,
-		selectCompositeProductMaxOptionalDiscountedPrice,
-		selectCompositeProductHasOptionalDiscountedPriceRange,
-		selectCompositeProductHasOptionalDiscount,
-		selectCompositeProductMinRequiredPrice,
-		selectCompositeProductMaxRequiredPrice,
-		selectCompositeProductHasRequiredPriceRange,
-		selectCompositeProductMinRequiredDiscountedPrice,
-		selectCompositeProductMaxRequiredDiscountedPrice,
-		selectCompositeProductHasRequiredDiscountedPriceRange,
-		selectCompositeProductHasRequiredDiscount
+		selectCompositeProductMinOptionalItemPrice,
+		selectCompositeProductMaxOptionalItemPrice,
+		selectCompositeProductHasOptionalItemPriceRange,
+		selectCompositeProductMinOptionalItemDiscountedPrice,
+		selectCompositeProductMaxOptionalItemDiscountedPrice,
+		selectCompositeProductHasOptionalItemDiscountedPriceRange,
+		selectCompositeProductHasOptionalItemDiscount,
+		selectCompositeProductMinRequiredItemPrice,
+		selectCompositeProductMaxRequiredItemPrice,
+		selectCompositeProductHasRequiredItemPriceRange,
+		selectCompositeProductMinRequiredItemDiscountedPrice,
+		selectCompositeProductMaxRequiredItemDiscountedPrice,
+		selectCompositeProductHasRequiredItemDiscountedPriceRange,
+		selectCompositeProductHasRequiredItemDiscount
 	}
 }
 

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -13,34 +13,34 @@ export interface DaffCompositeProductMemoizedSelectors {
 	 * Selector for the minimum price for a composite product, including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductMinOptionalItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMinPossibleItemPrice: MemoizedSelectorWithProps<object, object, number>;
 	/**
 	 * Selector for the maximum price for a composite product, including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductMaxOptionalItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMaxPossibleItemPrice: MemoizedSelectorWithProps<object, object, number>;
 	/**
 	 * Selector for whether the composite product could have a price range in any configuration,
 	 * including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductHasOptionalItemPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductPossiblyHasItemPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
 	/**
 	 * Selector for the minimum discounted price for a composite product, including optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductMinOptionalItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMinPossibleItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
 	/**
 	 * Selector for the maximum discounted price for a composite product, including optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductMaxOptionalItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMaxPossibleItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
 	/**
 	 * Selector for whether the composite product could have a discounted price range in any configuration,
 	 * including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductHasOptionalItemDiscountedPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductPossiblyHasItemDiscountedPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
 	/**
 	 * Selector for whether the minimum and maximum composite product discounted prices equal the minimum and maximum
 	 * pre discount prices, including optional items. Note: this intentionally misses a usecase where there is a discount
@@ -50,7 +50,7 @@ export interface DaffCompositeProductMemoizedSelectors {
 	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
 	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
 	 */
-	selectCompositeProductHasOptionalItemDiscount: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductPossiblyHasItemDiscount: MemoizedSelectorWithProps<object, object, boolean>;
 	/**
 	 * Selector for the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
 	 * This would be used for a composite product that has required items without default selections.
@@ -103,7 +103,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		selectProduct
 	} = getDaffProductEntitiesSelectors();
 
-	const selectCompositeProductMinOptionalItemPrice = createSelector(
+	const selectCompositeProductMinPossibleItemPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -119,7 +119,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	const selectCompositeProductMaxOptionalItemPrice = createSelector(
+	const selectCompositeProductMaxPossibleItemPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -135,13 +135,13 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	const selectCompositeProductHasOptionalItemPriceRange = createSelector(
+	const selectCompositeProductPossiblyHasItemPriceRange = createSelector(
 		selectProductEntities,
-		(products, props) => selectCompositeProductMinOptionalItemPrice.projector(products, { id: props.id }) 
-			!== selectCompositeProductMaxOptionalItemPrice.projector(products, { id: props.id })
+		(products, props) => selectCompositeProductMinPossibleItemPrice.projector(products, { id: props.id }) 
+			!== selectCompositeProductMaxPossibleItemPrice.projector(products, { id: props.id })
 	)
 
-	const selectCompositeProductMinOptionalItemDiscountedPrice = createSelector(
+	const selectCompositeProductMinPossibleItemDiscountedPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -155,7 +155,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	const selectCompositeProductMaxOptionalItemDiscountedPrice = createSelector(
+	const selectCompositeProductMaxPossibleItemDiscountedPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -169,13 +169,13 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	const selectCompositeProductHasOptionalItemDiscountedPriceRange = createSelector(
+	const selectCompositeProductPossiblyHasItemDiscountedPriceRange = createSelector(
 		selectProductEntities,
-		(products, props) => selectCompositeProductMinOptionalItemDiscountedPrice.projector(products, { id: props.id }) 
-			!== selectCompositeProductMaxOptionalItemDiscountedPrice.projector(products, { id: props.id })
+		(products, props) => selectCompositeProductMinPossibleItemDiscountedPrice.projector(products, { id: props.id }) 
+			!== selectCompositeProductMaxPossibleItemDiscountedPrice.projector(products, { id: props.id })
 	)
 
-	const selectCompositeProductHasOptionalItemDiscount = createSelector(
+	const selectCompositeProductPossiblyHasItemDiscount = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -183,10 +183,10 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 				return undefined;
 			}
 
-			return selectCompositeProductMinOptionalItemPrice.projector(products, { id: props.id }) !==
-				selectCompositeProductMinOptionalItemDiscountedPrice.projector(products, { id: props.id })
-		 || selectCompositeProductMaxOptionalItemPrice.projector(products, { id: props.id }) !==
-				selectCompositeProductMaxOptionalItemDiscountedPrice.projector(products, { id: props.id });
+			return selectCompositeProductMinPossibleItemPrice.projector(products, { id: props.id }) !==
+				selectCompositeProductMinPossibleItemDiscountedPrice.projector(products, { id: props.id })
+		 || selectCompositeProductMaxPossibleItemPrice.projector(products, { id: props.id }) !==
+				selectCompositeProductMaxPossibleItemDiscountedPrice.projector(products, { id: props.id });
 		}
 	);
 
@@ -297,13 +297,13 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	);
 
 	return { 
-		selectCompositeProductMinOptionalItemPrice,
-		selectCompositeProductMaxOptionalItemPrice,
-		selectCompositeProductHasOptionalItemPriceRange,
-		selectCompositeProductMinOptionalItemDiscountedPrice,
-		selectCompositeProductMaxOptionalItemDiscountedPrice,
-		selectCompositeProductHasOptionalItemDiscountedPriceRange,
-		selectCompositeProductHasOptionalItemDiscount,
+		selectCompositeProductMinPossibleItemPrice,
+		selectCompositeProductMaxPossibleItemPrice,
+		selectCompositeProductPossiblyHasItemPriceRange,
+		selectCompositeProductMinPossibleItemDiscountedPrice,
+		selectCompositeProductMaxPossibleItemDiscountedPrice,
+		selectCompositeProductPossiblyHasItemDiscountedPriceRange,
+		selectCompositeProductPossiblyHasItemDiscount,
 		selectCompositeProductMinRequiredItemPrice,
 		selectCompositeProductMaxRequiredItemPrice,
 		selectCompositeProductHasRequiredItemPriceRange,

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -9,19 +9,85 @@ import { DaffCompositeProduct } from '../../models/composite-product';
 import { DaffCompositeProductItem } from '../../models/composite-product-item';
 
 export interface DaffCompositeProductMemoizedSelectors {
+	/**
+	 * Selector for the minimum price for a composite product, including the optional items and regardless of the current item option selection.
+	 * This could be useful for a quick preview of the product.
+	 */
 	selectCompositeProductMinOptionalItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	/**
+	 * Selector for the maximum price for a composite product, including the optional items and regardless of the current item option selection.
+	 * This could be useful for a quick preview of the product.
+	 */
 	selectCompositeProductMaxOptionalItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	/**
+	 * Selector for whether the composite product could have a price range in any configuration,
+	 * including the optional items and regardless of the current item option selection.
+	 * This could be useful for a quick preview of the product.
+	 */
 	selectCompositeProductHasOptionalItemPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	/**
+	 * Selector for the minimum discounted price for a composite product, including optional items and regardless of the current selection of item options.
+	 * This could be useful for a quick preview of the product.
+	 */
 	selectCompositeProductMinOptionalItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	/**
+	 * Selector for the maximum discounted price for a composite product, including optional items and regardless of the current selection of item options.
+	 * This could be useful for a quick preview of the product.
+	 */
 	selectCompositeProductMaxOptionalItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	/**
+	 * Selector for whether the composite product could have a discounted price range in any configuration,
+	 * including the optional items and regardless of the current item option selection.
+	 * This could be useful for a quick preview of the product.
+	 */
 	selectCompositeProductHasOptionalItemDiscountedPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	/**
+	 * Selector for whether the minimum and maximum composite product discounted prices equal the minimum and maximum
+	 * pre discount prices, including optional items. Note: this intentionally misses a usecase where there is a discount
+	 * in between the minimum and maximum prices. This is because the resulting UI would be non-sensical to the customer for
+	 * this usecase. For example, if we have a set of item options' prices: (price, discount), (10, 0), (20, 0), (15, 4).
+	 * While it is true that there is technically a discounted price, the user would see the original price range (10-20) followed
+	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
+	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
+	 */
 	selectCompositeProductHasOptionalItemDiscount: MemoizedSelectorWithProps<object, object, boolean>;
+	/**
+	 * Selector for the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
+	 * This would be used for a composite product that has required items without default selections.
+	 */
 	selectCompositeProductMinRequiredItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	/**
+	 * Selector for the maximum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
+	 * This would be used for a composite product that has required items without default selections.
+	 */
 	selectCompositeProductMaxRequiredItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	/**
+	 * Selector for whether the composite product has a price range, excluding unselected optional items and based on the currently applied item options.
+	 */
 	selectCompositeProductHasRequiredItemPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	/**
+	 * Selector for the minimum discounted price for a composite product, excluding unselected optional items and depending on the current selection of item options.
+	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
+	 */
 	selectCompositeProductMinRequiredItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	/**
+	 * Selector for the maximum discounted price for a composite product, excluding unselected optional items and depending on the current selection of item options.
+	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
+	 */
 	selectCompositeProductMaxRequiredItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	/**
+	 * Selector for whether the composite product has a discounted price range, excluding unselected optional items and based on the currently applied item options.
+	 */
 	selectCompositeProductHasRequiredItemDiscountedPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	/**
+	 * Selector for whether the minimum and maximum composite product discounted prices equal the minimum and maximum
+	 * pre discount prices, excluding unselected optional items. Note: this intentionally misses a usecase where there is a discount
+	 * in between the minimum and maximum prices. This is because the resulting UI would be non-sensical to the customer for
+	 * this usecase. For example, if we have a set of item options' prices: (price, discount), (10, 0), (20, 0), (15, 4).
+	 * While it is true that there is technically a discounted price, the user would see the original price range (10-20) followed
+	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
+	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
+	 */
 	selectCompositeProductHasRequiredItemDiscount: MemoizedSelectorWithProps<object, object, boolean>;
 }
 
@@ -37,10 +103,6 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		selectProduct
 	} = getDaffProductEntitiesSelectors();
 
-	/**
-	 * Selector for the minimum price for a composite product, including the optional items and regardless of the current item option selection.
-	 * This could be useful for a quick preview of the product.
-	 */
 	const selectCompositeProductMinOptionalItemPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
@@ -57,10 +119,6 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	/**
-	 * Selector for the maximum price for a composite product, including the optional items and regardless of the current item option selection.
-	 * This could be useful for a quick preview of the product.
-	 */
 	const selectCompositeProductMaxOptionalItemPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
@@ -77,22 +135,12 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	/**
-	 * Selector for whether the composite product could have a price range in any configuration,
-	 * including the optional items and regardless of the current item option selection.
-	 * This could be useful for a quick preview of the product.
-	 */
 	const selectCompositeProductHasOptionalItemPriceRange = createSelector(
 		selectProductEntities,
 		(products, props) => selectCompositeProductMinOptionalItemPrice.projector(products, { id: props.id }) 
 			!== selectCompositeProductMaxOptionalItemPrice.projector(products, { id: props.id })
 	)
 
-	/**
-	 * Selector for the minimum discounted price for a composite product, including optional items and regardless of the current selection of item options.
-	 * This could be useful for a quick preview of the product.
-	 */
-	//todo use optional chaining where possible.
 	const selectCompositeProductMinOptionalItemDiscountedPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
@@ -102,16 +150,11 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			}
 			return (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
 				acc, 
-				Math.min(...item.options.map(option => daffSubtract(option.price, option.discount ? option.discount.amount : 0)))
-			), daffSubtract(product.price, product.discount ? product.discount.amount : 0));
+				Math.min(...getItemDiscountedPrices(item))
+			), product.discount ? daffSubtract(product.price, product.discount.amount) : product.price);
 		}
 	);
 
-	/**
-	 * Selector for the maximum discounted price for a composite product, including optional items and regardless of the current selection of item options.
-	 * This could be useful for a quick preview of the product.
-	 */
-	//todo use optional chaining where possible.
 	const selectCompositeProductMaxOptionalItemDiscountedPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
@@ -121,31 +164,17 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			}
 			return (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
 				acc, 
-				Math.max(...item.options.map(option => daffSubtract(option.price, option.discount ? option.discount.amount : 0)))
-			), daffSubtract(product.price, product.discount ? product.discount.amount : 0));
+				Math.max(...getItemDiscountedPrices(item))
+			), product.discount ? daffSubtract(product.price, product.discount.amount) : product.price);
 		}
 	);
 
-	/**
-	 * Selector for whether the composite product could have a discounted price range in any configuration,
-	 * including the optional items and regardless of the current item option selection.
-	 * This could be useful for a quick preview of the product.
-	 */
 	const selectCompositeProductHasOptionalItemDiscountedPriceRange = createSelector(
 		selectProductEntities,
 		(products, props) => selectCompositeProductMinOptionalItemDiscountedPrice.projector(products, { id: props.id }) 
 			!== selectCompositeProductMaxOptionalItemDiscountedPrice.projector(products, { id: props.id })
 	)
 
-	/**
-	 * Selector for whether the minimum and maximum composite product discounted prices equal the minimum and maximum
-	 * pre discount prices, including optional items. Note: this intentionally misses a usecase where there is a discount
-	 * in between the minimum and maximum prices. This is because the resulting UI would be non-sensical to the customer for
-	 * this usecase. For example, if we have a set of item options' prices: (price, discount), (10, 0), (20, 0), (15, 4).
-	 * While it is true that there is technically a discounted price, the user would see the original price range (10-20) followed
-	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
-	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
-	 */
 	const selectCompositeProductHasOptionalItemDiscount = createSelector(
 		selectProductEntities,
 		(products, props) => {
@@ -154,20 +183,13 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 				return undefined;
 			}
 
-			return daffSubtract(
-				selectCompositeProductMinOptionalItemPrice.projector(products, { id: props.id }), 
+			return selectCompositeProductMinOptionalItemPrice.projector(products, { id: props.id }) !==
 				selectCompositeProductMinOptionalItemDiscountedPrice.projector(products, { id: props.id })
-			) > 0 || daffSubtract(
-				selectCompositeProductMaxOptionalItemPrice.projector(products, { id: props.id }), 
-				selectCompositeProductMaxOptionalItemDiscountedPrice.projector(products, { id: props.id })
-			) > 0;
+		 || selectCompositeProductMaxOptionalItemPrice.projector(products, { id: props.id }) !==
+				selectCompositeProductMaxOptionalItemDiscountedPrice.projector(products, { id: props.id });
 		}
 	);
 
-	/**
-	 * Selector for the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
-	 * This would be used for a composite product that has required items without default selections.
-	 */
 	const selectCompositeProductMinRequiredItemPrice = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
@@ -184,10 +206,6 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	/**
-	 * Selector for the maximum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
-	 * This would be used for a composite product that has required items without default selections.
-	 */
 	const selectCompositeProductMaxRequiredItemPrice = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
@@ -206,9 +224,6 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	/**
-	 * Selector for whether the composite product has a price range, excluding unselected optional items and based on the currently applied item options.
-	 */
 	const selectCompositeProductHasRequiredItemPriceRange = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
@@ -216,11 +231,6 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			!== selectCompositeProductMaxRequiredItemPrice.projector(products, appliedOptionsEntities, { id: props.id })
 	)
 
-	/**
-	 * Selector for the minimum discounted price for a composite product, excluding unselected optional items and depending on the current selection of item options.
-	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
-	 */
-	//todo use optional chaining where possible.
 	const selectCompositeProductMinRequiredItemDiscountedPrice = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
@@ -234,19 +244,14 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 				acc, 
 				appliedOptions[item.id] ? 
 					daffMultiply(
-						daffSubtract(appliedOptions[item.id].price, appliedOptions[item.id].discount && appliedOptions[item.id].discount.amount), 
+						appliedOptions[item.id].discount ? daffSubtract(appliedOptions[item.id].price, appliedOptions[item.id].discount.amount) : appliedOptions[item.id].price, 
 						appliedOptions[item.id].quantity
 					) : 
 					getMinimumRequiredCompositeItemDiscountedPrice(item)
-			), daffSubtract(product.price, product.discount ? product.discount.amount : 0));
+			), product.discount ? daffSubtract(product.price, product.discount.amount) : product.price);
 		}
 	);
 
-	/**
-	 * Selector for the maximum discounted price for a composite product, excluding unselected optional items and depending on the current selection of item options.
-	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
-	 */
-	//todo use optional chaining where possible.
 	const selectCompositeProductMaxRequiredItemDiscountedPrice = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
@@ -260,17 +265,14 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 				acc, 
 				appliedOptions[item.id] ? 
 					daffMultiply(
-						daffSubtract(appliedOptions[item.id].price, appliedOptions[item.id].discount && appliedOptions[item.id].discount.amount),
+						appliedOptions[item.id].discount ? daffSubtract(appliedOptions[item.id].price, appliedOptions[item.id].discount.amount) : appliedOptions[item.id].price,
 						appliedOptions[item.id].quantity
 					) : 
 					getMaximumRequiredCompositeItemDiscountedPrice(item)
-			), daffSubtract(product.price, product.discount ? product.discount.amount : 0));
+			), product.discount.amount ? daffSubtract(product.price, product.discount.amount) : product.price);
 		}
 	);
 
-	/**
-	 * Selector for whether the composite product has a discounted price range, excluding unselected optional items and based on the currently applied item options.
-	 */
 	const selectCompositeProductHasRequiredItemDiscountedPriceRange = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
@@ -278,15 +280,6 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			!== selectCompositeProductMaxRequiredItemDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id })
 	)
 
-	/**
-	 * Selector for whether the minimum and maximum composite product discounted prices equal the minimum and maximum
-	 * pre discount prices, excluding unselected optional items. Note: this intentionally misses a usecase where there is a discount
-	 * in between the minimum and maximum prices. This is because the resulting UI would be non-sensical to the customer for
-	 * this usecase. For example, if we have a set of item options' prices: (price, discount), (10, 0), (20, 0), (15, 4).
-	 * While it is true that there is technically a discounted price, the user would see the original price range (10-20) followed
-	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
-	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
-	 */
 	const selectCompositeProductHasRequiredItemDiscount = createSelector(
 		selectProductEntities,
 		selectCompositeProductAppliedOptionsEntitiesState,
@@ -296,13 +289,10 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 				return undefined;
 			}
 
-			return daffSubtract(
-				selectCompositeProductMinRequiredItemPrice.projector(products, appliedOptionsEntities, { id: props.id }), 
+			return selectCompositeProductMinRequiredItemPrice.projector(products, appliedOptionsEntities, { id: props.id }) !==
 				selectCompositeProductMinRequiredItemDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id })
-			) > 0 || daffSubtract(
-				selectCompositeProductMaxRequiredItemPrice.projector(products, appliedOptionsEntities, { id: props.id }), 
-				selectCompositeProductMaxRequiredItemDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id })
-			) > 0;
+			|| selectCompositeProductMaxRequiredItemPrice.projector(products, appliedOptionsEntities, { id: props.id }) !==
+				selectCompositeProductMaxRequiredItemDiscountedPrice.projector(products, appliedOptionsEntities, { id: props.id });
 		}
 	);
 
@@ -366,4 +356,8 @@ function getMaximumRequiredCompositeItemDiscountedPrice(item: DaffCompositeProdu
 	return item.required ? Math.max(...item.options.map(option => 
 		daffSubtract(option.price, option.discount ? option.discount.amount : 0)
 	)) : 0;
+}
+
+function getItemDiscountedPrices(item: DaffCompositeProductItem): number[] {
+	return item.options.map(option => option.discount ? daffSubtract(option.price, option.discount.amount) : option.price);
 }

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -4,25 +4,25 @@ import { DaffCompositeProductFacadeInterface, DaffCompositeProductItemOption, Da
 import { Dictionary } from '@ngrx/entity';
 
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
-	getMinOptionalItemPrice(id: string): BehaviorSubject<number> {
+	getMinPossibleItemPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaxOptionalItemPrice(id: string): BehaviorSubject<number> {
+	getMaxPossibleItemPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	hasOptionalItemPriceRange(id: string): BehaviorSubject<boolean> {
+	possiblyHasItemPriceRange(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	getMinOptionalItemDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMinPossibleItemDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaxOptionalItemDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMaxPossibleItemDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	hasOptionalItemDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
+	possiblyHasItemDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	hasOptionalItemDiscount(id: string): BehaviorSubject<boolean> {
+	possiblyHasItemDiscount(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
 	getMinRequiredItemPrice(id: string): BehaviorSubject<number> {

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -4,49 +4,46 @@ import { DaffCompositeProductFacadeInterface, DaffCompositeProductItemOption, Da
 import { Dictionary } from '@ngrx/entity';
 
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
-	getMinPossiblePrice(id: string): BehaviorSubject<number> {
+	getMinOptionalPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaxPossiblePrice(id: string): BehaviorSubject<number> {
+	getMaxOptionalPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	possiblyHasPriceRange(id: string): BehaviorSubject<boolean> {
+	hasOptionalPriceRange(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	getMinPrice(id: string): BehaviorSubject<number> {
+	getMinOptionalDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaxPrice(id: string): BehaviorSubject<number> {
+	getMaxOptionalDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	hasPriceRange(id: string): BehaviorSubject<boolean> {
+	hasOptionalDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	getPrice(id: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
-	};
-	getMinDiscountedPrice(id: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
-	};
-	getMaxDiscountedPrice(id: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
-	};
-	hasDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
+	hasOptionalDiscount(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	/**
-	 * @deprecated
-	 */
-	getDiscountAmount(id: string): BehaviorSubject<number> {
+	getMinRequiredPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	/**
-	 * @deprecated Use getMinDiscountedPrice and getMaxDiscountedPrice instead
-	 */
-	getDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMaxRequiredPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	hasDiscount(id: string): BehaviorSubject<boolean> {
+	hasRequiredPriceRange(id: string): BehaviorSubject<boolean> {
+		return new BehaviorSubject(false);
+	};
+	getMinRequiredDiscountedPrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	getMaxRequiredDiscountedPrice(id: string): BehaviorSubject<number> {
+		return new BehaviorSubject(null);
+	};
+	hasRequiredDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
+		return new BehaviorSubject(false);
+	};
+	hasRequiredDiscount(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
 	getAppliedOptions(id: string): BehaviorSubject<Dictionary<DaffCompositeProductItemOption>> {

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -4,46 +4,46 @@ import { DaffCompositeProductFacadeInterface, DaffCompositeProductItemOption, Da
 import { Dictionary } from '@ngrx/entity';
 
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
-	getMinOptionalPrice(id: string): BehaviorSubject<number> {
+	getMinOptionalItemPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaxOptionalPrice(id: string): BehaviorSubject<number> {
+	getMaxOptionalItemPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	hasOptionalPriceRange(id: string): BehaviorSubject<boolean> {
+	hasOptionalItemPriceRange(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	getMinOptionalDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMinOptionalItemDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaxOptionalDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMaxOptionalItemDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	hasOptionalDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
+	hasOptionalItemDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	hasOptionalDiscount(id: string): BehaviorSubject<boolean> {
+	hasOptionalItemDiscount(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	getMinRequiredPrice(id: string): BehaviorSubject<number> {
+	getMinRequiredItemPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaxRequiredPrice(id: string): BehaviorSubject<number> {
+	getMaxRequiredItemPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	hasRequiredPriceRange(id: string): BehaviorSubject<boolean> {
+	hasRequiredItemPriceRange(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	getMinRequiredDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMinRequiredItemDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaxRequiredDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMaxRequiredItemDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	hasRequiredDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
+	hasRequiredItemDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	hasRequiredDiscount(id: string): BehaviorSubject<boolean> {
+	hasRequiredItemDiscount(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
 	getAppliedOptions(id: string): BehaviorSubject<Dictionary<DaffCompositeProductItemOption>> {


### PR DESCRIPTION
…ade fields

BREAKING CHANGE: nearly all of the DaffCompositeProductFacade fields and composite product selectors have changed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The facade fields and selectors for composite product prices and discounts are named poorly and don't cover all use cases needed.

## What is the new behavior?
This should be the final form of composite product selectors and facade fields, at least in terms of breaking changes to the public API. The naming is much more clear and sensical. The docs are a lot more accurate for each selector and facade field too.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Notes
The selectors are split into two groups: selectors meant to be used for a quick preview of a product (includes optional item prices), and selectors meant to be used for a product page (only includes required item prices).

The quick preview selectors consider the entire range of prices and discounts that are possible, **including optional product items and regardless of what items might be already selected or have a default value**. So even if a final price (a non-ranged price) is possible without selecting any items, the values given by these selectors will still be a range of prices if a range is possible. These quick preview selectors include:
```
selectCompositeProductMinPossibleItemPrice
selectCompositeProductMaxPossibleItemPrice
selectCompositeProductPossiblyHasItemPriceRange
selectCompositeProductMinPossibleItemDiscountedPrice
selectCompositeProductMaxPossibleItemDiscountedPrice
selectCompositeProductPossiblyHasItemDiscountedPriceRange
selectCompositeProductPossiblyHasItemDiscount
```

The product page selectors only consider the prices and discounts for **selected items and unselected required items**. If all required items are selected there will never be a range of prices, even though the price could change with the addition of another optional item. These include:
```
selectCompositeProductMinRequiredItemPrice
selectCompositeProductMaxRequiredItemPrice
selectCompositeProductHasRequiredItemPriceRange
selectCompositeProductMinRequiredItemDiscountedPrice
selectCompositeProductMaxRequiredItemDiscountedPrice
selectCompositeProductHasRequiredItemDiscountedPriceRange
selectCompositeProductHasRequiredItemDiscount
```

The "final" price (the price that is no longer a range of possible prices) comes from either the min or max price/discountedPrice selectors whenever the "hasPriceRange" selectors return false, since the min and max values will be equal when there is no price range.

The facade fields in the `DaffCompositeProductFacade` are identically named to the selectors minus the `selectCompositeProduct`