### PR TITLE
feat(all): swap error names to AOT compile-safe comparison

### DIFF
--- a/libs/auth/src/effects/auth.effects.spec.ts
+++ b/libs/auth/src/effects/auth.effects.spec.ts
@@ -52,7 +52,7 @@ describe('DaffAuthEffects', () => {
   const authFactory: DaffAuthTokenFactory = new DaffAuthTokenFactory();
 
   const authStorageFailureAction = new DaffAuthStorageFailure('Storage of auth token has failed.');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   let mockAuth: DaffAuthToken;
   let mockLoginInfo: DaffLoginInfo;

--- a/libs/auth/src/errors/authentication-failed.ts
+++ b/libs/auth/src/errors/authentication-failed.ts
@@ -1,5 +1,7 @@
-export class DaffAuthenticationFailedError extends Error {
-  public static readonly code: string = 'AUTHENTICATION_FAILED';
+import { DaffInheritableError } from '@daffodil/core';
+
+export class DaffAuthenticationFailedError extends DaffInheritableError {
+	public readonly code: string = 'AUTHENTICATION_FAILED';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/auth/src/errors/authentication-failed.ts
+++ b/libs/auth/src/errors/authentication-failed.ts
@@ -1,6 +1,5 @@
 export class DaffAuthenticationFailedError extends Error {
-	readonly name = 'DaffAuthenticationFailedError';
-  readonly code: string = 'AUTHENTICATION_FAILED';
+  public static readonly code: string = 'AUTHENTICATION_FAILED';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/auth/src/errors/bad-input.ts
+++ b/libs/auth/src/errors/bad-input.ts
@@ -1,6 +1,5 @@
 export class DaffBadInputError extends Error {
-	readonly name = 'DaffBadInputError';
-  readonly code: string = 'BAD_INPUT';
+  public static readonly code: string = 'BAD_INPUT';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/auth/src/errors/bad-input.ts
+++ b/libs/auth/src/errors/bad-input.ts
@@ -1,5 +1,7 @@
-export class DaffBadInputError extends Error {
-  public static readonly code: string = 'BAD_INPUT';
+import { DaffInheritableError } from '@daffodil/core';
+
+export class DaffBadInputError extends DaffInheritableError {
+	public readonly code: string = 'BAD_INPUT';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/auth/src/errors/invalid-api-response.ts
+++ b/libs/auth/src/errors/invalid-api-response.ts
@@ -1,5 +1,7 @@
-export class DaffInvalidAPIResponseError extends Error {
-  public static readonly code: string = 'INVALID_API_RESPONSE';
+import { DaffInheritableError } from '@daffodil/core';
+
+export class DaffInvalidAPIResponseError extends DaffInheritableError {
+	public readonly code: string = 'INVALID_API_RESPONSE';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/auth/src/errors/invalid-api-response.ts
+++ b/libs/auth/src/errors/invalid-api-response.ts
@@ -1,6 +1,5 @@
 export class DaffInvalidAPIResponseError extends Error {
-	readonly name = 'DaffInvalidAPIResponseError';
-  readonly code: string = 'INVALID_API_RESPONSE';
+  public static readonly code: string = 'INVALID_API_RESPONSE';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/auth/src/errors/unauthorized.ts
+++ b/libs/auth/src/errors/unauthorized.ts
@@ -1,6 +1,5 @@
 export class DaffUnauthorizedError extends Error {
-	readonly name = 'DaffUnauthorizedError';
-  readonly code: string = 'UNAUTHORIZED';
+  public static readonly code: string = 'UNAUTHORIZED';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/auth/src/errors/unauthorized.ts
+++ b/libs/auth/src/errors/unauthorized.ts
@@ -1,5 +1,7 @@
-export class DaffUnauthorizedError extends Error {
-  public static readonly code: string = 'UNAUTHORIZED';
+import { DaffInheritableError } from '@daffodil/core';
+
+export class DaffUnauthorizedError extends DaffInheritableError {
+	public readonly code: string = 'UNAUTHORIZED';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/cart/src/effects/cart-address.effects.spec.ts
+++ b/libs/cart/src/effects/cart-address.effects.spec.ts
@@ -37,7 +37,7 @@ describe('Daffodil | Cart | CartAddressEffects', () => {
 
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
   const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/libs/cart/src/effects/cart-address.effects.ts
+++ b/libs/cart/src/effects/cart-address.effects.ts
@@ -32,7 +32,7 @@ export class DaffCartAddressEffects<T extends DaffCartAddress, V extends DaffCar
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.update(cartId, action.payload)),
       map((resp: V) => new DaffCartAddressUpdateSuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error.code === DaffStorageServiceError.code
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartAddressUpdateFailure('Failed to update cart address')
       )),

--- a/libs/cart/src/effects/cart-address.effects.ts
+++ b/libs/cart/src/effects/cart-address.effects.ts
@@ -32,7 +32,7 @@ export class DaffCartAddressEffects<T extends DaffCartAddress, V extends DaffCar
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.update(cartId, action.payload)),
       map((resp: V) => new DaffCartAddressUpdateSuccess(resp)),
-      catchError(error => of(error.code === DaffStorageServiceError.code
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartAddressUpdateFailure('Failed to update cart address')
       )),

--- a/libs/cart/src/effects/cart-coupon.effects.spec.ts
+++ b/libs/cart/src/effects/cart-coupon.effects.spec.ts
@@ -50,7 +50,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
 
   const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/libs/cart/src/effects/cart-coupon.effects.ts
+++ b/libs/cart/src/effects/cart-coupon.effects.ts
@@ -46,7 +46,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.apply(cartId, action.payload)),
       map(resp => new DaffCartCouponApplySuccess(resp)),
-      catchError(error => of(error.code === DaffStorageServiceError.code
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponApplyFailure('Failed to apply coupon to cart')
       )),
@@ -60,7 +60,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.list(cartId)),
       map(resp => new DaffCartCouponListSuccess<V>(resp)),
-      catchError(error => of(error.code === DaffStorageServiceError.code
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponListFailure('Failed to list coupons')
       )),
@@ -74,7 +74,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.remove(cartId, action.payload)),
       map(resp => new DaffCartCouponRemoveSuccess(resp)),
-      catchError(error => of(error.code === DaffStorageServiceError.code
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponRemoveFailure('Failed to remove a coupon from the cart')
       )),
@@ -88,7 +88,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.removeAll(cartId)),
       map(resp => new DaffCartCouponRemoveAllSuccess(resp)),
-      catchError(error => of(error.code === DaffStorageServiceError.code
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponRemoveAllFailure('Failed to remove all coupons from the cart')
       )),

--- a/libs/cart/src/effects/cart-coupon.effects.ts
+++ b/libs/cart/src/effects/cart-coupon.effects.ts
@@ -46,7 +46,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.apply(cartId, action.payload)),
       map(resp => new DaffCartCouponApplySuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error.code === DaffStorageServiceError.code
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponApplyFailure('Failed to apply coupon to cart')
       )),
@@ -60,7 +60,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.list(cartId)),
       map(resp => new DaffCartCouponListSuccess<V>(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error.code === DaffStorageServiceError.code
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponListFailure('Failed to list coupons')
       )),
@@ -74,7 +74,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.remove(cartId, action.payload)),
       map(resp => new DaffCartCouponRemoveSuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error.code === DaffStorageServiceError.code
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponRemoveFailure('Failed to remove a coupon from the cart')
       )),
@@ -88,7 +88,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.removeAll(cartId)),
       map(resp => new DaffCartCouponRemoveAllSuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error.code === DaffStorageServiceError.code
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponRemoveAllFailure('Failed to remove all coupons from the cart')
       )),

--- a/libs/cart/src/effects/cart-order.effects.spec.ts
+++ b/libs/cart/src/effects/cart-order.effects.spec.ts
@@ -42,7 +42,7 @@ describe('Cart | Effect | CartOrderEffects', () => {
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
 
   const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/libs/cart/src/effects/cart-order.effects.ts
+++ b/libs/cart/src/effects/cart-order.effects.ts
@@ -40,7 +40,7 @@ export class DaffCartOrderEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.placeOrder(cartId, action.payload)),
       map((resp: R) => new DaffCartPlaceOrderSuccess<R>(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error.code === DaffStorageServiceError.code
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartPlaceOrderFailure('Failed to place order')
       )),

--- a/libs/cart/src/effects/cart-order.effects.ts
+++ b/libs/cart/src/effects/cart-order.effects.ts
@@ -40,7 +40,7 @@ export class DaffCartOrderEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.placeOrder(cartId, action.payload)),
       map((resp: R) => new DaffCartPlaceOrderSuccess<R>(resp)),
-      catchError(error => of(error.code === DaffStorageServiceError.code
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartPlaceOrderFailure('Failed to place order')
       )),

--- a/libs/cart/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.spec.ts
@@ -34,7 +34,7 @@ describe('DaffCartResolverEffects', () => {
 
   let cartStorageService: jasmine.SpyObj<DaffCartStorageService>;
   const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({

--- a/libs/cart/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.ts
@@ -48,10 +48,10 @@ export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
         return of(new DaffCartLoadSuccess(resp))
       }),
       catchError(error => {
-        switch(error.code) {
-          case DaffStorageServiceError.code:
-            return of(new DaffCartStorageFailure('Cart Storage Failed'))
-          case DaffCartNotFoundError.code:
+        switch(true) {
+          case error instanceof DaffStorageServiceError:
+            return of(new DaffCartStorageFailure('Cart Storage Failed'));
+          case error instanceof DaffCartNotFoundError:
             return of(new DaffCartCreate());
           default:
             return of(new DaffCartLoadFailure('Cart loading has failed'));

--- a/libs/cart/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.ts
@@ -48,10 +48,10 @@ export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
         return of(new DaffCartLoadSuccess(resp))
       }),
       catchError(error => {
-        switch(error.name) {
-          case DaffStorageServiceError.name:
+        switch(error.code) {
+          case DaffStorageServiceError.code:
             return of(new DaffCartStorageFailure('Cart Storage Failed'))
-          case DaffCartNotFoundError.name:
+          case DaffCartNotFoundError.code:
             return of(new DaffCartCreate());
           default:
             return of(new DaffCartLoadFailure('Cart loading has failed'));

--- a/libs/cart/src/effects/cart.effects.ts
+++ b/libs/cart/src/effects/cart.effects.ts
@@ -65,7 +65,7 @@ export class DaffCartEffects<T extends DaffCart> {
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.get(cartId)),
       map((resp: T) => new DaffCartLoadSuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error.code === DaffStorageServiceError.code
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartLoadFailure('Failed to load cart')
       )),
@@ -90,7 +90,7 @@ export class DaffCartEffects<T extends DaffCart> {
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.clear(cartId)),
       map((resp: T) => new DaffCartClearSuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error.code === DaffStorageServiceError.code
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartClearFailure('Failed to clear the cart.')
       )),

--- a/libs/cart/src/effects/cart.effects.ts
+++ b/libs/cart/src/effects/cart.effects.ts
@@ -65,7 +65,7 @@ export class DaffCartEffects<T extends DaffCart> {
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.get(cartId)),
       map((resp: T) => new DaffCartLoadSuccess(resp)),
-      catchError(error => of(error.code === DaffStorageServiceError.code
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartLoadFailure('Failed to load cart')
       )),
@@ -90,7 +90,7 @@ export class DaffCartEffects<T extends DaffCart> {
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.clear(cartId)),
       map((resp: T) => new DaffCartClearSuccess(resp)),
-      catchError(error => of(error.code === DaffStorageServiceError.code
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartClearFailure('Failed to clear the cart.')
       )),

--- a/libs/cart/src/errors/not-found.ts
+++ b/libs/cart/src/errors/not-found.ts
@@ -1,6 +1,5 @@
 export class DaffCartNotFoundError extends Error {
-	readonly name = 'DaffCartNotFoundError';
-  readonly code: string = 'CART_NOT_FOUND';
+  public static readonly code: string = 'CART_NOT_FOUND';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/cart/src/errors/not-found.ts
+++ b/libs/cart/src/errors/not-found.ts
@@ -1,7 +1,12 @@
-export class DaffCartNotFoundError extends Error {
-  public static readonly code: string = 'CART_NOT_FOUND';
+import { DaffInheritableError } from '@daffodil/core';
 
-	constructor(public message: string) {
+export class DaffCartNotFoundError extends DaffInheritableError {
+	/**
+	 * The particular error code of the error.
+	 */
+	public readonly code: string = 'CART_NOT_FOUND';
+
+	constructor(message?: string) {
 		super(message);
 	}
 }

--- a/libs/core/src/errors/inheritable-error.ts
+++ b/libs/core/src/errors/inheritable-error.ts
@@ -1,0 +1,27 @@
+/**
+ * A class which allows you to appropriately check the inheritance of an error.
+ * 
+ * In typescript, when you try to extend an error with a specialized error class,
+ * if you try to call something like:
+ * 
+ * ```ts
+ * class MyError extends Error {}
+ * 
+ * let myError = new MyError();
+ * 
+ * myError instanceof MyError; // returns false
+ * ```
+ * 
+ * You will see unexpected things. This class fixes that issue as described here
+ * https://github.com/microsoft/TypeScript/issues/13965
+ */
+export class DaffInheritableError extends Error {
+	__proto__: Error;
+
+	constructor(message?: string) {
+		const trueProto = new.target.prototype;
+		super(message);
+
+		Object.setPrototypeOf(this, trueProto);
+	}
+}

--- a/libs/core/src/errors/public_api.ts
+++ b/libs/core/src/errors/public_api.ts
@@ -1,1 +1,2 @@
 export { DaffErrorCodeMap } from './error-map';
+export { DaffInheritableError } from './inheritable-error';

--- a/libs/core/src/storage/error/error.ts
+++ b/libs/core/src/storage/error/error.ts
@@ -1,4 +1,6 @@
-export class DaffStorageServiceError extends Error {
+import { DaffInheritableError } from '../../errors/public_api';
+
+export class DaffStorageServiceError extends DaffInheritableError {
   public static readonly code: string = 'DaffStorageServiceError';
 
 	constructor(public message: string) {

--- a/libs/core/src/storage/error/error.ts
+++ b/libs/core/src/storage/error/error.ts
@@ -1,3 +1,7 @@
 export class DaffStorageServiceError extends Error {
-  readonly name = 'DaffStorageServiceError';
+  public static readonly code: string = 'DaffStorageServiceError';
+
+	constructor(public message: string) {
+		super(message);
+	}
 }

--- a/libs/driver/magento/src/errors/transform.spec.ts
+++ b/libs/driver/magento/src/errors/transform.spec.ts
@@ -5,8 +5,7 @@ import { DaffErrorCodeMap } from '@daffodil/core';
 import { daffTransformMagentoError } from './transform';
 
 class MockError extends Error {
-  readonly name = 'MockError';
-  readonly code: string = 'MOCK';
+  public static readonly code: string = 'MOCK';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/driver/magento/src/errors/transform.spec.ts
+++ b/libs/driver/magento/src/errors/transform.spec.ts
@@ -1,11 +1,11 @@
 import { ApolloError } from 'apollo-client';
 
-import { DaffErrorCodeMap } from '@daffodil/core';
+import { DaffErrorCodeMap, DaffInheritableError } from '@daffodil/core';
 
 import { daffTransformMagentoError } from './transform';
 
-class MockError extends Error {
-  public static readonly code: string = 'MOCK';
+class MockError extends DaffInheritableError {
+	public readonly code: string = 'MOCK';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/driver/src/errors/bad-input.ts
+++ b/libs/driver/src/errors/bad-input.ts
@@ -1,6 +1,5 @@
 export class DaffBadInputError extends Error {
-	readonly name = 'DaffBadInputError';
-  readonly code: string = 'BAD_INPUT';
+  public static readonly code: string = 'BAD_INPUT';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/driver/src/errors/bad-input.ts
+++ b/libs/driver/src/errors/bad-input.ts
@@ -1,5 +1,7 @@
-export class DaffBadInputError extends Error {
-  public static readonly code: string = 'BAD_INPUT';
+import { DaffInheritableError } from '@daffodil/core';
+
+export class DaffBadInputError extends DaffInheritableError {
+  public readonly code: string = 'BAD_INPUT';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/geography/src/errors/invalid-api-response.ts
+++ b/libs/geography/src/errors/invalid-api-response.ts
@@ -1,4 +1,6 @@
-export class DaffInvalidAPIResponseError extends Error {
+import { DaffInheritableError } from '@daffodil/core';
+
+export class DaffInvalidAPIResponseError extends DaffInheritableError {
   public static readonly code: string = 'INVALID_API_RESPONSE';
 
 	constructor(public message: string) {

--- a/libs/geography/src/errors/invalid-api-response.ts
+++ b/libs/geography/src/errors/invalid-api-response.ts
@@ -1,6 +1,5 @@
 export class DaffInvalidAPIResponseError extends Error {
-	readonly name = 'DaffInvalidAPIResponseError';
-  readonly code: string = 'INVALID_API_RESPONSE';
+  public static readonly code: string = 'INVALID_API_RESPONSE';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/geography/src/errors/not-found.ts
+++ b/libs/geography/src/errors/not-found.ts
@@ -1,6 +1,5 @@
 export class DaffCountryNotFoundError extends Error {
-	readonly name = 'DaffCountryNotFoundError';
-  readonly code: string = 'COUNTRY_NOT_FOUND';
+  public static readonly code: string = 'COUNTRY_NOT_FOUND';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/geography/src/errors/not-found.ts
+++ b/libs/geography/src/errors/not-found.ts
@@ -1,4 +1,6 @@
-export class DaffCountryNotFoundError extends Error {
+import { DaffInheritableError } from '@daffodil/core';
+
+export class DaffCountryNotFoundError extends DaffInheritableError {
   public static readonly code: string = 'COUNTRY_NOT_FOUND';
 
 	constructor(public message: string) {

--- a/libs/order/driver/src/errors/invalid-api-response.ts
+++ b/libs/order/driver/src/errors/invalid-api-response.ts
@@ -1,4 +1,6 @@
-export class DaffInvalidAPIResponseError extends Error {
+import { DaffInheritableError } from '@daffodil/core';
+
+export class DaffInvalidAPIResponseError extends DaffInheritableError {
   public static readonly code: string = 'INVALID_API_RESPONSE';
 
 	constructor(public message: string) {

--- a/libs/order/driver/src/errors/invalid-api-response.ts
+++ b/libs/order/driver/src/errors/invalid-api-response.ts
@@ -1,6 +1,5 @@
 export class DaffInvalidAPIResponseError extends Error {
-	readonly name = 'DaffInvalidAPIResponseError';
-  readonly code: string = 'INVALID_API_RESPONSE';
+  public static readonly code: string = 'INVALID_API_RESPONSE';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/order/driver/src/errors/order-not-found.ts
+++ b/libs/order/driver/src/errors/order-not-found.ts
@@ -1,6 +1,5 @@
 export class DaffOrderNotFoundError extends Error {
-	readonly name = 'DaffOrderNotFoundError';
-  readonly code: string = 'ORDER_NOT_FOUND';
+  public static readonly code: string = 'ORDER_NOT_FOUND';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/order/driver/src/errors/order-not-found.ts
+++ b/libs/order/driver/src/errors/order-not-found.ts
@@ -1,4 +1,6 @@
-export class DaffOrderNotFoundError extends Error {
+import { DaffInheritableError } from '@daffodil/core';
+
+export class DaffOrderNotFoundError extends DaffInheritableError {
   public static readonly code: string = 'ORDER_NOT_FOUND';
 
 	constructor(public message: string) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, we swap on function names on errors, turns out this doesn't actually work in AOT builds, as names are mutilated by the compiler. 

Fixes: N/A


## What is the new behavior?
This introduces a static "code" property to Daffodil errors that we can switch against reliably. 

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

This change is breaking, but more of a "fix" as the original code never really functioned correctly.

## Other information