### PR TITLE
feat(order): add extra order fragment extensions

### DIFF
--- a/libs/order/driver/magento/2.4.0/src/injection-tokens/fragments/order.ts
+++ b/libs/order/driver/magento/2.4.0/src/injection-tokens/fragments/order.ts
@@ -1,0 +1,11 @@
+import { InjectionToken } from '@angular/core';
+import { DocumentNode } from 'graphql';
+
+/**
+ * An multi-provider injection token for providing extra GraphQL fragments that will be spread into order queries.
+ * This can be used to retrieve additional data that is not covered by the standard Daffodil interfaces.
+ * The data will appear in DaffOrder#extra_attributes.
+ *
+ * Fragment structure is platform-specific and this feature should be used with care.
+ */
+export const DaffMagentoExtraOrderFragments = new InjectionToken<DocumentNode>('DaffMagentoExtraOrderFragments');

--- a/libs/order/driver/magento/2.4.0/src/injection-tokens/public_api.ts
+++ b/libs/order/driver/magento/2.4.0/src/injection-tokens/public_api.ts
@@ -1,0 +1,1 @@
+export { DaffMagentoExtraOrderFragments } from './fragments/order';

--- a/libs/order/driver/magento/2.4.0/src/order-driver.module.ts
+++ b/libs/order/driver/magento/2.4.0/src/order-driver.module.ts
@@ -4,6 +4,8 @@ import { CommonModule } from '@angular/common';
 import { DaffOrderDriver } from '@daffodil/order/driver';
 
 import { DaffOrderMagentoService } from './order.service';
+import { DaffMagentoExtraOrderFragments } from './injection-tokens/public_api';
+import { daffMagentoNoopOrderFragment } from './queries/public_api';
 
 @NgModule({
   imports: [
@@ -18,6 +20,11 @@ export class DaffOrderMagentoDriverModule {
         {
           provide: DaffOrderDriver,
           useExisting: DaffOrderMagentoService
+        },
+        {
+          provide: DaffMagentoExtraOrderFragments,
+          useValue: daffMagentoNoopOrderFragment,
+          multi: true
         }
       ]
     };

--- a/libs/order/driver/magento/2.4.0/src/order.service.spec.ts
+++ b/libs/order/driver/magento/2.4.0/src/order.service.spec.ts
@@ -46,8 +46,9 @@ import {
   MagentoGraycoreOrderShipment
 } from './models/responses/public_api';
 import { DaffOrderMagentoService } from './order.service';
-import { getGuestOrders, MagentoGetGuestOrdersResponse } from './queries/public_api';
+import { daffMagentoNoopOrderFragment, getGuestOrders, MagentoGetGuestOrdersResponse } from './queries/public_api';
 import * as validators from './validators/public_api';
+import { DaffMagentoExtraOrderFragments } from './injection-tokens/public_api';
 
 describe('Driver | Magento | Order | OrderService', () => {
   let service: DaffOrderMagentoService;
@@ -103,6 +104,11 @@ describe('Driver | Magento | Order | OrderService', () => {
       ],
       providers: [
         DaffOrderMagentoService,
+        {
+          provide: DaffMagentoExtraOrderFragments,
+          useValue: daffMagentoNoopOrderFragment,
+          multi: true
+        }
       ]
     });
 
@@ -339,7 +345,7 @@ describe('Driver | Magento | Order | OrderService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(getGuestOrders);
+          const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
           op.flush({
             data: mockGetOrdersResponse
@@ -359,7 +365,7 @@ describe('Driver | Magento | Order | OrderService', () => {
               done();
             });
 
-            const op = controller.expectOne(getGuestOrders);
+            const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
             op.flush({
               data: mockGetOrdersResponse
@@ -385,7 +391,7 @@ describe('Driver | Magento | Order | OrderService', () => {
               done();
             });
 
-            const op = controller.expectOne(getGuestOrders);
+            const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
             op.flush({
               data: mockGetOrdersResponse
@@ -405,7 +411,7 @@ describe('Driver | Magento | Order | OrderService', () => {
           })
         ).subscribe();
 
-        const op = controller.expectOne(getGuestOrders);
+        const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
         op.graphqlErrors([new GraphQLError(
           'Can\'t find a cart with that ID.',
@@ -433,7 +439,7 @@ describe('Driver | Magento | Order | OrderService', () => {
             done();
           });
 
-          const op = controller.expectOne(getGuestOrders);
+          const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
           op.flush({
             data: mockGetOrdersResponse
@@ -457,7 +463,7 @@ describe('Driver | Magento | Order | OrderService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(getGuestOrders);
+          const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
           op.flush({
             data: mockGetOrdersResponse
@@ -476,7 +482,7 @@ describe('Driver | Magento | Order | OrderService', () => {
           })
         ).subscribe();
 
-        const op = controller.expectOne(getGuestOrders);
+        const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
         op.graphqlErrors([new GraphQLError(
           'Can\'t find a cart with that ID.',

--- a/libs/order/driver/magento/2.4.0/src/order.service.spec.ts
+++ b/libs/order/driver/magento/2.4.0/src/order.service.spec.ts
@@ -306,6 +306,7 @@ describe('Driver | Magento | Order | OrderService', () => {
       invoices: [mockMagentoOrderInvoice],
       credits: [mockMagentoOrderInvoice]
     };
+    mockDaffOrder.extra_attributes = mockMagentoOrder;
     mockGetOrdersResponse = {
       graycoreGuestOrders: {
         orders: [mockMagentoOrder]

--- a/libs/order/driver/magento/2.4.0/src/order.service.ts
+++ b/libs/order/driver/magento/2.4.0/src/order.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { DocumentNode } from 'graphql';
+import { Inject, Injectable } from '@angular/core';
 import { Apollo } from 'apollo-angular';
 
 import { Observable, throwError } from 'rxjs';
@@ -17,6 +18,7 @@ import { getGuestOrders, MagentoGetGuestOrdersResponse } from './queries/public_
 import { validateGetOrdersResponse } from './validators/public_api';
 import { transformMagentoOrderError } from './errors/transform';
 import { daffMagentoTransformOrder } from './transforms/responses/order';
+import { DaffMagentoExtraOrderFragments } from './injection-tokens/public_api';
 
 /**
  * A service for making Magento GraphQL queries for orders.
@@ -27,11 +29,12 @@ import { daffMagentoTransformOrder } from './transforms/responses/order';
 export class DaffOrderMagentoService implements DaffOrderServiceInterface {
   constructor(
     private apollo: Apollo,
+    @Inject(DaffMagentoExtraOrderFragments) public extraOrderFragments: DocumentNode[],
   ) {}
 
   list(cartId?: DaffCart['id']): Observable<DaffOrder[]> {
     return this.apollo.query<MagentoGetGuestOrdersResponse>({
-      query: getGuestOrders,
+      query: getGuestOrders(this.extraOrderFragments),
       variables: {
         cartId
       }

--- a/libs/order/driver/magento/2.4.0/src/public_api.ts
+++ b/libs/order/driver/magento/2.4.0/src/public_api.ts
@@ -1,7 +1,8 @@
 export { daffMagentoTransformOrder } from './transforms/responses/order';
 
 export * from './models/responses/public_api';
+export * from './injection-tokens/public_api';
 
+export { daffMagentoNoopOrderFragment } from './queries/public_api';
 export { DaffOrderMagentoService } from './order.service';
-
 export { DaffOrderMagentoDriverModule } from './order-driver.module';

--- a/libs/order/driver/magento/2.4.0/src/queries/fragments/noop-order.ts
+++ b/libs/order/driver/magento/2.4.0/src/queries/fragments/noop-order.ts
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export const daffMagentoNoopOrderFragment = gql`
+  fragment daffMagentoNoopOrderFragment on GraycoreOrder {
+    __typename
+  }
+`;

--- a/libs/order/driver/magento/2.4.0/src/queries/fragments/public_api.ts
+++ b/libs/order/driver/magento/2.4.0/src/queries/fragments/public_api.ts
@@ -6,3 +6,4 @@ export { orderPaymentFragment } from './order-payment';
 export { orderShipmentFragment } from './order-shipment';
 export { orderShipmentItemFragment } from './order-shipment-item';
 export { orderShipmentTrackingFragment } from './order-shipment-tracking';
+export { daffMagentoNoopOrderFragment } from './noop-order';

--- a/libs/order/driver/magento/2.4.0/src/queries/get-guest-orders.ts
+++ b/libs/order/driver/magento/2.4.0/src/queries/get-guest-orders.ts
@@ -1,14 +1,19 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core/graphql';
 
 import { orderFragment } from './fragments/public_api';
 
-export const getGuestOrders = gql`
+export const getGuestOrders = (extraOrderFragments: DocumentNode[] = []) => gql`
   query GetGuestOrders($cartId: String!) {
     graycoreGuestOrders(cartId: $cartId) {
       orders {
         ...order
+        ${daffBuildFragmentNameSpread(...extraOrderFragments)}
       }
     }
   }
   ${orderFragment}
+  ${daffBuildFragmentDefinition(...extraOrderFragments)}
 `;

--- a/libs/order/driver/magento/2.4.0/src/transforms/responses/order.spec.ts
+++ b/libs/order/driver/magento/2.4.0/src/transforms/responses/order.spec.ts
@@ -274,6 +274,8 @@ describe('Driver | Magento | Order | Transformer | Order', () => {
       invoices: [mockMagentoOrderInvoice],
       credits: [mockMagentoOrderInvoice]
     };
+
+    mockDaffOrder.extra_attributes = mockMagentoOrder;
   });
 
   describe('daffMagentoTransformOrder | transforming a magento order into a daff order', () => {

--- a/libs/order/driver/magento/2.4.0/src/transforms/responses/order.ts
+++ b/libs/order/driver/magento/2.4.0/src/transforms/responses/order.ts
@@ -176,6 +176,8 @@ function transformInvoice(invoice: MagentoGraycoreOrderInvoice): DaffOrderInvoic
  */
 export function daffMagentoTransformOrder(order: MagentoGraycoreOrder): DaffOrder {
   return {
+    extra_attributes: order,
+
     id: order.order_number,
     customer_id: order.customer_id,
     created_at: order.created_at,

--- a/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
+++ b/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
@@ -509,6 +509,8 @@ export class MagentoOrderTestDataFactory {
       credit_memos: [mockMagentoOrderCredit]
     };
 
+    mockDaffOrder.extra_attributes = mockMagentoOrder;
+
     return {
       mockDaffOrder,
       mockMagentoOrder

--- a/libs/order/driver/magento/2.4.1/src/injection-tokens/fragments/order.ts
+++ b/libs/order/driver/magento/2.4.1/src/injection-tokens/fragments/order.ts
@@ -1,0 +1,10 @@
+import { InjectionToken } from '@angular/core';
+import { DocumentNode } from 'graphql';
+/**
+ * An multi-provider injection token for providing extra GraphQL fragments that will be spread into order queries.
+ * This can be used to retrieve additional data that is not covered by the standard Daffodil interfaces.
+ * The data will appear in DaffOrder#extra_attributes.
+ *
+ * Fragment structure is platform-specific and this feature should be used with care.
+ */
+export const DaffMagentoExtraOrderFragments = new InjectionToken<DocumentNode>('DaffMagentoExtraOrderFragments');

--- a/libs/order/driver/magento/2.4.1/src/injection-tokens/public_api.ts
+++ b/libs/order/driver/magento/2.4.1/src/injection-tokens/public_api.ts
@@ -1,0 +1,1 @@
+export { DaffMagentoExtraOrderFragments } from './fragments/order';

--- a/libs/order/driver/magento/2.4.1/src/order-driver.module.ts
+++ b/libs/order/driver/magento/2.4.1/src/order-driver.module.ts
@@ -4,6 +4,8 @@ import { CommonModule } from '@angular/common';
 import { DaffOrderDriver } from '@daffodil/order/driver';
 
 import { DaffOrderMagentoService } from './order.service';
+import { DaffMagentoExtraOrderFragments } from './injection-tokens/public_api';
+import { daffMagentoNoopOrderFragment } from './queries/public_api';
 
 @NgModule({
   imports: [
@@ -18,6 +20,11 @@ export class DaffOrderMagentoDriverModule {
         {
           provide: DaffOrderDriver,
           useExisting: DaffOrderMagentoService
+        },
+        {
+          provide: DaffMagentoExtraOrderFragments,
+          useValue: daffMagentoNoopOrderFragment,
+          multi: true
         }
       ]
     };

--- a/libs/order/driver/magento/2.4.1/src/order.service.spec.ts
+++ b/libs/order/driver/magento/2.4.1/src/order.service.spec.ts
@@ -15,9 +15,10 @@ import {
   MagentoOrder,
 } from './models/responses/public_api';
 import { DaffOrderMagentoService } from './order.service';
-import { getGuestOrders, MagentoGetGuestOrdersResponse } from './queries/public_api';
+import { daffMagentoNoopOrderFragment, getGuestOrders, MagentoGetGuestOrdersResponse } from './queries/public_api';
 import * as validators from './validators/public_api';
 import { MagentoOrderTestDataFactory } from './helpers/test-data.service';
+import { DaffMagentoExtraOrderFragments } from './injection-tokens/public_api';
 
 describe('Driver | Magento | Order | OrderService', () => {
   let service: DaffOrderMagentoService;
@@ -39,6 +40,11 @@ describe('Driver | Magento | Order | OrderService', () => {
       ],
       providers: [
         DaffOrderMagentoService,
+        {
+          provide: DaffMagentoExtraOrderFragments,
+          useValue: daffMagentoNoopOrderFragment,
+          multi: true
+        }
       ]
     });
 
@@ -85,7 +91,7 @@ describe('Driver | Magento | Order | OrderService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(getGuestOrders);
+          const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
           op.flush({
             data: mockGetOrdersResponse
@@ -105,7 +111,7 @@ describe('Driver | Magento | Order | OrderService', () => {
               done();
             });
 
-            const op = controller.expectOne(getGuestOrders);
+            const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
             op.flush({
               data: mockGetOrdersResponse
@@ -131,7 +137,7 @@ describe('Driver | Magento | Order | OrderService', () => {
               done();
             });
 
-            const op = controller.expectOne(getGuestOrders);
+            const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
             op.flush({
               data: mockGetOrdersResponse
@@ -151,7 +157,7 @@ describe('Driver | Magento | Order | OrderService', () => {
           })
         ).subscribe();
 
-        const op = controller.expectOne(getGuestOrders);
+        const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
         op.graphqlErrors([new GraphQLError(
           'Can\'t find a cart with that ID.',
@@ -179,7 +185,7 @@ describe('Driver | Magento | Order | OrderService', () => {
             done();
           });
 
-          const op = controller.expectOne(getGuestOrders);
+          const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
           op.flush({
             data: mockGetOrdersResponse
@@ -203,7 +209,7 @@ describe('Driver | Magento | Order | OrderService', () => {
             })
           ).subscribe();
 
-          const op = controller.expectOne(getGuestOrders);
+          const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
           op.flush({
             data: mockGetOrdersResponse
@@ -222,7 +228,7 @@ describe('Driver | Magento | Order | OrderService', () => {
           })
         ).subscribe();
 
-        const op = controller.expectOne(getGuestOrders);
+        const op = controller.expectOne(getGuestOrders([daffMagentoNoopOrderFragment]));
 
         op.graphqlErrors([new GraphQLError(
           'Can\'t find a cart with that ID.',

--- a/libs/order/driver/magento/2.4.1/src/order.service.ts
+++ b/libs/order/driver/magento/2.4.1/src/order.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { DocumentNode } from 'graphql';
+import { Inject, Injectable } from '@angular/core';
 import { Apollo } from 'apollo-angular';
 
 import { Observable, throwError } from 'rxjs';
@@ -17,6 +18,7 @@ import { getGuestOrders, MagentoGetGuestOrdersResponse } from './queries/public_
 import { validateGetOrdersResponse } from './validators/public_api';
 import { transformMagentoOrderError } from './errors/transform';
 import { daffMagentoTransformOrder } from './transforms/responses/order';
+import { DaffMagentoExtraOrderFragments } from './injection-tokens/public_api';
 
 /**
  * A service for making Magento GraphQL queries for orders.
@@ -27,11 +29,15 @@ import { daffMagentoTransformOrder } from './transforms/responses/order';
 export class DaffOrderMagentoService implements DaffOrderServiceInterface {
   constructor(
     private apollo: Apollo,
-  ) {}
+    @Inject(DaffMagentoExtraOrderFragments) public extraOrderFragments: DocumentNode[],
+  ) {
+    console.log(this.extraOrderFragments);
+
+  }
 
   list(cartId?: DaffCart['id']): Observable<DaffOrder[]> {
     return this.apollo.query<MagentoGetGuestOrdersResponse>({
-      query: getGuestOrders,
+      query: getGuestOrders(this.extraOrderFragments),
       variables: {
         cartId
       }

--- a/libs/order/driver/magento/2.4.1/src/public_api.ts
+++ b/libs/order/driver/magento/2.4.1/src/public_api.ts
@@ -1,7 +1,8 @@
 export { daffMagentoTransformOrder } from './transforms/responses/order';
 
 export * from './models/responses/public_api';
+export * from './injection-tokens/public_api';
 
+export { daffMagentoNoopOrderFragment } from './queries/public_api';
 export { DaffOrderMagentoService } from './order.service';
-
 export { DaffOrderMagentoDriverModule } from './order-driver.module';

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/noop-order.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/noop-order.ts
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export const daffMagentoNoopOrderFragment = gql`
+  fragment daffMagentoNoopOrderFragment on GraycoreGuestOrder {
+    __typename
+  }
+`;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/public_api.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/public_api.ts
@@ -6,3 +6,4 @@ export { orderPaymentFragment } from './order-payment';
 export { orderShipmentFragment } from './order-shipment';
 export { orderShipmentItemFragment } from './order-shipment-item';
 export { orderShipmentTrackingFragment } from './order-shipment-tracking';
+export { daffMagentoNoopOrderFragment } from './noop-order';

--- a/libs/order/driver/magento/2.4.1/src/queries/get-guest-orders.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/get-guest-orders.ts
@@ -1,14 +1,19 @@
+import { DocumentNode } from 'graphql';
 import gql from 'graphql-tag';
+
+import { daffBuildFragmentNameSpread, daffBuildFragmentDefinition } from '@daffodil/core/graphql';
 
 import { orderFragment } from './fragments/public_api';
 
-export const getGuestOrders = gql`
+export const getGuestOrders = (extraOrderFragments: DocumentNode[] = []) => gql`
   query GetGuestOrders($cartId: String!) {
     graycoreGuestOrders(cartId: $cartId) {
-      items {
+      orders {
         ...order
+        ${daffBuildFragmentNameSpread(...extraOrderFragments)}
       }
     }
   }
   ${orderFragment}
+  ${daffBuildFragmentDefinition(...extraOrderFragments)}
 `;

--- a/libs/order/driver/magento/2.4.1/src/transforms/responses/order.ts
+++ b/libs/order/driver/magento/2.4.1/src/transforms/responses/order.ts
@@ -256,6 +256,8 @@ function transformCredit(credit: MagentoOrderCredit, order: MagentoOrder): DaffO
  */
 export function daffMagentoTransformOrder(order: MagentoOrder): DaffOrder {
   return {
+    extra_attributes: order,
+
     id: order.id,
     customer_id: null,
     updated_at: null,

--- a/libs/order/src/models/order.ts
+++ b/libs/order/src/models/order.ts
@@ -22,4 +22,9 @@ export interface DaffOrder {
   payment: DaffOrderPayment;
   invoices: DaffOrderInvoice[];
   credits: DaffOrderCredit[];
+  /**
+   * The field is set to the platform order object returned by the most recent driver call.
+   * No fields are guaranteed here.
+   */
+  extra_attributes?: any;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?
- Adds `extra_attributes` field to `DaffOrder`.
- Adds an extra order fragments injection token and spreads it into guest order queries.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information