### PR TITLE
fix(order): email field present on order

### DIFF
--- a/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
+++ b/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
@@ -101,7 +101,9 @@ export class MagentoOrderTestDataFactory {
     let mockMagentoOrderCredit: MagentoOrderCredit;
     let mockMagentoOrderCreditItem: MagentoOrderCreditItem;
 
-    mockDaffOrderAddress = this.daffOrderAddressFactory.create();
+    mockDaffOrderAddress = this.daffOrderAddressFactory.create({
+      email: null
+    });
     mockDaffOrderCoupon = this.daffOrderCouponFactory.create();
     mockDaffOrderPayment = this.daffOrderPaymentFactory.create({
       created_at: null,
@@ -469,7 +471,6 @@ export class MagentoOrderTestDataFactory {
       order_date: mockDaffOrder.created_at,
       carrier: mockDaffOrderShipment.carrier,
       shipping_method: mockDaffOrderShipment.method,
-      email: mockDaffOrderAddress.email,
       total: {
         grand_total: {
           value: mockDaffOrderGrandTotal.value,

--- a/libs/order/driver/magento/2.4.1/src/models/responses/order.ts
+++ b/libs/order/driver/magento/2.4.1/src/models/responses/order.ts
@@ -13,7 +13,6 @@ export interface MagentoOrder {
   carrier: string;
   number: string;
   shipping_method: string;
-  email: string;
   items: MagentoOrderItem[];
   billing_address: MagentoOrderAddress;
   shipping_address: MagentoOrderAddress;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order.ts
@@ -15,7 +15,6 @@ export const orderFragment = gql`
     carrier
     number
     shipping_method
-    email
     items {
       ...orderItem
       ...orderBundleItem

--- a/libs/order/driver/magento/2.4.1/src/transforms/responses/order.ts
+++ b/libs/order/driver/magento/2.4.1/src/transforms/responses/order.ts
@@ -156,7 +156,7 @@ function transformAddress(address: MagentoOrderAddress, order: MagentoOrder): Da
     middlename: address.middlename,
     lastname: address.lastname,
     telephone: address.telephone,
-    email: order.email,
+    email: null,
     street: address.street[0],
     street2: address.street[1],
     city: address.city,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The 2.4.1 Magento driver was querying the email field, which is not present on the orders endpoint. This will cause the driver call to fail.


## What is the new behavior?
The 2.4.1 Magento driver doesn't query any fields that are not present on the endpoint.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information