### PR TITLE
fix(tools-dgeni): make types for properties HTML compatible

### DIFF
--- a/tools/dgeni/src/processors/makeTypesHtmlCompatible.ts
+++ b/tools/dgeni/src/processors/makeTypesHtmlCompatible.ts
@@ -1,0 +1,26 @@
+import { Processor, Document } from 'dgeni';
+
+/**
+ * Exchange < for &lt; and > for &gt; so that generic types can be rendered correctly as html.
+ */
+export class MakeTypesHtmlCompatibleProcessor implements Processor {
+	name = 'makeTypesHtmlCompatible';
+	$runAfter = ['docs-processed'];
+	$runBefore = ['rendering-docs'];
+
+	$process(docs: Document[]): Document[] {
+		docs.map(doc => {
+			if(!doc.members) return doc;
+			
+			doc.members.map(member => {
+				member.type = fixGenericTypes(member.type);
+			})
+		})
+
+		return docs;
+	}
+}
+
+function fixGenericTypes(type: string): string {
+	return type.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}

--- a/tools/dgeni/src/transforms/daffodil-api-package/index.ts
+++ b/tools/dgeni/src/transforms/daffodil-api-package/index.ts
@@ -8,6 +8,7 @@ import { GenerateApiListProcessor } from '../../processors/generateApiList';
 import { PackagesProcessor } from '../../processors/packages';
 import { FilterContainedDocsProcessor } from '../../processors/filterDocs';
 import { CleanSelectorsProcessor } from '../../processors/cleanSelectors';
+import { MakeTypesHtmlCompatibleProcessor } from '../../processors/makeTypesHtmlCompatible';
 
 //List of packages to be left out of API generation
 const excludedPackages = ['branding'];
@@ -20,6 +21,7 @@ export const apiDocs =  new Package('checkout', [
   //Register Processors for this package
   .processor(new FilterContainedDocsProcessor())
   .processor(new CleanSelectorsProcessor())
+  .processor(new MakeTypesHtmlCompatibleProcessor())
   .processor(new GenerateApiListProcessor())
   .processor(new PackagesProcessor())
   .factory(function API_DOC_TYPES_TO_RENDER(EXPORT_DOC_TYPES) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The docs generated by dgeni aren't compatible with HTML because angle brackets (`<`, `>`) get processed by the angular `innerHtml` injector as HTML elements rather than strings.

Fixes: https://github.com/graycoreio/daffodil/issues/1095


## What is the new behavior?
The angle brackets in types are replaced with their string equivalents (`&lt;`, `&gt;`) during docs generation.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```