### PR TITLE
docs(design): mark internal properties as private

### DIFF
--- a/libs/design/src/atoms/button/button.component.ts
+++ b/libs/design/src/atoms/button/button.component.ts
@@ -73,8 +73,9 @@ export class DaffButtonComponent
   extends _daffButtonBase
   implements OnInit, DaffPrefixable, DaffSuffixable, DaffColorable, DaffSizeable<DaffButtonSize> {
     @Input() color: DaffPalette;
-    buttonType: DaffButtonType;
-    @Input() size: DaffButtonSize;
+		@Input() size: DaffButtonSize;
+		
+    private buttonType: DaffButtonType;
 
     constructor(private elementRef: ElementRef, private renderer: Renderer2) {
       super(elementRef, renderer);
@@ -86,6 +87,10 @@ export class DaffButtonComponent
       }
     }
 
+
+		/**
+		 * @docs-private
+		 */
     ngOnInit() {
       for (const attr of BUTTON_HOST_ATTRIBUTES) {
         if (this._hasHostAttributes(attr)) {
@@ -94,32 +99,49 @@ export class DaffButtonComponent
       }
     }
 
+		/**
+		 * @docs-private
+		 */
     @HostBinding('class.daff-button') get button() {
       return this.buttonType === DaffButtonTypeEnum.Default || this.buttonType === undefined;
     }
   
+		/**
+		 * @docs-private
+		 */
     @HostBinding('class.daff-stroked-button') get stroked() {
       return this.buttonType === DaffButtonTypeEnum.Stroked;
     }
 
+		/**
+		 * @docs-private
+		 */
     @HostBinding('class.daff-raised-button') get raised() {
       return this.buttonType === DaffButtonTypeEnum.Raised;
     }
   
+		/**
+		 * @docs-private
+		 */
     @HostBinding('class.daff-icon-button') get icon() {
       return this.buttonType === DaffButtonTypeEnum.Icon;
     }
 
+		/**
+		 * @docs-private
+		 */
     @HostBinding('class.daff-underline-button') get underline() {
       return this.buttonType === DaffButtonTypeEnum.Underline;
     }
 
-    _getHostElement() {
+    private _getHostElement() {
       return this.elementRef.nativeElement;
     }
   
-    /** Gets whether the button has one of the given attributes. */
-    _hasHostAttributes(...attributes: string[]) {
+    /** 
+		 * Gets whether the button has one of the given attributes. 
+		 * */
+    private _hasHostAttributes(...attributes: string[]) {
       return attributes.some(attribute => this._getHostElement().hasAttribute(attribute));
     }
 }

--- a/libs/design/src/atoms/container/container.component.ts
+++ b/libs/design/src/atoms/container/container.component.ts
@@ -21,7 +21,10 @@ export class DaffContainerComponent extends _daffContainerBase implements DaffSi
 
   @Input() size: DaffSizeAllType;
 
-  @HostBinding('class.daff-container') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-container') class = true;
 
   constructor(private elementRef: ElementRef, private renderer: Renderer2) {
     super(elementRef, renderer);

--- a/libs/design/src/atoms/container/container.component.ts
+++ b/libs/design/src/atoms/container/container.component.ts
@@ -21,7 +21,7 @@ export class DaffContainerComponent extends _daffContainerBase implements DaffSi
 
   @Input() size: DaffSizeAllType;
 
-  @HostBinding('class.daff-container') class = true;
+  @HostBinding('class.daff-container') private class = true;
 
   constructor(private elementRef: ElementRef, private renderer: Renderer2) {
     super(elementRef, renderer);

--- a/libs/design/src/atoms/form/checkbox-set/checkbox-set.component.ts
+++ b/libs/design/src/atoms/form/checkbox-set/checkbox-set.component.ts
@@ -29,10 +29,11 @@ export class DaffCheckboxSetComponent {
   /**
    * The role of the component. Set to "checkbox".
    */
-  @HostBinding('attr.role') role = 'group';
+  @HostBinding('attr.role') private role = 'group';
 
   /**
    * The list of checkboxes in the set.
+	 * @docs-private
    */
   @ContentChildren(DaffCheckboxComponent) checkboxes: QueryList<DaffCheckboxComponent>;
 

--- a/libs/design/src/atoms/form/checkbox-set/checkbox-set.component.ts
+++ b/libs/design/src/atoms/form/checkbox-set/checkbox-set.component.ts
@@ -28,8 +28,9 @@ export class DaffCheckboxSetComponent {
 
   /**
    * The role of the component. Set to "checkbox".
+	 * @docs-private
    */
-  @HostBinding('attr.role') private role = 'group';
+  @HostBinding('attr.role') role = 'group';
 
   /**
    * The list of checkboxes in the set.

--- a/libs/design/src/atoms/form/checkbox/checkbox.component.ts
+++ b/libs/design/src/atoms/form/checkbox/checkbox.component.ts
@@ -20,6 +20,9 @@ let checkboxIdNum = 0;
 
 })
 export class DaffCheckboxComponent {
+	/**
+	 * @docs-private
+	 */
   @ViewChild('inputElement', {static: true, read: ElementRef}) nativeCheckbox: ElementRef<HTMLInputElement>;
   /**
    * The name of the checkbox.
@@ -32,7 +35,8 @@ export class DaffCheckboxComponent {
   /**
    * Boolean value to determine whether or not the checkbox is checked.
    */
-  _checked = false;
+	private _checked = false;
+
   @Input()
   get checked() {
     return this._checked;
@@ -84,17 +88,21 @@ export class DaffCheckboxComponent {
 
   /**
    * The role of the component. Set to "checkbox".
+	 * @docs-private
    */
   @HostBinding('attr.role') role = 'checkbox';
 
 
+	/**
+	 * @docs-private
+	 */
   _onChange(val: Event) {
     (val.target as HTMLInputElement).checked ? this.select() : this.deselect();
   };
-  @HostBinding('class.focused') get focusClass() {
+  @HostBinding('class.focused') private get focusClass() {
     return this.focused === true;
   };
-  @HostBinding('class.disabled') get disabledClass() {
+  @HostBinding('class.disabled') private get disabledClass() {
     return this.disabled === true;
   };
   /**

--- a/libs/design/src/atoms/form/checkbox/checkbox.component.ts
+++ b/libs/design/src/atoms/form/checkbox/checkbox.component.ts
@@ -98,11 +98,17 @@ export class DaffCheckboxComponent {
 	 */
   _onChange(val: Event) {
     (val.target as HTMLInputElement).checked ? this.select() : this.deselect();
-  };
-  @HostBinding('class.focused') private get focusClass() {
+	};
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.focused') get focusClass() {
     return this.focused === true;
-  };
-  @HostBinding('class.disabled') private get disabledClass() {
+	};
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.disabled') get disabledClass() {
     return this.disabled === true;
   };
   /**

--- a/libs/design/src/atoms/form/form-field/form-field/form-field.component.ts
+++ b/libs/design/src/atoms/form/form-field/form-field/form-field.component.ts
@@ -16,7 +16,10 @@ import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 
 export class DaffFormFieldComponent implements DoCheck, AfterContentInit, AfterContentChecked {
 
-  private faChevronDown = faChevronDown;
+	/**
+	 * @docs-private
+	 */
+  faChevronDown = faChevronDown;
 
   /**
    * The tracking property used to determine if the parent form has been submitted,

--- a/libs/design/src/atoms/form/form-field/form-field/form-field.component.ts
+++ b/libs/design/src/atoms/form/form-field/form-field/form-field.component.ts
@@ -15,7 +15,8 @@ import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 })
 
 export class DaffFormFieldComponent implements DoCheck, AfterContentInit, AfterContentChecked {
-  faChevronDown = faChevronDown;
+
+  private faChevronDown = faChevronDown;
 
   /**
    * The tracking property used to determine if the parent form has been submitted,
@@ -28,6 +29,7 @@ export class DaffFormFieldComponent implements DoCheck, AfterContentInit, AfterC
 
   /**
    * The child form control that the form-field manages
+	 * @docs-private
    */
   @ContentChild(DaffFormFieldControl, { static: false }) _control: DaffFormFieldControl;
 
@@ -48,6 +50,8 @@ export class DaffFormFieldComponent implements DoCheck, AfterContentInit, AfterC
    * 
    * TODO: consider whether or not this can be refactored to some kind of 
    * observable to remove unnecessary change detection.
+	 * 
+	 * @docs-private
    */
   ngDoCheck() {
     if (this._control) {
@@ -70,6 +74,8 @@ export class DaffFormFieldComponent implements DoCheck, AfterContentInit, AfterC
    * Life cycle hook to verify that the form field has an acceptable
    * child control instance. Mostly useful for development-time 
    * validation of usage.
+	 * 
+	 * @docs-private
    */
   ngAfterContentInit() {
     this._validateFormControl();
@@ -79,6 +85,8 @@ export class DaffFormFieldComponent implements DoCheck, AfterContentInit, AfterC
    * Life cycle hook to verify that the form field has an acceptable
    * child control instance. Mostly useful for development-time 
    * validation of usage.
+	 * 
+	 * @docs-private
    */
   ngAfterContentChecked() {
     this._validateFormControl();

--- a/libs/design/src/atoms/form/input/input.component.ts
+++ b/libs/design/src/atoms/form/input/input.component.ts
@@ -17,22 +17,34 @@ import { DaffFormFieldControl } from '../form-field/form-field-control';
 })
 export class DaffInputComponent implements DaffFormFieldControl {
 
+	/**
+	 * Has the form been submitted.
+	 */
+	@Input() formSubmitted: boolean;
+
   focused = false;
-
-  /**
-   * Has the form been submitted.
-   */
-  @Input() formSubmitted: boolean;
-
+	
+	/**
+	 * @docs-private
+	 */
   @HostListener('focus') focus() {
     this.focused = true;
   }
 
+	/**
+	 * @docs-private
+	 */
   @HostListener('blur') blur() {
     this.focused = false;
   }
 
-  constructor(@Optional() @Self() public ngControl: NgControl, private _elementRef: ElementRef<HTMLInputElement>) {}
+  constructor(
+		/**
+		 * @docs-private
+		 */
+		@Optional() @Self() public ngControl: NgControl, 
+		private _elementRef: ElementRef<HTMLInputElement>
+	) {}
 
   onFocus() {
     this._elementRef.nativeElement.focus();

--- a/libs/design/src/atoms/form/radio-set/radio-set.component.ts
+++ b/libs/design/src/atoms/form/radio-set/radio-set.component.ts
@@ -13,6 +13,9 @@ export class DaffRadioSetComponent {
 
   constructor() { }
 
+	/**
+	 * @docs-private
+	 */
   @HostBinding('attr.role') role = 'radiogroup';
 
 }

--- a/libs/design/src/atoms/form/radio/radio.component.ts
+++ b/libs/design/src/atoms/form/radio/radio.component.ts
@@ -20,70 +20,76 @@ let radioUniqueId = 0;
 
 export class DaffRadioComponent implements OnInit {
 
+	/**
+	 * @docs-private
+	 */
   @HostBinding('attr.role') role = 'radio';
-  @HostBinding('class.focused') get focusClass() {
+  @HostBinding('class.focused') private get focusClass() {
     return this.focused === true;
   };
-  @HostBinding('class.disabled') get disabledClass() {
+  @HostBinding('class.disabled') private get disabledClass() {
     return this.disabled === true;
   };
 
+	/**
+	 * @docs-private
+	 */
+	_checked = false;
   /**
-   * Output event of selection being changed
+	 * The checked property of the radio
    */
-  @Output() selectionChange: EventEmitter<boolean> = new EventEmitter();
-
-
-  _checked = false;
-  /**
-   * The checked property of the radio
-   */
-  @Input()
+	@Input()
 	get checked() {
 		return this._checked;
 	}
 	set checked(value: boolean) {
 		if (this._checked !== value) {
-      this._checked = value;
+			this._checked = value;
 			this.selectionChange.emit(this.value);
 		}
 	}
   /**
-   * The value of the radio
+	 * The value of the radio
    */
-  @Input() value: any;
+	@Input() value: any;
   /**
-   * The id of the radio. It is uniquely generated but can be overwritten by the user. Must be unique.
+	 * The id of the radio. It is uniquely generated but can be overwritten by the user. Must be unique.
    */
-  @Input() id: string = 'daff-radio-' + radioUniqueId;
+	@Input() id: string = 'daff-radio-' + radioUniqueId;
   /**
-   * Name of the Radio
+	 * Name of the Radio
    */
-  @Input() name: string;
-
+	@Input() name: string;
+	
   /**
-   * Used for aria-label. Default to name if user does not input a label.
+	 * Used for aria-label. Default to name if user does not input a label.
    */
-  //tslint:disable-next-line:no-input-rename
+	//tslint:disable-next-line:no-input-rename
   @Input('aria-label') label = name;
   /**
-   * Used for aria-labelledby. 
+	 * Used for aria-labelledby. 
    */
-  //tslint:disable-next-line:no-input-rename
+	//tslint:disable-next-line:no-input-rename
   @Input('aria-labelledby') labelledby;
-
+	
+	/**
+	 * Output event of selection being changed
+	 */
+	@Output() selectionChange: EventEmitter<boolean> = new EventEmitter();
 
   disabled = false;
   focused = false;
 
   constructor(@Optional() private radioset: DaffRadioSetComponent) {
     radioUniqueId++;
-  }
+	}
+
+	/**
+	 * @docs-private
+	 */
   ngOnInit() {
     this.name = this.radioset ? this.radioset.name : this.name
   }
-
-
 
   /**
    * updates Focus styling
@@ -98,13 +104,13 @@ export class DaffRadioComponent implements OnInit {
     this.focused = false;
   }
   /**
-   * toggeles checked attribute on
+   * toggles checked attribute on
    */
   select(): void {
     this.checked = true;
   }
   /**
-   * toggeles checked attribute off
+   * toggles checked attribute off
    */
   deselect(): void {
     this.checked = false;

--- a/libs/design/src/atoms/form/radio/radio.component.ts
+++ b/libs/design/src/atoms/form/radio/radio.component.ts
@@ -23,11 +23,17 @@ export class DaffRadioComponent implements OnInit {
 	/**
 	 * @docs-private
 	 */
-  @HostBinding('attr.role') role = 'radio';
-  @HostBinding('class.focused') private get focusClass() {
+	@HostBinding('attr.role') role = 'radio';
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.focused') get focusClass() {
     return this.focused === true;
-  };
-  @HostBinding('class.disabled') private get disabledClass() {
+	};
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.disabled') get disabledClass() {
     return this.disabled === true;
   };
 

--- a/libs/design/src/atoms/form/select/select/select.component.ts
+++ b/libs/design/src/atoms/form/select/select/select.component.ts
@@ -16,23 +16,38 @@ import { DaffFormFieldControl } from '../../form-field/form-field-control';
 })
 
 export class DaffNativeSelectComponent implements DaffFormFieldControl {
+	/**
+	 * @docs-private
+	 */
   controlType = 'native-select';
-  focused = false;
-
+	
   /**
-   * Has the form been submitted.
+	 * Has the form been submitted.
    */
-  @Input() formSubmitted: boolean;
+	@Input() formSubmitted: boolean;
+	focused = false;
 
+	/**
+	 * @docs-private
+	 */
   @HostListener('focus') focus() {
     this.focused = true;
   }
 
+	/**
+	 * @docs-private
+	 */
   @HostListener('blur') blur() {
     this.focused = false;
   }
 
-  constructor(@Optional() @Self() public ngControl: NgControl, private _elementRef: ElementRef<HTMLInputElement>) {}
+  constructor(
+		/**
+		 * @docs-private
+		 */
+		@Optional() @Self() public ngControl: NgControl, 
+		private _elementRef: ElementRef<HTMLInputElement>
+	) {}
 
   onFocus() {
     this._elementRef.nativeElement.focus();

--- a/libs/design/src/atoms/image/image.component.ts
+++ b/libs/design/src/atoms/image/image.component.ts
@@ -31,14 +31,12 @@ const validateProperties = (object: Object, props: string[]) => {
 })
 export class DaffImageComponent implements OnInit {
 
-  @Output() load: EventEmitter<void> = new EventEmitter();
-  
-  private _src: string;
+	private _src: string;
 
   @Input()
   get src(): string { return this._src; }
   set src(value: string) {
-    this._src = value;
+		this._src = value;
     validateProperty(this, 'src');
   }
 
@@ -47,34 +45,42 @@ export class DaffImageComponent implements OnInit {
   @Input()
   get alt(): string { return this._alt; }
   set alt(value: string) {
-    this._alt = value;
+		this._alt = value;
     validateProperty(this, 'alt');
   }
-
+	
   private _width: number;
-
+	
   @Input()
   get width(): number { return this._width; }
   set width(value: number) {
-    this._width = value;
+		this._width = value;
     validateProperty(this, 'width');
   }
-
+	
   private _height: number;
-
+	
   @Input()
   get height(): number { return this._height; }
   set height(value: number) {
-    this._height = value;
+		this._height = value;
     validateProperty(this, 'height');
-  }
+	}
 
+	@Output() load: EventEmitter<void> = new EventEmitter();
+
+	/**
+	 * @docs-private
+	 */
   ngOnInit(): void {
     validateProperties(this, ['src', 'alt', 'width', 'height'])
   }
 
   constructor(private sanitizer: DomSanitizer) {}
 
+	/**
+	 * @docs-private
+	 */
   get paddingTop(): any {
     if (!this.height || !this.width ) {
       return undefined;
@@ -83,6 +89,9 @@ export class DaffImageComponent implements OnInit {
     return this.sanitizer.bypassSecurityTrustStyle('calc(' + this.height + ' / ' + this.width + ' * 100%)');
   }
 
+	/**
+	 * @docs-private
+	 */
   @HostBinding('style.max-width') get maxWidth(): string {
     return this.width + 'px';
   }

--- a/libs/design/src/atoms/loading-icon/loading-icon.component.ts
+++ b/libs/design/src/atoms/loading-icon/loading-icon.component.ts
@@ -25,8 +25,8 @@ export class DaffLoadingIconComponent extends _daffLoadingIconBase implements Da
   // tslint:disable-next-line: no-inferrable-types
   @Input() diameter: number = 60;
 
-  @HostBinding('class.daff-loading-icon') class = true;
-  @HostBinding('style.max-width') get maxWidth() {
+  @HostBinding('class.daff-loading-icon') private class = true;
+  @HostBinding('style.max-width') private get maxWidth() {
     return this.diameter + 'px';
   }
 

--- a/libs/design/src/atoms/loading-icon/loading-icon.component.ts
+++ b/libs/design/src/atoms/loading-icon/loading-icon.component.ts
@@ -25,8 +25,14 @@ export class DaffLoadingIconComponent extends _daffLoadingIconBase implements Da
   // tslint:disable-next-line: no-inferrable-types
   @Input() diameter: number = 60;
 
-  @HostBinding('class.daff-loading-icon') private class = true;
-  @HostBinding('style.max-width') private get maxWidth() {
+	/**
+	 * @docs-private
+	 */
+	@HostBinding('class.daff-loading-icon') class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('style.max-width') get maxWidth() {
     return this.diameter + 'px';
   }
 

--- a/libs/design/src/atoms/progress-indicator/progress-indicator.component.ts
+++ b/libs/design/src/atoms/progress-indicator/progress-indicator.component.ts
@@ -24,7 +24,10 @@ const _daffProgressIndicatorBase = daffColorMixin(DaffProgressIndicatorBase, 'pr
 })
 export class DaffProgressIndicatorComponent extends _daffProgressIndicatorBase implements DaffColorable {
 
-  @HostBinding('class.daff-progress-indicator') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-progress-indicator') class = true;
 
   /**
    * The color of the progress indicator

--- a/libs/design/src/atoms/progress-indicator/progress-indicator.component.ts
+++ b/libs/design/src/atoms/progress-indicator/progress-indicator.component.ts
@@ -24,7 +24,7 @@ const _daffProgressIndicatorBase = daffColorMixin(DaffProgressIndicatorBase, 'pr
 })
 export class DaffProgressIndicatorComponent extends _daffProgressIndicatorBase implements DaffColorable {
 
-  @HostBinding('class.daff-progress-indicator') class = true;
+  @HostBinding('class.daff-progress-indicator') private class = true;
 
   /**
    * The color of the progress indicator
@@ -59,6 +59,9 @@ export class DaffProgressIndicatorComponent extends _daffProgressIndicatorBase i
     }
   }
 
+	/**
+	 * @docs-private
+	 */
   get fillState(): any {
     return {
       value: this.percentage,

--- a/libs/design/src/molecules/accordion/accordion-item-content/accordion-item-content.directive.ts
+++ b/libs/design/src/molecules/accordion/accordion-item-content/accordion-item-content.directive.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffAccordionItemContentDirective {
 
-  @HostBinding('class.daff-accordion-item__content') class = true;
+  @HostBinding('class.daff-accordion-item__content') private class = true;
 }

--- a/libs/design/src/molecules/accordion/accordion-item-content/accordion-item-content.directive.ts
+++ b/libs/design/src/molecules/accordion/accordion-item-content/accordion-item-content.directive.ts
@@ -5,5 +5,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffAccordionItemContentDirective {
 
-  @HostBinding('class.daff-accordion-item__content') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-accordion-item__content') class = true;
 }

--- a/libs/design/src/molecules/accordion/accordion-item-title/accordion-item-title.directive.ts
+++ b/libs/design/src/molecules/accordion/accordion-item-title/accordion-item-title.directive.ts
@@ -4,6 +4,9 @@ import { Directive, HostBinding } from '@angular/core';
   selector: '[daffAccordionItemTitle]',
 })
 export class DaffAccordionItemTitleDirective {
-  
-  @HostBinding('class.daff-accordion-item__title') private class = true;
+	
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-accordion-item__title') class = true;
 }

--- a/libs/design/src/molecules/accordion/accordion-item-title/accordion-item-title.directive.ts
+++ b/libs/design/src/molecules/accordion/accordion-item-title/accordion-item-title.directive.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffAccordionItemTitleDirective {
   
-  @HostBinding('class.daff-accordion-item__title') class = true;
+  @HostBinding('class.daff-accordion-item__title') private class = true;
 }

--- a/libs/design/src/molecules/accordion/accordion-item/accordion-item.component.ts
+++ b/libs/design/src/molecules/accordion/accordion-item/accordion-item.component.ts
@@ -15,15 +15,24 @@ import { getAnimationState } from '../animation/accordion-animation-state';
   ]
 })
 export class DaffAccordionItemComponent implements OnInit {
-  faChevronDown = faChevronDown;
-  faChevronUp = faChevronUp;
+  private faChevronDown = faChevronDown;
+  private faChevronUp = faChevronUp;
 
-  @HostBinding('class.daff-accordion-item') class = true;
+  @HostBinding('class.daff-accordion-item') private class = true;
 
-  @Input() initiallyActive: boolean;
-  _open = false;
+	@Input() initiallyActive: boolean;
+	/**
+	 * @docs-private
+	 */
+	_open = false;
+	/**
+	 * @docs-private
+	 */
   _animationState: string;
-  
+
+	/**
+	 * @docs-private
+	 */
   ngOnInit() {
     this._open = this.initiallyActive ? this.initiallyActive : this._open;
     this._animationState = getAnimationState(this._open);

--- a/libs/design/src/molecules/accordion/accordion-item/accordion-item.component.ts
+++ b/libs/design/src/molecules/accordion/accordion-item/accordion-item.component.ts
@@ -15,10 +15,19 @@ import { getAnimationState } from '../animation/accordion-animation-state';
   ]
 })
 export class DaffAccordionItemComponent implements OnInit {
-  private faChevronDown = faChevronDown;
-  private faChevronUp = faChevronUp;
+	/**
+	 * @docs-private
+	 */
+	faChevronDown = faChevronDown;
+	/**
+	 * @docs-private
+	 */
+  faChevronUp = faChevronUp;
 
-  @HostBinding('class.daff-accordion-item') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-accordion-item') class = true;
 
 	@Input() initiallyActive: boolean;
 	/**

--- a/libs/design/src/molecules/article/article-lead/article-lead.component.ts
+++ b/libs/design/src/molecules/article/article-lead/article-lead.component.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffArticleLeadDirective {
 
-  @HostBinding('class.daff-article__lead') class = true;
+  @HostBinding('class.daff-article__lead') private class = true;
 }

--- a/libs/design/src/molecules/article/article-lead/article-lead.component.ts
+++ b/libs/design/src/molecules/article/article-lead/article-lead.component.ts
@@ -5,5 +5,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffArticleLeadDirective {
 
-  @HostBinding('class.daff-article__lead') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-article__lead') class = true;
 }

--- a/libs/design/src/molecules/article/article-meta/article-meta.component.ts
+++ b/libs/design/src/molecules/article/article-meta/article-meta.component.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffArticleMetaDirective {
 
-  @HostBinding('class.daff-article__meta') class = true;
+  @HostBinding('class.daff-article__meta') private class = true;
 }

--- a/libs/design/src/molecules/article/article-meta/article-meta.component.ts
+++ b/libs/design/src/molecules/article/article-meta/article-meta.component.ts
@@ -5,5 +5,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffArticleMetaDirective {
 
-  @HostBinding('class.daff-article__meta') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-article__meta') class = true;
 }

--- a/libs/design/src/molecules/article/article-title/article-title.component.ts
+++ b/libs/design/src/molecules/article/article-title/article-title.component.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffArticleTitleDirective {
 
-  @HostBinding('class.daff-article__title') class = true;
+  @HostBinding('class.daff-article__title') private class = true;
 }

--- a/libs/design/src/molecules/article/article-title/article-title.component.ts
+++ b/libs/design/src/molecules/article/article-title/article-title.component.ts
@@ -5,5 +5,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffArticleTitleDirective {
 
-  @HostBinding('class.daff-article__title') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-article__title') class = true;
 }

--- a/libs/design/src/molecules/article/article/article.component.ts
+++ b/libs/design/src/molecules/article/article/article.component.ts
@@ -11,7 +11,7 @@ import { Component, ViewEncapsulation, HostBinding } from '@angular/core';
 })
 export class DaffArticleComponent {
 
-  @HostBinding('class.daff-article') class = true;
+  @HostBinding('class.daff-article') private class = true;
 
-  @HostBinding('attr.role') role = 'article';
+  @HostBinding('attr.role') private role = 'article';
 }

--- a/libs/design/src/molecules/article/article/article.component.ts
+++ b/libs/design/src/molecules/article/article/article.component.ts
@@ -11,7 +11,13 @@ import { Component, ViewEncapsulation, HostBinding } from '@angular/core';
 })
 export class DaffArticleComponent {
 
-  @HostBinding('class.daff-article') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-article') class = true;
 
-  @HostBinding('attr.role') private role = 'article';
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('attr.role') role = 'article';
 }

--- a/libs/design/src/molecules/button-set/button-set.component.ts
+++ b/libs/design/src/molecules/button-set/button-set.component.ts
@@ -7,5 +7,8 @@ import { Component, ViewEncapsulation, HostBinding } from '@angular/core';
   encapsulation: ViewEncapsulation.None
 })
 export class DaffButtonSetComponent {
-  @HostBinding('class.daff-button-set') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-button-set') class = true;
 }

--- a/libs/design/src/molecules/button-set/button-set.component.ts
+++ b/libs/design/src/molecules/button-set/button-set.component.ts
@@ -7,5 +7,5 @@ import { Component, ViewEncapsulation, HostBinding } from '@angular/core';
   encapsulation: ViewEncapsulation.None
 })
 export class DaffButtonSetComponent {
-  @HostBinding('class.daff-button-set') class = true;
+  @HostBinding('class.daff-button-set') private class = true;
 }

--- a/libs/design/src/molecules/callout/callout-subtitle/callout-subtitle.directive.ts
+++ b/libs/design/src/molecules/callout/callout-subtitle/callout-subtitle.directive.ts
@@ -6,5 +6,8 @@ import { Directive, HostBinding } from '@angular/core';
 
 export class DaffCalloutSubtitleDirective {
 
-  @HostBinding('class.daff-callout__subtitle') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-callout__subtitle') class = true;
 }

--- a/libs/design/src/molecules/callout/callout-subtitle/callout-subtitle.directive.ts
+++ b/libs/design/src/molecules/callout/callout-subtitle/callout-subtitle.directive.ts
@@ -6,5 +6,5 @@ import { Directive, HostBinding } from '@angular/core';
 
 export class DaffCalloutSubtitleDirective {
 
-  @HostBinding('class.daff-callout__subtitle') class = true;
+  @HostBinding('class.daff-callout__subtitle') private class = true;
 }

--- a/libs/design/src/molecules/callout/callout-title/callout-title.directive.ts
+++ b/libs/design/src/molecules/callout/callout-title/callout-title.directive.ts
@@ -6,5 +6,8 @@ import { Directive, HostBinding } from '@angular/core';
 
 export class DaffCalloutTitleDirective {
 
-  @HostBinding('class.daff-callout__title') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-callout__title') class = true;
 }

--- a/libs/design/src/molecules/callout/callout-title/callout-title.directive.ts
+++ b/libs/design/src/molecules/callout/callout-title/callout-title.directive.ts
@@ -6,5 +6,5 @@ import { Directive, HostBinding } from '@angular/core';
 
 export class DaffCalloutTitleDirective {
 
-  @HostBinding('class.daff-callout__title') class = true;
+  @HostBinding('class.daff-callout__title') private class = true;
 }

--- a/libs/design/src/molecules/callout/callout/callout.component.ts
+++ b/libs/design/src/molecules/callout/callout/callout.component.ts
@@ -39,15 +39,15 @@ export class DaffCalloutComponent extends _daffCalloutBase implements DaffColora
     super(elementRef, renderer);
   }
 
-  @HostBinding('class.daff-callout') class = true;
+  @HostBinding('class.daff-callout') private class = true;
 
   // Will be deprecated in v1.0.0
-  @HostBinding('class.daff-callout--centered') get centered() {
+  @HostBinding('class.daff-callout--centered') private get centered() {
     return this.layout === DaffCalloutLayoutEnum.Centered;
   }
 
   // Will be deprecated in v1.0.0
-  @HostBinding('class.daff-callout--compact') get compact() {
+  @HostBinding('class.daff-callout--compact') private get compact() {
     return this.size === DaffCalloutSizeEnum.Compact;
   }
 }

--- a/libs/design/src/molecules/callout/callout/callout.component.ts
+++ b/libs/design/src/molecules/callout/callout/callout.component.ts
@@ -39,15 +39,24 @@ export class DaffCalloutComponent extends _daffCalloutBase implements DaffColora
     super(elementRef, renderer);
   }
 
-  @HostBinding('class.daff-callout') private class = true;
+  /**
+	 * @docs-private
+	 */
+	@HostBinding('class.daff-callout') class = true;
 
-  // Will be deprecated in v1.0.0
-  @HostBinding('class.daff-callout--centered') private get centered() {
+  /**
+	 * Will be deprecated in v1.0.0
+	 * @docs-private
+	 */
+	@HostBinding('class.daff-callout--centered') get centered() {
     return this.layout === DaffCalloutLayoutEnum.Centered;
   }
 
-  // Will be deprecated in v1.0.0
-  @HostBinding('class.daff-callout--compact') private get compact() {
+  /**
+	 * Will be deprecated in v1.0.0
+	 * @docs-private
+	 */
+	@HostBinding('class.daff-callout--compact') get compact() {
     return this.size === DaffCalloutSizeEnum.Compact;
   }
 }

--- a/libs/design/src/molecules/card/card-image/card-image.directive.ts
+++ b/libs/design/src/molecules/card/card-image/card-image.directive.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffCardImageDirective {
   
-  @HostBinding('class.daff-card__image') class = true;
+  @HostBinding('class.daff-card__image') private class = true;
 }

--- a/libs/design/src/molecules/card/card-image/card-image.directive.ts
+++ b/libs/design/src/molecules/card/card-image/card-image.directive.ts
@@ -4,6 +4,9 @@ import { Directive, HostBinding } from '@angular/core';
   selector: '[daffCardImage]'
 })
 export class DaffCardImageDirective {
-  
-  @HostBinding('class.daff-card__image') private class = true;
+	
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-card__image') class = true;
 }

--- a/libs/design/src/molecules/card/card-title/card-title.directive.ts
+++ b/libs/design/src/molecules/card/card-title/card-title.directive.ts
@@ -5,5 +5,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffCardTitleDirective {
 
-  @HostBinding('class.daff-card__title') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-card__title') class = true;
 }

--- a/libs/design/src/molecules/card/card-title/card-title.directive.ts
+++ b/libs/design/src/molecules/card/card-title/card-title.directive.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffCardTitleDirective {
 
-  @HostBinding('class.daff-card__title') class = true;
+  @HostBinding('class.daff-card__title') private class = true;
 }

--- a/libs/design/src/molecules/card/card/card.component.ts
+++ b/libs/design/src/molecules/card/card/card.component.ts
@@ -29,8 +29,11 @@ const _daffCardBase = daffColorMixin(DaffCardBase)
 
 export class DaffCardComponent extends _daffCardBase implements DaffColorable {
 
-  @Input() color: DaffPalette;
-  @HostBinding('class.daff-card') private class = true;
+	@Input() color: DaffPalette;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-card') class = true;
 
   constructor(private elementRef: ElementRef, private renderer: Renderer2) {
     super(elementRef, renderer);

--- a/libs/design/src/molecules/card/card/card.component.ts
+++ b/libs/design/src/molecules/card/card/card.component.ts
@@ -30,7 +30,7 @@ const _daffCardBase = daffColorMixin(DaffCardBase)
 export class DaffCardComponent extends _daffCardBase implements DaffColorable {
 
   @Input() color: DaffPalette;
-  @HostBinding('class.daff-card') class = true;
+  @HostBinding('class.daff-card') private class = true;
 
   constructor(private elementRef: ElementRef, private renderer: Renderer2) {
     super(elementRef, renderer);

--- a/libs/design/src/molecules/feature/feature-icon/feature-icon.directive.ts
+++ b/libs/design/src/molecules/feature/feature-icon/feature-icon.directive.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffFeatureIconDirective {
 
-  @HostBinding('class.daff-feature__icon') class = true;
+  @HostBinding('class.daff-feature__icon') private class = true;
 }

--- a/libs/design/src/molecules/feature/feature-icon/feature-icon.directive.ts
+++ b/libs/design/src/molecules/feature/feature-icon/feature-icon.directive.ts
@@ -5,5 +5,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffFeatureIconDirective {
 
-  @HostBinding('class.daff-feature__icon') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-feature__icon') class = true;
 }

--- a/libs/design/src/molecules/feature/feature-subheader/feature-subheader.directive.ts
+++ b/libs/design/src/molecules/feature/feature-subheader/feature-subheader.directive.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffFeatureSubheaderDirective {
 
-  @HostBinding('class.daff-feature__subheader') class = true;
+  @HostBinding('class.daff-feature__subheader') private class = true;
 }

--- a/libs/design/src/molecules/feature/feature-subheader/feature-subheader.directive.ts
+++ b/libs/design/src/molecules/feature/feature-subheader/feature-subheader.directive.ts
@@ -5,5 +5,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffFeatureSubheaderDirective {
 
-  @HostBinding('class.daff-feature__subheader') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-feature__subheader') class = true;
 }

--- a/libs/design/src/molecules/feature/feature-subtitle/feature-subtitle.directive.ts
+++ b/libs/design/src/molecules/feature/feature-subtitle/feature-subtitle.directive.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffFeatureSubtitleDirective {
 
-  @HostBinding('class.daff-feature__subtitle') class = true;
+  @HostBinding('class.daff-feature__subtitle') private class = true;
 }

--- a/libs/design/src/molecules/feature/feature-subtitle/feature-subtitle.directive.ts
+++ b/libs/design/src/molecules/feature/feature-subtitle/feature-subtitle.directive.ts
@@ -5,5 +5,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffFeatureSubtitleDirective {
 
-  @HostBinding('class.daff-feature__subtitle') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-feature__subtitle') class = true;
 }

--- a/libs/design/src/molecules/feature/feature-title/feature-title.directive.ts
+++ b/libs/design/src/molecules/feature/feature-title/feature-title.directive.ts
@@ -5,5 +5,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffFeatureTitleDirective {
 
-  @HostBinding('class.daff-feature__title') class = true;
+  @HostBinding('class.daff-feature__title') private class = true;
 }

--- a/libs/design/src/molecules/feature/feature-title/feature-title.directive.ts
+++ b/libs/design/src/molecules/feature/feature-title/feature-title.directive.ts
@@ -5,5 +5,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffFeatureTitleDirective {
 
-  @HostBinding('class.daff-feature__title') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-feature__title') class = true;
 }

--- a/libs/design/src/molecules/feature/feature/feature.component.ts
+++ b/libs/design/src/molecules/feature/feature/feature.component.ts
@@ -16,15 +16,15 @@ export enum DaffFeatureModeEnum {
 
 export class DaffFeatureComponent {
 
-  @HostBinding('class.daff-feature') class = true;
+  @HostBinding('class.daff-feature') private class = true;
 
   @Input() mode: DaffFeatureMode = DaffFeatureModeEnum.Normal;
 
-  @HostBinding('class.daff-feature--compact') get compact() {
+  @HostBinding('class.daff-feature--compact') private get compact() {
     return this.mode === DaffFeatureModeEnum.Compact;
   }
 
-  @HostBinding('class.daff-feature--normal') get normal() {
+  @HostBinding('class.daff-feature--normal') private get normal() {
     return this.mode === DaffFeatureModeEnum.Normal;
   }
 }

--- a/libs/design/src/molecules/feature/feature/feature.component.ts
+++ b/libs/design/src/molecules/feature/feature/feature.component.ts
@@ -16,15 +16,24 @@ export enum DaffFeatureModeEnum {
 
 export class DaffFeatureComponent {
 
-  @HostBinding('class.daff-feature') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-feature') class = true;
 
   @Input() mode: DaffFeatureMode = DaffFeatureModeEnum.Normal;
 
-  @HostBinding('class.daff-feature--compact') private get compact() {
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-feature--compact') get compact() {
     return this.mode === DaffFeatureModeEnum.Compact;
   }
 
-  @HostBinding('class.daff-feature--normal') private get normal() {
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-feature--normal') get normal() {
     return this.mode === DaffFeatureModeEnum.Normal;
   }
 }

--- a/libs/design/src/molecules/hero/hero-subtitle/hero-subtitle.directive.ts
+++ b/libs/design/src/molecules/hero/hero-subtitle/hero-subtitle.directive.ts
@@ -6,5 +6,5 @@ import { Directive, HostBinding } from '@angular/core';
 
 export class DaffHeroSubtitleDirective {
 
-  @HostBinding('class.daff-hero__subtitle') class = true;
+  @HostBinding('class.daff-hero__subtitle') private class = true;
 }

--- a/libs/design/src/molecules/hero/hero-subtitle/hero-subtitle.directive.ts
+++ b/libs/design/src/molecules/hero/hero-subtitle/hero-subtitle.directive.ts
@@ -6,5 +6,8 @@ import { Directive, HostBinding } from '@angular/core';
 
 export class DaffHeroSubtitleDirective {
 
-  @HostBinding('class.daff-hero__subtitle') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-hero__subtitle') class = true;
 }

--- a/libs/design/src/molecules/hero/hero-title/hero-title.directive.ts
+++ b/libs/design/src/molecules/hero/hero-title/hero-title.directive.ts
@@ -6,5 +6,5 @@ import { Directive, HostBinding } from '@angular/core';
 
 export class DaffHeroTitleDirective {
   
-  @HostBinding('class.daff-hero__title') class = true;
+  @HostBinding('class.daff-hero__title') private class = true;
 }

--- a/libs/design/src/molecules/hero/hero-title/hero-title.directive.ts
+++ b/libs/design/src/molecules/hero/hero-title/hero-title.directive.ts
@@ -5,6 +5,9 @@ import { Directive, HostBinding } from '@angular/core';
 })
 
 export class DaffHeroTitleDirective {
-  
-  @HostBinding('class.daff-hero__title') private class = true;
+	
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-hero__title') class = true;
 }

--- a/libs/design/src/molecules/hero/hero/hero.component.ts
+++ b/libs/design/src/molecules/hero/hero/hero.component.ts
@@ -41,20 +41,20 @@ export class DaffHeroComponent extends _daffHeroBase implements DaffColorable {
     super(elementRef, renderer);
   }
 
-  @HostBinding('class.daff-hero') class = true;
+  @HostBinding('class.daff-hero') private class = true;
 
   // Will be deprecated in v1.0.0
-  @HostBinding('class.daff-hero--centered') get centered() {
+  @HostBinding('class.daff-hero--centered') private get centered() {
     return this.layout === DaffHeroLayoutEnum.Centered;
   }
 
   // Will be deprecated in v1.0.0
-  @HostBinding('class.daff-hero--small') get small() {
+  @HostBinding('class.daff-hero--small') private get small() {
     return this.size === DaffHeroSizeEnum.Small;
   }
 
   // Will be deprecated in v1.0.0
-  @HostBinding('class.daff-hero--compact') get compact() {
+  @HostBinding('class.daff-hero--compact') private get compact() {
     return this.size === DaffHeroSizeEnum.Compact;
   }
 }

--- a/libs/design/src/molecules/hero/hero/hero.component.ts
+++ b/libs/design/src/molecules/hero/hero/hero.component.ts
@@ -41,20 +41,32 @@ export class DaffHeroComponent extends _daffHeroBase implements DaffColorable {
     super(elementRef, renderer);
   }
 
-  @HostBinding('class.daff-hero') private class = true;
+  /**
+	 * @docs-private
+	 */
+	@HostBinding('class.daff-hero') class = true;
 
-  // Will be deprecated in v1.0.0
-  @HostBinding('class.daff-hero--centered') private get centered() {
+  /**
+	 * Will be deprecated in v1.0.0
+	 * @docs-private
+	 */
+	@HostBinding('class.daff-hero--centered') get centered() {
     return this.layout === DaffHeroLayoutEnum.Centered;
   }
 
-  // Will be deprecated in v1.0.0
-  @HostBinding('class.daff-hero--small') private get small() {
+  /**
+	 * Will be deprecated in v1.0.0
+	 * @docs-private
+	 */
+	@HostBinding('class.daff-hero--small') get small() {
     return this.size === DaffHeroSizeEnum.Small;
   }
 
-  // Will be deprecated in v1.0.0
-  @HostBinding('class.daff-hero--compact') private get compact() {
+  /**
+	 * Will be deprecated in v1.0.0
+	 * @docs-private
+	 */
+	@HostBinding('class.daff-hero--compact') get compact() {
     return this.size === DaffHeroSizeEnum.Compact;
   }
 }

--- a/libs/design/src/molecules/image-list/image-list.component.ts
+++ b/libs/design/src/molecules/image-list/image-list.component.ts
@@ -8,5 +8,8 @@ import { Component, ViewEncapsulation, HostBinding } from '@angular/core';
 })
 export class DaffImageListComponent {
 
-  @HostBinding('class.daff-image-list') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-image-list') class = true;
 }

--- a/libs/design/src/molecules/image-list/image-list.component.ts
+++ b/libs/design/src/molecules/image-list/image-list.component.ts
@@ -8,5 +8,5 @@ import { Component, ViewEncapsulation, HostBinding } from '@angular/core';
 })
 export class DaffImageListComponent {
 
-  @HostBinding('class.daff-image-list') class = true;
+  @HostBinding('class.daff-image-list') private class = true;
 }

--- a/libs/design/src/molecules/link-set/link-set-heading/link-set-heading.directive.ts
+++ b/libs/design/src/molecules/link-set/link-set-heading/link-set-heading.directive.ts
@@ -8,5 +8,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffLinkSetHeadingDirective {
 
-  @HostBinding('class.daff-link-set__heading') class = true;
+  @HostBinding('class.daff-link-set__heading') private class = true;
 }

--- a/libs/design/src/molecules/link-set/link-set-heading/link-set-heading.directive.ts
+++ b/libs/design/src/molecules/link-set/link-set-heading/link-set-heading.directive.ts
@@ -8,5 +8,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffLinkSetHeadingDirective {
 
-  @HostBinding('class.daff-link-set__heading') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-link-set__heading') class = true;
 }

--- a/libs/design/src/molecules/link-set/link-set-item/link-set-item.component.ts
+++ b/libs/design/src/molecules/link-set/link-set-item/link-set-item.component.ts
@@ -9,5 +9,8 @@ import { Component, ViewEncapsulation, ChangeDetectionStrategy, HostBinding } fr
 })
 export class DaffLinkSetItemComponent {
 
-  @HostBinding('class.daff-link-set__item') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-link-set__item') class = true;
 }

--- a/libs/design/src/molecules/link-set/link-set-item/link-set-item.component.ts
+++ b/libs/design/src/molecules/link-set/link-set-item/link-set-item.component.ts
@@ -9,5 +9,5 @@ import { Component, ViewEncapsulation, ChangeDetectionStrategy, HostBinding } fr
 })
 export class DaffLinkSetItemComponent {
 
-  @HostBinding('class.daff-link-set__item') class = true;
+  @HostBinding('class.daff-link-set__item') private class = true;
 }

--- a/libs/design/src/molecules/link-set/link-set-subheading/link-set-subheading.directive.ts
+++ b/libs/design/src/molecules/link-set/link-set-subheading/link-set-subheading.directive.ts
@@ -8,5 +8,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffLinkSetSubheadingDirective {
 
-  @HostBinding('class.daff-link-set__subheading') class = true;
+  @HostBinding('class.daff-link-set__subheading') private class = true;
 }

--- a/libs/design/src/molecules/link-set/link-set-subheading/link-set-subheading.directive.ts
+++ b/libs/design/src/molecules/link-set/link-set-subheading/link-set-subheading.directive.ts
@@ -8,5 +8,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffLinkSetSubheadingDirective {
 
-  @HostBinding('class.daff-link-set__subheading') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-link-set__subheading') class = true;
 }

--- a/libs/design/src/molecules/link-set/link-set/link-set.component.ts
+++ b/libs/design/src/molecules/link-set/link-set/link-set.component.ts
@@ -12,5 +12,8 @@ import { Component, HostBinding, ViewEncapsulation, Input, ChangeDetectionStrate
 })
 export class DaffLinkSetComponent {
 
-  @HostBinding('class.daff-link-set') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-link-set') class = true;
 }

--- a/libs/design/src/molecules/link-set/link-set/link-set.component.ts
+++ b/libs/design/src/molecules/link-set/link-set/link-set.component.ts
@@ -12,5 +12,5 @@ import { Component, HostBinding, ViewEncapsulation, Input, ChangeDetectionStrate
 })
 export class DaffLinkSetComponent {
 
-  @HostBinding('class.daff-link-set') class = true;
+  @HostBinding('class.daff-link-set') private class = true;
 }

--- a/libs/design/src/molecules/list/list-item/list-item.component.ts
+++ b/libs/design/src/molecules/list/list-item/list-item.component.ts
@@ -11,15 +11,16 @@ import { DaffPrefixDirective, DaffSuffixDirective } from '../../../core/prefix-s
 
 export class DaffListItemComponent {
 
-  @HostBinding('class.daff-list-item') class = true;
+  @HostBinding('class.daff-list-item') private class = true;
 
-  @ContentChild(DaffPrefixDirective, { static: false }) _prefix: DaffPrefixDirective;
-  @ContentChild(DaffSuffixDirective, { static: false }) _suffix: DaffSuffixDirective;
+  @ContentChild(DaffPrefixDirective, { static: false }) private _prefix: DaffPrefixDirective;
+  @ContentChild(DaffSuffixDirective, { static: false }) private _suffix: DaffSuffixDirective;
 
   constructor(private elementRef: ElementRef) {}
 
   /**
    * Sets the role for a regular `<daff-list-item>` to listitem.
+	 * @docs-private
    */
   @HostBinding('attr.role') get role() {
     return this._isAnchor() ? null : 'listitem';

--- a/libs/design/src/molecules/list/list-item/list-item.component.ts
+++ b/libs/design/src/molecules/list/list-item/list-item.component.ts
@@ -11,10 +11,19 @@ import { DaffPrefixDirective, DaffSuffixDirective } from '../../../core/prefix-s
 
 export class DaffListItemComponent {
 
-  @HostBinding('class.daff-list-item') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-list-item') class = true;
 
-  @ContentChild(DaffPrefixDirective, { static: false }) private _prefix: DaffPrefixDirective;
-  @ContentChild(DaffSuffixDirective, { static: false }) private _suffix: DaffSuffixDirective;
+	/**
+	 * @docs-private
+	 */
+	@ContentChild(DaffPrefixDirective, { static: false }) _prefix: DaffPrefixDirective;
+	/**
+	 * @docs-private
+	 */
+  @ContentChild(DaffSuffixDirective, { static: false }) _suffix: DaffSuffixDirective;
 
   constructor(private elementRef: ElementRef) {}
 

--- a/libs/design/src/molecules/list/list-subheader/list-subheader.directive.ts
+++ b/libs/design/src/molecules/list/list-subheader/list-subheader.directive.ts
@@ -8,5 +8,5 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffListSubheaderDirective {
 
-  @HostBinding('class.daff-list__subheader') class = true;
+  @HostBinding('class.daff-list__subheader') private class = true;
 }

--- a/libs/design/src/molecules/list/list-subheader/list-subheader.directive.ts
+++ b/libs/design/src/molecules/list/list-subheader/list-subheader.directive.ts
@@ -8,5 +8,8 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class DaffListSubheaderDirective {
 
-  @HostBinding('class.daff-list__subheader') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-list__subheader') class = true;
 }

--- a/libs/design/src/molecules/list/list/list.component.ts
+++ b/libs/design/src/molecules/list/list/list.component.ts
@@ -34,11 +34,15 @@ export class DaffListComponent {
    * */
   @Input() mode: DaffListMode;
 
+	/**
+	 * @docs-private
+	 */
   @HostBinding('class.daff-list') get list() {
     return this.listType === DaffListTypeEnum.Default;
   }
 
   /**
+	 * @docs-private
    * @deprecated
    * */
   @HostBinding('class.daff-list--multi-line') get multiline() {
@@ -46,6 +50,7 @@ export class DaffListComponent {
   }
 
   /**
+	 * @docs-private
    * @deprecated
    * */
   @HostBinding('class.daff-list--link') get link() {
@@ -53,25 +58,32 @@ export class DaffListComponent {
   }
 
   /**
+	 * @docs-private
    * @deprecated
    * */
   @HostBinding('class.daff-list--navigation') get navigation() {
     return this.mode === DaffListModeEnum.Navigation;
   }
-  
+	
+	/**
+	 * @docs-private
+	 */
   get listType(): DaffListType {
     return this._getHostElement().localName;
    }
 
   constructor(private elementRef: ElementRef) {}
 
-
+	/**
+	 * @docs-private
+	 */
   @HostBinding('class.daff-nav-list') get nav() {
     return this.listType === DaffListTypeEnum.Nav;
   }
 
   /**
    * Sets the role for a `<daff-nav-list>` to navigation.
+	 * @docs-private
    */
   @HostBinding('attr.role') get role() {
     return this.listType === DaffListTypeEnum.Nav ? 'navigation' : 'list';

--- a/libs/design/src/molecules/modal/modal-header/modal-header.component.ts
+++ b/libs/design/src/molecules/modal/modal-header/modal-header.component.ts
@@ -8,5 +8,8 @@ import { Component, ViewEncapsulation, HostBinding, ChangeDetectionStrategy } fr
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DaffModalHeaderComponent {
-  @HostBinding('class.daff-modal-header') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-modal-header') class = true;
 }

--- a/libs/design/src/molecules/modal/modal-header/modal-header.component.ts
+++ b/libs/design/src/molecules/modal/modal-header/modal-header.component.ts
@@ -8,5 +8,5 @@ import { Component, ViewEncapsulation, HostBinding, ChangeDetectionStrategy } fr
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DaffModalHeaderComponent {
-  @HostBinding('class.daff-modal-header') class = true;
+  @HostBinding('class.daff-modal-header') private class = true;
 }

--- a/libs/design/src/molecules/modal/modal-title/modal-title.directive.ts
+++ b/libs/design/src/molecules/modal/modal-title/modal-title.directive.ts
@@ -4,5 +4,8 @@ import { Directive, HostBinding } from '@angular/core';
   selector: '[daffModalTitle]'
 })
 export class DaffModalTitleDirective {
-  @HostBinding('class.daff-modal-title') private class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-modal-title') class = true;
 }

--- a/libs/design/src/molecules/modal/modal-title/modal-title.directive.ts
+++ b/libs/design/src/molecules/modal/modal-title/modal-title.directive.ts
@@ -4,5 +4,5 @@ import { Directive, HostBinding } from '@angular/core';
   selector: '[daffModalTitle]'
 })
 export class DaffModalTitleDirective {
-  @HostBinding('class.daff-modal-title') class = true;
+  @HostBinding('class.daff-modal-title') private class = true;
 }

--- a/libs/design/src/molecules/modal/modal/modal.component.ts
+++ b/libs/design/src/molecules/modal/modal/modal.component.ts
@@ -53,8 +53,9 @@ export class DaffModalComponent {
 
 	/**
 	 * Hostbinding to set the default modal class on the host element
+	 * @docs-private
 	 */
-	@HostBinding('class.daff-modal') private modalClass = true;
+	@HostBinding('class.daff-modal') modalClass = true;
 
 	/**
 	 * Helper method to attach portable content to modal

--- a/libs/design/src/molecules/modal/modal/modal.component.ts
+++ b/libs/design/src/molecules/modal/modal/modal.component.ts
@@ -31,7 +31,7 @@ export class DaffModalComponent {
 	/**
 	 * The CDK Portal outlet used to portal content into the modal.
 	 */
-	@ViewChild(CdkPortalOutlet, { static: true }) _portalOutlet: CdkPortalOutlet;
+	@ViewChild(CdkPortalOutlet, { static: true }) private _portalOutlet: CdkPortalOutlet;
 
 	/**
 	 * Event fired when the close animation is completed.
@@ -54,7 +54,7 @@ export class DaffModalComponent {
 	/**
 	 * Hostbinding to set the default modal class on the host element
 	 */
-	@HostBinding('class.daff-modal') modalClass = true;
+	@HostBinding('class.daff-modal') private modalClass = true;
 
 	/**
 	 * Helper method to attach portable content to modal

--- a/libs/design/src/molecules/navbar/navbar.component.ts
+++ b/libs/design/src/molecules/navbar/navbar.component.ts
@@ -25,11 +25,17 @@ export class DaffNavbarComponent extends _daffNavbarBase implements DaffColorabl
 
   @Input() shadowed = false;
 
-  @HostBinding('class.daff-navbar--shadowed') private get shadowClass() {
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-navbar--shadowed') get shadowClass() {
     return this.shadowed;
   };
 
-  @HostBinding('class.daff-navbar') private hostClass = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('class.daff-navbar') hostClass = true;
 
   constructor(private elementRef: ElementRef, private renderer: Renderer2) {
     super(elementRef, renderer);

--- a/libs/design/src/molecules/navbar/navbar.component.ts
+++ b/libs/design/src/molecules/navbar/navbar.component.ts
@@ -25,11 +25,11 @@ export class DaffNavbarComponent extends _daffNavbarBase implements DaffColorabl
 
   @Input() shadowed = false;
 
-  @HostBinding('class.daff-navbar--shadowed') get shadowClass() {
+  @HostBinding('class.daff-navbar--shadowed') private get shadowClass() {
     return this.shadowed;
   };
 
-  @HostBinding('class.daff-navbar') hostClass = true;
+  @HostBinding('class.daff-navbar') private hostClass = true;
 
   constructor(private elementRef: ElementRef, private renderer: Renderer2) {
     super(elementRef, renderer);

--- a/libs/design/src/molecules/paginator/paginator.component.ts
+++ b/libs/design/src/molecules/paginator/paginator.component.ts
@@ -23,17 +23,20 @@ const visiblePageRange = 2;
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChanges, DaffColorable {
-  @HostBinding('class.daff-paginator') class = true;
-  @HostBinding('attr.role') role = 'navigation';
+  @HostBinding('class.daff-paginator') private class = true;
+  @HostBinding('attr.role') private role = 'navigation';
 
-  faChevronRight = faChevronRight;
-  faChevronLeft = faChevronLeft;
+  private faChevronRight = faChevronRight;
+  private faChevronLeft = faChevronLeft;
 
   /**
    * The color theme of the paginator.
    */
   @Input() color: DaffPalette;
-  _paginatorId: string;
+	/**
+	 * @docs-private
+	 */
+	_paginatorId: string;
 
   constructor(private elementRef: ElementRef, private renderer: Renderer2) {
     super(elementRef, renderer);
@@ -52,6 +55,9 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
    */
   @Input() currentPage: number;
 
+	/**
+	 * @docs-private
+	 */
   _numberOfPagesArray: number[];
 
   /**
@@ -59,6 +65,9 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
    */
   @Output() notifyPageChange: EventEmitter<any> = new EventEmitter();
 
+	/**
+	 * @docs-private
+	 */
   ngOnChanges() {
     if(this.numberOfPages < 1) {
       throw new Error(DaffPaginatorNumberOfPagesErrorMessage);
@@ -71,6 +80,7 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
 
   /**
    * Emits the previous page number through notifyPageChange Output.
+	 * @docs-private
    */
   _onNotifyPrevPageChange() {
     this.notifyPageChange.emit(this.currentPage - 1);
@@ -78,6 +88,7 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
 
   /**
    * Emits the next page number through notifyPageChange Output.
+	 * @docs-private
    */
   _onNotifyNextPageChange() {
     this.notifyPageChange.emit(this.currentPage + 1);
@@ -85,6 +96,7 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
 
   /**
    * Emits a pageNumber to notifyPageChange Output.
+	 * @docs-private
    * @param pageNumber a page number
    */
   _onNotifyPageChange(pageNumber: number) {
@@ -93,6 +105,7 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
 
   /**
    * A simple function that determines if the given page number is the current page number.
+	 * @docs-private
    * @param page a page number
    */
   _isSelected(page: number): boolean {
@@ -101,6 +114,7 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
 
   /**
    * Determines when ellipsis after the first page number should show.
+	 * @docs-private
    */
   _showFirstEllipsis(): boolean {
     return this.currentPage >= visiblePageRange+2;
@@ -108,6 +122,7 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
 
   /**
    * Determines when ellipsis before the final page number should show.
+	 * @docs-private
    */
   _showLastEllipsis(): boolean {
     return this.currentPage < (this.numberOfPages - visiblePageRange);
@@ -116,6 +131,7 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
   /**
    * Determines if the given page number should be shown. The two additional 'or' conditionals are needed 
    * so the paginator retains the same total width at the extreme page numbers (1 and numberOfPages).
+	 * @docs-private
    * @param pageNumber page number to check.
    */
   _showNumber(pageNumber: number): boolean {
@@ -126,6 +142,7 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
 
   /**
    * Determines when the Previous button should be disabled.
+	 * @docs-private
    */
   _disablePrev(): boolean {
     return this.currentPage === 1;
@@ -133,6 +150,7 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
 
   /**
    * Determines when the Next button should be disabled.
+	 * @docs-private
    */
   _disableNext(): boolean {
     return this.currentPage === this.numberOfPages;

--- a/libs/design/src/molecules/paginator/paginator.component.ts
+++ b/libs/design/src/molecules/paginator/paginator.component.ts
@@ -23,11 +23,24 @@ const visiblePageRange = 2;
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChanges, DaffColorable {
-  @HostBinding('class.daff-paginator') private class = true;
-  @HostBinding('attr.role') private role = 'navigation';
+	
+	/**
+	 * @docs-private
+	 */
+	@HostBinding('class.daff-paginator') class = true;
+	/**
+	 * @docs-private
+	 */
+  @HostBinding('attr.role') role = 'navigation';
 
-  private faChevronRight = faChevronRight;
-  private faChevronLeft = faChevronLeft;
+	/**
+	 * @docs-private
+	 */
+	faChevronRight = faChevronRight;
+	/**
+	 * @docs-private
+	 */
+  faChevronLeft = faChevronLeft;
 
   /**
    * The color theme of the paginator.

--- a/libs/design/src/molecules/qty-dropdown/qty-dropdown.component.ts
+++ b/libs/design/src/molecules/qty-dropdown/qty-dropdown.component.ts
@@ -13,13 +13,28 @@ export class DaffQtyDropdownComponent implements OnInit {
   @Input() id: number | string;
   @Output() qtyChanged: EventEmitter<number> = new EventEmitter<number>();
 
-  dropdownItemCounter: number[];
-  inputHasBeenShown: boolean;
-  onChange = (qty: number) => {};
+	/**
+	 * @docs-private
+	 */
+	dropdownItemCounter: number[];
+	/**
+	 * @docs-private
+	 */
+	inputHasBeenShown: boolean;
+	/**
+	 * @docs-private
+	 */
+	onChange = (qty: number) => {};
+	/**
+	 * @docs-private
+	 */
   onTouched = () => {};
 
   constructor(private renderer: Renderer2) { }
 
+	/**
+	 * @docs-private
+	 */
   ngOnInit() {
     this.dropdownItemCounter = Array.from(Array(this.dropdownRange),(x,i)=>i);
 
@@ -28,19 +43,31 @@ export class DaffQtyDropdownComponent implements OnInit {
     }
   }
 
+	/**
+	 * @docs-private
+	 */
   writeValue(qty: number): void {
     this.qty = qty;
     this.onChange(this.qty);
   }
 
+	/**
+	 * @docs-private
+	 */
   registerOnChange(fn: (qty: number) => void): void {
     this.onChange = fn;
   }
 
+	/**
+	 * @docs-private
+	 */
   registerOnTouched(fn: any): void {
     this.onTouched = fn;
   }
 
+	/**
+	 * @docs-private
+	 */
   setDisabledState(isDisabled: boolean): void {
     if (this.inputHasBeenShown) {
       this.renderer.setProperty(document.getElementById('input_' + this.id), 'disabled', isDisabled);
@@ -49,6 +76,9 @@ export class DaffQtyDropdownComponent implements OnInit {
     }
   }
 
+	/**
+	 * @docs-private
+	 */
   get showQtyInputField() : boolean {
     if (!this.isQtyOutsideDropdownRange() && !this.inputHasBeenShown) {
       return false
@@ -58,6 +88,9 @@ export class DaffQtyDropdownComponent implements OnInit {
     }
   }
 
+	/**
+	 * @docs-private
+	 */
   onChangedWrapper(value: any) {
     value = parseInt(value, 10);
     if (value === 10) {

--- a/libs/design/src/molecules/sidebar/sidebar-viewport/sidebar-viewport.component.ts
+++ b/libs/design/src/molecules/sidebar/sidebar-viewport/sidebar-viewport.component.ts
@@ -18,15 +18,25 @@ import { DaffSidebarComponent } from '../sidebar/sidebar.component';
 export class DaffSidebarViewportComponent implements OnInit, AfterViewInit {
 
   constructor(private ref: ChangeDetectorRef) {
-  }
+	}
+	/**
+	 * @docs-private
+	 */
   _animationState: string;
 
+	/**
+	 * @docs-private
+	 */
   @ContentChild(DaffSidebarComponent, { static: false }) sidebar: DaffSidebarComponent;
   /**
    * Internal tracking variable for the state of sidebar viewport.
+	 * @docs-private
    */
   _opened = false;
 
+	/**
+	 * @docs-private
+	 */
   _mode: DaffSidebarMode = 'side';
 
   /**
@@ -45,20 +55,39 @@ export class DaffSidebarViewportComponent implements OnInit, AfterViewInit {
    */
   // tslint:disable-next-line: no-inferrable-types
   @Input() backdropIsVisible: boolean = true;
+	
+	/**
+	 * Property for the "opened" state of the sidebar
+	 */
+	@Input()
+	get opened(): boolean { return this._opened; }
+	set opened(value: boolean) {
+		this._opened = value;
+		this._animationState = getAnimationState(value, this.animationsEnabled);
+	}
   /**
    * Event fired when the backdrop is clicked
    * This is often used to close the sidebar
    */
   @Output() backdropClicked: EventEmitter<void> = new EventEmitter<void>();
 
-  get animationsEnabled(): boolean {
+	/**
+	 * @docs-private
+	 */
+	get animationsEnabled(): boolean {
     return (this.mode === 'over' || this.mode === 'push') ? true : false;
   }
 
+	/**
+	 * @docs-private
+	 */
   ngOnInit() {
     this._animationState = getAnimationState(this.opened, this.animationsEnabled);
-
-  }
+	}
+	
+	/**
+	 * @docs-private
+	 */
   ngAfterViewInit() {
     if (this.sidebar) {
       this.sidebar.escapePressed.subscribe(() => {
@@ -67,25 +96,23 @@ export class DaffSidebarViewportComponent implements OnInit, AfterViewInit {
     }
   }
 
-
-  /**
-   * Property for the "opened" state of the sidebar
-   */
-  @Input()
-  get opened(): boolean { return this._opened; }
-  set opened(value: boolean) {
-    this._opened = value;
-    this._animationState = getAnimationState(value, this.animationsEnabled);
-  }
-
-
+	/**
+	 * @docs-private
+	 */
   _backdropClicked(): void {
     this.backdropClicked.emit();
   }
 
+	/**
+	 * @docs-private
+	 */
   get hasBackdrop(): boolean {
     return (this.mode === 'over' || this.mode === 'push');
-  }
+	}
+	
+	/**
+	 * @docs-private
+	 */
   onEscape() {
     if (this.hasBackdrop) {
       this.opened = false;

--- a/libs/design/src/molecules/sidebar/sidebar/sidebar.component.ts
+++ b/libs/design/src/molecules/sidebar/sidebar/sidebar.component.ts
@@ -7,7 +7,7 @@ import { fromEvent } from 'rxjs';
  * DaffSidebar is heavily based upon the work done by the @angular/material2
  * team on `mat-drawer` and `mat-sidenav`. `daff-sidebar` is intended to be
  * a simplified version (with a different design) of `mat-drawer` which 
- * follows a stricter `dumb` component pattern than `mat-drawer`
+ * follows a stricter "dumb" component pattern than `mat-drawer`
  */
 @Component({
   selector: 'daff-sidebar',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Many internal properties are included in the generated api docs, because they are not marked as private.

## What is the new behavior?
The internal properties are all marked as `private`, so they will not end up in the generated api docs.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

I also moved some properties around so that they would show up in a desired order in the API docs. For example, I made `Input`s come before `Output`s, which come before all non-decorated properties.