### PR TITLE
fix(product): make any product percentages a whole number to avoid re…

### DIFF
--- a/libs/product/testing/src/factories/configurable-product.factory.spec.ts
+++ b/libs/product/testing/src/factories/configurable-product.factory.spec.ts
@@ -42,7 +42,7 @@ describe('Product | Testing | Factories | DaffConfigurableProductFactory', () =>
 		});
 		
 		it('should return any percents as whole numbers', () => {
-			expect(result.variants[0].discount.percent%1).toEqual(0);
+			expect(result.variants[0].discount.percent % 1).toEqual(0);
 		});
   });
 });

--- a/libs/product/testing/src/factories/configurable-product.factory.spec.ts
+++ b/libs/product/testing/src/factories/configurable-product.factory.spec.ts
@@ -39,6 +39,10 @@ describe('Product | Testing | Factories | DaffConfigurableProductFactory', () =>
 			expect(result.configurableAttributes).toBeDefined();
 			expect(result.variants).toBeDefined();
 			expect(result.variants[0].in_stock).toBeDefined();
-    });
+		});
+		
+		it('should return any percents as whole numbers', () => {
+			expect(Math.floor(result.variants[0].discount.percent)).toEqual(result.variants[0].discount.percent);
+		});
   });
 });

--- a/libs/product/testing/src/factories/configurable-product.factory.spec.ts
+++ b/libs/product/testing/src/factories/configurable-product.factory.spec.ts
@@ -42,7 +42,7 @@ describe('Product | Testing | Factories | DaffConfigurableProductFactory', () =>
 		});
 		
 		it('should return any percents as whole numbers', () => {
-			expect(Math.floor(result.variants[0].discount.percent)).toEqual(result.variants[0].discount.percent);
+			expect(result.variants[0].discount.percent%1).toEqual(0);
 		});
   });
 });

--- a/libs/product/testing/src/factories/configurable-product.factory.ts
+++ b/libs/product/testing/src/factories/configurable-product.factory.ts
@@ -109,7 +109,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1.toString(),
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
+				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -123,7 +123,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1.toString(),
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
+				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -137,7 +137,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant3.toString(),
 			discount: {
 				amount: this.stubDiscountVariant3,
-				percent: Math.floor(this.stubDiscountVariant3/this.stubPriceVariant3)
+				percent: Math.floor((this.stubDiscountVariant3/this.stubPriceVariant3) * 100)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -151,7 +151,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1.toString(),
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
+				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -165,7 +165,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1.toString(),
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
+				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -179,7 +179,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant3.toString(),
 			discount: {
 				amount: this.stubDiscountVariant3,
-				percent: Math.floor(this.stubDiscountVariant3/this.stubPriceVariant3)
+				percent: Math.floor((this.stubDiscountVariant3/this.stubPriceVariant3) * 100)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -193,7 +193,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1,
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
+				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -207,7 +207,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant2,
 			discount: {
 				amount: this.stubDiscountVariant2,
-				percent: Math.floor(this.stubDiscountVariant2/this.stubPriceVariant2)
+				percent: Math.floor((this.stubDiscountVariant2/this.stubPriceVariant2) * 100)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -221,7 +221,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant3,
 			discount: {
 				amount: this.stubDiscountVariant3,
-				percent: Math.floor(this.stubDiscountVariant3/this.stubPriceVariant3)
+				percent: Math.floor((this.stubDiscountVariant3/this.stubPriceVariant3) * 100)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -235,7 +235,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1.toString(),
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
+				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true

--- a/libs/product/testing/src/factories/configurable-product.factory.ts
+++ b/libs/product/testing/src/factories/configurable-product.factory.ts
@@ -109,7 +109,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1.toString(),
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: this.stubDiscountVariant1/this.stubPriceVariant1
+				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -123,7 +123,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1.toString(),
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: this.stubDiscountVariant1/this.stubPriceVariant1
+				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -137,7 +137,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant3.toString(),
 			discount: {
 				amount: this.stubDiscountVariant3,
-				percent: this.stubDiscountVariant3/this.stubPriceVariant3
+				percent: Math.floor(this.stubDiscountVariant3/this.stubPriceVariant3)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -151,7 +151,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1.toString(),
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: this.stubDiscountVariant1/this.stubPriceVariant1
+				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -165,7 +165,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1.toString(),
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: this.stubDiscountVariant1/this.stubPriceVariant1
+				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -179,7 +179,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant3.toString(),
 			discount: {
 				amount: this.stubDiscountVariant3,
-				percent: this.stubDiscountVariant3/this.stubPriceVariant3
+				percent: Math.floor(this.stubDiscountVariant3/this.stubPriceVariant3)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -193,7 +193,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1,
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: this.stubDiscountVariant1/this.stubPriceVariant1
+				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -207,7 +207,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant2,
 			discount: {
 				amount: this.stubDiscountVariant2,
-				percent: this.stubDiscountVariant2/this.stubPriceVariant2
+				percent: Math.floor(this.stubDiscountVariant2/this.stubPriceVariant2)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -221,7 +221,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant3,
 			discount: {
 				amount: this.stubDiscountVariant3,
-				percent: this.stubDiscountVariant3/this.stubPriceVariant3
+				percent: Math.floor(this.stubDiscountVariant3/this.stubPriceVariant3)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true
@@ -235,7 +235,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 			price: this.stubPriceVariant1.toString(),
 			discount: {
 				amount: this.stubDiscountVariant1,
-				percent: this.stubDiscountVariant1/this.stubPriceVariant1
+				percent: Math.floor(this.stubDiscountVariant1/this.stubPriceVariant1)
 			},
 			id: faker.random.alphaNumeric(16),
 			in_stock: true

--- a/libs/product/testing/src/factories/product.factory.spec.ts
+++ b/libs/product/testing/src/factories/product.factory.spec.ts
@@ -40,7 +40,7 @@ describe('Product | Testing | Factories | DaffProductFactory', () => {
 		});
 		
 		it('should the percentage as a whole number', () => {
-			expect(Math.floor(result.discount.percent)).toEqual(result.discount.percent);
+			expect(result.discount.percent%1).toEqual(0);
 		});
   });
 

--- a/libs/product/testing/src/factories/product.factory.spec.ts
+++ b/libs/product/testing/src/factories/product.factory.spec.ts
@@ -40,7 +40,7 @@ describe('Product | Testing | Factories | DaffProductFactory', () => {
 		});
 		
 		it('should the percentage as a whole number', () => {
-			expect(result.discount.percent%1).toEqual(0);
+			expect(result.discount.percent % 1).toEqual(0);
 		});
   });
 

--- a/libs/product/testing/src/factories/product.factory.spec.ts
+++ b/libs/product/testing/src/factories/product.factory.spec.ts
@@ -37,7 +37,11 @@ describe('Product | Testing | Factories | DaffProductFactory', () => {
       expect(result.brand).toBeDefined(); 
       expect(result.description).toBeDefined();     
       expect(result.in_stock).toBeDefined();     
-    });
+		});
+		
+		it('should the percentage as a whole number', () => {
+			expect(Math.floor(result.discount.percent)).toEqual(result.discount.percent);
+		});
   });
 
   describe('createMany', () => {

--- a/libs/product/testing/src/factories/product.factory.ts
+++ b/libs/product/testing/src/factories/product.factory.ts
@@ -17,7 +17,7 @@ export class MockProduct implements DaffProduct {
 	in_stock = true;
 	discount = {
 		amount: this.stubDiscount,
-		percent: Math.floor(this.stubDiscount/this.stubPrice)
+		percent: Math.floor((this.stubDiscount/this.stubPrice) * 100)
 	}
   name = faker.commerce.productName();
   brand = faker.company.companyName();

--- a/libs/product/testing/src/factories/product.factory.ts
+++ b/libs/product/testing/src/factories/product.factory.ts
@@ -17,7 +17,7 @@ export class MockProduct implements DaffProduct {
 	in_stock = true;
 	discount = {
 		amount: this.stubDiscount,
-		percent: this.stubDiscount/this.stubPrice
+		percent: Math.floor(this.stubDiscount/this.stubPrice)
 	}
   name = faker.commerce.productName();
   brand = faker.company.companyName();


### PR DESCRIPTION
…ally long decimals

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The percent discount coming through the in memory api is computed by dividing the discount amount by the price which results in a big, ugly decimal.

## What is the new behavior?
The percentage is now a whole number and easy on the eyes. It's also more what you'd expect from a real backend.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```