### PR TITLE
fix(order): using wrong item quantity field

### DIFF
--- a/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
+++ b/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
@@ -127,6 +127,7 @@ export class MagentoOrderTestDataFactory {
       updated_at: null,
       weight: null,
     });
+    mockDaffOrderItem.qty_ordered = mockDaffOrderItem.qty;
     mockDaffOrderCompositeItem = this.daffOrderCompositeItemFactory.create({
       image: {
         url: 'url',
@@ -144,6 +145,7 @@ export class MagentoOrderTestDataFactory {
       updated_at: null,
       weight: null,
     });
+    mockDaffOrderCompositeItem.qty_ordered = mockDaffOrderCompositeItem.qty;
     mockDaffOrderConfigurableItem = this.daffOrderConfigurableItemFactory.create({
       image: {
         url: 'url',
@@ -161,9 +163,11 @@ export class MagentoOrderTestDataFactory {
       updated_at: null,
       weight: null,
     });
+    mockDaffOrderConfigurableItem.qty_ordered = mockDaffOrderConfigurableItem.qty;
     mockDaffOrderShipmentItem = this.daffOrderShipmentItemFactory.create({
       item: mockDaffOrderItem
     });
+    mockDaffOrderShipmentItem.qty = mockDaffOrderItem.qty;
     mockDaffOrderShipmentTracking = this.daffOrderShipmentTrackingFactory.create({
       tracking_url: null,
       carrier_logo: null
@@ -254,7 +258,7 @@ export class MagentoOrderTestDataFactory {
       entered_options: [],
       status: null,
       product_type: MagentoOrderItemType.Simple,
-      quantity_ordered: mockDaffOrderItem.qty_ordered,
+      quantity_ordered: mockDaffOrderItem.qty,
       quantity_canceled: mockDaffOrderItem.qty_canceled,
       quantity_refunded: mockDaffOrderItem.qty_canceled,
       quantity_returned: mockDaffOrderItem.qty_canceled,
@@ -295,7 +299,7 @@ export class MagentoOrderTestDataFactory {
       })),
       status: null,
       product_type: MagentoOrderItemType.Bundle,
-      quantity_ordered: mockDaffOrderCompositeItem.qty_ordered,
+      quantity_ordered: mockDaffOrderCompositeItem.qty,
       quantity_canceled: mockDaffOrderCompositeItem.qty_canceled,
       quantity_refunded: mockDaffOrderCompositeItem.qty_canceled,
       quantity_returned: mockDaffOrderCompositeItem.qty_canceled,
@@ -325,7 +329,7 @@ export class MagentoOrderTestDataFactory {
       entered_options: [],
       status: null,
       product_type: MagentoOrderItemType.Configurable,
-      quantity_ordered: mockDaffOrderConfigurableItem.qty_ordered,
+      quantity_ordered: mockDaffOrderConfigurableItem.qty,
       quantity_canceled: mockDaffOrderConfigurableItem.qty_canceled,
       quantity_refunded: mockDaffOrderConfigurableItem.qty_canceled,
       quantity_returned: mockDaffOrderConfigurableItem.qty_canceled,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The order item transformer was using the `quantity_invoiced` field for all kinds of order items. This would result in some order items having a quantity of 0.

## What is the new behavior?
The order item transformer uses the correct quantity fields for each kind of order item.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information