### PR TITLE
fix(product): fix the facade and selector names for composite product…

### DIFF
--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -14,14 +14,14 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * This would be useful for a quick preview of a product.
 	 * @param id the id of the composite product.
 	 */
-	getMinPossibleItemPrice(id: string): Observable<number>;
+	getMinPossiblePrice(id: string): Observable<number>;
 
 	/**
    * Get the maximum price for a composite product, including optional items and regardless of applied options.
 	 * This would be useful for a quick preview of a product.	 
 	 * @param id the id of the composite product.
 	 */
-	getMaxPossibleItemPrice(id: string): Observable<number>;
+	getMaxPossiblePrice(id: string): Observable<number>;
 
 	/**
 	 * Returns whether the composite product could have a price range in any configuration,
@@ -29,21 +29,21 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	possiblyHasItemPriceRange(id: string): Observable<boolean>;
+	possiblyHasPriceRange(id: string): Observable<boolean>;
 
 	/**
 	 * Get the minimum discounted price for a composite product, including optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	getMinPossibleItemDiscountedPrice(id: string): Observable<number>;
+	getMinPossibleDiscountedPrice(id: string): Observable<number>;
 
 	/**
 	 * Get the maximum discounted price for a composite product, including optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	getMaxPossibleItemDiscountedPrice(id: string): Observable<number>;
+	getMaxPossibleDiscountedPrice(id: string): Observable<number>;
 
 	/**
 	 * Selector for whether the composite product could have a discounted price range in any configuration,
@@ -51,7 +51,7 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */
-	possiblyHasItemDiscountedPriceRange(id: string): Observable<boolean>;
+	possiblyHasDiscountedPriceRange(id: string): Observable<boolean>;
 
 	/**
 	 * Returns whether the minimum and maximum composite product discounted prices equal the minimum and maximum
@@ -63,7 +63,7 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
 	 * @param id the id of the composite product.
 	 */
-	possiblyHasItemDiscount(id: string): Observable<boolean>;
+	possiblyHasDiscount(id: string): Observable<boolean>;
 
 	/**
 	 * Get the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -58,7 +58,7 @@ describe('DaffCompositeProductFacade', () => {
     expect(store.dispatch).toHaveBeenCalledTimes(1);
   });
 
-  describe('getMinPossibleItemPrice', () => {
+  describe('getMinPossiblePrice', () => {
 
     it('should return the minimum price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -67,11 +67,11 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[0].price
 			});
 
-			expect(facade.getMinPossibleItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMinPossiblePrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxPossibleItemPrice', () => {
+  describe('getMaxPossiblePrice', () => {
 
     it('should return the maximum price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -80,20 +80,20 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[1].price
 			});
 
-			expect(facade.getMaxPossibleItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMaxPossiblePrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('possiblyHasItemPriceRange', () => {
+  describe('possiblyHasPriceRange', () => {
 
     it('should return whether the product could have a price range', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.possiblyHasItemPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.possiblyHasPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
 	});
 
-  describe('getMinPossibleItemDiscountedPrice', () => {
+  describe('getMinPossibleDiscountedPrice', () => {
 
     it('should return the minimum discounted price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -102,11 +102,11 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[0].price
 			});
 
-			expect(facade.getMinPossibleItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMinPossibleDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxPossibleItemDiscountedPrice', () => {
+  describe('getMaxPossibleDiscountedPrice', () => {
 
     it('should return the maximum discounted price possible for the product', () => {
 			const expected = cold('a', { a:
@@ -115,20 +115,20 @@ describe('DaffCompositeProductFacade', () => {
 				stubCompositeProduct.items[1].options[1].price
 			});
 
-			expect(facade.getMaxPossibleItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getMaxPossibleDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('possiblyHasItemDiscountedPriceRange', () => {
+  describe('possiblyHasDiscountedPriceRange', () => {
 
     it('should return whether the product could have a discounted price range', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.possiblyHasItemDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.possiblyHasDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
 		});
 	});
 
-  describe('possiblyHasItemDiscount', () => {
+  describe('possiblyHasDiscount', () => {
     let productWithDiscount;
 
     beforeEach(() => {
@@ -144,7 +144,7 @@ describe('DaffCompositeProductFacade', () => {
     it('should return whether the product has a discount including optional items', () => {
 			const expected = cold('a', { a: true });
 
-			expect(facade.possiblyHasItemDiscount(productWithDiscount.id)).toBeObservable(expected);
+			expect(facade.possiblyHasDiscount(productWithDiscount.id)).toBeObservable(expected);
 		});
 	});
 

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -23,32 +23,32 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 	
 	constructor(private store: Store<DaffProductReducersState<T>>) {}
 	
-	getMinPossibleItemPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinPossibleItemPrice, { id }));
+	getMinPossiblePrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinPossiblePrice, { id }));
 	}
 
-	getMaxPossibleItemPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPossibleItemPrice, { id }));
+	getMaxPossiblePrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPossiblePrice, { id }));
 	}
 
-	possiblyHasItemPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasItemPriceRange, { id }));
+	possiblyHasPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasPriceRange, { id }));
 	}
 
-	getMinPossibleItemDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinPossibleItemDiscountedPrice, { id }));
+	getMinPossibleDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMinPossibleDiscountedPrice, { id }));
 	}
 
-	getMaxPossibleItemDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPossibleItemDiscountedPrice, { id }));
+	getMaxPossibleDiscountedPrice(id: string): Observable<number> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPossibleDiscountedPrice, { id }));
 	}
 
-	possiblyHasItemDiscountedPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasItemDiscountedPriceRange, { id }));
+	possiblyHasDiscountedPriceRange(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasDiscountedPriceRange, { id }));
 	}
 
-	possiblyHasItemDiscount(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasItemDiscount, { id }));
+	possiblyHasDiscount(id: string): Observable<boolean> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasDiscount, { id }));
 	}
 
 	getMinRequiredItemPrice(id: string): Observable<number> {

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -22,13 +22,13 @@ describe('Composite Product Selectors | integration tests', () => {
 	let stubCompositeProduct: DaffCompositeProduct;
 	let stubProduct: DaffProduct;
 	const {
-		selectCompositeProductMinPossibleItemPrice,
-		selectCompositeProductMaxPossibleItemPrice,
-		selectCompositeProductPossiblyHasItemPriceRange,
-		selectCompositeProductMinPossibleItemDiscountedPrice,
-		selectCompositeProductMaxPossibleItemDiscountedPrice,
-		selectCompositeProductPossiblyHasItemDiscountedPriceRange,
-		selectCompositeProductPossiblyHasItemDiscount,
+		selectCompositeProductMinPossiblePrice,
+		selectCompositeProductMaxPossiblePrice,
+		selectCompositeProductPossiblyHasPriceRange,
+		selectCompositeProductMinPossibleDiscountedPrice,
+		selectCompositeProductMaxPossibleDiscountedPrice,
+		selectCompositeProductPossiblyHasDiscountedPriceRange,
+		selectCompositeProductPossiblyHasDiscount,
 		selectCompositeProductMinRequiredItemPrice,
 		selectCompositeProductMaxRequiredItemPrice,
 		selectCompositeProductHasRequiredItemPriceRange,
@@ -80,17 +80,17 @@ describe('Composite Product Selectors | integration tests', () => {
 		store.dispatch(new DaffProductLoadSuccess(stubProduct));
 	});
 
-	describe('selectCompositeProductMinPossibleItemPrice', () => {
+	describe('selectCompositeProductMinPossiblePrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPossibleItemPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the minimum price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPossibleItemPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
@@ -102,24 +102,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMinPossibleItemPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMaxPossibleItemPrice', () => {
+	describe('selectCompositeProductMaxPossiblePrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossiblePrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the maximum price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossiblePrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
@@ -131,24 +131,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossiblePrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductPossiblyHasItemPriceRange', () => {
+	describe('selectCompositeProductPossiblyHasPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return true if the possible min and max prices are not equal', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -161,24 +161,24 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].price = 0;
 			newCompositeProduct.items[1].options[1].price = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMinPossibleItemDiscountedPrice', () => {
+	describe('selectCompositeProductMinPossibleDiscountedPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPossibleItemDiscountedPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossibleDiscountedPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the minimum discounted price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPossibleItemDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossibleDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
@@ -190,24 +190,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMinPossibleItemDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMinPossibleDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 + stubPrice10 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMaxPossibleItemDiscountedPrice', () => {
+	describe('selectCompositeProductMaxPossibleDiscountedPrice', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemDiscountedPrice, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossibleDiscountedPrice, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should initialize to the maximum discounted price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossibleDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice01 - stubDiscountAmount1 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
@@ -219,24 +219,24 @@ describe('Composite Product Selectors | integration tests', () => {
 				<string>stubCompositeProduct.items[0].id,
 				stubCompositeProduct.items[0].options[1].id
 			));
-			const selector = store.pipe(select(selectCompositeProductMaxPossibleItemDiscountedPrice, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductMaxPossibleDiscountedPrice, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice01 - stubDiscountAmount1 + stubPrice11 });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductPossiblyHasItemDiscountedPriceRange', () => {
+	describe('selectCompositeProductPossiblyHasDiscountedPriceRange', () => {
 
 		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscountedPriceRange, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscountedPriceRange, { id: stubProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return true if the min and max prices including optional items are not equal', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscountedPriceRange, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscountedPriceRange, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -249,24 +249,24 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].price = 0;
 			newCompositeProduct.items[1].options[1].price = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscountedPriceRange, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscountedPriceRange, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductPossiblyHasItemDiscount', () => {
+	describe('selectCompositeProductPossiblyHasDiscount', () => {
 
 		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscount, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscount, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return true if the product, including optional items, has a discount', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscount, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscount, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: true });
 
 			expect(selector).toBeObservable(expected);
@@ -284,7 +284,7 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].discount.amount = 0;
 			newCompositeProduct.items[1].options[1].discount.amount = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscount, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscount, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);
@@ -314,7 +314,7 @@ describe('Composite Product Selectors | integration tests', () => {
 			newCompositeProduct.items[1].options[0].discount.amount = 0;
 			newCompositeProduct.items[1].options[1].discount.amount = 0;
 			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasItemDiscount, { id: newCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscount, { id: newCompositeProduct.id }));
 			const expected = cold('a', { a: false });
 
 			expect(selector).toBeObservable(expected);

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -13,34 +13,34 @@ export interface DaffCompositeProductMemoizedSelectors {
 	 * Selector for the minimum price for a composite product, including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductMinPossibleItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMinPossiblePrice: MemoizedSelectorWithProps<object, object, number>;
 	/**
 	 * Selector for the maximum price for a composite product, including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductMaxPossibleItemPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMaxPossiblePrice: MemoizedSelectorWithProps<object, object, number>;
 	/**
 	 * Selector for whether the composite product could have a price range in any configuration,
 	 * including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductPossiblyHasItemPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductPossiblyHasPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
 	/**
 	 * Selector for the minimum discounted price for a composite product, including optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductMinPossibleItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMinPossibleDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
 	/**
 	 * Selector for the maximum discounted price for a composite product, including optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductMaxPossibleItemDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
+	selectCompositeProductMaxPossibleDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
 	/**
 	 * Selector for whether the composite product could have a discounted price range in any configuration,
 	 * including the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
-	selectCompositeProductPossiblyHasItemDiscountedPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductPossiblyHasDiscountedPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
 	/**
 	 * Selector for whether the minimum and maximum composite product discounted prices equal the minimum and maximum
 	 * pre discount prices, including optional items. Note: this intentionally misses a usecase where there is a discount
@@ -50,7 +50,7 @@ export interface DaffCompositeProductMemoizedSelectors {
 	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
 	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
 	 */
-	selectCompositeProductPossiblyHasItemDiscount: MemoizedSelectorWithProps<object, object, boolean>;
+	selectCompositeProductPossiblyHasDiscount: MemoizedSelectorWithProps<object, object, boolean>;
 	/**
 	 * Selector for the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
 	 * This would be used for a composite product that has required items without default selections.
@@ -103,7 +103,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		selectProduct
 	} = getDaffProductEntitiesSelectors();
 
-	const selectCompositeProductMinPossibleItemPrice = createSelector(
+	const selectCompositeProductMinPossiblePrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -119,7 +119,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	const selectCompositeProductMaxPossibleItemPrice = createSelector(
+	const selectCompositeProductMaxPossiblePrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -135,13 +135,13 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	const selectCompositeProductPossiblyHasItemPriceRange = createSelector(
+	const selectCompositeProductPossiblyHasPriceRange = createSelector(
 		selectProductEntities,
-		(products, props) => selectCompositeProductMinPossibleItemPrice.projector(products, { id: props.id }) 
-			!== selectCompositeProductMaxPossibleItemPrice.projector(products, { id: props.id })
+		(products, props) => selectCompositeProductMinPossiblePrice.projector(products, { id: props.id }) 
+			!== selectCompositeProductMaxPossiblePrice.projector(products, { id: props.id })
 	)
 
-	const selectCompositeProductMinPossibleItemDiscountedPrice = createSelector(
+	const selectCompositeProductMinPossibleDiscountedPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -155,7 +155,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	const selectCompositeProductMaxPossibleItemDiscountedPrice = createSelector(
+	const selectCompositeProductMaxPossibleDiscountedPrice = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -169,13 +169,13 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		}
 	);
 
-	const selectCompositeProductPossiblyHasItemDiscountedPriceRange = createSelector(
+	const selectCompositeProductPossiblyHasDiscountedPriceRange = createSelector(
 		selectProductEntities,
-		(products, props) => selectCompositeProductMinPossibleItemDiscountedPrice.projector(products, { id: props.id }) 
-			!== selectCompositeProductMaxPossibleItemDiscountedPrice.projector(products, { id: props.id })
+		(products, props) => selectCompositeProductMinPossibleDiscountedPrice.projector(products, { id: props.id }) 
+			!== selectCompositeProductMaxPossibleDiscountedPrice.projector(products, { id: props.id })
 	)
 
-	const selectCompositeProductPossiblyHasItemDiscount = createSelector(
+	const selectCompositeProductPossiblyHasDiscount = createSelector(
 		selectProductEntities,
 		(products, props) => {
 			const product = selectProduct.projector(products, { id: props.id });
@@ -183,10 +183,10 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 				return undefined;
 			}
 
-			return selectCompositeProductMinPossibleItemPrice.projector(products, { id: props.id }) !==
-				selectCompositeProductMinPossibleItemDiscountedPrice.projector(products, { id: props.id })
-		 || selectCompositeProductMaxPossibleItemPrice.projector(products, { id: props.id }) !==
-				selectCompositeProductMaxPossibleItemDiscountedPrice.projector(products, { id: props.id });
+			return selectCompositeProductMinPossiblePrice.projector(products, { id: props.id }) !==
+				selectCompositeProductMinPossibleDiscountedPrice.projector(products, { id: props.id })
+		 || selectCompositeProductMaxPossiblePrice.projector(products, { id: props.id }) !==
+				selectCompositeProductMaxPossibleDiscountedPrice.projector(products, { id: props.id });
 		}
 	);
 
@@ -297,13 +297,13 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 	);
 
 	return { 
-		selectCompositeProductMinPossibleItemPrice,
-		selectCompositeProductMaxPossibleItemPrice,
-		selectCompositeProductPossiblyHasItemPriceRange,
-		selectCompositeProductMinPossibleItemDiscountedPrice,
-		selectCompositeProductMaxPossibleItemDiscountedPrice,
-		selectCompositeProductPossiblyHasItemDiscountedPriceRange,
-		selectCompositeProductPossiblyHasItemDiscount,
+		selectCompositeProductMinPossiblePrice,
+		selectCompositeProductMaxPossiblePrice,
+		selectCompositeProductPossiblyHasPriceRange,
+		selectCompositeProductMinPossibleDiscountedPrice,
+		selectCompositeProductMaxPossibleDiscountedPrice,
+		selectCompositeProductPossiblyHasDiscountedPriceRange,
+		selectCompositeProductPossiblyHasDiscount,
 		selectCompositeProductMinRequiredItemPrice,
 		selectCompositeProductMaxRequiredItemPrice,
 		selectCompositeProductHasRequiredItemPriceRange,

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -4,25 +4,25 @@ import { DaffCompositeProductFacadeInterface, DaffCompositeProductItemOption, Da
 import { Dictionary } from '@ngrx/entity';
 
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
-	getMinPossibleItemPrice(id: string): BehaviorSubject<number> {
+	getMinPossiblePrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaxPossibleItemPrice(id: string): BehaviorSubject<number> {
+	getMaxPossiblePrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	possiblyHasItemPriceRange(id: string): BehaviorSubject<boolean> {
+	possiblyHasPriceRange(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	getMinPossibleItemDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMinPossibleDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaxPossibleItemDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMaxPossibleDiscountedPrice(id: string): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	possiblyHasItemDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
+	possiblyHasDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
-	possiblyHasItemDiscount(id: string): BehaviorSubject<boolean> {
+	possiblyHasDiscount(id: string): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	};
 	getMinRequiredItemPrice(id: string): BehaviorSubject<number> {


### PR DESCRIPTION
… prices

BREAKING CHANGE: Some of the composite product price selectors have been renamed, because they were incorrect/misleading.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Some of the Composite Product Price selectors are misnamed.

## What is the new behavior?
`getMinPossibleItemPrice` --> `getMinPossiblePrice`
etc.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```