### PR TITLE
fix(cart): make cart discounts separate and give their label more spe…

### DIFF
--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.spec.ts
@@ -57,11 +57,11 @@ describe('transformCartTotals', () => {
 					label: 'Tax',
 					value: totalTax
 				},
-				{
+				...stubMagentoCart.prices.discounts.map(discount => ({
 					name: DaffCartTotalTypeEnum.discount,
-					label: 'Discount',
-					value: stubMagentoCart.prices.discounts.reduce((acc, discount) => (daffAdd(acc, discount.amount.value)), 0)
-				},
+					label: discount.label,
+					value: discount.amount.value
+				})),
 				{
 					name: DaffCartTotalTypeEnum.shipping,
 					label: 'Shipping',
@@ -106,11 +106,6 @@ describe('transformCartTotals', () => {
 				{
 					name: DaffCartTotalTypeEnum.tax,
 					label: 'Tax',
-					value: 0
-				},
-				{
-					name: DaffCartTotalTypeEnum.discount,
-					label: 'Discount',
 					value: 0
 				},
 				{
@@ -162,11 +157,6 @@ describe('transformCartTotals', () => {
 				{
 					name: DaffCartTotalTypeEnum.tax,
 					label: 'Tax',
-					value: 0
-				},
-				{
-					name: DaffCartTotalTypeEnum.discount,
-					label: 'Discount',
 					value: 0
 				},
 				{

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-totals-transformer.ts
@@ -2,7 +2,7 @@ import { daffAdd } from '@daffodil/core';
 
 import { MagentoCart } from '../../models/outputs/cart';
 import { DaffCart } from '../../../../models/cart';
-import { DaffCartTotalTypeEnum } from '../../../../models/cart-total';
+import { DaffCartTotal, DaffCartTotalTypeEnum } from '../../../../models/cart-total';
 
 export function transformCartTotals(cart: Partial<MagentoCart>): {totals: DaffCart['totals']} {
 	const totalTax = cart.prices.applied_taxes ? cart.prices.applied_taxes.reduce((acc, tax) => (daffAdd(acc, tax.amount.value)), 0) : 0;
@@ -40,11 +40,7 @@ export function transformCartTotals(cart: Partial<MagentoCart>): {totals: DaffCa
 				label: 'Tax',
 				value: totalTax
 			},
-			{
-				name: DaffCartTotalTypeEnum.discount,
-				label: 'Discount',
-				value: cart.prices.discounts ? cart.prices.discounts.reduce((acc, discount) => (daffAdd(acc, discount.amount.value)), 0) : 0
-			},
+			...transformDiscounts(cart.prices.discounts),
 			{
 				name: DaffCartTotalTypeEnum.shipping,
 				label: 'Shipping',
@@ -52,6 +48,14 @@ export function transformCartTotals(cart: Partial<MagentoCart>): {totals: DaffCa
 			}
 		],
 	}
+}
+
+function transformDiscounts(discounts): DaffCartTotal[] {
+	return discounts ? discounts.map(discount => ({
+		name: DaffCartTotalTypeEnum.discount,
+		label: discount.label,
+		value: discount.amount.value
+	})) : [];
 }
 
 function validateSelectedShippingAddress(cart: Partial<MagentoCart>): boolean {

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart.service.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart.service.spec.ts
@@ -191,11 +191,11 @@ describe('Driver | Magento | Cart | Transformer | MagentoCart', () => {
 						label: 'Tax',
 						value: totalTax
 					},
-					{
+					...mockMagentoCart.prices.discounts.map(discount => ({
 						name: DaffCartTotalTypeEnum.discount,
-						label: 'Discount',
-						value: mockMagentoCart.prices.discounts.reduce((acc, discount) => (daffAdd(acc, discount.amount.value)), 0)
-					},
+						label: discount.label,
+						value: discount.amount.value
+					})),
 					{
 						name: DaffCartTotalTypeEnum.shipping,
 						label: 'Shipping',

--- a/libs/cart/src/facades/cart/cart-facade.interface.ts
+++ b/libs/cart/src/facades/cart/cart-facade.interface.ts
@@ -181,7 +181,7 @@ export interface DaffCartFacadeInterface<
   subtotalIncludingTax$: Observable<DaffCartTotal['value']>;
   subtotalWithDiscountExcludingTax$: Observable<DaffCartTotal['value']>;
   subtotalWithDiscountIncludingTax$: Observable<DaffCartTotal['value']>;
-  totalDiscount$: Observable<DaffCartTotal['value']>;
+  discountTotals$: Observable<DaffCartTotal[]>;
   totalTax$: Observable<DaffCartTotal['value']>;
   shippingTotal$: Observable<DaffCartTotal['value']>;
   coupons$: Observable<DaffCart['coupons']>;

--- a/libs/cart/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/src/facades/cart/cart.facade.spec.ts
@@ -970,13 +970,13 @@ describe('DaffCartFacade', () => {
     });
   });
 
-  describe('totalDiscount$', () => {
+  describe('discountTotals$', () => {
 
-    it('should be the cart total discount upon a successful cart load', () => {
+    it('should be the cart discount totals upon a successful cart load', () => {
       const cart = cartFactory.create();
-      const expected = cold('a', { a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.discount).value });
+      const expected = cold('a', { a: cart.totals.filter(total => total.name === DaffCartTotalTypeEnum.discount) });
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      expect(facade.totalDiscount$).toBeObservable(expected);
+      expect(facade.discountTotals$).toBeObservable(expected);
     });
   });
 

--- a/libs/cart/src/facades/cart/cart.facade.ts
+++ b/libs/cart/src/facades/cart/cart.facade.ts
@@ -15,7 +15,7 @@ import { DaffConfigurableCartItemAttribute } from '../../models/configurable-car
 import { DaffCompositeCartItemOption } from '../../models/composite-cart-item';
 import { DaffCartTotal } from '../../models/cart-total';
 import { DaffCartPaymentMethodIdMap } from '../../injection-tokens/public_api';
-import { filter, map, tap } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { DaffCartLoading } from '../../reducers/loading/cart-loading.type';
 
 @Injectable({
@@ -77,7 +77,7 @@ export class DaffCartFacade<
   subtotalIncludingTax$: Observable<DaffCartTotal['value']>;
   subtotalWithDiscountExcludingTax$: Observable<DaffCartTotal['value']>;
   subtotalWithDiscountIncludingTax$: Observable<DaffCartTotal['value']>;
-  totalDiscount$: Observable<DaffCartTotal['value']>;
+  discountTotals$: Observable<DaffCartTotal[]>;
   totalTax$: Observable<DaffCartTotal['value']>;
   shippingTotal$: Observable<DaffCartTotal['value']>;
   coupons$: Observable<DaffCart['coupons']>;
@@ -170,7 +170,7 @@ export class DaffCartFacade<
 			selectCartSubtotalIncludingTax,
 			selectCartSubtotalWithDiscountExcludingTax,
 			selectCartSubtotalWithDiscountIncludingTax,
-			selectCartTotalDiscount,
+			selectCartDiscountTotals,
 			selectCartTotalTax,
 			selectCartShippingTotal,
 			selectCartCoupons,
@@ -261,7 +261,7 @@ export class DaffCartFacade<
     this.subtotalIncludingTax$ = this.store.pipe(select(selectCartSubtotalIncludingTax));
     this.subtotalWithDiscountExcludingTax$ = this.store.pipe(select(selectCartSubtotalWithDiscountExcludingTax));
     this.subtotalWithDiscountIncludingTax$ = this.store.pipe(select(selectCartSubtotalWithDiscountIncludingTax));
-    this.totalDiscount$ = this.store.pipe(select(selectCartTotalDiscount));
+    this.discountTotals$ = this.store.pipe(select(selectCartDiscountTotals));
     this.totalTax$ = this.store.pipe(select(selectCartTotalTax));
     this.shippingTotal$ = this.store.pipe(select(selectCartShippingTotal));
     this.coupons$ = this.store.pipe(select(selectCartCoupons));

--- a/libs/cart/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/src/selectors/cart/cart.selector.spec.ts
@@ -90,7 +90,7 @@ describe('Cart | Selector | Cart', () => {
 		selectCartSubtotalWithDiscountExcludingTax,
 		selectCartSubtotalWithDiscountIncludingTax,
 		selectCartTotalTax,
-		selectCartTotalDiscount,
+		selectCartDiscountTotals,
 		selectCartShippingTotal,
 		selectCartCoupons,
 		selectCartItems,
@@ -1324,10 +1324,10 @@ describe('Cart | Selector | Cart', () => {
     });
   });
 
-  describe('selectCartTotalDiscount', () => {
-    it('returns cart total discount', () => {
-      const selector = store.pipe(select(selectCartTotalDiscount));
-      const expected = cold('a', {a: cart.totals.find(total => total.name === DaffCartTotalTypeEnum.discount).value});
+  describe('selectCartDiscountTotals', () => {
+    it('returns cart discount totals', () => {
+      const selector = store.pipe(select(selectCartDiscountTotals));
+      const expected = cold('a', {a: cart.totals.filter(total => total.name === DaffCartTotalTypeEnum.discount)});
 
       expect(selector).toBeObservable(expected);
     });

--- a/libs/cart/src/selectors/cart/cart.selector.ts
+++ b/libs/cart/src/selectors/cart/cart.selector.ts
@@ -183,7 +183,10 @@ export interface DaffCartStateMemoizedSelectors<
 	selectCartSubtotalWithDiscountExcludingTax: MemoizedSelector<object, DaffCartTotal['value']>;
 	selectCartSubtotalWithDiscountIncludingTax: MemoizedSelector<object, DaffCartTotal['value']>;
 	selectCartTotalTax: MemoizedSelector<object, DaffCartTotal['value']>;
-	selectCartTotalDiscount: MemoizedSelector<object, DaffCartTotal['value']>;
+	/**
+	 * Selects the DaffCartTotals for cart discounts. These are discounts associated with coupon codes.
+	 */
+	selectCartDiscountTotals: MemoizedSelector<object, DaffCartTotal[]>;
 	selectCartShippingTotal: MemoizedSelector<object, DaffCartTotal['value']>;
 	selectCartCoupons: MemoizedSelector<object, T['coupons']>;
 	selectCartItems: MemoizedSelector<object, T['items']>;
@@ -478,11 +481,11 @@ const createCartSelectors = <
 			return taxObject ? taxObject.value : null;
 		}
 	);
-	const selectCartTotalDiscount = createSelector(
+	const selectCartDiscountTotals = createSelector(
 		selectCartValue,
 		(state: DaffCartReducerState<T>['cart']) => {
-			const discountObject = state.totals.find(total => total.name === DaffCartTotalTypeEnum.discount);
-			return discountObject ? discountObject.value : null;
+			const discounts: DaffCartTotal[] = state.totals.filter(total => total.name === DaffCartTotalTypeEnum.discount);
+			return discounts ? discounts : [];
 		}
 	);
 	const selectCartShippingTotal = createSelector(
@@ -642,7 +645,7 @@ const createCartSelectors = <
 		selectCartSubtotalIncludingTax,
 		selectCartSubtotalWithDiscountExcludingTax,
 		selectCartSubtotalWithDiscountIncludingTax,
-		selectCartTotalDiscount,
+		selectCartDiscountTotals,
 		selectCartTotalTax,
 		selectCartShippingTotal,
 		selectCartCoupons,

--- a/libs/cart/testing/src/helpers/mock-cart-facade.ts
+++ b/libs/cart/testing/src/helpers/mock-cart-facade.ts
@@ -67,7 +67,7 @@ export class MockDaffCartFacade implements DaffCartFacadeInterface {
   subtotalIncludingTax$: BehaviorSubject<DaffCartTotal['value']> = new BehaviorSubject(null);
   subtotalWithDiscountExcludingTax$: BehaviorSubject<DaffCartTotal['value']> = new BehaviorSubject(null);
   subtotalWithDiscountIncludingTax$: BehaviorSubject<DaffCartTotal['value']> = new BehaviorSubject(null);
-  totalDiscount$: BehaviorSubject<DaffCartTotal['value']> = new BehaviorSubject(null);
+  discountTotals$: BehaviorSubject<DaffCartTotal[]> = new BehaviorSubject([]);
   totalTax$: BehaviorSubject<DaffCartTotal['value']> = new BehaviorSubject(null);
   shippingTotal$: BehaviorSubject<DaffCartTotal['value']> = new BehaviorSubject(null);
   coupons$: BehaviorSubject<DaffCart['coupons']> = new BehaviorSubject([]);


### PR DESCRIPTION
…cificity

BREAKING CHANGE: The DaffCartFacade.totalDiscount is now DaffCartFacade.discountTotals and is an array of DaffCartTotal instead of a single number. Similarly the getDaffCartSelectors.selectCartTotalDiscount is now selectCartDiscountTotals.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The cart discounts are all being added together into a single value.

## What is the new behavior?
The cart discounts are separated into different `DaffCartTotal`s, and are identified by their discount code label.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```