### PR TITLE
feat(cart): add option_id to the DaffCompositeCartItemOption

### DIFF
--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-item/bundle-cart-item-transformer.spec.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-item/bundle-cart-item-transformer.spec.ts
@@ -14,6 +14,7 @@ describe('transformMagentoBundleCartItem', () => {
 	});
 	
 	it('should return the expected composite product', () => {
+		expect(transformedCartItem.options[0].option_id).toEqual(stubMagentoBundleCartItem.bundle_options[0].id.toString());
 		expect(transformedCartItem.options[0].option_label).toEqual(stubMagentoBundleCartItem.bundle_options[0].label);
 		expect(transformedCartItem.options[0].value_label).toEqual(stubMagentoBundleCartItem.bundle_options[0].values[0].label);
 	});

--- a/libs/cart/src/drivers/magento/transforms/outputs/cart-item/bundle-cart-item-transformer.ts
+++ b/libs/cart/src/drivers/magento/transforms/outputs/cart-item/bundle-cart-item-transformer.ts
@@ -18,6 +18,7 @@ export function transformMagentoBundleCartItem(bundleCartItem: MagentoBundleCart
 
 function transformBundleCartItemOption(option: MagentoBundleCartItem['bundle_options'][0]): DaffCompositeCartItemOption {
 	return {
+		option_id: option.id.toString(),
 		option_label: option.label,
 		value_label: option.values[0].label
 	}

--- a/libs/cart/src/models/composite-cart-item.ts
+++ b/libs/cart/src/models/composite-cart-item.ts
@@ -6,6 +6,7 @@ export interface DaffCompositeCartItem extends DaffCartItem {
 }
 
 export interface DaffCompositeCartItemOption {
+	option_id: string;
 	option_label: string;
 	value_label: string;
 }

--- a/libs/cart/testing/src/factories/cart-item/composite-cart-item.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart-item/composite-cart-item.factory.spec.ts
@@ -38,6 +38,7 @@ describe('Cart | Testing | Factories | CompositeCartItemFactory', () => {
       expect(result.price).not.toBeNull();
       expect(result.row_total).not.toBeNull();
       expect(result.total_discount).not.toBeNull();
+      expect(result.options[0].option_id).not.toBeNull();
       expect(result.options[0].option_label).not.toBeNull();
       expect(result.options[0].value_label).not.toBeNull();
     });

--- a/libs/cart/testing/src/factories/cart-item/composite-cart-item.factory.ts
+++ b/libs/cart/testing/src/factories/cart-item/composite-cart-item.factory.ts
@@ -9,10 +9,12 @@ export class MockCompositeCartItem extends MockCartItem implements DaffComposite
 	type = DaffCartItemInputType.Composite;
 	options = [
 		{
+			option_id: faker.random.number(1000).toString(),
 			option_label: faker.random.word(),
 			value_label: faker.random.word()
 		},
 		{
+			option_id: faker.random.number(1000).toString(),
 			option_label: faker.random.word(),
 			value_label: faker.random.word()
 		}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
This is to allow the app dev to identify composite products of the same product but with different item options. This should enable the app dev to add custom effects to cart items when they are added/mutated/etc.