### PR TITLE
fix(product): the min possible composite product price should not inc…

### DIFF
--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -10,7 +10,7 @@ import { DaffCompositeProduct } from '../../models/composite-product';
 export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Action> {
 
 	/**
-	 * Get the minimum price for a composite product, including optional items and regardless of applied options.
+	 * Get the minimum price for a composite product, excluding optional items and regardless of applied options.
 	 * This would be useful for a quick preview of a product.
 	 * @param id the id of the composite product.
 	 */
@@ -32,7 +32,7 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	possiblyHasPriceRange(id: string): Observable<boolean>;
 
 	/**
-	 * Get the minimum discounted price for a composite product, including optional items and regardless of the current selection of item options.
+	 * Get the minimum discounted price for a composite product, excluding optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 * @param id the id of the composite product.
 	 */

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -63,8 +63,7 @@ describe('DaffCompositeProductFacade', () => {
     it('should return the minimum price possible for the product', () => {
 			const expected = cold('a', { a:
 				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[0].price +
-				stubCompositeProduct.items[1].options[0].price
+				stubCompositeProduct.items[0].options[0].price
 			});
 
 			expect(facade.getMinPossiblePrice(stubCompositeProduct.id)).toBeObservable(expected);
@@ -98,8 +97,7 @@ describe('DaffCompositeProductFacade', () => {
     it('should return the minimum discounted price possible for the product', () => {
 			const expected = cold('a', { a:
 				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
-				stubCompositeProduct.items[0].options[0].price +
-				stubCompositeProduct.items[1].options[0].price
+				stubCompositeProduct.items[0].options[0].price
 			});
 
 			expect(facade.getMinPossibleDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -89,9 +89,9 @@ describe('Composite Product Selectors | integration tests', () => {
 			expect(selector).toBeObservable(expected);
 		});
 
-		it('should initialize to the minimum price for the composite product including optional items', () => {
+		it('should initialize to the minimum price for the composite product excluding optional items', () => {
 			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 + stubPrice10 });
+			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 });
 
 			expect(selector).toBeObservable(expected);
 		});
@@ -103,7 +103,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				stubCompositeProduct.items[0].options[1].id
 			));
 			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 + stubPrice10 });
+			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 });
 
 			expect(selector).toBeObservable(expected);
 		});
@@ -179,7 +179,7 @@ describe('Composite Product Selectors | integration tests', () => {
 
 		it('should initialize to the minimum discounted price for the composite product including optional items', () => {
 			const selector = store.pipe(select(selectCompositeProductMinPossibleDiscountedPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 + stubPrice10 });
+			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 });
 
 			expect(selector).toBeObservable(expected);
 		});
@@ -191,7 +191,7 @@ describe('Composite Product Selectors | integration tests', () => {
 				stubCompositeProduct.items[0].options[1].id
 			));
 			const selector = store.pipe(select(selectCompositeProductMinPossibleDiscountedPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 + stubPrice10 });
+			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 });
 
 			expect(selector).toBeObservable(expected);
 		});

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -10,7 +10,7 @@ import { DaffCompositeProductItem } from '../../models/composite-product-item';
 
 export interface DaffCompositeProductMemoizedSelectors {
 	/**
-	 * Selector for the minimum price for a composite product, including the optional items and regardless of the current item option selection.
+	 * Selector for the minimum price for a composite product, excluding the optional items and regardless of the current item option selection.
 	 * This could be useful for a quick preview of the product.
 	 */
 	selectCompositeProductMinPossiblePrice: MemoizedSelectorWithProps<object, object, number>;
@@ -26,7 +26,7 @@ export interface DaffCompositeProductMemoizedSelectors {
 	 */
 	selectCompositeProductPossiblyHasPriceRange: MemoizedSelectorWithProps<object, object, boolean>;
 	/**
-	 * Selector for the minimum discounted price for a composite product, including optional items and regardless of the current selection of item options.
+	 * Selector for the minimum discounted price for a composite product, excluding optional items and regardless of the current selection of item options.
 	 * This could be useful for a quick preview of the product.
 	 */
 	selectCompositeProductMinPossibleDiscountedPrice: MemoizedSelectorWithProps<object, object, number>;
@@ -114,7 +114,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			return (<DaffCompositeProduct>product).items.reduce((acc, item) => 
 				daffAdd(
 					acc, 
-					Math.min(...item.options.map(option => option.price))
+					getMinimumRequiredCompositeItemPrice(item)
 				), product.price);
 		}
 	);
@@ -150,7 +150,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			}
 			return (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
 				acc, 
-				Math.min(...getItemDiscountedPrices(item))
+				getMinimumRequiredCompositeItemDiscountedPrice(item)
 			), product.discount ? daffSubtract(product.price, product.discount.amount) : product.price);
 		}
 	);
@@ -164,7 +164,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			}
 			return (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
 				acc, 
-				Math.max(...getItemDiscountedPrices(item))
+				Math.max(...item.options.map(option => option.discount ? daffSubtract(option.price, option.discount.amount) : option.price))
 			), product.discount ? daffSubtract(product.price, product.discount.amount) : product.price);
 		}
 	);
@@ -356,8 +356,4 @@ function getMaximumRequiredCompositeItemDiscountedPrice(item: DaffCompositeProdu
 	return item.required ? Math.max(...item.options.map(option => 
 		daffSubtract(option.price, option.discount ? option.discount.amount : 0)
 	)) : 0;
-}
-
-function getItemDiscountedPrices(item: DaffCompositeProductItem): number[] {
-	return item.options.map(option => option.discount ? daffSubtract(option.price, option.discount.amount) : option.price);
 }


### PR DESCRIPTION
…lude prices for optional items

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The "minPossible" price and discounted price selectors for composite products include optional item prices, which will not yield the minimum possible price for the product.

## What is the new behavior?
The "minPossible" price and discounted price selectors now exclude optional item prices.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```