### PR TITLE
fix(cart): cart create success action should reset the cart state

### DIFF
--- a/libs/cart/src/reducers/cart/cart.reducer.spec.ts
+++ b/libs/cart/src/reducers/cart/cart.reducer.spec.ts
@@ -186,8 +186,11 @@ describe('Cart | Reducer | Cart', () => {
       result = cartReducer(state, cartCreateSuccess);
     });
 
-    it('should set cart from action.payload', () => {
-      expect(result.cart.id).toEqual(cart.id)
+    it('should set the cart to initial state plus the payload cart id', () => {
+      expect(result.cart).toEqual({
+				...initialState.cart,
+				id: cart.id
+			})
     });
 
     it('should indicate that the cart is not loading', () => {

--- a/libs/cart/src/reducers/cart/cart.reducer.ts
+++ b/libs/cart/src/reducers/cart/cart.reducer.ts
@@ -49,7 +49,17 @@ export function cartReducer<T extends DaffCart>(
         ...setLoading(state.loading, DaffLoadingState.Complete),
       };
 
-    case DaffCartActionTypes.CartLoadFailureAction:
+		case DaffCartActionTypes.CartCreateSuccessAction:
+			return {
+        ...state,
+        ...resetErrors(state.errors),
+        cart: {
+          ...initialState.cart,
+          ...action.payload
+        },
+        ...setLoading(state.loading, DaffLoadingState.Complete),
+      };
+		case DaffCartActionTypes.CartLoadFailureAction:
     case DaffCartActionTypes.CartClearFailureAction:
     case DaffCartActionTypes.AddToCartFailureAction:
     case DaffCartActionTypes.CartCreateFailureAction:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The Cart create success action does not reset the cart state. It only resets the cart id.

## What is the new behavior?
The Cart create success action resets the cart to the initialState, then sets the cart id from the payload.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```