### PR TITLE
feat(all): swap error names to compile-safe static codes

### DIFF
--- a/libs/auth/src/drivers/magento/auth.service.spec.ts
+++ b/libs/auth/src/drivers/magento/auth.service.spec.ts
@@ -17,7 +17,7 @@ import { DaffAccountRegistration } from '../../models/account-registration';
 import { DaffAuthToken } from '../../models/auth-token';
 import { DaffLoginInfo } from '../../models/login-info';
 import { checkTokenQuery, MagentoCheckTokenResponse } from './queries/public_api';
-import { DaffUnauthorizedError, DaffInvalidAPIResponseError } from '../../errors/public_api';
+import { DaffUnauthorizedError, DaffAuthInvalidAPIResponseError } from '../../errors/public_api';
 import * as validators from './validators/public_api';
 
 describe('Driver | Magento | Auth | AuthService', () => {
@@ -108,14 +108,14 @@ describe('Driver | Magento | Auth | AuthService', () => {
       describe('and the response fails validation', () => {
         beforeEach(() => {
           validatorSpy.and.callFake(() => {
-            throw new DaffInvalidAPIResponseError('Check token response is invalid.')
+            throw new DaffAuthInvalidAPIResponseError('Check token response is invalid.')
           });
         });
 
-        it('should throw a DaffInvalidAPIResponseError', done => {
+        it('should throw a DaffAuthInvalidAPIResponseError', done => {
           service.check().pipe(
             catchError(err => {
-              expect(err).toEqual(jasmine.any(DaffInvalidAPIResponseError));
+              expect(err).toEqual(jasmine.any(DaffAuthInvalidAPIResponseError));
               done();
               return [];
             })

--- a/libs/auth/src/drivers/magento/errors/map.ts
+++ b/libs/auth/src/drivers/magento/errors/map.ts
@@ -1,10 +1,10 @@
 import { DaffErrorCodeMap } from '@daffodil/core';
+import { DaffBadInputError } from '@daffodil/driver';
 
 import { MagentoAuthGraphQlErrorCode } from './codes';
 import {
   DaffUnauthorizedError,
   DaffAuthenticationFailedError,
-  DaffBadInputError
 } from '../../../errors/public_api';
 
 export const DaffAuthMagentoErrorMap: DaffErrorCodeMap = {

--- a/libs/auth/src/drivers/magento/login.service.spec.ts
+++ b/libs/auth/src/drivers/magento/login.service.spec.ts
@@ -26,7 +26,7 @@ import * as validators from './validators/public_api';
 import {
   DaffAuthenticationFailedError,
   DaffUnauthorizedError,
-  DaffInvalidAPIResponseError
+  DaffAuthInvalidAPIResponseError
 } from '../../errors/public_api';
 
 describe('Driver | Magento | Auth | LoginService', () => {
@@ -136,14 +136,14 @@ describe('Driver | Magento | Auth | LoginService', () => {
       describe('and the response fails validation', () => {
         beforeEach(() => {
           generateTokenValidatorSpy.and.callFake(() => {
-            throw new DaffInvalidAPIResponseError('Generate token response is invalid.')
+            throw new DaffAuthInvalidAPIResponseError('Generate token response is invalid.')
           });
         });
 
-        it('should throw a DaffInvalidAPIResponseError', done => {
+        it('should throw a DaffAuthInvalidAPIResponseError', done => {
           service.login(mockLoginInfo).pipe(
             catchError(err => {
-              expect(err).toEqual(jasmine.any(DaffInvalidAPIResponseError));
+              expect(err).toEqual(jasmine.any(DaffAuthInvalidAPIResponseError));
               done();
               return [];
             })
@@ -222,7 +222,7 @@ describe('Driver | Magento | Auth | LoginService', () => {
       describe('and the response fails validation', () => {
         beforeEach(() => {
           revokeTokenValidatorSpy.and.callFake(() => {
-            throw new DaffInvalidAPIResponseError('Revoke token response is invalid.')
+            throw new DaffAuthInvalidAPIResponseError('Revoke token response is invalid.')
           });
         });
 
@@ -230,7 +230,7 @@ describe('Driver | Magento | Auth | LoginService', () => {
         it('should throw an error', done => {
           service.logout().pipe(
             catchError(err => {
-              expect(err).toEqual(jasmine.any(DaffInvalidAPIResponseError));
+              expect(err).toEqual(jasmine.any(DaffAuthInvalidAPIResponseError));
               done();
               return [];
             })

--- a/libs/auth/src/drivers/magento/register.service.spec.ts
+++ b/libs/auth/src/drivers/magento/register.service.spec.ts
@@ -9,12 +9,12 @@ import { catchError } from 'rxjs/operators';
 import {
   DaffAccountRegistrationFactory,
 } from '@daffodil/auth/testing';
+import { DaffBadInputError } from '@daffodil/driver';
 
 import { DaffMagentoRegisterService } from './register.service';
 import { DaffAccountRegistration } from '../../models/account-registration';
 import { DaffLoginInfo } from '../../models/login-info';
 import { createCustomerMutation } from './queries/public_api';
-import { DaffBadInputError } from '../../errors/public_api';
 
 describe('Driver | Magento | Auth | RegisterService', () => {
   let controller: ApolloTestingController;

--- a/libs/auth/src/drivers/magento/validators/check-token.spec.ts
+++ b/libs/auth/src/drivers/magento/validators/check-token.spec.ts
@@ -2,7 +2,7 @@ import { ApolloQueryResult } from 'apollo-client';
 
 import { MagentoCheckTokenResponse } from '../queries/public_api';
 import { validateCheckTokenResponse as validator } from './check-token';
-import { DaffInvalidAPIResponseError } from '../../../errors/public_api';
+import { DaffAuthInvalidAPIResponseError } from '../../../errors/public_api';
 
 describe('Driver | Magento | Auth | Validator | CheckToken', () => {
   let response: ApolloQueryResult<MagentoCheckTokenResponse>;
@@ -33,8 +33,8 @@ describe('Driver | Magento | Auth | Validator | CheckToken', () => {
       response.data.customer.id = null;
     });
 
-    it('should throw a DaffInvalidAPIResponseError', () => {
-      expect(() => validator(response)).toThrow(jasmine.any(DaffInvalidAPIResponseError));
+    it('should throw a DaffAuthInvalidAPIResponseError', () => {
+      expect(() => validator(response)).toThrow(jasmine.any(DaffAuthInvalidAPIResponseError));
     });
   });
 });

--- a/libs/auth/src/drivers/magento/validators/check-token.ts
+++ b/libs/auth/src/drivers/magento/validators/check-token.ts
@@ -1,12 +1,12 @@
 import { ApolloQueryResult } from 'apollo-client';
 
 import { MagentoCheckTokenResponse } from '../queries/public_api';
-import { DaffInvalidAPIResponseError } from '../../../errors/public_api';
+import { DaffAuthInvalidAPIResponseError } from '../../../errors/public_api';
 
 export const validateCheckTokenResponse = (response: ApolloQueryResult<MagentoCheckTokenResponse>) => {
   if (response.data.customer.id) {
     return response
   } else {
-    throw new DaffInvalidAPIResponseError('Check token response does not contain a valid customer ID.')
+    throw new DaffAuthInvalidAPIResponseError('Check token response does not contain a valid customer ID.')
   }
 }

--- a/libs/auth/src/drivers/magento/validators/generate-token.spec.ts
+++ b/libs/auth/src/drivers/magento/validators/generate-token.spec.ts
@@ -2,7 +2,7 @@ import { ApolloQueryResult } from 'apollo-client';
 
 import { MagentoGenerateTokenResponse } from '../queries/public_api';
 import { validateGenerateTokenResponse as validator } from './generate-token';
-import { DaffInvalidAPIResponseError } from '../../../errors/public_api';
+import { DaffAuthInvalidAPIResponseError } from '../../../errors/public_api';
 
 describe('Driver | Magento | Auth | Validator | GenerateToken', () => {
   let response: ApolloQueryResult<MagentoGenerateTokenResponse>;
@@ -33,8 +33,8 @@ describe('Driver | Magento | Auth | Validator | GenerateToken', () => {
       response.data.generateCustomerToken.token = null;
     });
 
-    it('should throw a DaffInvalidAPIResponseError', () => {
-      expect(() => validator(response)).toThrow(jasmine.any(DaffInvalidAPIResponseError));
+    it('should throw a DaffAuthInvalidAPIResponseError', () => {
+      expect(() => validator(response)).toThrow(jasmine.any(DaffAuthInvalidAPIResponseError));
     });
   });
 });

--- a/libs/auth/src/drivers/magento/validators/generate-token.ts
+++ b/libs/auth/src/drivers/magento/validators/generate-token.ts
@@ -1,12 +1,12 @@
 import { ApolloQueryResult } from 'apollo-client';
 
 import { MagentoGenerateTokenResponse } from '../queries/public_api';
-import { DaffInvalidAPIResponseError } from '../../../errors/public_api';
+import { DaffAuthInvalidAPIResponseError } from '../../../errors/public_api';
 
 export const validateGenerateTokenResponse = (response: ApolloQueryResult<MagentoGenerateTokenResponse>) => {
   if (response.data.generateCustomerToken.token) {
     return response
   } else {
-    throw new DaffInvalidAPIResponseError('Generate token response does not contain an auth token.')
+    throw new DaffAuthInvalidAPIResponseError('Generate token response does not contain an auth token.')
   }
 }

--- a/libs/auth/src/drivers/magento/validators/revoke-token.spec.ts
+++ b/libs/auth/src/drivers/magento/validators/revoke-token.spec.ts
@@ -2,7 +2,7 @@ import { ApolloQueryResult } from 'apollo-client';
 
 import { MagentoRevokeCustomerTokenResponse } from '../queries/public_api';
 import { validateRevokeTokenResponse as validator } from './revoke-token';
-import { DaffInvalidAPIResponseError } from '../../../errors/public_api';
+import { DaffAuthInvalidAPIResponseError } from '../../../errors/public_api';
 
 describe('Driver | Magento | Auth | Validator | RevokeToken', () => {
   let response: ApolloQueryResult<MagentoRevokeCustomerTokenResponse>;
@@ -33,8 +33,8 @@ describe('Driver | Magento | Auth | Validator | RevokeToken', () => {
       response.data.revokeCustomerToken.result = false;
     });
 
-    it('should throw a DaffInvalidAPIResponseError', () => {
-      expect(() => validator(response)).toThrow(jasmine.any(DaffInvalidAPIResponseError));
+    it('should throw a DaffAuthInvalidAPIResponseError', () => {
+      expect(() => validator(response)).toThrow(jasmine.any(DaffAuthInvalidAPIResponseError));
     });
   });
 });

--- a/libs/auth/src/drivers/magento/validators/revoke-token.ts
+++ b/libs/auth/src/drivers/magento/validators/revoke-token.ts
@@ -1,12 +1,12 @@
 import { ApolloQueryResult } from 'apollo-client';
 
 import { MagentoRevokeCustomerTokenResponse } from '../queries/public_api';
-import { DaffInvalidAPIResponseError } from '../../../errors/public_api';
+import { DaffAuthInvalidAPIResponseError } from '../../../errors/public_api';
 
 export const validateRevokeTokenResponse = (response: ApolloQueryResult<MagentoRevokeCustomerTokenResponse>) => {
   if (response.data.revokeCustomerToken.result) {
     return response
   } else {
-    throw new DaffInvalidAPIResponseError('Revoke token response does not contain a successful result.')
+    throw new DaffAuthInvalidAPIResponseError('Revoke token response does not contain a successful result.')
   }
 }

--- a/libs/auth/src/effects/auth.effects.spec.ts
+++ b/libs/auth/src/effects/auth.effects.spec.ts
@@ -52,7 +52,7 @@ describe('DaffAuthEffects', () => {
   const authFactory: DaffAuthTokenFactory = new DaffAuthTokenFactory();
 
   const authStorageFailureAction = new DaffAuthStorageFailure('Storage of auth token has failed.');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   let mockAuth: DaffAuthToken;
   let mockLoginInfo: DaffLoginInfo;

--- a/libs/auth/src/errors/authentication-failed.ts
+++ b/libs/auth/src/errors/authentication-failed.ts
@@ -1,6 +1,7 @@
-export class DaffAuthenticationFailedError extends Error {
-	readonly name = 'DaffAuthenticationFailedError';
-  readonly code: string = 'AUTHENTICATION_FAILED';
+import { DaffError, DaffInheritableError } from '@daffodil/core';
+
+export class DaffAuthenticationFailedError extends DaffInheritableError implements DaffError {
+	public readonly code: string = 'DAFF_AUTH_AUTHENTICATION_FAILED';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/auth/src/errors/bad-input.ts
+++ b/libs/auth/src/errors/bad-input.ts
@@ -1,8 +1,0 @@
-export class DaffBadInputError extends Error {
-	readonly name = 'DaffBadInputError';
-  readonly code: string = 'BAD_INPUT';
-
-	constructor(public message: string) {
-		super(message);
-	}
-}

--- a/libs/auth/src/errors/invalid-api-response.ts
+++ b/libs/auth/src/errors/invalid-api-response.ts
@@ -1,6 +1,7 @@
-export class DaffInvalidAPIResponseError extends Error {
-	readonly name = 'DaffInvalidAPIResponseError';
-  readonly code: string = 'INVALID_API_RESPONSE';
+import { DaffError, DaffInheritableError } from '@daffodil/core';
+
+export class DaffAuthInvalidAPIResponseError extends DaffInheritableError implements DaffError {
+  public readonly code: string = 'DAFF_AUTH_INVALID_API_RESPONSE';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/auth/src/errors/public_api.ts
+++ b/libs/auth/src/errors/public_api.ts
@@ -1,4 +1,3 @@
 export { DaffUnauthorizedError } from './unauthorized';
 export { DaffAuthenticationFailedError } from './authentication-failed';
-export { DaffInvalidAPIResponseError } from './invalid-api-response';
-export { DaffBadInputError } from './bad-input';
+export { DaffAuthInvalidAPIResponseError } from './invalid-api-response';

--- a/libs/auth/src/errors/unauthorized.ts
+++ b/libs/auth/src/errors/unauthorized.ts
@@ -1,6 +1,7 @@
-export class DaffUnauthorizedError extends Error {
-	readonly name = 'DaffUnauthorizedError';
-  readonly code: string = 'UNAUTHORIZED';
+import { DaffError, DaffInheritableError } from '@daffodil/core';
+
+export class DaffUnauthorizedError extends DaffInheritableError implements DaffError {
+	public readonly code: string = 'DAFF_AUTH_UNAUTHORIZED';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/cart/src/effects/cart-address.effects.spec.ts
+++ b/libs/cart/src/effects/cart-address.effects.spec.ts
@@ -37,7 +37,7 @@ describe('Daffodil | Cart | CartAddressEffects', () => {
 
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
   const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/libs/cart/src/effects/cart-address.effects.ts
+++ b/libs/cart/src/effects/cart-address.effects.ts
@@ -32,7 +32,7 @@ export class DaffCartAddressEffects<T extends DaffCartAddress, V extends DaffCar
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.update(cartId, action.payload)),
       map((resp: V) => new DaffCartAddressUpdateSuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartAddressUpdateFailure('Failed to update cart address')
       )),

--- a/libs/cart/src/effects/cart-coupon.effects.spec.ts
+++ b/libs/cart/src/effects/cart-coupon.effects.spec.ts
@@ -50,7 +50,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
 
   const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/libs/cart/src/effects/cart-coupon.effects.ts
+++ b/libs/cart/src/effects/cart-coupon.effects.ts
@@ -46,7 +46,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.apply(cartId, action.payload)),
       map(resp => new DaffCartCouponApplySuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponApplyFailure('Failed to apply coupon to cart')
       )),
@@ -60,7 +60,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.list(cartId)),
       map(resp => new DaffCartCouponListSuccess<V>(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponListFailure('Failed to list coupons')
       )),
@@ -74,7 +74,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.remove(cartId, action.payload)),
       map(resp => new DaffCartCouponRemoveSuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponRemoveFailure('Failed to remove a coupon from the cart')
       )),
@@ -88,7 +88,7 @@ export class DaffCartCouponEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.removeAll(cartId)),
       map(resp => new DaffCartCouponRemoveAllSuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartCouponRemoveAllFailure('Failed to remove all coupons from the cart')
       )),

--- a/libs/cart/src/effects/cart-order.effects.spec.ts
+++ b/libs/cart/src/effects/cart-order.effects.spec.ts
@@ -42,7 +42,7 @@ describe('Cart | Effect | CartOrderEffects', () => {
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
 
   const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/libs/cart/src/effects/cart-order.effects.ts
+++ b/libs/cart/src/effects/cart-order.effects.ts
@@ -40,7 +40,7 @@ export class DaffCartOrderEffects<
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.placeOrder(cartId, action.payload)),
       map((resp: R) => new DaffCartPlaceOrderSuccess<R>(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartPlaceOrderFailure('Failed to place order')
       )),

--- a/libs/cart/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.spec.ts
@@ -22,7 +22,7 @@ import {
   DaffCartCreateSuccess,
   DaffResolveCartFailure
 } from '../actions/public_api';
-import { DaffCartNotFoundError } from '../errors/not-found';
+import { DaffCartNotFoundError } from '../errors/cart-not-found';
 
 describe('DaffCartResolverEffects', () => {
 	let actions$: Observable<any>;
@@ -34,7 +34,7 @@ describe('DaffCartResolverEffects', () => {
 
   let cartStorageService: jasmine.SpyObj<DaffCartStorageService>;
   const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({

--- a/libs/cart/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/src/effects/cart-resolver.effects.ts
@@ -22,7 +22,7 @@ import {
 import { DaffCartStorageService } from '../storage/cart-storage.service';
 import { DaffCartDriver, DaffCartServiceInterface } from '../drivers/public_api';
 import { DaffCart } from '../models/cart';
-import { DaffCartNotFoundError } from '../errors/not-found';
+import { DaffCartNotFoundError } from '../errors/cart-not-found';
 
 /**
  * An effect for resolving the Cart. It will check local state for a cart id, and retrieve the cart if it exists. If a cart
@@ -48,10 +48,10 @@ export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
         return of(new DaffCartLoadSuccess(resp))
       }),
       catchError(error => {
-        switch(error.name) {
-          case DaffStorageServiceError.name:
-            return of(new DaffCartStorageFailure('Cart Storage Failed'))
-          case DaffCartNotFoundError.name:
+        switch(true) {
+          case error instanceof DaffStorageServiceError:
+            return of(new DaffCartStorageFailure('Cart Storage Failed'));
+          case error instanceof DaffCartNotFoundError:
             return of(new DaffCartCreate());
           default:
             return of(new DaffCartLoadFailure('Cart loading has failed'));

--- a/libs/cart/src/effects/cart.effects.spec.ts
+++ b/libs/cart/src/effects/cart.effects.spec.ts
@@ -44,7 +44,7 @@ describe('Daffodil | Cart | CartEffects', () => {
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
 
   const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
-  const throwStorageError = () => { throw new DaffStorageServiceError() };
+  const throwStorageError = () => { throw new DaffStorageServiceError('message') };
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/libs/cart/src/effects/cart.effects.ts
+++ b/libs/cart/src/effects/cart.effects.ts
@@ -65,7 +65,7 @@ export class DaffCartEffects<T extends DaffCart> {
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.get(cartId)),
       map((resp: T) => new DaffCartLoadSuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartLoadFailure('Failed to load cart')
       )),
@@ -90,7 +90,7 @@ export class DaffCartEffects<T extends DaffCart> {
       map(() => this.storage.getCartId()),
       switchMap(cartId => this.driver.clear(cartId)),
       map((resp: T) => new DaffCartClearSuccess(resp)),
-      catchError(error => of(error.name === DaffStorageServiceError.name
+      catchError(error => of(error instanceof DaffStorageServiceError
         ? new DaffCartStorageFailure('Cart Storage Failed')
         : new DaffCartClearFailure('Failed to clear the cart.')
       )),

--- a/libs/cart/src/errors/cart-not-found.ts
+++ b/libs/cart/src/errors/cart-not-found.ts
@@ -1,0 +1,9 @@
+import { DaffError, DaffInheritableError } from '@daffodil/core';
+
+export class DaffCartNotFoundError extends DaffInheritableError implements DaffError {
+	public readonly code: string = 'DAFF_CART_NOT_FOUND';
+
+	constructor(message?: string) {
+		super(message);
+	}
+}

--- a/libs/cart/src/errors/not-found.ts
+++ b/libs/cart/src/errors/not-found.ts
@@ -1,8 +1,0 @@
-export class DaffCartNotFoundError extends Error {
-	readonly name = 'DaffCartNotFoundError';
-  readonly code: string = 'CART_NOT_FOUND';
-
-	constructor(public message: string) {
-		super(message);
-	}
-}

--- a/libs/cart/src/errors/public_api.ts
+++ b/libs/cart/src/errors/public_api.ts
@@ -1,1 +1,1 @@
-export { DaffCartNotFoundError } from './not-found';
+export { DaffCartNotFoundError } from './cart-not-found';

--- a/libs/core/src/errors/inheritable-error.spec.ts
+++ b/libs/core/src/errors/inheritable-error.spec.ts
@@ -1,0 +1,15 @@
+import { DaffInheritableError } from './inheritable-error';
+
+class MockError extends DaffInheritableError {}
+
+describe('Core | Error | DaffInheritableError', () => {
+  let mockError: MockError;
+
+  beforeEach(() => {
+    mockError = new MockError();
+  });
+
+  it('should detect the error class with instanceof', () => {
+    expect(mockError instanceof MockError).toBeTruthy();
+  });
+});

--- a/libs/core/src/errors/inheritable-error.ts
+++ b/libs/core/src/errors/inheritable-error.ts
@@ -1,0 +1,27 @@
+/**
+ * A class which allows you to appropriately check the inheritance of an error.
+ * 
+ * In typescript, when you try to extend an error with a specialized error class,
+ * if you try to call something like:
+ * 
+ * ```ts
+ * class MyError extends Error {}
+ * 
+ * let myError = new MyError();
+ * 
+ * myError instanceof MyError; // returns false
+ * ```
+ * 
+ * You will see unexpected things. This class fixes that issue as described here
+ * https://github.com/microsoft/TypeScript/issues/13965
+ */
+export class DaffInheritableError extends Error {
+	__proto__: Error;
+
+	constructor(message?: string) {
+		const trueProto = new.target.prototype;
+		super(message);
+
+		Object.setPrototypeOf(this, trueProto);
+	}
+}

--- a/libs/core/src/errors/public_api.ts
+++ b/libs/core/src/errors/public_api.ts
@@ -1,2 +1,3 @@
 export { DaffErrorCodeMap } from './error-map';
 export { DaffError } from './error.interface';
+export { DaffInheritableError } from './inheritable-error';

--- a/libs/core/src/storage/error/error.ts
+++ b/libs/core/src/storage/error/error.ts
@@ -1,3 +1,9 @@
-export class DaffStorageServiceError extends Error {
-  readonly name = 'DaffStorageServiceError';
+import { DaffError, DaffInheritableError } from '../../errors/public_api';
+
+export class DaffStorageServiceError extends DaffInheritableError implements DaffError {
+  public readonly code: string = 'DAFF_STORAGE_FAILURE';
+
+	constructor(public message: string) {
+		super(message);
+	}
 }

--- a/libs/driver/magento/src/errors/transform.spec.ts
+++ b/libs/driver/magento/src/errors/transform.spec.ts
@@ -1,12 +1,11 @@
 import { ApolloError } from 'apollo-client';
 
-import { DaffErrorCodeMap } from '@daffodil/core';
+import { DaffError, DaffErrorCodeMap, DaffInheritableError } from '@daffodil/core';
 
 import { daffTransformMagentoError } from './transform';
 
-class MockError extends Error {
-  readonly name = 'MockError';
-  readonly code: string = 'MOCK';
+class MockError extends DaffInheritableError implements DaffError {
+	public readonly code: string = 'MOCK';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/driver/src/errors/bad-input.ts
+++ b/libs/driver/src/errors/bad-input.ts
@@ -1,6 +1,7 @@
-export class DaffBadInputError extends Error {
-	readonly name = 'DaffBadInputError';
-  readonly code: string = 'BAD_INPUT';
+import { DaffError, DaffInheritableError } from '@daffodil/core';
+
+export class DaffBadInputError extends DaffInheritableError implements DaffError {
+  public readonly code: string = 'DAFF_BAD_INPUT';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/geography/src/drivers/magento/geography.service.spec.ts
+++ b/libs/geography/src/drivers/magento/geography.service.spec.ts
@@ -18,7 +18,7 @@ import { getCountries, MagentoGetCountriesResponse } from './queries/public_api'
 import { MagentoRegion, MagentoCountry } from './models/responses/public_api';
 import { getCountry } from './queries/get-country';
 import { MagentoGetCountryResponse } from './queries/responses/get-country';
-import { DaffCountryNotFoundError, DaffInvalidAPIResponseError } from '../../errors/public_api';
+import { DaffCountryNotFoundError, DaffGeographyInvalidAPIResponseError } from '../../errors/public_api';
 import * as validators from './validators/public_api';
 
 describe('Driver | Magento | Geography | GeographyService', () => {
@@ -192,14 +192,14 @@ describe('Driver | Magento | Geography | GeographyService', () => {
       describe('and the response fails validation', () => {
         beforeEach(() => {
           validatorSpy.and.callFake(() => {
-            throw new DaffInvalidAPIResponseError('Get countries response does not contain a valid list of countries.')
+            throw new DaffGeographyInvalidAPIResponseError('Get countries response does not contain a valid list of countries.')
           });
         });
 
-        it('should throw a DaffInvalidAPIResponseError', done => {
+        it('should throw a DaffGeographyInvalidAPIResponseError', done => {
           service.list().pipe(
             catchError(err => {
-              expect(err).toEqual(jasmine.any(DaffInvalidAPIResponseError));
+              expect(err).toEqual(jasmine.any(DaffGeographyInvalidAPIResponseError));
               done();
               return [];
             })

--- a/libs/geography/src/drivers/magento/validators/get-countries.spec.ts
+++ b/libs/geography/src/drivers/magento/validators/get-countries.spec.ts
@@ -2,7 +2,7 @@ import { ApolloQueryResult } from 'apollo-client';
 
 import { MagentoGetCountriesResponse } from '../queries/public_api';
 import { validateGetCountriesResponse as validator } from './get-countries';
-import { DaffInvalidAPIResponseError } from '../../../errors/public_api';
+import { DaffGeographyInvalidAPIResponseError } from '../../../errors/public_api';
 
 describe('Driver | Magento | Auth | Validator | CheckToken', () => {
   let response: ApolloQueryResult<MagentoGetCountriesResponse>;
@@ -31,8 +31,8 @@ describe('Driver | Magento | Auth | Validator | CheckToken', () => {
       response.data.countries = null;
     });
 
-    it('should throw a DaffInvalidAPIResponseError', () => {
-      expect(() => validator(response)).toThrow(jasmine.any(DaffInvalidAPIResponseError));
+    it('should throw a DaffGeographyInvalidAPIResponseError', () => {
+      expect(() => validator(response)).toThrow(jasmine.any(DaffGeographyInvalidAPIResponseError));
     });
   });
 });

--- a/libs/geography/src/drivers/magento/validators/get-countries.ts
+++ b/libs/geography/src/drivers/magento/validators/get-countries.ts
@@ -1,12 +1,12 @@
 import { ApolloQueryResult } from 'apollo-client';
 
 import { MagentoGetCountriesResponse } from '../queries/public_api';
-import { DaffInvalidAPIResponseError } from '../../../errors/public_api';
+import { DaffGeographyInvalidAPIResponseError } from '../../../errors/public_api';
 
 export const validateGetCountriesResponse = (response: ApolloQueryResult<MagentoGetCountriesResponse>) => {
   if (response.data.countries) {
     return response
   } else {
-    throw new DaffInvalidAPIResponseError('Get countries response does not contain a valid list of countries.')
+    throw new DaffGeographyInvalidAPIResponseError('Get countries response does not contain a valid list of countries.')
   }
 }

--- a/libs/geography/src/errors/country-not-found.ts
+++ b/libs/geography/src/errors/country-not-found.ts
@@ -1,0 +1,9 @@
+import { DaffError, DaffInheritableError } from '@daffodil/core';
+
+export class DaffCountryNotFoundError extends DaffInheritableError implements DaffError {
+  public readonly code: string = 'DAFF_GEOGRAPHY_COUNTRY_NOT_FOUND';
+
+	constructor(public message: string) {
+		super(message);
+	}
+}

--- a/libs/geography/src/errors/invalid-api-response.ts
+++ b/libs/geography/src/errors/invalid-api-response.ts
@@ -1,6 +1,7 @@
-export class DaffInvalidAPIResponseError extends Error {
-	readonly name = 'DaffInvalidAPIResponseError';
-  readonly code: string = 'INVALID_API_RESPONSE';
+import { DaffError, DaffInheritableError } from '@daffodil/core';
+
+export class DaffGeographyInvalidAPIResponseError extends DaffInheritableError implements DaffError {
+  public readonly code: string = 'DAFF_GEOGRAPHY_INVALID_API_RESPONSE';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/geography/src/errors/not-found.ts
+++ b/libs/geography/src/errors/not-found.ts
@@ -1,8 +1,0 @@
-export class DaffCountryNotFoundError extends Error {
-	readonly name = 'DaffCountryNotFoundError';
-  readonly code: string = 'COUNTRY_NOT_FOUND';
-
-	constructor(public message: string) {
-		super(message);
-	}
-}

--- a/libs/geography/src/errors/public_api.ts
+++ b/libs/geography/src/errors/public_api.ts
@@ -1,2 +1,2 @@
-export { DaffCountryNotFoundError } from './not-found';
-export { DaffInvalidAPIResponseError } from './invalid-api-response';
+export { DaffCountryNotFoundError } from './country-not-found';
+export { DaffGeographyInvalidAPIResponseError } from './invalid-api-response';

--- a/libs/order/driver/magento/2.4.0/src/order.service.spec.ts
+++ b/libs/order/driver/magento/2.4.0/src/order.service.spec.ts
@@ -19,7 +19,7 @@ import {
 } from '@daffodil/order';
 import {
   DaffOrderNotFoundError,
-  DaffInvalidAPIResponseError,
+  DaffOrderInvalidAPIResponseError,
 } from '@daffodil/order/driver';
 import {
   DaffOrderFactory,
@@ -332,14 +332,14 @@ describe('Driver | Magento | Order | OrderService', () => {
       describe('and the response fails validation', () => {
         beforeEach(() => {
           validatorSpy.and.callFake(() => {
-            throw new DaffInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
+            throw new DaffOrderInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
           });
         });
 
-        it('should throw a DaffInvalidAPIResponseError', done => {
+        it('should throw a DaffOrderInvalidAPIResponseError', done => {
           service.list(cartId).pipe(
             catchError(err => {
-              expect(err).toEqual(jasmine.any(DaffInvalidAPIResponseError));
+              expect(err).toEqual(jasmine.any(DaffOrderInvalidAPIResponseError));
               done();
               return [];
             })
@@ -450,14 +450,14 @@ describe('Driver | Magento | Order | OrderService', () => {
       describe('and the response fails validation', () => {
         beforeEach(() => {
           validatorSpy.and.callFake(() => {
-            throw new DaffInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
+            throw new DaffOrderInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
           });
         });
 
-        it('should throw a DaffInvalidAPIResponseError', done => {
+        it('should throw a DaffOrderInvalidAPIResponseError', done => {
           service.list(cartId).pipe(
             catchError(err => {
-              expect(err).toEqual(jasmine.any(DaffInvalidAPIResponseError));
+              expect(err).toEqual(jasmine.any(DaffOrderInvalidAPIResponseError));
               done();
               return [];
             })

--- a/libs/order/driver/magento/2.4.0/src/validators/get-orders.spec.ts
+++ b/libs/order/driver/magento/2.4.0/src/validators/get-orders.spec.ts
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from 'apollo-client';
 
-import { DaffInvalidAPIResponseError } from '@daffodil/order/driver';
+import { DaffOrderInvalidAPIResponseError } from '@daffodil/order/driver';
 
 import { MagentoGetGuestOrdersResponse } from '../queries/public_api';
 import { validateGetOrdersResponse as validator } from './get-orders';
@@ -34,8 +34,8 @@ describe('Driver | Magento | Order | Validator | GetOrders', () => {
       response.data.graycoreGuestOrders.orders = null;
     });
 
-    it('should throw a DaffInvalidAPIResponseError', () => {
-      expect(() => validator(response)).toThrow(jasmine.any(DaffInvalidAPIResponseError));
+    it('should throw a DaffOrderInvalidAPIResponseError', () => {
+      expect(() => validator(response)).toThrow(jasmine.any(DaffOrderInvalidAPIResponseError));
     });
   });
 
@@ -44,8 +44,8 @@ describe('Driver | Magento | Order | Validator | GetOrders', () => {
       response.data.graycoreGuestOrders.orders = [{} as any];
     });
 
-    it('should throw a DaffInvalidAPIResponseError', () => {
-      expect(() => validator(response)).toThrow(jasmine.any(DaffInvalidAPIResponseError));
+    it('should throw a DaffOrderInvalidAPIResponseError', () => {
+      expect(() => validator(response)).toThrow(jasmine.any(DaffOrderInvalidAPIResponseError));
     });
   });
 });

--- a/libs/order/driver/magento/2.4.0/src/validators/get-orders.ts
+++ b/libs/order/driver/magento/2.4.0/src/validators/get-orders.ts
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from 'apollo-client';
 
-import { DaffInvalidAPIResponseError } from '@daffodil/order/driver';
+import { DaffOrderInvalidAPIResponseError } from '@daffodil/order/driver';
 
 import { MagentoGetGuestOrdersResponse } from '../queries/public_api';
 
@@ -13,9 +13,9 @@ export const validateGetOrdersResponse = (response: ApolloQueryResult<MagentoGet
     ), true)) {
       return response
     } else {
-      throw new DaffInvalidAPIResponseError('One of the orders does not contain required fields.')
+      throw new DaffOrderInvalidAPIResponseError('One of the orders does not contain required fields.')
     }
   } else {
-    throw new DaffInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
+    throw new DaffOrderInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
   }
 }

--- a/libs/order/driver/magento/2.4.1/src/order.service.spec.ts
+++ b/libs/order/driver/magento/2.4.1/src/order.service.spec.ts
@@ -7,7 +7,7 @@ import {
   DaffOrder,
 } from '@daffodil/order';
 import {
-  DaffInvalidAPIResponseError,
+  DaffOrderInvalidAPIResponseError,
   DaffOrderNotFoundError,
 } from '@daffodil/order/driver';
 
@@ -78,14 +78,14 @@ describe('Driver | Magento | Order | OrderService', () => {
       describe('and the response fails validation', () => {
         beforeEach(() => {
           validatorSpy.and.callFake(() => {
-            throw new DaffInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
+            throw new DaffOrderInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
           });
         });
 
-        it('should throw a DaffInvalidAPIResponseError', done => {
+        it('should throw a DaffOrderInvalidAPIResponseError', done => {
           service.list(cartId).pipe(
             catchError(err => {
-              expect(err).toEqual(jasmine.any(DaffInvalidAPIResponseError));
+              expect(err).toEqual(jasmine.any(DaffOrderInvalidAPIResponseError));
               done();
               return [];
             })
@@ -196,14 +196,14 @@ describe('Driver | Magento | Order | OrderService', () => {
       describe('and the response fails validation', () => {
         beforeEach(() => {
           validatorSpy.and.callFake(() => {
-            throw new DaffInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
+            throw new DaffOrderInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
           });
         });
 
-        it('should throw a DaffInvalidAPIResponseError', done => {
+        it('should throw a DaffOrderInvalidAPIResponseError', done => {
           service.list(cartId).pipe(
             catchError(err => {
-              expect(err).toEqual(jasmine.any(DaffInvalidAPIResponseError));
+              expect(err).toEqual(jasmine.any(DaffOrderInvalidAPIResponseError));
               done();
               return [];
             })

--- a/libs/order/driver/magento/2.4.1/src/validators/get-orders.spec.ts
+++ b/libs/order/driver/magento/2.4.1/src/validators/get-orders.spec.ts
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from 'apollo-client';
 
-import { DaffInvalidAPIResponseError } from '@daffodil/order/driver';
+import { DaffOrderInvalidAPIResponseError } from '@daffodil/order/driver';
 
 import { MagentoGetGuestOrdersResponse } from '../queries/public_api';
 import { validateGetOrdersResponse as validator } from './get-orders';
@@ -34,8 +34,8 @@ describe('Driver | Magento | Order | Validator | GetOrders', () => {
       response.data.graycoreGuestOrders.items = null;
     });
 
-    it('should throw a DaffInvalidAPIResponseError', () => {
-      expect(() => validator(response)).toThrow(jasmine.any(DaffInvalidAPIResponseError));
+    it('should throw a DaffOrderInvalidAPIResponseError', () => {
+      expect(() => validator(response)).toThrow(jasmine.any(DaffOrderInvalidAPIResponseError));
     });
   });
 
@@ -44,8 +44,8 @@ describe('Driver | Magento | Order | Validator | GetOrders', () => {
       response.data.graycoreGuestOrders.items = [{} as any];
     });
 
-    it('should throw a DaffInvalidAPIResponseError', () => {
-      expect(() => validator(response)).toThrow(jasmine.any(DaffInvalidAPIResponseError));
+    it('should throw a DaffOrderInvalidAPIResponseError', () => {
+      expect(() => validator(response)).toThrow(jasmine.any(DaffOrderInvalidAPIResponseError));
     });
   });
 });

--- a/libs/order/driver/magento/2.4.1/src/validators/get-orders.ts
+++ b/libs/order/driver/magento/2.4.1/src/validators/get-orders.ts
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from 'apollo-client';
 
-import { DaffInvalidAPIResponseError } from '@daffodil/order/driver';
+import { DaffOrderInvalidAPIResponseError } from '@daffodil/order/driver';
 
 import { MagentoGetGuestOrdersResponse } from '../queries/public_api';
 
@@ -13,9 +13,9 @@ export const validateGetOrdersResponse = (response: ApolloQueryResult<MagentoGet
     ), true)) {
       return response
     } else {
-      throw new DaffInvalidAPIResponseError('One of the orders does not contain required fields.')
+      throw new DaffOrderInvalidAPIResponseError('One of the orders does not contain required fields.')
     }
   } else {
-    throw new DaffInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
+    throw new DaffOrderInvalidAPIResponseError('Get orders response does not contain a valid list of orders.')
   }
 }

--- a/libs/order/driver/src/errors/invalid-api-response.ts
+++ b/libs/order/driver/src/errors/invalid-api-response.ts
@@ -1,6 +1,7 @@
-export class DaffInvalidAPIResponseError extends Error {
-	readonly name = 'DaffInvalidAPIResponseError';
-  readonly code: string = 'INVALID_API_RESPONSE';
+import { DaffError, DaffInheritableError } from '@daffodil/core';
+
+export class DaffOrderInvalidAPIResponseError extends DaffInheritableError implements DaffError {
+  public readonly code: string = 'DAFF_ORDER_INVALID_API_RESPONSE';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/order/driver/src/errors/order-not-found.ts
+++ b/libs/order/driver/src/errors/order-not-found.ts
@@ -1,6 +1,7 @@
-export class DaffOrderNotFoundError extends Error {
-	readonly name = 'DaffOrderNotFoundError';
-  readonly code: string = 'ORDER_NOT_FOUND';
+import { DaffError, DaffInheritableError } from '@daffodil/core';
+
+export class DaffOrderNotFoundError extends DaffInheritableError implements DaffError {
+  public readonly code: string = 'DAFF_ORDER_NOT_FOUND';
 
 	constructor(public message: string) {
 		super(message);

--- a/libs/order/driver/src/errors/public_api.ts
+++ b/libs/order/driver/src/errors/public_api.ts
@@ -1,2 +1,2 @@
-export { DaffInvalidAPIResponseError } from './invalid-api-response';
+export { DaffOrderInvalidAPIResponseError } from './invalid-api-response';
 export { DaffOrderNotFoundError } from './order-not-found';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Errors instances cannot be compared with `instanceof`.


## What is the new behavior?
- Adds `DaffInheritableError`
- Changes error classes to extend from `DaffInheritableError` and implement `DaffError`
- Prefixes error codes with `DAFF_`  and the lib name.
- Changes effects to use `instanceof` comparisons for errors.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Changes the names of some of the errors.

## Other information
This is basically #1111, but rebased and updated for `DaffError` because this is now blocking other features.