### PR TITLE
feat(product): change the api for composite product facade and selectors

### DIFF
--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -23,7 +23,7 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	getPricesForConfiguration(id: string, configuration: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange>;
 
 	/**
-	 * Get the broadest possible DaffPriceRange for a composite product excluding optional item prices.
+	 * Get the broadest possible DaffPriceRange for a composite product including optional item prices.
 	 * @param id the id of the composite product.
 	 */
 	getPrices(id: string): Observable<DaffPriceRange>;

--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -6,6 +6,8 @@ import { DaffStoreFacade } from '@daffodil/core/state';
 
 import { DaffCompositeProductItemOption, DaffCompositeProductItem } from '../../models/composite-product-item';
 import { DaffCompositeProduct } from '../../models/composite-product';
+import { DaffPriceRange } from '../../models/prices';
+import { DaffCompositeConfigurationItem } from '../../models/composite-configuration-item';
 
 /**
  * A facade for interacting with the composite product state.
@@ -14,112 +16,23 @@ import { DaffCompositeProduct } from '../../models/composite-product';
 export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Action> {
 
 	/**
-	 * Get the minimum price for a composite product, excluding optional items and regardless of applied options.
-	 * This would be useful for a quick preview of a product.
-	 * @param id the id of the composite product.
+	 * Get a DaffPriceRange for a composite product based on the configuration provided.
+	 * @param id an id for a composite product
+	 * @param configuration a Dictionary of DaffCompositeConfigurationItems
 	 */
-	getMinPossiblePrice(id: string): Observable<number>;
+	getPricesForConfiguration(id: string, configuration: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange>;
 
 	/**
-   * Get the maximum price for a composite product, including optional items and regardless of applied options.
-	 * This would be useful for a quick preview of a product.
+	 * Get the broadest possible DaffPriceRange for a composite product excluding optional item prices.
 	 * @param id the id of the composite product.
 	 */
-	getMaxPossiblePrice(id: string): Observable<number>;
+	getPrices(id: string): Observable<DaffPriceRange>;
 
 	/**
-	 * Returns whether the composite product could have a price range in any configuration,
-	 * including the optional items and regardless of the current item option selection.
-	 * This could be useful for a quick preview of the product.
+	 * Get the DaffPriceRange for a composite product based on the current configuration of selected item options in redux state.
 	 * @param id the id of the composite product.
 	 */
-	possiblyHasPriceRange(id: string): Observable<boolean>;
-
-	/**
-	 * Get the minimum discounted price for a composite product, excluding optional items and regardless of the current selection of item options.
-	 * This could be useful for a quick preview of the product.
-	 * @param id the id of the composite product.
-	 */
-	getMinPossibleDiscountedPrice(id: string): Observable<number>;
-
-	/**
-	 * Get the maximum discounted price for a composite product, including optional items and regardless of the current selection of item options.
-	 * This could be useful for a quick preview of the product.
-	 * @param id the id of the composite product.
-	 */
-	getMaxPossibleDiscountedPrice(id: string): Observable<number>;
-
-	/**
-	 * Selector for whether the composite product could have a discounted price range in any configuration,
-	 * including the optional items and regardless of the current item option selection.
-	 * This could be useful for a quick preview of the product.
-	 * @param id the id of the composite product.
-	 */
-	possiblyHasDiscountedPriceRange(id: string): Observable<boolean>;
-
-	/**
-	 * Returns whether the minimum and maximum composite product discounted prices equal the minimum and maximum
-	 * pre discount prices, including optional items. Note: this intentionally misses a usecase where there is a discount
-	 * in between the minimum and maximum prices. This is because the resulting UI would be non-sensical to the customer for
-	 * this usecase. For example, if we have a set of item options' prices: (price, discount), (10, 0), (20, 0), (15, 4).
-	 * While it is true that there is a discounted price (15, 4), the user would see the original price range (10-20) followed
-	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
-	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
-	 * @param id the id of the composite product.
-	 */
-	possiblyHasDiscount(id: string): Observable<boolean>;
-
-	/**
-	 * Get the minimum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
-	 * This will be equal to getMaxRequiredItemPrice when all required items already have default selections.
-	 * @param id the id of the composite product.
-	 */
-	getMinRequiredItemPrice(id: string): Observable<number>;
-
-	/**
-	 * Get the maximum price for a composite product, excluding unselected optional items and depending on the current selection of item options.
-	 * This will be equal to getMinRequiredItemPrice when all required items already have default selections.
-	 * @param id the id of the composite product.
-	 */
-	getMaxRequiredItemPrice(id: string): Observable<number>;
-
-	/**
-	 * Selector for whether the composite product has a price range, excluding unselected optional items and based on the currently applied item options.
-	 * @param id the id of the composite product.
-	 */
-	hasRequiredItemPriceRange(id: string): Observable<boolean>;
-
-	/**
-	 * Get the minimum discounted price for a composite product, excluding unselected optional items and depending on the current selection of item options.
-	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
-	 * @param id the id of the composite product.
-	 */
-	getMinRequiredItemDiscountedPrice(id: string): Observable<number>;
-
-	/**
-	 * Get the maximum discounted price for a composite product, excluding unselected optional items and depending on the current selection of item options.
-	 * This would be used for a composite product that has required items without default selections or just the final price of a product with no price range.
-	 * @param id the id of the composite product.
-	 */
-	getMaxRequiredItemDiscountedPrice(id: string): Observable<number>;
-
-	/**
-	 * Returns whether the composite product has a discounted price range, excluding unselected optional items and based on the currently applied item options.
-	 * @param id the id of the composite product.
-	 */
-	hasRequiredItemDiscountedPriceRange(id: string): Observable<boolean>;
-
-	/**
-	 * Returns whether the minimum and maximum composite product discounted prices equal the minimum and maximum
-	 * pre discount prices, excluding unselected optional items. Note: this intentionally misses a usecase where there is a discount
-	 * in between the minimum and maximum prices. This is because the resulting UI would be non-sensical to the customer for
-	 * this usecase. For example, if we have a set of item options' prices: (price, discount), (10, 0), (20, 0), (15, 4).
-	 * While it is true that there is technically a discounted price, the user would see the original price range (10-20) followed
-	 * by the discounted price range (10-20). This would happen, because the 15-4=11 price would fall between the two extremes
-	 * of the discounted prices and it wouldn't make sense to the customer what is happening.
-	 * @param id the id of the composite product.
-	 */
-	hasRequiredItemDiscount(id: string): Observable<boolean>;
+	getPricesAsCurrentlyConfigured(id: string): Observable<DaffPriceRange>;
 
 	/**
 	 * Returns the applied options for a composite product.

--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -16,7 +16,7 @@ import { DaffCompositeConfigurationItem } from '../../models/composite-configura
 export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Action> {
 
 	/**
-	 * Get a DaffPriceRange for a composite product based on the configuration provided.
+	 * Get a DaffPriceRange for a composite product based on the configuration provided excluding unselected, optional item prices.
 	 * @param id an id for a composite product
 	 * @param configuration a Dictionary of DaffCompositeConfigurationItems
 	 */
@@ -29,7 +29,8 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	getPrices(id: string): Observable<DaffPriceRange>;
 
 	/**
-	 * Get the DaffPriceRange for a composite product based on the current configuration of selected item options in redux state.
+	 * Get the DaffPriceRange for a composite product based on the current configuration of selected item options in redux state and
+	 * excluding unselected, optional item prices.
 	 * @param id the id of the composite product.
 	 */
 	getPricesAsCurrentlyConfigured(id: string): Observable<DaffPriceRange>;

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -118,7 +118,7 @@ describe('DaffCompositeProductFacade', () => {
 
   describe('getPrices', () => {
 
-    it('should return the broadest price range for a composite product excluding optional items', () => {
+    it('should return the broadest price range for a composite product including optional items', () => {
 			const expected = cold('a', { a: {
 				minPrice: {
 					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
@@ -131,12 +131,13 @@ describe('DaffCompositeProductFacade', () => {
 				},
 				maxPrice: {
 					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
-						stubPrice01 - stubDiscountAmount01,
+						stubPrice01 - stubDiscountAmount01 +
+						stubPrice11 - stubDiscountAmount11,
 					discount: {
 						amount: null,
 						percent: null
 					},
-					originalPrice: stubCompositeProduct.price + stubPrice01
+					originalPrice: stubCompositeProduct.price + stubPrice01 + stubPrice11
 				}
 			}
 			});

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { MockStore } from '@ngrx/store/testing';
 import { Store, StoreModule, combineReducers } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
+import { Dictionary } from '@ngrx/entity';
 
 import {
 	DaffCompositeProduct,
@@ -12,12 +13,22 @@ import {
 import { DaffCompositeProductFactory } from '@daffodil/product/testing';
 
 import { DaffCompositeProductFacade } from './composite-product.facade';
+import { DaffCompositeConfigurationItem } from '../../models/composite-configuration-item';
+import { DaffCompositeProductApplyOption } from '../../actions/composite-product.actions';
 
 describe('DaffCompositeProductFacade', () => {
   let store: MockStore<Partial<DaffProductReducersState>>;
 	let facade: DaffCompositeProductFacade;
 	let stubCompositeProduct: DaffCompositeProduct;
 	let compositeProductFactory: DaffCompositeProductFactory;
+	const stubPrice00 = 10;
+	const stubDiscountAmount00 = 2;
+	const stubPrice01 = 20;
+	const stubDiscountAmount01 = 1;
+	const stubPrice10 = 30;
+	const stubDiscountAmount10 = 3;
+	const stubPrice11 = 40;
+	const stubDiscountAmount11 = 4;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -38,10 +49,22 @@ describe('DaffCompositeProductFacade', () => {
 		stubCompositeProduct = compositeProductFactory.create();
 		stubCompositeProduct.items[0].required = true;
 		stubCompositeProduct.items[1].required = false;
-		stubCompositeProduct.items[0].options[0].price = 10;
-		stubCompositeProduct.items[0].options[1].price = 20;
-		stubCompositeProduct.items[1].options[0].price = 30;
-		stubCompositeProduct.items[1].options[1].price = 40;
+		stubCompositeProduct.items[0].options[0].is_default = true;
+		stubCompositeProduct.items[0].options[1].is_default = false;
+		stubCompositeProduct.items[1].options[0].is_default = false;
+		stubCompositeProduct.items[1].options[1].is_default = false;
+		stubCompositeProduct.items[0].options[0].price = stubPrice00;
+		stubCompositeProduct.items[0].options[1].price = stubPrice01;
+		stubCompositeProduct.items[1].options[0].price = stubPrice10;
+		stubCompositeProduct.items[1].options[1].price = stubPrice11;
+		stubCompositeProduct.items[0].options[0].discount.amount = stubDiscountAmount00;
+		stubCompositeProduct.items[0].options[1].discount.amount = stubDiscountAmount01;
+		stubCompositeProduct.items[1].options[0].discount.amount = stubDiscountAmount10;
+		stubCompositeProduct.items[1].options[1].discount.amount = stubDiscountAmount11;
+		stubCompositeProduct.items[0].options[0].quantity = 1;
+		stubCompositeProduct.items[0].options[1].quantity = 1;
+		stubCompositeProduct.items[1].options[0].quantity = 1;
+		stubCompositeProduct.items[1].options[1].quantity = 1;
 		store.dispatch(new DaffProductLoadSuccess(stubCompositeProduct));
 	});
 
@@ -58,190 +81,111 @@ describe('DaffCompositeProductFacade', () => {
     expect(store.dispatch).toHaveBeenCalledTimes(1);
   });
 
-  describe('getMinPossiblePrice', () => {
+  describe('getPricesForConfiguration', () => {
 
-    it('should return the minimum price possible for the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[0].price
+    it('should return the expected price range for the configuration provided', () => {
+			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
+				[stubCompositeProduct.items[0].id]: {
+					value: stubCompositeProduct.items[0].options[1].id,
+					qty: 1
+				}
+			}
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice01 - stubDiscountAmount01,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice01 - stubDiscountAmount01,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01
+				}
+			}
 			});
 
-			expect(facade.getMinPossiblePrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getPricesForConfiguration(stubCompositeProduct.id, stubConfiguration)).toBeObservable(expected);
 		});
   });
 
-  describe('getMaxPossiblePrice', () => {
+  describe('getPrices', () => {
 
-    it('should return the maximum price possible for the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[1].price +
-				stubCompositeProduct.items[1].options[1].price
+    it('should return the broadest price range for a composite product excluding optional items', () => {
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice00 - stubDiscountAmount00,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice00
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice01 - stubDiscountAmount01,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01
+				}
+			}
 			});
 
-			expect(facade.getMaxPossiblePrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getPrices(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 
-  describe('possiblyHasPriceRange', () => {
+  describe('getPricesAsCurrentlyConfigured', () => {
 
-    it('should return whether the product could have a price range', () => {
-			const expected = cold('a', { a: true });
-
-			expect(facade.possiblyHasPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-	});
-
-  describe('getMinPossibleDiscountedPrice', () => {
-
-    it('should return the minimum discounted price possible for the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
-				stubCompositeProduct.items[0].options[0].price
+    it('should return the expected price range for the current configuration of the product in state', () => {
+			store.dispatch(new DaffCompositeProductApplyOption(
+				stubCompositeProduct.id,
+				<string>stubCompositeProduct.items[0].id,
+				stubCompositeProduct.items[0].options[1].id,
+				1
+			));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice01 - stubDiscountAmount01,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice01 - stubDiscountAmount01,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01
+				}
+			}
 			});
 
-			expect(facade.getMinPossibleDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getPricesAsCurrentlyConfigured(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
-
-  describe('getMaxPossibleDiscountedPrice', () => {
-
-    it('should return the maximum discounted price possible for the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
-				stubCompositeProduct.items[0].options[1].price +
-				stubCompositeProduct.items[1].options[1].price
-			});
-
-			expect(facade.getMaxPossibleDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('possiblyHasDiscountedPriceRange', () => {
-
-    it('should return whether the product could have a discounted price range', () => {
-			const expected = cold('a', { a: true });
-
-			expect(facade.possiblyHasDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-	});
-
-  describe('possiblyHasDiscount', () => {
-    let productWithDiscount;
-
-    beforeEach(() => {
-      productWithDiscount = compositeProductFactory.create({
-        discount: {
-          amount: 10,
-          percent: 10
-        }
-      })
-      store.dispatch(new DaffProductLoadSuccess(productWithDiscount));
-    })
-
-    it('should return whether the product has a discount including optional items', () => {
-			const expected = cold('a', { a: true });
-
-			expect(facade.possiblyHasDiscount(productWithDiscount.id)).toBeObservable(expected);
-		});
-	});
-
-  describe('getMinRequiredItemPrice', () => {
-
-    it('should return the minimum price for the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity +
-				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
-			});
-
-			expect(facade.getMinRequiredItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('getMaxRequiredItemPrice', () => {
-
-    it('should return the maximum price for the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price +
-				stubCompositeProduct.items[0].options[0].price*stubCompositeProduct.items[0].options[0].quantity +
-				stubCompositeProduct.items[1].options[0].price*stubCompositeProduct.items[1].options[0].quantity
-			});
-
-			expect(facade.getMaxRequiredItemPrice(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('hasRequiredItemPriceRange', () => {
-
-    it('should return whether the product currently has a price range', () => {
-			const expected = cold('a', { a: false });
-
-			expect(facade.hasRequiredItemPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-	});
-
-  describe('getMinRequiredItemDiscountedPrice', () => {
-
-    it('should return the discounted price of the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
-				(stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount)*stubCompositeProduct.items[0].options[0].quantity +
-				(stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount)*stubCompositeProduct.items[1].options[0].quantity
-			});
-
-			expect(facade.getMinRequiredItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('getMaxRequiredItemDiscountedPrice', () => {
-
-    it('should return the price of the product', () => {
-			const expected = cold('a', { a:
-				stubCompositeProduct.price - stubCompositeProduct.discount.amount +
-				(stubCompositeProduct.items[0].options[0].price - stubCompositeProduct.items[0].options[0].discount.amount)*stubCompositeProduct.items[0].options[0].quantity +
-				(stubCompositeProduct.items[1].options[0].price - stubCompositeProduct.items[1].options[0].discount.amount)*stubCompositeProduct.items[1].options[0].quantity
-			});
-
-			expect(facade.getMaxRequiredItemDiscountedPrice(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('hasRequiredItemDiscountedPriceRange', () => {
-
-    it('should return whether the product currently has a discounted price range', () => {
-			const expected = cold('a', { a: false });
-
-			expect(facade.hasRequiredItemDiscountedPriceRange(stubCompositeProduct.id)).toBeObservable(expected);
-		});
-  });
-
-  describe('hasRequiredItemDiscount', () => {
-    let productWithDiscount;
-
-    beforeEach(() => {
-      productWithDiscount = compositeProductFactory.create({
-        discount: {
-          amount: 10,
-          percent: 10
-        }
-      })
-      store.dispatch(new DaffProductLoadSuccess(productWithDiscount));
-    })
-
-    it('should return whether the product has a discount excluding optional items', () => {
-			const expected = cold('a', { a: true });
-
-			expect(facade.hasRequiredItemDiscount(productWithDiscount.id)).toBeObservable(expected);
-		});
-	});
 
 	describe('getAppliedOptions', () => {
 
 		it('should return the applied option for a composite product', () => {
 			const expected = cold('a', { a: {
 				[stubCompositeProduct.items[0].id]: stubCompositeProduct.items[0].options[0],
-				[stubCompositeProduct.items[1].id]: stubCompositeProduct.items[1].options[0]
+				[stubCompositeProduct.items[1].id]: null
 			}});
 
 			expect(facade.getAppliedOptions(stubCompositeProduct.id)).toBeObservable(expected);

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -10,6 +10,9 @@ import { getDaffProductSelectors } from '../../selectors/public_api';
 import { DaffCompositeProductFacadeInterface } from './composite-product-facade.interface';
 import { DaffCompositeProductItemOption, DaffCompositeProductItem } from '../../models/composite-product-item';
 import { DaffCompositeProduct } from '../../models/composite-product';
+import { DaffPriceRange } from '../../models/prices';
+import { DaffCompositeConfigurationItem } from '../../models/composite-configuration-item';
+import { productPriceRangeHasDiscount, productPriceRangeHasPriceRange } from '../helpers';
 
 /**
  * A facade for interacting with the composite product state.
@@ -21,65 +24,33 @@ import { DaffCompositeProduct } from '../../models/composite-product';
   providedIn: DaffProductModule
 })
 export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> implements DaffCompositeProductFacadeInterface {
-
-	selectors = getDaffProductSelectors<T>();
 	
 	constructor(private store: Store<DaffProductReducersState<T>>) {}
 
-	getMinPossiblePrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinPossiblePrice, { id }));
+	selectors = getDaffProductSelectors<T>();
+
+	/**
+	 * Returns whether a DaffPriceRange has a discount.
+	 * @param priceRange a DaffPriceRange
+	 */
+	hasDiscount = productPriceRangeHasDiscount;
+
+	/**
+	 * Returns whether the min and max prices of a DaffPriceRange are different.
+	 * @param priceRange a DaffPriceRange
+	 */
+	hasPriceRange = productPriceRangeHasPriceRange;
+
+	getPricesForConfiguration(id: string, configuration: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPricesForConfiguration, { id, configuration }));
 	}
 
-	getMaxPossiblePrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPossiblePrice, { id }));
+	getPrices(id: string): Observable<DaffPriceRange> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPrices, { id }));
 	}
 
-	possiblyHasPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasPriceRange, { id }));
-	}
-
-	getMinPossibleDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinPossibleDiscountedPrice, { id }));
-	}
-
-	getMaxPossibleDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxPossibleDiscountedPrice, { id }));
-	}
-
-	possiblyHasDiscountedPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasDiscountedPriceRange, { id }));
-	}
-
-	possiblyHasDiscount(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductPossiblyHasDiscount, { id }));
-	}
-
-	getMinRequiredItemPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinRequiredItemPrice, { id }));
-	}
-
-	getMaxRequiredItemPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxRequiredItemPrice, { id }));
-	}
-
-	hasRequiredItemPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredItemPriceRange, { id }));
-	}
-
-	getMinRequiredItemDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMinRequiredItemDiscountedPrice, { id }));
-	}
-
-	getMaxRequiredItemDiscountedPrice(id: string): Observable<number> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductMaxRequiredItemDiscountedPrice, { id }));
-	}
-
-	hasRequiredItemDiscountedPriceRange(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredItemDiscountedPriceRange, { id }));
-	}
-
-	hasRequiredItemDiscount(id: string): Observable<boolean> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductHasRequiredItemDiscount, { id }));
+	getPricesAsCurrentlyConfigured(id: string): Observable<DaffPriceRange> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductPricesAsCurrentlyConfigured, { id }));
 	}
 
 	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption>> {

--- a/libs/product/src/facades/helpers.spec.ts
+++ b/libs/product/src/facades/helpers.spec.ts
@@ -1,0 +1,106 @@
+import { productPriceRangeHasDiscount, productPriceRangeHasPriceRange } from './helpers';
+
+describe('facade helper functions', () => {
+	
+	describe('productPriceRangeHasDiscount', () => {
+		
+		it('should return true when the original and discounted min price are different', () => {
+			const stubPriceRange = {
+				minPrice: {
+					discountedPrice: 8,
+					discount: { amount: null, percent: null},
+					originalPrice: 10
+				},
+				maxPrice: {
+					discountedPrice: 10,
+					discount: { amount: null, percent: null},
+					originalPrice: 10
+				}
+			}
+			expect(productPriceRangeHasDiscount(stubPriceRange)).toBeTruthy();
+		});
+
+		it('should return true when the original and discounted max price are different', () => {
+			const stubPriceRange = {
+				minPrice: {
+					discountedPrice: 10,
+					discount: { amount: null, percent: null},
+					originalPrice: 10
+				},
+				maxPrice: {
+					discountedPrice: 18,
+					discount: { amount: null, percent: null},
+					originalPrice: 20
+				}
+			}
+			expect(productPriceRangeHasDiscount(stubPriceRange)).toBeTruthy();
+		});
+
+		it('should return false when the original and discounted prices are the same', () => {
+			const stubPriceRange = {
+				minPrice: {
+					discountedPrice: 10,
+					discount: { amount: null, percent: null},
+					originalPrice: 10
+				},
+				maxPrice: {
+					discountedPrice: 10,
+					discount: { amount: null, percent: null},
+					originalPrice: 10
+				}
+			}
+			expect(productPriceRangeHasDiscount(stubPriceRange)).toBeFalsy();
+		});
+	});
+	
+	describe('productPriceRangeHasPriceRange', () => {
+		
+		it('should return true when the min and max original prices are different', () => {
+			const stubPriceRange = {
+				minPrice: {
+					discountedPrice: 10,
+					discount: { amount: null, percent: null},
+					originalPrice: 10
+				},
+				maxPrice: {
+					discountedPrice: 10,
+					discount: { amount: null, percent: null},
+					originalPrice: 20
+				}
+			}
+			expect(productPriceRangeHasPriceRange(stubPriceRange)).toBeTruthy();
+		});
+
+		it('should return true when the min and max discounted prices are different', () => {
+			const stubPriceRange = {
+				minPrice: {
+					discountedPrice: 8,
+					discount: { amount: null, percent: null},
+					originalPrice: 10
+				},
+				maxPrice: {
+					discountedPrice: 18,
+					discount: { amount: null, percent: null},
+					originalPrice: 20
+				}
+			}
+			expect(productPriceRangeHasPriceRange(stubPriceRange)).toBeTruthy();
+		});
+
+		it('should return false when the min and max prices are the same', () => {
+			const stubPriceRange = {
+				minPrice: {
+					discountedPrice: 10,
+					discount: { amount: null, percent: null},
+					originalPrice: 10
+				},
+				maxPrice: {
+					discountedPrice: 10,
+					discount: { amount: null, percent: null},
+					originalPrice: 10
+				}
+			}
+			expect(productPriceRangeHasPriceRange(stubPriceRange)).toBeFalsy();
+		});
+	});
+});

--- a/libs/product/src/facades/helpers.ts
+++ b/libs/product/src/facades/helpers.ts
@@ -1,0 +1,19 @@
+import { DaffPriceRange } from '../models/prices';
+
+/**
+ * Returns whether a DaffPriceRange has a discount.
+ * @param priceRange a DaffPriceRange
+ */
+export const productPriceRangeHasDiscount = (priceRange: DaffPriceRange): boolean => {
+	return priceRange.minPrice.originalPrice !== priceRange.minPrice.discountedPrice ||
+		priceRange.maxPrice.originalPrice !== priceRange.maxPrice.discountedPrice;
+}
+
+/**
+ * Returns whether the min and max prices of a DaffPriceRange are different.
+ * @param priceRange a DaffPriceRange
+ */
+export const productPriceRangeHasPriceRange = (priceRange: DaffPriceRange): boolean => {
+	return priceRange.minPrice.originalPrice !== priceRange.maxPrice.originalPrice ||
+		priceRange.minPrice.discountedPrice !== priceRange.maxPrice.discountedPrice;
+}

--- a/libs/product/src/index.ts
+++ b/libs/product/src/index.ts
@@ -9,6 +9,8 @@ export { DaffProductImage } from './models/product-image';
 export * from './models/composite-product';
 export * from './models/composite-product-item';
 export * from './models/configurable-product';
+export * from './models/prices';
+export * from './models/composite-configuration-item';
 
 export * from './reducers/public_api';
 export * from './selectors/public_api';
@@ -29,5 +31,6 @@ export { DaffConfigurableProductFacadeInterface } from './facades/configurable-p
 export { DaffCompositeProductFacade } from './facades/composite-product/composite-product.facade';
 export { DaffCompositeProductFacadeInterface } from './facades/composite-product/composite-product-facade.interface';
 export { DaffBestSellersFacade } from './facades/best-sellers/best-sellers.facade';
+export * from './facades/helpers';
 
 export * from './drivers/magento/public_api';

--- a/libs/product/src/models/composite-configuration-item.ts
+++ b/libs/product/src/models/composite-configuration-item.ts
@@ -1,0 +1,4 @@
+export interface DaffCompositeConfigurationItem {
+	qty: number;
+	value: string;
+}

--- a/libs/product/src/models/prices.ts
+++ b/libs/product/src/models/prices.ts
@@ -1,0 +1,12 @@
+import { DaffProductDiscount } from './product';
+
+export interface DaffProductPrices {
+	discountedPrice: number;
+	discount: DaffProductDiscount;
+	originalPrice: number;
+}
+
+export interface DaffPriceRange {
+	maxPrice: DaffProductPrices;
+	minPrice: DaffProductPrices;
+}

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -7,8 +7,9 @@ import { daffCompositeProductAppliedOptionsEntitiesAdapter } from './composite-p
 import { DaffProduct, DaffProductTypeEnum } from '../../models/product';
 import { DaffCompositeProductActions, DaffCompositeProductActionTypes } from '../../actions/composite-product.actions';
 import { DaffCompositeProduct } from '../../models/composite-product';
-import { DaffCompositeProductEntity, DaffCompositeProductEntityItem } from './composite-product-entity';
+import { DaffCompositeProductEntity } from './composite-product-entity';
 import { DaffCompositeProductItem } from '../../models/composite-product-item';
+import { DaffCompositeConfigurationItem } from '../../models/composite-configuration-item';
 
 /**
  * Reducer function that catches actions and changes/overwrites composite product entities state.
@@ -72,7 +73,7 @@ function buildCompositeProductAppliedOptionsEntity(product: DaffCompositeProduct
  * Does not set a default option if a default is not specified or if the default is out of stock.
  * @param item a DaffCompositeProductItem
  */
-function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeProductEntityItem {
+function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeConfigurationItem {
 	const defaultOptionIndex = item.options.findIndex(option => option.is_default);
 
 	if(defaultOptionIndex > -1 && item.options[defaultOptionIndex].in_stock) {

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
@@ -1,11 +1,7 @@
 import { Dictionary } from '@ngrx/entity';
+import { DaffCompositeConfigurationItem } from '../../models/composite-configuration-item';
 
 export interface DaffCompositeProductEntity {
 	id: string;
-	items: Dictionary<DaffCompositeProductEntityItem>;
-}
-
-export interface DaffCompositeProductEntityItem {
-	value: string;
-	qty: number;
+	items: Dictionary<DaffCompositeConfigurationItem>;
 }

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -198,7 +198,7 @@ describe('Composite Product Selectors | integration tests', () => {
 			expect(selector).toBeObservable(expected);
 		});
 		
-		it('should return the broadest price range for a composite product excluding optional items', () => {
+		it('should return the broadest price range for a composite product including optional items', () => {
 			const selector = store.pipe(select(selectCompositeProductPrices, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: {
 				minPrice: {
@@ -210,12 +210,13 @@ describe('Composite Product Selectors | integration tests', () => {
 					originalPrice: stubCompositeProduct.price + stubPrice00
 				},
 				maxPrice: {
-					discountedPrice: stubCompositeProduct.price + stubPrice01 - stubCompositeProduct.discount.amount - stubDiscountAmount01,
+					discountedPrice: stubCompositeProduct.price + stubPrice01 + stubPrice11 - 
+						stubCompositeProduct.discount.amount - stubDiscountAmount01 - stubDiscountAmount11,
 					discount: {
 						amount: null,
 						percent: null
 					},
-					originalPrice: stubCompositeProduct.price + stubPrice01
+					originalPrice: stubCompositeProduct.price + stubPrice01 + stubPrice11
 				}
 			}});
 

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { StoreModule, combineReducers, Store, select } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
+import { Dictionary } from '@ngrx/entity';
 
 import { DaffCompositeProductFactory, DaffProductFactory } from '@daffodil/product/testing';
 import {
@@ -13,6 +14,7 @@ import {
 } from '@daffodil/product';
 
 import { getDaffCompositeProductSelectors } from './composite-product.selectors';
+import { DaffCompositeConfigurationItem } from '../../models/composite-configuration-item';
 
 describe('Composite Product Selectors | integration tests', () => {
 
@@ -22,28 +24,20 @@ describe('Composite Product Selectors | integration tests', () => {
 	let stubCompositeProduct: DaffCompositeProduct;
 	let stubProduct: DaffProduct;
 	const {
-		selectCompositeProductMinPossiblePrice,
-		selectCompositeProductMaxPossiblePrice,
-		selectCompositeProductPossiblyHasPriceRange,
-		selectCompositeProductMinPossibleDiscountedPrice,
-		selectCompositeProductMaxPossibleDiscountedPrice,
-		selectCompositeProductPossiblyHasDiscountedPriceRange,
-		selectCompositeProductPossiblyHasDiscount,
-		selectCompositeProductMinRequiredItemPrice,
-		selectCompositeProductMaxRequiredItemPrice,
-		selectCompositeProductHasRequiredItemPriceRange,
-		selectCompositeProductMinRequiredItemDiscountedPrice,
-		selectCompositeProductMaxRequiredItemDiscountedPrice,
-		selectCompositeProductHasRequiredItemDiscountedPriceRange,
-		selectCompositeProductHasRequiredItemDiscount
+		selectCompositeProductPricesForConfiguration,
+		selectCompositeProductPrices,
+		selectCompositeProductPricesAsCurrentlyConfigured
 	} = getDaffCompositeProductSelectors();
 	const stubPrice00 = 10;
-	const stubDiscountAmount0 = 2;
+	const stubDiscountAmount00 = 2;
 	const stubPrice01 = 20;
-	const stubDiscountAmount1 = 1;
+	const stubDiscountAmount01 = 1;
 	const stubPrice10 = 30;
+	const stubDiscountAmount10 = 3;
 	const stubPrice11 = 40;
+	const stubDiscountAmount11 = 4;
 	const stubQty0 = 3;
+	const stubQty1 = 2;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -63,616 +57,218 @@ describe('Composite Product Selectors | integration tests', () => {
 		stubCompositeProduct.items[0].options[0].price = stubPrice00;
 		stubCompositeProduct.items[0].options[0].quantity = stubQty0;
 		stubCompositeProduct.items[0].options[1].price = stubPrice01;
+		stubCompositeProduct.items[0].options[0].quantity = stubQty1;
 		stubCompositeProduct.items[0].options[0].discount = {
-			amount: stubDiscountAmount0,
+			amount: stubDiscountAmount00,
 			percent: null
 		}
 		stubCompositeProduct.items[0].options[1].discount = {
-			amount: stubDiscountAmount1,
+			amount: stubDiscountAmount01,
 			percent: null
 		}
 		stubCompositeProduct.items[1].required = false;
 		stubCompositeProduct.items[1].options[0].is_default = false;
 		stubCompositeProduct.items[1].options[0].price = stubPrice10;
 		stubCompositeProduct.items[1].options[1].price = stubPrice11;
+		stubCompositeProduct.items[1].options[0].discount = {
+			amount: stubDiscountAmount10,
+			percent: null
+		};
+		stubCompositeProduct.items[1].options[1].discount = {
+			amount: stubDiscountAmount11,
+			percent: null
+		};
 		store = TestBed.get(Store);
 		store.dispatch(new DaffProductLoadSuccess(stubCompositeProduct));
 		store.dispatch(new DaffProductLoadSuccess(stubProduct));
 	});
 
-	describe('selectCompositeProductMinPossiblePrice', () => {
+	describe('selectCompositeProductPricesForConfiguration', () => {
 
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubProduct.id }));
+		it('should return undefined when the product is not a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductPricesForConfiguration, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
-		it('should initialize to the minimum price for the composite product excluding optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should not update the price when an option change occurs', () => {
-			store.dispatch(new DaffCompositeProductApplyOption(
-				stubCompositeProduct.id,
-				<string>stubCompositeProduct.items[0].id,
-				stubCompositeProduct.items[0].options[1].id
-			));
-			const selector = store.pipe(select(selectCompositeProductMinPossiblePrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00 });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductMaxPossiblePrice', () => {
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPossiblePrice, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should initialize to the maximum price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPossiblePrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 + stubPrice11 });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should not update the price when an option change occurs', () => {
-			store.dispatch(new DaffCompositeProductApplyOption(
-				stubCompositeProduct.id,
-				<string>stubCompositeProduct.items[0].id,
-				stubCompositeProduct.items[0].options[1].id
-			));
-			const selector = store.pipe(select(selectCompositeProductMaxPossiblePrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 + stubPrice11 });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductPossiblyHasPriceRange', () => {
-
-		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasPriceRange, { id: stubProduct.id }));
-			const expected = cold('a', { a: false });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should return true if the possible min and max prices are not equal', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasPriceRange, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: true });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should return false if the possible min and max prices are equal', () => {
-			const newCompositeProduct = compositeProductFactory.create();
-			newCompositeProduct.items[0].options[0].price = 0;
-			newCompositeProduct.items[0].options[1].price = 0;
-			newCompositeProduct.items[1].options[0].price = 0;
-			newCompositeProduct.items[1].options[1].price = 0;
-			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasPriceRange, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: false });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductMinPossibleDiscountedPrice', () => {
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPossibleDiscountedPrice, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should initialize to the minimum discounted price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMinPossibleDiscountedPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should not update the price when an option change occurs', () => {
-			store.dispatch(new DaffCompositeProductApplyOption(
-				stubCompositeProduct.id,
-				<string>stubCompositeProduct.items[0].id,
-				stubCompositeProduct.items[0].options[1].id
-			));
-			const selector = store.pipe(select(selectCompositeProductMinPossibleDiscountedPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice00 - stubDiscountAmount0 });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductMaxPossibleDiscountedPrice', () => {
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPossibleDiscountedPrice, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should initialize to the maximum discounted price for the composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxPossibleDiscountedPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice01 - stubDiscountAmount1 + stubPrice11 });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should not update the price when an option change occurs', () => {
-			store.dispatch(new DaffCompositeProductApplyOption(
-				stubCompositeProduct.id,
-				<string>stubCompositeProduct.items[0].id,
-				stubCompositeProduct.items[0].options[1].id
-			));
-			const selector = store.pipe(select(selectCompositeProductMaxPossibleDiscountedPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price - stubCompositeProduct.discount.amount + stubPrice01 - stubDiscountAmount1 + stubPrice11 });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductPossiblyHasDiscountedPriceRange', () => {
-
-		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscountedPriceRange, { id: stubProduct.id }));
-			const expected = cold('a', { a: false });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should return true if the min and max prices including optional items are not equal', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscountedPriceRange, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: true });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should return false if the possible min and max prices including optional items are equal', () => {
-			const newCompositeProduct = compositeProductFactory.create();
-			newCompositeProduct.items[0].options[0].price = 0;
-			newCompositeProduct.items[0].options[1].price = 0;
-			newCompositeProduct.items[1].options[0].price = 0;
-			newCompositeProduct.items[1].options[1].price = 0;
-			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscountedPriceRange, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: false });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductPossiblyHasDiscount', () => {
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscount, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should return true if the product, including optional items, has a discount', () => {
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscount, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: true });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should return false if the product, including optional items, does not have a discount', () => {
-			const newCompositeProduct = compositeProductFactory.create();
-			newCompositeProduct.discount.amount = 0;
-			newCompositeProduct.items[0].options[0].price = 10;
-			newCompositeProduct.items[0].options[1].price = 20;
-			newCompositeProduct.items[1].options[0].price = 30;
-			newCompositeProduct.items[1].options[1].price = 40;
-			newCompositeProduct.items[0].options[0].discount.amount = 0;
-			newCompositeProduct.items[0].options[1].discount.amount = 0;
-			newCompositeProduct.items[1].options[0].discount.amount = 0;
-			newCompositeProduct.items[1].options[1].discount.amount = 0;
-			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscount, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: false });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it(`should return false if the product\'s min and max discount amounts are zero, 
-				but there is a discount in between those extremes`, () => {
-			const newCompositeProduct = compositeProductFactory.create();
-			newCompositeProduct.discount.amount = 0;
-			newCompositeProduct.items[0].options[0].price = 10;
-			newCompositeProduct.items[0].options[1].price = 20;
-			newCompositeProduct.items[0].options.push({
-				id: 'id',
-				name: 'inbetween option with discount',
-				price: 15,
-				is_default: false,
-				quantity: 1,
-				discount: {
-					amount: 4,
-					percent: 10
+		it('should return the broadest price range when no configuration is provided', () => {
+			const selector = store.pipe(select(selectCompositeProductPricesForConfiguration, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price + stubPrice00 - stubCompositeProduct.discount.amount - stubDiscountAmount00,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice00
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price + stubPrice01 - stubCompositeProduct.discount.amount - stubDiscountAmount01,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01
 				}
-			})
-			newCompositeProduct.items[1].options[0].price = 0;
-			newCompositeProduct.items[1].options[1].price = 0;
-			newCompositeProduct.items[0].options[0].discount.amount = 0;
-			newCompositeProduct.items[0].options[1].discount.amount = 0;
-			newCompositeProduct.items[1].options[0].discount.amount = 0;
-			newCompositeProduct.items[1].options[1].discount.amount = 0;
-			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductPossiblyHasDiscount, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: false });
+			}});
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should return the expected price range when a partial configuration is provided', () => {
+			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
+				[stubCompositeProduct.items[1].id]: {
+					value: stubCompositeProduct.items[1].options[1].id,
+					qty: stubQty1
+				}
+			}
+			const selector = store.pipe(select(selectCompositeProductPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice00 - stubDiscountAmount00 + 
+						(stubPrice11 - stubDiscountAmount11) * stubQty1,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice00 + (stubPrice11 * stubQty1)
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice01 - stubDiscountAmount01 +
+						(stubPrice11 - stubDiscountAmount11) * stubQty1,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01 + (stubPrice11 * stubQty1)
+				}
+			}});
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should return the expected price range when a full configuration is provided', () => {
+			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
+				[stubCompositeProduct.items[0].id]: {
+					value: stubCompositeProduct.items[0].options[1].id,
+					qty: stubQty0
+				},
+				[stubCompositeProduct.items[1].id]: {
+					value: stubCompositeProduct.items[1].options[1].id,
+					qty: stubQty1
+				}
+			}
+			const selector = store.pipe(select(selectCompositeProductPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice01 - stubDiscountAmount01) * stubQty0 + 
+						(stubPrice11 - stubDiscountAmount11) * stubQty1,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice01 * stubQty0) + (stubPrice11 * stubQty1)
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice01 - stubDiscountAmount01) * stubQty0 +
+						(stubPrice11 - stubDiscountAmount11) * stubQty1,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice01 * stubQty0) + (stubPrice11 * stubQty1)
+				}
+			}});
 
 			expect(selector).toBeObservable(expected);
 		});
 	});
 
-	describe('selectCompositeProductMinRequiredItemPrice', () => {
+	describe('selectCompositeProductPrices', () => {
 
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinRequiredItemPrice, { id: stubProduct.id }));
+		it('should return undefined when the product is not a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductPrices, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
-		});
-
-		it('should initialize to the current minimum price', () => {
-			const selector = store.pipe(select(selectCompositeProductMinRequiredItemPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00*stubQty0 });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should update the price when an option change occurs', () => {
-			store.dispatch(new DaffCompositeProductApplyOption(
-				stubCompositeProduct.id,
-				<string>stubCompositeProduct.items[0].id,
-				stubCompositeProduct.items[0].options[1].id
-			));
-			const selector = store.pipe(select(selectCompositeProductMinRequiredItemPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductMaxRequiredItemPrice', () => {
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemPrice, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should initialize to the current maximum price', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice00*stubQty0 });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should update the price when an option change occurs', () => {
-			store.dispatch(new DaffCompositeProductApplyOption(
-				stubCompositeProduct.id,
-				<string>stubCompositeProduct.items[0].id,
-				stubCompositeProduct.items[0].options[1].id
-			));
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemPrice, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: stubCompositeProduct.price + stubPrice01 });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductHasRequiredItemPriceRange', () => {
-
-		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasRequiredItemPriceRange, { id: stubProduct.id }));
-			const expected = cold('a', { a: false });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should return true if the current min and max prices are not equal', () => {
-			store.dispatch(new DaffCompositeProductApplyOption(
-				stubCompositeProduct.id,
-				<string>stubCompositeProduct.items[0].id,
-				null
-			));
-			const selector = store.pipe(select(selectCompositeProductHasRequiredItemPriceRange, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: true });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should return false if the current min and max prices are equal', () => {
-			const newCompositeProduct = compositeProductFactory.create();
-			newCompositeProduct.items[0].options[0].price = 0;
-			newCompositeProduct.items[0].options[1].price = 0;
-			newCompositeProduct.items[1].options[0].price = 0;
-			newCompositeProduct.items[1].options[1].price = 0;
-			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasRequiredItemPriceRange, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: false });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductMinRequiredItemDiscountedPrice', () => {
-
-		let newCompositeProduct;
-		const item0Option0Price = 10;
-		const item0Option1Price = 10;
-		const item0Option0DiscountAmount = 5;
-		const item0Option1DiscountAmount = 2;
-		const item1Option0Price = 20;
-		const item1Option1Price = 10;
-		const item1Option0DiscountAmount = 2;
-		const item1Option1DiscountAmount = 4;
-
-		beforeEach(() => {
-			newCompositeProduct = compositeProductFactory.create();
-			newCompositeProduct.items[0].required = true;
-			newCompositeProduct.items[0].options[0].is_default = false;
-			newCompositeProduct.items[0].options[1].is_default = false;
-			newCompositeProduct.items[0].options[0].price = item0Option0Price;
-			newCompositeProduct.items[0].options[1].price = item0Option1Price;
-			newCompositeProduct.items[0].options[0].discount.amount = item0Option0DiscountAmount;
-			newCompositeProduct.items[0].options[1].discount.amount = item0Option1DiscountAmount;
-			newCompositeProduct.items[1].required = true;
-			newCompositeProduct.items[1].options[0].is_default = false;
-			newCompositeProduct.items[1].options[1].is_default = false;
-			newCompositeProduct.items[1].options[0].price = item1Option0Price;
-			newCompositeProduct.items[1].options[1].price = item1Option1Price;
-			newCompositeProduct.items[1].options[0].discount.amount = item1Option0DiscountAmount;
-			newCompositeProduct.items[1].options[1].discount.amount = item1Option1DiscountAmount;
-			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-		});
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMinRequiredItemDiscountedPrice, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should initialize to the expected minimum discounted price', () => {
-			const smallestItem0DiscountedPrice = item0Option0Price - item0Option0DiscountAmount;
-			const smallestItem1DiscountedPrice = item1Option1Price - item1Option1DiscountAmount;
-			const selector = store.pipe(select(selectCompositeProductMinRequiredItemDiscountedPrice, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: 
-				newCompositeProduct.price - newCompositeProduct.discount.amount + 
-				smallestItem0DiscountedPrice + 
-				smallestItem1DiscountedPrice
-			});
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should update the price when an option change occurs', () => {
-			const updatedOption01Quantity = 3;
-			const selectedItem0DiscountedPrice = (item0Option1Price - item0Option1DiscountAmount) * updatedOption01Quantity;
-			const smallestItem1DiscountedPrice = item1Option1Price - item1Option1DiscountAmount;
-
-			store.dispatch(new DaffCompositeProductApplyOption(
-				newCompositeProduct.id,
-				<string>newCompositeProduct.items[0].id,
-				newCompositeProduct.items[0].options[1].id,
-				updatedOption01Quantity
-			));
-			const selector = store.pipe(select(selectCompositeProductMinRequiredItemDiscountedPrice, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
-				selectedItem0DiscountedPrice + 
-				smallestItem1DiscountedPrice 
-			});
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductMaxRequiredItemDiscountedPrice', () => {
-
-		let newCompositeProduct;
-		const item0Option0Price = 10;
-		const item0Option1Price = 10;
-		const item0Option0DiscountAmount = 5;
-		const item0Option1DiscountAmount = 2;
-		const item1Option0Price = 20;
-		const item1Option1Price = 10;
-		const item1Option0DiscountAmount = 2;
-		const item1Option1DiscountAmount = 4;
-
-		beforeEach(() => {
-			newCompositeProduct = compositeProductFactory.create();
-			newCompositeProduct.items[0].required = true;
-			newCompositeProduct.items[0].options[0].is_default = false;
-			newCompositeProduct.items[0].options[1].is_default = false;
-			newCompositeProduct.items[0].options[0].price = item0Option0Price;
-			newCompositeProduct.items[0].options[1].price = item0Option1Price;
-			newCompositeProduct.items[0].options[0].discount.amount = item0Option0DiscountAmount;
-			newCompositeProduct.items[0].options[1].discount.amount = item0Option1DiscountAmount;
-			newCompositeProduct.items[1].required = true;
-			newCompositeProduct.items[1].options[0].is_default = false;
-			newCompositeProduct.items[1].options[1].is_default = false;
-			newCompositeProduct.items[1].options[0].price = item1Option0Price;
-			newCompositeProduct.items[1].options[1].price = item1Option1Price;
-			newCompositeProduct.items[1].options[0].discount.amount = item1Option0DiscountAmount;
-			newCompositeProduct.items[1].options[1].discount.amount = item1Option1DiscountAmount;
-			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-		});
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemDiscountedPrice, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should initialize to the expected maximum discounted price', () => {
-			const largestItem0DiscountedPrice = item0Option1Price - item0Option1DiscountAmount;
-			const largestItem1DiscountedPrice = item1Option0Price - item1Option0DiscountAmount;
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemDiscountedPrice, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
-				largestItem0DiscountedPrice + 
-				largestItem1DiscountedPrice
-			});
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should update the price when an option change occurs', () => {
-			const updatedOption00Quantity = 3;
-			const selectedItem0DiscountedPrice = (item0Option0Price - item0Option0DiscountAmount) * updatedOption00Quantity;
-			const largestItem1DiscountedPrice = item1Option0Price - item1Option0DiscountAmount;
-			store.dispatch(new DaffCompositeProductApplyOption(
-				newCompositeProduct.id,
-				<string>newCompositeProduct.items[0].id,
-				newCompositeProduct.items[0].options[0].id,
-				updatedOption00Quantity
-			));
-			const selector = store.pipe(select(selectCompositeProductMaxRequiredItemDiscountedPrice, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: newCompositeProduct.price - newCompositeProduct.discount.amount + 
-				selectedItem0DiscountedPrice + 
-				largestItem1DiscountedPrice
-			});
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductHasRequiredItemDiscountedPriceRange', () => {
-
-		it('should return false if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscountedPriceRange, { id: stubProduct.id }));
-			const expected = cold('a', { a: false });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should return true if the current min and max prices are not equal', () => {
-			store.dispatch(new DaffCompositeProductApplyOption(
-				stubCompositeProduct.id,
-				<string>stubCompositeProduct.items[0].id,
-				null
-			));
-			const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscountedPriceRange, { id: stubCompositeProduct.id }));
-			const expected = cold('a', { a: true });
-
-			expect(selector).toBeObservable(expected);
-		});
-
-		it('should return false if the current min and max prices are equal', () => {
-			const newCompositeProduct = compositeProductFactory.create();
-			newCompositeProduct.items[0].options[0].price = 0;
-			newCompositeProduct.items[0].options[1].price = 0;
-			newCompositeProduct.items[1].options[0].price = 0;
-			newCompositeProduct.items[1].options[1].price = 0;
-			newCompositeProduct.items[1].options[1].discount.amount = 0;
-			newCompositeProduct.items[1].options[1].discount.amount = 0;
-			newCompositeProduct.items[1].options[1].discount.amount = 0;
-			newCompositeProduct.items[1].options[1].discount.amount = 0;
-			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscountedPriceRange, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: false });
-
-			expect(selector).toBeObservable(expected);
-		});
-	});
-
-	describe('selectCompositeProductHasRequiredItemDiscount', () => {
-
-		it('should return undefined if the given product id is not from a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscount, { id: stubProduct.id }));
-			const expected = cold('a', { a: undefined });
-
-			expect(selector).toBeObservable(expected);
-    });
-
-    describe('when the product has a discount', () => {
-      let mockProduct;
-
-      beforeEach(() => {
-        mockProduct = compositeProductFactory.create({
-          discount: {
-            amount: 10,
-            percent: 10
-          }
-        });
-        store.dispatch(new DaffProductLoadSuccess(mockProduct));
-      });
-
-      it('should return true', () => {
-        const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscount, { id: mockProduct.id }));
-        const expected = cold('a', { a: true });
-
-        expect(selector).toBeObservable(expected);
-      });
-    });
-
-    describe('when the product does not have a discount', () => {
-      let mockProduct;
-
-      beforeEach(() => {
-        mockProduct = compositeProductFactory.create({
-          discount: {
-            amount: 0,
-            percent: 0
-          }
-        });
-        store.dispatch(new DaffProductLoadSuccess(mockProduct));
-      });
-
-      it('should return false', () => {
-        const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscount, { id: mockProduct.id }));
-        const expected = cold('a', { a: false });
-
-        expect(selector).toBeObservable(expected);
-      });
 		});
 		
-		it(`should return false if the product\'s min and max discount amounts are zero, 
-				but there is a discount in between those extremes`, () => {
-			const newCompositeProduct = compositeProductFactory.create();
-			newCompositeProduct.discount.amount = 0;
-			newCompositeProduct.items[0].options[0].price = 10;
-			newCompositeProduct.items[0].options[1].price = 20;
-			newCompositeProduct.items[1].options[0].price = 0;
-			newCompositeProduct.items[1].options[1].price = 0;
-			newCompositeProduct.items[0].options[0].discount.amount = 0;
-			newCompositeProduct.items[0].options[1].discount.amount = 0;
-			newCompositeProduct.items[1].options[0].discount.amount = 0;
-			newCompositeProduct.items[1].options[1].discount.amount = 0;
-			newCompositeProduct.items[0].required = true;
-			newCompositeProduct.items[0].options.push({
-				id: 'id',
-				name: 'inbetween option with discount',
-				price: 15,
-				is_default: false,
-				quantity: 1,
-				discount: {
-					amount: 4,
-					percent: 10
+		it('should return the broadest price range for a composite product excluding optional items', () => {
+			const selector = store.pipe(select(selectCompositeProductPrices, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price + stubPrice00 - stubCompositeProduct.discount.amount - stubDiscountAmount00,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice00
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price + stubPrice01 - stubCompositeProduct.discount.amount - stubDiscountAmount01,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01
 				}
-			})
-			store.dispatch(new DaffProductLoadSuccess(newCompositeProduct));
-			const selector = store.pipe(select(selectCompositeProductHasRequiredItemDiscount, { id: newCompositeProduct.id }));
-			const expected = cold('a', { a: false });
+			}});
+
+			expect(selector).toBeObservable(expected);
+		});
+	});
+
+	describe('selectCompositeProductPricesAsCurrentlyConfigured', () => {
+
+		it('should return undefined when the product is not a composite product', () => {
+			const selector = store.pipe(select(selectCompositeProductPricesAsCurrentlyConfigured, { id: stubProduct.id }));
+			const expected = cold('a', { a: undefined });
+
+			expect(selector).toBeObservable(expected);
+		});
+		
+		it('should return the expected price range for the current configuration of the product in state', () => {
+			store.dispatch(new DaffCompositeProductApplyOption(
+				stubCompositeProduct.id,
+				<string>stubCompositeProduct.items[0].id,
+				stubCompositeProduct.items[0].options[1].id,
+				stubQty0
+			));
+			store.dispatch(new DaffCompositeProductApplyOption(
+				stubCompositeProduct.id,
+				<string>stubCompositeProduct.items[1].id,
+				stubCompositeProduct.items[1].options[1].id,
+				stubQty1
+			));
+
+			const selector = store.pipe(select(selectCompositeProductPricesAsCurrentlyConfigured, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice01 - stubDiscountAmount01) * stubQty0 + 
+						(stubPrice11 - stubDiscountAmount11) * stubQty1,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice01 * stubQty0) + (stubPrice11 * stubQty1)
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice01 - stubDiscountAmount01) * stubQty0 +
+						(stubPrice11 - stubDiscountAmount11) * stubQty1,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice01 * stubQty0) + (stubPrice11 * stubQty1)
+				}
+			}});
 
 			expect(selector).toBeObservable(expected);
 		});

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -3,7 +3,7 @@ import { Dictionary } from '@ngrx/entity';
 
 import { daffAdd, daffMultiply, daffSubtract } from '@daffodil/core';
 
-import { DaffProductTypeEnum } from '../../models/product';
+import { DaffProduct, DaffProductTypeEnum } from '../../models/product';
 import { getDaffCompositeProductEntitiesSelectors } from '../composite-product-entities/composite-product-entities.selectors';
 import { getDaffProductEntitiesSelectors } from '../product-entities/product-entities.selectors';
 import { DaffCompositeProduct } from '../../models/composite-product';
@@ -144,7 +144,7 @@ function getMinPricesForConfiguration(product: DaffCompositeProduct, appliedOpti
 					appliedOptions[item.id].quantity
 				) : 
 				getMinimumRequiredCompositeItemDiscountedPrice(item)
-		), product.discount ? daffSubtract(product.price, product.discount.amount) : product.price),
+		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },
 		originalPrice: product.items.reduce((acc, item) => daffAdd(
 			acc, 
@@ -172,7 +172,7 @@ function getMaxPricesForConfiguration(product: DaffCompositeProduct, appliedOpti
 					appliedOptions[item.id].quantity
 				) : 
 				getMaximumRequiredCompositeItemDiscountedPrice(item)
-		), product.discount ? daffSubtract(product.price, product.discount.amount) : product.price),
+		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },
 		originalPrice: product.items.reduce((acc, item) => daffAdd(
 			acc,
@@ -185,6 +185,10 @@ function getMaxPricesForConfiguration(product: DaffCompositeProduct, appliedOpti
 	}
 }
 
+function getDiscountedPrice(product: DaffProduct): number {
+  return product.discount ? daffSubtract(product.price, product.discount.amount) : product.price
+}
+
 /**
  * Gets the maximum prices of a composite product including optional item prices.
  * @param product a DaffCompositeProduct
@@ -193,8 +197,8 @@ function getMaxPricesIncludingOptionalItems(product: DaffCompositeProduct): Daff
 	return {
 		discountedPrice: (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
 			acc, 
-			Math.max(...item.options.map(option => option.discount ? daffSubtract(option.price, option.discount.amount) : option.price))
-		), product.discount ? daffSubtract(product.price, product.discount.amount) : product.price),
+			Math.max(...item.options.map(getDiscountedPrice))
+		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },
 		originalPrice: (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
 			acc,

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -115,9 +115,7 @@ function getMaximumRequiredCompositeItemPrice(item: DaffCompositeProductItem): n
  */
 //todo use optional chaining when possible
 function getMinimumRequiredCompositeItemDiscountedPrice(item: DaffCompositeProductItem): number {
-	return item.required ? Math.min(...item.options.map(option =>
-		daffSubtract(option.price, option.discount ? option.discount.amount : 0)
-	)) : 0;
+	return item.required ? Math.min(...item.options.map(getDiscountedPrice)) : 0;
 }
 /**
  * The maximum discounted price of an item is zero if the item is optional.
@@ -125,9 +123,7 @@ function getMinimumRequiredCompositeItemDiscountedPrice(item: DaffCompositeProdu
  */
 //todo use optional chaining when possible
 function getMaximumRequiredCompositeItemDiscountedPrice(item: DaffCompositeProductItem): number {
-	return item.required ? Math.max(...item.options.map(option => 
-		daffSubtract(option.price, option.discount ? option.discount.amount : 0)
-	)) : 0;
+	return item.required ? Math.max(...item.options.map(getDiscountedPrice)) : 0;
 }
 
 /**

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -13,7 +13,7 @@ import { DaffCompositeConfigurationItem } from '../../models/composite-configura
 
 export interface DaffCompositeProductMemoizedSelectors {
 	/**
-	 * Get a DaffPriceRange for a composite product based on the configuration provided.
+	 * Get a DaffPriceRange for a composite product based on the configuration provided excluding unselected, optional item prices.
 	 */
 	selectCompositeProductPricesForConfiguration: MemoizedSelectorWithProps<object, { id: string, configuration?: Dictionary<DaffCompositeConfigurationItem> }, DaffPriceRange>;
 	/**
@@ -21,7 +21,8 @@ export interface DaffCompositeProductMemoizedSelectors {
 	 */
 	selectCompositeProductPrices: MemoizedSelectorWithProps<object, { id: string }, DaffPriceRange>;
 	/**
-	 * Get the DaffPriceRange for a composite product based on the current configuration of selected item options in redux state.
+	 * Get the DaffPriceRange for a composite product based on the current configuration of selected item options in redux state and
+	 * excluding unselected, optional item prices.
 	 */
 	selectCompositeProductPricesAsCurrentlyConfigured: MemoizedSelectorWithProps<object, { id: string }, DaffPriceRange>;
 }
@@ -130,7 +131,7 @@ function getMaximumRequiredCompositeItemDiscountedPrice(item: DaffCompositeProdu
 }
 
 /**
- * Gets the minimum prices of a composite product for the configuration provided.
+ * Gets the minimum prices of a composite product for the configuration provided excluding unselected, optional item prices.
  * @param product a DaffCompositeProduct
  * @param appliedOptions a Dictionary<DaffCompositeProductItemOption> that determines the current configuration of the composite product.
  */
@@ -158,7 +159,7 @@ function getMinPricesForConfiguration(product: DaffCompositeProduct, appliedOpti
 }
 
 /**
- * Gets the maximum prices of a composite product for the configuration provided.
+ * Gets the maximum prices of a composite product for the configuration provided excluding unselected, optional item prices.
  * @param product a DaffCompositeProduct
  * @param appliedOptions a Dictionary<DaffCompositeProductItemOption> that determines the current configuration of the composite product.
  */

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -140,10 +140,7 @@ function getMinPricesForConfiguration(product: DaffCompositeProduct, appliedOpti
 		discountedPrice: product.items.reduce((acc, item) => daffAdd(
 			acc, 
 			appliedOptions && appliedOptions[item.id] ? 
-				daffMultiply(
-					appliedOptions[item.id].discount ? daffSubtract(appliedOptions[item.id].price, appliedOptions[item.id].discount.amount) : appliedOptions[item.id].price, 
-					appliedOptions[item.id].quantity
-				) : 
+				daffMultiply(getDiscountedPrice(appliedOptions[item.id]), appliedOptions[item.id].quantity) : 
 				getMinimumRequiredCompositeItemDiscountedPrice(item)
 		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },
@@ -168,10 +165,7 @@ function getMaxPricesForConfiguration(product: DaffCompositeProduct, appliedOpti
 		discountedPrice: product.items.reduce((acc, item) => daffAdd(
 			acc, 
 			appliedOptions && appliedOptions[item.id] ? 
-				daffMultiply(
-					appliedOptions[item.id].discount ? daffSubtract(appliedOptions[item.id].price, appliedOptions[item.id].discount.amount) : appliedOptions[item.id].price, 
-					appliedOptions[item.id].quantity
-				) : 
+				daffMultiply(getDiscountedPrice(appliedOptions[item.id]), appliedOptions[item.id].quantity) : 
 				getMaximumRequiredCompositeItemDiscountedPrice(item)
 		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -1,51 +1,25 @@
 import { BehaviorSubject } from 'rxjs';
 
-import { DaffCompositeProductFacadeInterface, DaffCompositeProductItemOption, DaffCompositeProduct, DaffCompositeProductItem } from '@daffodil/product';
+import { 
+	DaffCompositeProductFacadeInterface, 
+	DaffCompositeProductItemOption, 
+	DaffCompositeProduct, 
+	DaffCompositeProductItem,
+	DaffPriceRange,
+	DaffCompositeConfigurationItem
+} from '@daffodil/product';
 import { Dictionary } from '@ngrx/entity';
 
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
-	getMinPossiblePrice(id: string): BehaviorSubject<number> {
+	getPricesForConfiguration(id: string, configuration: Dictionary<DaffCompositeConfigurationItem>): BehaviorSubject<DaffPriceRange> {
 		return new BehaviorSubject(null);
-	};
-	getMaxPossiblePrice(id: string): BehaviorSubject<number> {
+	}
+	getPrices(id: string): BehaviorSubject<DaffPriceRange> {
 		return new BehaviorSubject(null);
-	};
-	possiblyHasPriceRange(id: string): BehaviorSubject<boolean> {
-		return new BehaviorSubject(false);
-	};
-	getMinPossibleDiscountedPrice(id: string): BehaviorSubject<number> {
+	}
+	getPricesAsCurrentlyConfigured(id: string): BehaviorSubject<DaffPriceRange> {
 		return new BehaviorSubject(null);
-	};
-	getMaxPossibleDiscountedPrice(id: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
-	};
-	possiblyHasDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
-		return new BehaviorSubject(false);
-	};
-	possiblyHasDiscount(id: string): BehaviorSubject<boolean> {
-		return new BehaviorSubject(false);
-	};
-	getMinRequiredItemPrice(id: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
-	};
-	getMaxRequiredItemPrice(id: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
-	};
-	hasRequiredItemPriceRange(id: string): BehaviorSubject<boolean> {
-		return new BehaviorSubject(false);
-	};
-	getMinRequiredItemDiscountedPrice(id: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
-	};
-	getMaxRequiredItemDiscountedPrice(id: string): BehaviorSubject<number> {
-		return new BehaviorSubject(null);
-	};
-	hasRequiredItemDiscountedPriceRange(id: string): BehaviorSubject<boolean> {
-		return new BehaviorSubject(false);
-	};
-	hasRequiredItemDiscount(id: string): BehaviorSubject<boolean> {
-		return new BehaviorSubject(false);
-	};
+	}
 	getAppliedOptions(id: string): BehaviorSubject<Dictionary<DaffCompositeProductItemOption>> {
 		return new BehaviorSubject({});
 	}
@@ -53,4 +27,7 @@ export class MockDaffCompositeProductFacade implements DaffCompositeProductFacad
 		return new BehaviorSubject(false);
 	}
 	dispatch(action) {};
+
+	hasDiscount(priceRange: DaffPriceRange) {};
+	hasPriceRange(priceRange: DaffPriceRange) {};
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
The composite product selectors are now replaced with 
`selectCompositeProductPricesForConfiguration`, 
`selectCompositeProductPrices`,
`selectCompositeProductPricesAsCurrentlyConfigured`

and two functions:
`productPriceRangeHasDiscount`,
`productPriceRangeHasPriceRange`


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information
- I decided against using a union type (of `DaffPriceRange` and `DaffPrice`) for the return type of the selectors (Damien and I had originally planned on this). I'm actually sure if this is even accurately called a "union" type, because the two types don't share anything in common. It turned out that in order to decide whether to return a `DaffPriceRange` or a `DaffPrice`, I would basically need to pass the final value (a `DaffPriceRange`) into the `productPriceRangeHasPriceRange` helper function, then rebuild the object into a `DaffPrice` if it is not a range of prices. Then the app dev would need to call some function to find out if they're being passed a `DaffPriceRange` or a `DaffPrice` anyway. I figure it's easier for us to just pass the app dev a `DaffPriceRange`, have them call the `productPriceRangeHasPriceRange` function through the facade, then just have them access the minimum values as if it was the only price given (since they now know the min and max prices are equal).
- I made the discounts null for both the amount and percent, because those values really don't make any sense with the composite product. Because each option can have different prices and discounts, the discount amount ceases to mean anything once it is disassociated from a particular item option. For example, one item option might be really cheap ($4), and has a small discount ($0.50). If another option is more expensive ($10) with a large discount ($9), the largest discount amount won't make any sense to the end user. They would see something like 
```
Original Price: $4 - $10; 
DiscountedPrice: $1-$3.5; 
discount of $0.5-9$
``` 
It isn't very obvious how the discount amount is derived from the original and discounted prices. 