### PR TITLE
fix(order): bad bundle item fragments and query field

### DIFF
--- a/libs/order/driver/magento/2.4.1/src/order.service.ts
+++ b/libs/order/driver/magento/2.4.1/src/order.service.ts
@@ -30,10 +30,7 @@ export class DaffOrderMagentoService implements DaffOrderServiceInterface {
   constructor(
     private apollo: Apollo,
     @Inject(DaffMagentoExtraOrderFragments) public extraOrderFragments: DocumentNode[],
-  ) {
-    console.log(this.extraOrderFragments);
-
-  }
+  ) {}
 
   list(cartId?: DaffCart['id']): Observable<DaffOrder[]> {
     return this.apollo.query<MagentoGetGuestOrdersResponse>({

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-address.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-address.ts
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 
 export const orderAddressFragment = gql`
   fragment orderAddress on OrderAddress {
+    __typename
     city
     company
     country_code

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-credit-item.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-credit-item.ts
@@ -1,25 +1,15 @@
 import gql from 'graphql-tag';
 
-import { orderBundleItemFragment, orderItemFragment } from './order-item';
+import { orderItemFragment } from './order-item';
 
 export const orderCreditItemFragment = gql`
-  fragment orderCreditItem on CreditMemoItem {
+  fragment orderCreditItem on CreditMemoItemInterface {
+    __typename
+    id
     quantity_refunded
     order_item {
       ...orderItem
     }
   }
   ${orderItemFragment}
-`;
-
-export const orderCreditBundleItemFragment = gql`
-  fragment orderCreditBundleItem on BundleCreditMemoItem {
-    quantity_refunded
-    order_item {
-      ...orderItem
-      ...orderBundleItem
-    }
-  }
-  ${orderItemFragment}
-  ${orderBundleItemFragment}
 `;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-credit-total.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-credit-total.ts
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 
 export const orderCreditTotalFragment = gql`
   fragment orderCreditTotal on CreditMemoTotal {
+    __typename
     discounts {
       amount {
         value

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-credit.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-credit.ts
@@ -1,19 +1,19 @@
 import gql from 'graphql-tag';
 
-import { orderCreditItemFragment, orderCreditBundleItemFragment } from './order-credit-item';
+import { orderCreditItemFragment } from './order-credit-item';
 import { orderCreditTotalFragment } from './order-credit-total';
 
 export const orderCreditFragment = gql`
   fragment orderCredit on CreditMemo {
+    __typename
+    id
     items {
       ...orderCreditItem
-      ...orderCreditBundleItem
     }
     total {
       ...orderCreditTotal
     }
   }
   ${orderCreditItemFragment}
-  ${orderCreditBundleItemFragment}
   ${orderCreditTotalFragment}
 `;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-invoice-item.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-invoice-item.ts
@@ -1,25 +1,15 @@
 import gql from 'graphql-tag';
 
-import { orderBundleItemFragment, orderItemFragment } from './order-item';
+import { orderItemFragment } from './order-item';
 
 export const orderInvoiceItemFragment = gql`
-  fragment orderInvoiceItem on InvoiceItem {
+  fragment orderInvoiceItem on InvoiceItemInterface {
+    __typename
+    id
     quantity_invoiced
     order_item {
       ...orderItem
     }
   }
   ${orderItemFragment}
-`;
-
-export const orderInvoiceBundleItemFragment = gql`
-  fragment orderInvoiceBundleItem on BundleInvoiceItem {
-    quantity_invoiced
-    order_item {
-      ...orderItem
-      ...orderBundleItem
-    }
-  }
-  ${orderItemFragment}
-  ${orderBundleItemFragment}
 `;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-invoice-total.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-invoice-total.ts
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 
 export const orderInvoiceTotalFragment = gql`
   fragment orderInvoiceTotal on InvoiceTotal {
+    __typename
     discounts {
       amount {
         value

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-invoice.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-invoice.ts
@@ -1,19 +1,19 @@
 import gql from 'graphql-tag';
 
-import { orderInvoiceItemFragment, orderInvoiceBundleItemFragment } from './order-invoice-item';
+import { orderInvoiceItemFragment } from './order-invoice-item';
 import { orderInvoiceTotalFragment } from './order-invoice-total';
 
 export const orderInvoiceFragment = gql`
   fragment orderInvoice on Invoice {
+    __typename
+    id
     items {
       ...orderInvoiceItem
-      ...orderInvoiceBundleItem
     }
     total {
       ...orderInvoiceTotal
     }
   }
   ${orderInvoiceItemFragment}
-  ${orderInvoiceBundleItemFragment}
   ${orderInvoiceTotalFragment}
 `;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-item.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-item.ts
@@ -43,4 +43,5 @@ export const orderItemFragment = gql`
       }
     }
   }
+  ${orderBundleItemSelectedOptionFragment}
 `;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-item.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-item.ts
@@ -2,15 +2,21 @@ import gql from 'graphql-tag';
 
 export const orderBundleItemSelectedOptionFragment = gql`
   fragment orderBundleItemSelectedOption on ItemSelectedBundleOption {
+    __typename
+    id
     label
     values {
+      __typename
+      id
       product_name
     }
   }
 `;
 
 export const orderItemFragment = gql`
-  fragment orderItem on OrderItem {
+  fragment orderItem on OrderItemInterface {
+    __typename
+    id
     quantity_ordered
     quantity_canceled
     quantity_shipped
@@ -18,6 +24,7 @@ export const orderItemFragment = gql`
     product_url_key
     product_sku
     product_name
+    product_type
     product_sale_price {
       value
     }
@@ -30,14 +37,10 @@ export const orderItemFragment = gql`
       label
       value
     }
-  }
-`;
-
-export const orderBundleItemFragment = gql`
-  fragment orderBundleItem on BundleOrderItem {
-    bundle_options {
-      ...orderBundleItemSelectedOption
+    ... on BundleOrderItem {
+      bundle_options {
+        ...orderBundleItemSelectedOption
+      }
     }
   }
-  ${orderBundleItemSelectedOptionFragment}
 `;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-payment.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-payment.ts
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 
 export const orderPaymentFragment = gql`
   fragment orderPayment on OrderPaymentMethod {
+    __typename
     name
     type
     additional_data {

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-shipment-item.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-shipment-item.ts
@@ -1,25 +1,15 @@
 import gql from 'graphql-tag';
 
-import { orderBundleItemFragment, orderItemFragment } from './order-item';
+import { orderItemFragment } from './order-item';
 
 export const orderShipmentItemFragment = gql`
-  fragment orderShipmentItem on ShipmentItem {
+  fragment orderShipmentItem on ShipmentItemInterface {
+    __typename
+    id
     quantity_shipped
     order_item {
       ...orderItem
     }
   }
   ${orderItemFragment}
-`;
-
-export const orderShipmentBundleItemFragment = gql`
-  fragment orderShipmentBundleItem on BundleShipmentItem {
-    quantity_shipped
-    order_item {
-      ...orderItem
-      ...orderBundleItem
-    }
-  }
-  ${orderItemFragment}
-  ${orderBundleItemFragment}
 `;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-shipment-tracking.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-shipment-tracking.ts
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 
 export const orderShipmentTrackingFragment = gql`
   fragment orderShipmentTracking on ShipmentTracking {
+    __typename
     number
     carrier
     title

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-shipment.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-shipment.ts
@@ -1,19 +1,19 @@
 import gql from 'graphql-tag';
 
-import { orderShipmentBundleItemFragment, orderShipmentItemFragment } from './order-shipment-item';
+import { orderShipmentItemFragment } from './order-shipment-item';
 import { orderShipmentTrackingFragment } from './order-shipment-tracking';
 
 export const orderShipmentFragment = gql`
   fragment orderShipment on OrderShipment {
+    __typename
+    id
     tracking {
       ...orderShipmentTracking
     }
     items {
       ...orderShipmentItem
-      ...orderShipmentBundleItem
     }
   }
   ${orderShipmentItemFragment}
-  ${orderShipmentBundleItemFragment}
   ${orderShipmentTrackingFragment}
 `;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-total.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-total.ts
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 
 export const orderTotalFragment = gql`
   fragment orderTotal on OrderTotal {
+    __typename
     discounts {
       amount {
         value

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
-import { orderBundleItemFragment, orderItemFragment } from './order-item';
+
+import { orderItemFragment } from './order-item';
 import { orderAddressFragment } from './order-address';
 import { orderShipmentFragment } from './order-shipment';
 import { orderPaymentFragment } from './order-payment';
@@ -9,6 +10,7 @@ import { orderTotalFragment } from './order-total';
 
 export const orderFragment = gql`
   fragment order on GraycoreGuestOrder {
+    __typename
     id
     order_date
     status
@@ -17,7 +19,6 @@ export const orderFragment = gql`
     shipping_method
     items {
       ...orderItem
-      ...orderBundleItem
     }
     billing_address {
       ...orderAddress
@@ -42,7 +43,6 @@ export const orderFragment = gql`
     }
   }
   ${orderItemFragment}
-  ${orderBundleItemFragment}
   ${orderShipmentFragment}
   ${orderPaymentFragment}
   ${orderInvoiceFragment}

--- a/libs/order/driver/magento/2.4.1/src/queries/get-guest-orders.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/get-guest-orders.ts
@@ -8,7 +8,7 @@ import { orderFragment } from './fragments/public_api';
 export const getGuestOrders = (extraOrderFragments: DocumentNode[] = []) => gql`
   query GetGuestOrders($cartId: String!) {
     graycoreGuestOrders(cartId: $cartId) {
-      orders {
+      items {
         ...order
         ${daffBuildFragmentNameSpread(...extraOrderFragments)}
       }

--- a/libs/order/driver/magento/2.4.1/src/transforms/responses/order.ts
+++ b/libs/order/driver/magento/2.4.1/src/transforms/responses/order.ts
@@ -258,7 +258,7 @@ export function daffMagentoTransformOrder(order: MagentoOrder): DaffOrder {
   return {
     extra_attributes: order,
 
-    id: order.id,
+    id: order.number,
     customer_id: null,
     updated_at: null,
     created_at: order.order_date,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- The guest orders query tries to query the `orders` field; the correct field is `items`.
- Fragments on different types of item cannot be combined.
- Some order "placed order" state operations will fail because `id` was set for the `DaffOrder#id` and that cannot be used for matching to cart place order result order ID.
- The driver does not query for product type.

## What is the new behavior?
- The guest orders query tries to query `items`.
- Fragments on different types of item define all the item fields.
- "placed order" state operations works as expected when operating on a ID that is set to the Magento order number.
- The driver queries for product type.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information