### PR TITLE
fix(builders): generate-fragment-types builder directory

### DIFF
--- a/tools/builders/package.json
+++ b/tools/builders/package.json
@@ -4,8 +4,12 @@
   "description": "Custom Angular builders for Daffodil projects.",
   "builders": "builders.json",
   "scripts": {
-    "build": "tsc && cp src/generate-fragment-types/schema.json ../../dist/builders/generate-fragment-types/schema.json && cp builders.json ../../dist/builders/builders.json && cp package.json ../../dist/builders/package.json",
-    "postbuild": "mkdir -p ../../node_modules/@daffodil/builders && cp -r ../../dist/builders ../../node_modules/@daffodil/builders"
+    "build:copy-schema": "cp src/generate-fragment-types/schema.json ../../dist/builders/generate-fragment-types/schema.json",
+    "build:copy-builders": "cp builders.json ../../dist/builders/builders.json",
+    "build:copy-package": "cp package.json ../../dist/builders/package.json",
+    "build:copy-static": "npm run build:copy-schema && npm run build:copy-builders && npm run build:copy-package",
+    "build": "tsc && npm run build:copy-static",
+    "postbuild": "mkdir -p ../../node_modules/@daffodil/builders && cp -r ../../dist/builders/* ../../node_modules/@daffodil/builders"
   },
   "main": "./index.js"
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, for demo, we need to build the `@daffodil/builders` package into `node_modules`. This path looks like:

```bash
node_modules/@daffodil/builders/builders
```

due to a globbing error.

Fixes: N/A

## What is the new behavior?
This corrects the path, along with a minor legibility update, to::

```bash
node_modules/@daffodil/builders
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

## Other information
cc: @danslo 