### PR TITLE
feat(cart): transform cart errors with injectable error matcher

### DIFF
--- a/libs/authorizenet/state/src/effects/authorize-net.effects.spec.ts
+++ b/libs/authorizenet/state/src/effects/authorize-net.effects.spec.ts
@@ -138,10 +138,11 @@ describe('DaffAuthorizeNetEffects', () => {
 
 		it('should dispatch DaffAuthorizeNetUpdatePaymentFailure when the cart payment method has failed to update', () => {
       const authorizeNetUpdatePayment = new DaffAuthorizeNetUpdatePayment(paymentTokenRequest, stubAddress);
+      const mockCode = 'code'
       const mockErrorMessage = 'Cart payment with billing update failed.'
-			const cartPaymentUpdateWithBillingFailure = new DaffCartPaymentUpdateWithBillingFailure(mockErrorMessage);
+			const cartPaymentUpdateWithBillingFailure = new DaffCartPaymentUpdateWithBillingFailure({code: mockCode, message: mockErrorMessage});
 			const authorizeNetPaymentUpdateFailure = new DaffAuthorizeNetUpdatePaymentFailure({
-        code: 'DaffCartPaymentUpdateWithBillingFailure placeholder code',
+        code: mockCode,
         message: mockErrorMessage
       });
 			actions$ = hot('--ab', { a: authorizeNetUpdatePayment, b: cartPaymentUpdateWithBillingFailure });

--- a/libs/authorizenet/state/src/effects/authorize-net.effects.ts
+++ b/libs/authorizenet/state/src/effects/authorize-net.effects.ts
@@ -65,11 +65,7 @@ export class DaffAuthorizeNetEffects<T extends DaffAuthorizeNetTokenRequest = Da
 			DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingSuccessAction
 		),
     map(([updatePaymentAction, updatePaymentFailureAction]: [DaffAuthorizeNetUpdatePayment, DaffCartPaymentUpdateWithBillingFailure]) =>
-      // TODO: change once cart failure actions use DaffStateError
-      new DaffAuthorizeNetUpdatePaymentFailure(this.errorMatcher({
-        code: 'DaffCartPaymentUpdateWithBillingFailure placeholder code',
-        message: updatePaymentFailureAction.payload
-      }))
+      new DaffAuthorizeNetUpdatePaymentFailure(this.errorMatcher(updatePaymentFailureAction.payload))
     )
 	)
 

--- a/libs/cart/state/src/actions/cart-address.actions.ts
+++ b/libs/cart/state/src/actions/cart-address.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCartAddress, DaffCart } from '@daffodil/cart';
 
 export enum DaffCartAddressActionTypes {
@@ -32,7 +33,7 @@ export class DaffCartAddressUpdateSuccess<T extends DaffCart = DaffCart> impleme
 export class DaffCartAddressUpdateFailure implements Action {
   readonly type = DaffCartAddressActionTypes.CartAddressUpdateFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export type DaffCartAddressActions<

--- a/libs/cart/state/src/actions/cart-billing-address.actions.ts
+++ b/libs/cart/state/src/actions/cart-billing-address.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCartAddress, DaffCart } from '@daffodil/cart';
 
 export enum DaffCartBillingAddressActionTypes {
@@ -24,7 +25,7 @@ export class DaffCartBillingAddressLoadSuccess<T extends DaffCartAddress> implem
 export class DaffCartBillingAddressLoadFailure implements Action {
   readonly type = DaffCartBillingAddressActionTypes.CartBillingAddressLoadFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartBillingAddressUpdate<T extends DaffCartAddress = DaffCartAddress> implements Action {
@@ -42,7 +43,7 @@ export class DaffCartBillingAddressUpdateSuccess<T extends DaffCart = DaffCart> 
 export class DaffCartBillingAddressUpdateFailure implements Action {
   readonly type = DaffCartBillingAddressActionTypes.CartBillingAddressUpdateFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export type DaffCartBillingAddressActions<

--- a/libs/cart/state/src/actions/cart-coupon.actions.ts
+++ b/libs/cart/state/src/actions/cart-coupon.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCartCoupon, DaffCart } from '@daffodil/cart';
 
 export enum DaffCartCouponActionTypes {
@@ -32,7 +33,7 @@ export class DaffCartCouponApplySuccess<T extends DaffCart = DaffCart> implement
 export class DaffCartCouponApplyFailure implements Action {
   readonly type = DaffCartCouponActionTypes.CartCouponApplyFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartCouponList implements Action {
@@ -48,7 +49,7 @@ export class DaffCartCouponListSuccess<T extends DaffCartCoupon = DaffCartCoupon
 export class DaffCartCouponListFailure implements Action {
   readonly type = DaffCartCouponActionTypes.CartCouponListFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartCouponRemove<T extends DaffCartCoupon = DaffCartCoupon> implements Action {
@@ -66,7 +67,7 @@ export class DaffCartCouponRemoveSuccess<T extends DaffCart = DaffCart> implemen
 export class DaffCartCouponRemoveFailure implements Action {
   readonly type = DaffCartCouponActionTypes.CartCouponRemoveFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartCouponRemoveAll implements Action {
@@ -82,7 +83,7 @@ export class DaffCartCouponRemoveAllSuccess<T extends DaffCart = DaffCart> imple
 export class DaffCartCouponRemoveAllFailure implements Action {
   readonly type = DaffCartCouponActionTypes.CartCouponRemoveAllFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export type DaffCartCouponActions<

--- a/libs/cart/state/src/actions/cart-item.actions.ts
+++ b/libs/cart/state/src/actions/cart-item.actions.ts
@@ -1,6 +1,8 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartItemInput } from '@daffodil/cart';
+
 import { DaffStatefulCartItem } from '../models/public_api';
 
 export enum DaffCartItemActionTypes {
@@ -35,7 +37,7 @@ export class DaffCartItemListSuccess<T extends DaffStatefulCartItem = DaffStatef
 export class DaffCartItemListFailure implements Action {
   readonly type = DaffCartItemActionTypes.CartItemListFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartItemLoad<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
@@ -53,7 +55,7 @@ export class DaffCartItemLoadSuccess<T extends DaffStatefulCartItem = DaffStatef
 export class DaffCartItemLoadFailure implements Action {
   readonly type = DaffCartItemActionTypes.CartItemLoadFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartItemUpdate<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
@@ -71,7 +73,7 @@ export class DaffCartItemUpdateSuccess<T extends DaffCart = DaffCart, V extends 
 export class DaffCartItemUpdateFailure implements Action {
   readonly type = DaffCartItemActionTypes.CartItemUpdateFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartItemAdd<T extends DaffCartItemInput = DaffCartItemInput> implements Action {
@@ -89,7 +91,7 @@ export class DaffCartItemAddSuccess<T extends DaffCart = DaffCart> implements Ac
 export class DaffCartItemAddFailure implements Action {
   readonly type = DaffCartItemActionTypes.CartItemAddFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartItemDelete<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
@@ -107,7 +109,7 @@ export class DaffCartItemDeleteSuccess<T extends DaffCart = DaffCart> implements
 export class DaffCartItemDeleteFailure implements Action {
   readonly type = DaffCartItemActionTypes.CartItemDeleteFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartItemStateReset implements Action {

--- a/libs/cart/state/src/actions/cart-order.actions.ts
+++ b/libs/cart/state/src/actions/cart-order.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCartPaymentMethod, DaffCartOrderResult } from '@daffodil/cart';
 
 export enum DaffCartOrderActionTypes {
@@ -23,7 +24,7 @@ export class DaffCartPlaceOrderSuccess<T extends DaffCartOrderResult = DaffCartO
 export class DaffCartPlaceOrderFailure implements Action {
   readonly type = DaffCartOrderActionTypes.CartPlaceOrderFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export type DaffCartOrderActions<

--- a/libs/cart/state/src/actions/cart-payment-methods.actions.ts
+++ b/libs/cart/state/src/actions/cart-payment-methods.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCartPaymentMethod } from '@daffodil/cart';
 
 export enum DaffCartPaymentMethodsActionTypes {
@@ -23,7 +24,7 @@ export class DaffCartPaymentMethodsLoadSuccess<T extends DaffCartPaymentMethod =
 export class DaffCartPaymentMethodsLoadFailure implements Action {
   readonly type = DaffCartPaymentMethodsActionTypes.CartPaymentMethodsLoadFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export type DaffCartPaymentMethodsActions<T extends DaffCartPaymentMethod = DaffCartPaymentMethod> =

--- a/libs/cart/state/src/actions/cart-payment.actions.ts
+++ b/libs/cart/state/src/actions/cart-payment.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCartPaymentMethod, DaffCart, DaffCartAddress } from '@daffodil/cart';
 
 export enum DaffCartPaymentActionTypes {
@@ -31,7 +32,7 @@ export class DaffCartPaymentLoadSuccess<T extends DaffCartPaymentMethod = DaffCa
 export class DaffCartPaymentLoadFailure implements Action {
   readonly type = DaffCartPaymentActionTypes.CartPaymentLoadFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartPaymentUpdate<T extends DaffCartPaymentMethod = DaffCartPaymentMethod> implements Action {
@@ -49,7 +50,7 @@ export class DaffCartPaymentUpdateSuccess<T extends DaffCart = DaffCart> impleme
 export class DaffCartPaymentUpdateFailure implements Action {
   readonly type = DaffCartPaymentActionTypes.CartPaymentUpdateFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 /**
@@ -86,7 +87,7 @@ export class DaffCartPaymentUpdateWithBillingSuccess<T extends DaffCart = DaffCa
 export class DaffCartPaymentUpdateWithBillingFailure implements Action {
   readonly type = DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartPaymentRemove implements Action {
@@ -100,7 +101,7 @@ export class DaffCartPaymentRemoveSuccess implements Action {
 export class DaffCartPaymentRemoveFailure implements Action {
   readonly type = DaffCartPaymentActionTypes.CartPaymentRemoveFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart-shipping-address.actions.ts
+++ b/libs/cart/state/src/actions/cart-shipping-address.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCartAddress, DaffCart } from '@daffodil/cart';
 
 export enum DaffCartShippingAddressActionTypes {
@@ -24,7 +25,7 @@ export class DaffCartShippingAddressLoadSuccess<T extends DaffCartAddress = Daff
 export class DaffCartShippingAddressLoadFailure implements Action {
   readonly type = DaffCartShippingAddressActionTypes.CartShippingAddressLoadFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartShippingAddressUpdate<T extends DaffCartAddress = DaffCartAddress> implements Action {
@@ -42,7 +43,7 @@ export class DaffCartShippingAddressUpdateSuccess<T extends DaffCart = DaffCart>
 export class DaffCartShippingAddressUpdateFailure implements Action {
   readonly type = DaffCartShippingAddressActionTypes.CartShippingAddressUpdateFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export type DaffCartShippingAddressActions<

--- a/libs/cart/state/src/actions/cart-shipping-information.actions.ts
+++ b/libs/cart/state/src/actions/cart-shipping-information.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCartShippingRate, DaffCart } from '@daffodil/cart';
 
 export enum DaffCartShippingInformationActionTypes {
@@ -27,7 +28,7 @@ export class DaffCartShippingInformationLoadSuccess<T extends DaffCartShippingRa
 export class DaffCartShippingInformationLoadFailure implements Action {
   readonly type = DaffCartShippingInformationActionTypes.CartShippingInformationLoadFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartShippingInformationUpdate<T extends DaffCartShippingRate = DaffCartShippingRate> implements Action {
@@ -45,7 +46,7 @@ export class DaffCartShippingInformationUpdateSuccess<T extends DaffCart = DaffC
 export class DaffCartShippingInformationUpdateFailure implements Action {
   readonly type = DaffCartShippingInformationActionTypes.CartShippingInformationUpdateFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartShippingInformationDelete<T extends DaffCartShippingRate = DaffCartShippingRate> implements Action {
@@ -63,7 +64,7 @@ export class DaffCartShippingInformationDeleteSuccess<T extends DaffCart = DaffC
 export class DaffCartShippingInformationDeleteFailure implements Action {
   readonly type = DaffCartShippingInformationActionTypes.CartShippingInformationDeleteFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export type DaffCartShippingInformationActions<

--- a/libs/cart/state/src/actions/cart-shipping-methods.actions.ts
+++ b/libs/cart/state/src/actions/cart-shipping-methods.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCartShippingRate } from '@daffodil/cart';
 
 export enum DaffCartShippingMethodsActionTypes {
@@ -23,7 +24,7 @@ export class DaffCartShippingMethodsLoadSuccess<T extends DaffCartShippingRate =
 export class DaffCartShippingMethodsLoadFailure implements Action {
   readonly type = DaffCartShippingMethodsActionTypes.CartShippingMethodsLoadFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export type DaffCartShippingMethodsActions<T extends DaffCartShippingRate = DaffCartShippingRate> =

--- a/libs/cart/state/src/actions/cart.actions.ts
+++ b/libs/cart/state/src/actions/cart.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCart } from '@daffodil/cart';
 
 export enum DaffCartActionTypes {
@@ -24,7 +25,7 @@ export enum DaffCartActionTypes {
 export class DaffCartStorageFailure implements Action {
   readonly type = DaffCartActionTypes.CartStorageFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartLoad implements Action {
@@ -40,7 +41,7 @@ export class DaffCartLoadSuccess<T extends DaffCart = DaffCart> implements Actio
 export class DaffCartLoadFailure implements Action {
   readonly type = DaffCartActionTypes.CartLoadFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartCreate implements Action {
@@ -56,7 +57,7 @@ export class DaffCartCreateSuccess<T extends DaffCart = DaffCart> implements Act
 export class DaffCartCreateFailure implements Action {
   readonly type = DaffCartActionTypes.CartCreateFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffAddToCart implements Action {
@@ -74,7 +75,7 @@ export class DaffAddToCartSuccess implements Action {
 export class DaffAddToCartFailure implements Action {
   readonly type = DaffCartActionTypes.AddToCartFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffCartClear implements Action {
@@ -90,7 +91,7 @@ export class DaffCartClearSuccess<T extends DaffCart = DaffCart> implements Acti
 export class DaffCartClearFailure implements Action {
   readonly type = DaffCartActionTypes.CartClearFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export class DaffResolveCart implements Action {
@@ -106,7 +107,7 @@ export class DaffResolveCartSuccess<T extends DaffCart = DaffCart> implements Ac
 export class DaffResolveCartFailure implements Action {
   readonly type = DaffCartActionTypes.ResolveCartFailureAction;
 
-  constructor(public payload: string) {}
+  constructor(public payload: DaffStateError) {}
 }
 
 export type DaffCartActions<T extends DaffCart = DaffCart> =

--- a/libs/cart/state/src/effects/cart-address.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-address.effects.spec.ts
@@ -15,6 +15,7 @@ import {
   DaffCartFactory,
   DaffCartAddressFactory
 } from '@daffodil/cart/testing';
+import { DaffStateError, daffTransformErrorToStateError } from '@daffodil/core/state';
 
 import { DaffCartAddressEffects } from './cart-address.effects';
 
@@ -31,7 +32,7 @@ describe('Daffodil | Cart | CartAddressEffects', () => {
   let daffAddressDriverSpy: jasmine.SpyObj<DaffCartAddressServiceInterface>;
 
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
-  const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
+  const cartStorageFailureAction = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
   const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   beforeEach(() => {
@@ -106,7 +107,7 @@ describe('Daffodil | Cart | CartAddressEffects', () => {
 
     describe('and the call to CartAddressService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to update cart address';
+        const error: DaffStateError = {code: 'code', message: 'Failed to update cart address'};
         const response = cold('#', {}, error);
         daffAddressDriverSpy.update.and.returnValue(response);
         const cartAddressUpdateFailureAction = new DaffCartAddressUpdateFailure(error);

--- a/libs/cart/state/src/effects/cart-address.effects.ts
+++ b/libs/cart/state/src/effects/cart-address.effects.ts
@@ -6,7 +6,6 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import { DaffStorageServiceError } from '@daffodil/core';
 import { DaffCartAddress, DaffCart, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartAddressDriver, DaffCartAddressServiceInterface } from '@daffodil/cart/driver';
-import { daffTransformErrorToStateError } from '@daffodil/core/state';
 
 import {
   DaffCartAddressActionTypes,

--- a/libs/cart/state/src/effects/cart-billing-address.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-billing-address.effects.spec.ts
@@ -14,6 +14,7 @@ import {
   DaffCartFactory,
   DaffCartAddressFactory
 } from '@daffodil/cart/testing';
+import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffCartBillingAddressEffects } from './cart-billing-address.effects';
 
@@ -84,7 +85,7 @@ describe('Daffodil | Cart | CartBillingAddressEffects', () => {
 
     describe('and the call to CartBillingAddressService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to load cart billing address';
+        const error: DaffStateError = {code: 'code', message: 'Failed to load cart billing address'};
         const response = cold('#', {}, error);
         daffBillingAddressDriverSpy.get.and.returnValue(response);
         const cartBillingAddressLoadFailureAction = new DaffCartBillingAddressLoadFailure(error);
@@ -123,7 +124,7 @@ describe('Daffodil | Cart | CartBillingAddressEffects', () => {
 
     describe('and the call to CartBillingAddressService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to update cart billing address';
+        const error: DaffStateError = {code: 'code', message: 'Failed to update cart billing address'};
         const response = cold('#', {}, error);
         daffBillingAddressDriverSpy.update.and.returnValue(response);
         const cartCreateFailureAction = new DaffCartBillingAddressUpdateFailure(error);

--- a/libs/cart/state/src/effects/cart-billing-address.effects.ts
+++ b/libs/cart/state/src/effects/cart-billing-address.effects.ts
@@ -3,7 +3,7 @@ import { switchMap, map, catchError } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 
-import { DaffCartAddress, DaffCart, DaffCartStorageService } from '@daffodil/cart';
+import { DaffCartAddress, DaffCart, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartBillingAddressDriver, DaffCartBillingAddressServiceInterface } from '@daffodil/cart/driver';
 
 import {
@@ -20,6 +20,7 @@ import {
 export class DaffCartBillingAddressEffects<T extends DaffCartAddress, V extends DaffCart> {
   constructor(
     private actions$: Actions,
+    @Inject(DAFF_CART_ERROR_MATCHER) private errorMatcher: Function,
     @Inject(DaffCartBillingAddressDriver) private driver: DaffCartBillingAddressServiceInterface<T, V>,
     private storage: DaffCartStorageService
   ) {}
@@ -30,7 +31,7 @@ export class DaffCartBillingAddressEffects<T extends DaffCartAddress, V extends 
     switchMap((action: DaffCartBillingAddressLoad) =>
       this.driver.get(this.storage.getCartId()).pipe(
         map((resp: T) => new DaffCartBillingAddressLoadSuccess(resp)),
-        catchError(error => of(new DaffCartBillingAddressLoadFailure('Failed to load cart billing address')))
+        catchError(error => of(new DaffCartBillingAddressLoadFailure(this.errorMatcher(error))))
       )
     )
   )
@@ -41,7 +42,7 @@ export class DaffCartBillingAddressEffects<T extends DaffCartAddress, V extends 
     switchMap((action: DaffCartBillingAddressUpdate<T>) =>
       this.driver.update(this.storage.getCartId(), action.payload).pipe(
         map((resp: V) => new DaffCartBillingAddressUpdateSuccess(resp)),
-        catchError(error => of(new DaffCartBillingAddressUpdateFailure('Failed to update cart billing address')))
+        catchError(error => of(new DaffCartBillingAddressUpdateFailure(this.errorMatcher(error))))
       )
     )
   )

--- a/libs/cart/state/src/effects/cart-coupon.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-coupon.effects.spec.ts
@@ -6,6 +6,7 @@ import { hot, cold } from 'jasmine-marbles';
 import {
   DaffStorageServiceError
 } from '@daffodil/core'
+import { DaffStateError, daffTransformErrorToStateError } from '@daffodil/core/state';
 import {
   DaffCart,
   DaffCartCoupon,
@@ -34,7 +35,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
 
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
 
-  const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
+  const cartStorageFailureAction = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
   const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   beforeEach(() => {
@@ -88,7 +89,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
 
     describe('and the call to CartCouponService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to apply coupon to cart';
+        const error: DaffStateError = {code: 'code', message: 'Failed to apply coupon to cart'};
         const response = cold('#', {}, error);
         daffDriverSpy.apply.and.returnValue(response);
         const cartCouponApplyFailureAction = new DaffCartCouponApplyFailure(error);
@@ -134,7 +135,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
 
     describe('and the call to CartCouponService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to list coupons';
+        const error: DaffStateError = {code: 'code', message: 'Failed to list coupons'};
         const response = cold('#', {}, error);
         daffDriverSpy.list.and.returnValue(response);
         const cartCouponListFailureAction = new DaffCartCouponListFailure(error);
@@ -180,7 +181,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
 
     describe('and the call to CartCouponService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to remove a coupon from the cart';
+        const error: DaffStateError = {code: 'code', message: 'Failed to remove a coupon from the cart'};
         const response = cold('#', {}, error);
         daffDriverSpy.remove.and.returnValue(response);
         const cartCouponRemoveFailureAction = new DaffCartCouponRemoveFailure(error);
@@ -226,7 +227,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
 
     describe('and the call to CartCouponService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to remove all coupons from the cart';
+        const error: DaffStateError = {code: 'code', message: 'Failed to remove all coupons from the cart'};
         const response = cold('#', {}, error);
         daffDriverSpy.removeAll.and.returnValue(response);
         const cartCouponRemoveAllFailureAction = new DaffCartCouponRemoveAllFailure(error);

--- a/libs/cart/state/src/effects/cart-coupon.effects.ts
+++ b/libs/cart/state/src/effects/cart-coupon.effects.ts
@@ -6,7 +6,7 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import {
   DaffStorageServiceError
 } from '@daffodil/core'
-import { DaffCart, DaffCartCoupon, DaffCartStorageService } from '@daffodil/cart';
+import { DaffCart, DaffCartCoupon, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartCouponDriver, DaffCartCouponServiceInterface } from '@daffodil/cart/driver';
 
 import {
@@ -33,6 +33,7 @@ export class DaffCartCouponEffects<
 > {
   constructor(
     private actions$: Actions,
+    @Inject(DAFF_CART_ERROR_MATCHER) private errorMatcher: Function,
     @Inject(DaffCartCouponDriver) private driver: DaffCartCouponServiceInterface<T, V>,
     private storage: DaffCartStorageService,
   ) {}
@@ -45,8 +46,8 @@ export class DaffCartCouponEffects<
       switchMap(cartId => this.driver.apply(cartId, action.payload)),
       map(resp => new DaffCartCouponApplySuccess(resp)),
       catchError(error => of(error instanceof DaffStorageServiceError
-        ? new DaffCartStorageFailure('Cart Storage Failed')
-        : new DaffCartCouponApplyFailure('Failed to apply coupon to cart')
+        ? new DaffCartStorageFailure(this.errorMatcher(error))
+        : new DaffCartCouponApplyFailure(this.errorMatcher(error))
       )),
     )),
   )
@@ -59,8 +60,8 @@ export class DaffCartCouponEffects<
       switchMap(cartId => this.driver.list(cartId)),
       map(resp => new DaffCartCouponListSuccess<V>(resp)),
       catchError(error => of(error instanceof DaffStorageServiceError
-        ? new DaffCartStorageFailure('Cart Storage Failed')
-        : new DaffCartCouponListFailure('Failed to list coupons')
+        ? new DaffCartStorageFailure(this.errorMatcher(error))
+        : new DaffCartCouponListFailure(this.errorMatcher(error))
       )),
     )),
   )
@@ -73,8 +74,8 @@ export class DaffCartCouponEffects<
       switchMap(cartId => this.driver.remove(cartId, action.payload)),
       map(resp => new DaffCartCouponRemoveSuccess(resp)),
       catchError(error => of(error instanceof DaffStorageServiceError
-        ? new DaffCartStorageFailure('Cart Storage Failed')
-        : new DaffCartCouponRemoveFailure('Failed to remove a coupon from the cart')
+        ? new DaffCartStorageFailure(this.errorMatcher(error))
+        : new DaffCartCouponRemoveFailure(this.errorMatcher(error))
       )),
     )),
   )
@@ -87,8 +88,8 @@ export class DaffCartCouponEffects<
       switchMap(cartId => this.driver.removeAll(cartId)),
       map(resp => new DaffCartCouponRemoveAllSuccess(resp)),
       catchError(error => of(error instanceof DaffStorageServiceError
-        ? new DaffCartStorageFailure('Cart Storage Failed')
-        : new DaffCartCouponRemoveAllFailure('Failed to remove all coupons from the cart')
+        ? new DaffCartStorageFailure(this.errorMatcher(error))
+        : new DaffCartCouponRemoveAllFailure(this.errorMatcher(error))
       )),
     )),
   )

--- a/libs/cart/state/src/effects/cart-item.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-item.effects.spec.ts
@@ -7,14 +7,14 @@ import { TestScheduler } from 'rxjs/testing';
 
 import { DaffCartItemInput, DaffCart, DaffCartStorageService, DaffCartItemInputType } from '@daffodil/cart';
 import { DaffCartItemServiceInterface, DaffCartItemDriver } from '@daffodil/cart/driver';
-import { DaffCartItemList, DaffCartItemListSuccess, DaffCartItemListFailure, DaffCartItemLoad, DaffCartItemLoadSuccess, DaffCartItemLoadFailure, DaffCartItemAdd, DaffCartItemAddSuccess, DaffCartItemAddFailure, DaffCartItemUpdate, DaffCartItemUpdateSuccess, DaffCartItemUpdateFailure, DaffCartItemDelete, DaffCartItemDeleteSuccess, DaffCartItemDeleteFailure } from '@daffodil/cart/state';
-import { DaffCartFactory } from '@daffodil/cart/testing';
+import { DaffCartItemList, DaffCartItemListSuccess, DaffCartItemListFailure, DaffCartItemLoad, DaffCartItemLoadSuccess, DaffCartItemLoadFailure, DaffCartItemAdd, DaffCartItemAddSuccess, DaffCartItemAddFailure, DaffCartItemUpdate, DaffCartItemUpdateSuccess, DaffCartItemUpdateFailure, DaffCartItemDelete, DaffCartItemDeleteSuccess, DaffCartItemDeleteFailure, DaffStatefulCartItem, DaffCartItemStateReset, DaffCartItemStateDebounceTime } from '@daffodil/cart/state';
+import {
+  DaffCartFactory,
+} from '@daffodil/cart/testing';
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffStatefulCartItemFactory } from '@daffodil/cart/state/testing';
 
 import { DaffCartItemEffects } from './cart-item.effects';
-import { DaffCartItemStateReset } from '../actions/public_api';
-import { DaffStatefulCartItem } from '../models/public_api';
-import { DaffCartItemStateDebounceTime } from '../injection-tokens/cart-item-state-debounce-time';
 
 describe('Daffodil | Cart | CartItemEffects', () => {
   let actions$: Observable<any>;
@@ -41,7 +41,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
           provide: DaffCartItemDriver,
           useValue: jasmine.createSpyObj('DaffCartItemDriver', ['list', 'get', 'update', 'add', 'delete'])
 				},
-				{ 
+				{
 					provide: DaffCartItemStateDebounceTime,
 					useValue: 4000
 				},
@@ -53,8 +53,8 @@ describe('Daffodil | Cart | CartItemEffects', () => {
     });
 
 		effects = TestBed.get<DaffCartItemEffects<
-			DaffStatefulCartItem, 
-			DaffCartItemInput, 
+			DaffStatefulCartItem,
+			DaffCartItemInput,
 			DaffCart
 		>>(DaffCartItemEffects);
 
@@ -100,7 +100,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
 
     describe('and the call to CartItemService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to list cart items';
+        const error: DaffStateError = {code: 'code', message: 'Failed to list cart items'};
         const response = cold('#', {}, error);
         daffCartItemDriverSpy.list.and.returnValue(response);
         const cartItemListFailureAction = new DaffCartItemListFailure(error);
@@ -137,7 +137,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
 
     describe('and the call to CartItemService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to load cart item';
+        const error: DaffStateError = {code: 'code', message: 'Failed to load cart item'};
         const response = cold('#', {}, error);
         daffCartItemDriverSpy.get.and.returnValue(response);
         const cartItemLoadFailureAction = new DaffCartItemLoadFailure(error);
@@ -161,7 +161,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
     });
 
     describe('and the call to CartItemService is successful', () => {
-			beforeEach(() => {	
+			beforeEach(() => {
         mockCart.items.push(mockCartItem);
         daffCartItemDriverSpy.add.and.returnValue(of(mockCart));
         const cartItemAddSuccessAction = new DaffCartItemAddSuccess(mockCart);
@@ -176,7 +176,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
 
     describe('and the call to CartItemService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to add cart item';
+        const error: DaffStateError = {code: 'code', message: 'Failed to add cart item'};
         const response = cold('#', {}, error);
         daffCartItemDriverSpy.add.and.returnValue(response);
         const cartItemAddFailureAction = new DaffCartItemAddFailure(error);
@@ -216,7 +216,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
 
     describe('and the call to CartItemService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to update cart item';
+        const error: DaffStateError = {code: 'code', message: 'Failed to update cart item'};
         const response = cold('#', {}, error);
         daffCartItemDriverSpy.update.and.returnValue(response);
         const cartItemUpdateFailureAction = new DaffCartItemUpdateFailure(error);
@@ -232,7 +232,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
 
   describe('resetCartItemStateAfterChange$', () => {
 		let expectedObservable;
-		
+
 		describe('when a DaffCartItemAddSuccess action is dispatched', () => {
 
 			it('should dispatch a DaffCartItemStateReset after the specified amount of time', () => {
@@ -245,7 +245,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
 					const shopCartItemReset = new DaffCartItemStateReset();
 					actions$ = helpers.hot('a', { a: cartItemAddSuccess });
 					expectedObservable = {a: shopCartItemReset};
-	
+
 					helpers.expectObservable(effects.resetCartItemStateAfterChange$).toBe(expectedMarble, expectedObservable);
 				});
 			});
@@ -263,7 +263,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
 					const shopCartItemReset = new DaffCartItemStateReset();
 					actions$ = helpers.hot('a', { a: cartItemUpdateSuccess });
 					expectedObservable = {a: shopCartItemReset};
-	
+
 					helpers.expectObservable(effects.resetCartItemStateAfterChange$).toBe(expectedMarble, expectedObservable);
 				});
 			});
@@ -293,7 +293,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
 
     describe('and the call to CartItemService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to remove the cart item';
+        const error: DaffStateError = {code: 'code', message: 'Failed to remove the cart item'};
         const response = cold('#', {}, error);
         daffCartItemDriverSpy.delete.and.returnValue(response);
         const cartItemRemoveCartFailureAction = new DaffCartItemDeleteFailure(error);

--- a/libs/cart/state/src/effects/cart-order.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-order.effects.spec.ts
@@ -6,6 +6,7 @@ import { hot, cold } from 'jasmine-marbles';
 import {
   DaffStorageServiceError
 } from '@daffodil/core'
+import { DaffStateError, daffTransformErrorToStateError } from '@daffodil/core/state';
 import {
   DaffCart,
   DaffCartPaymentMethod,
@@ -35,7 +36,7 @@ describe('Cart | Effect | CartOrderEffects', () => {
   let cartOrderDriverSpy: jasmine.SpyObj<DaffCartOrderServiceInterface>;
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
 
-  const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
+  const cartStorageFailureAction = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
   const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   beforeEach(() => {
@@ -95,7 +96,7 @@ describe('Cart | Effect | CartOrderEffects', () => {
 
     describe('and the call to CartOrderService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to place order';
+        const error: DaffStateError = {code: 'code', message: 'Failed to place order'};
         const response = cold('#', {}, error);
         const cartPlaceOrderFailureAction = new DaffCartPlaceOrderFailure(error);
 

--- a/libs/cart/state/src/effects/cart-order.effects.ts
+++ b/libs/cart/state/src/effects/cart-order.effects.ts
@@ -6,7 +6,7 @@ import { Actions, Effect, ofType } from '@ngrx/effects';
 import {
   DaffStorageServiceError
 } from '@daffodil/core'
-import { DaffCart, DaffCartPaymentMethod, DaffCartOrderResult, DaffCartStorageService } from '@daffodil/cart';
+import { DaffCart, DaffCartPaymentMethod, DaffCartOrderResult, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartOrderDriver, DaffCartOrderServiceInterface } from '@daffodil/cart/driver';
 
 import {
@@ -26,6 +26,7 @@ export class DaffCartOrderEffects<
 > {
   constructor(
     private actions$: Actions,
+    @Inject(DAFF_CART_ERROR_MATCHER) private errorMatcher: Function,
     @Inject(DaffCartOrderDriver) private driver: DaffCartOrderServiceInterface<T, V, R>,
     private storage: DaffCartStorageService,
   ) {}
@@ -38,8 +39,8 @@ export class DaffCartOrderEffects<
       switchMap(cartId => this.driver.placeOrder(cartId, action.payload)),
       map((resp: R) => new DaffCartPlaceOrderSuccess<R>(resp)),
       catchError(error => of(error instanceof DaffStorageServiceError
-        ? new DaffCartStorageFailure('Cart Storage Failed')
-        : new DaffCartPlaceOrderFailure('Failed to place order')
+        ? new DaffCartStorageFailure(this.errorMatcher(error))
+        : new DaffCartPlaceOrderFailure(this.errorMatcher(error))
       )),
     )),
   )

--- a/libs/cart/state/src/effects/cart-payment-methods.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-payment-methods.effects.spec.ts
@@ -14,6 +14,7 @@ import {
   DaffCartFactory,
   DaffCartPaymentFactory,
 } from '@daffodil/cart/testing';
+import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffCartPaymentMethodsEffects } from './cart-payment-methods.effects';
 
@@ -84,7 +85,7 @@ describe('Daffodil | Cart | DaffCartPaymentMethodsEffects', () => {
 
     describe('and the call to CartService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to list cart payment methods';
+        const error: DaffStateError = {code: 'code', message: 'Failed to list cart payment methods'};
         const response = cold('#', {}, error);
         paymentMethodsDriverSpy.list.and.returnValue(response);
         const cartCreateFailureAction = new DaffCartPaymentMethodsLoadFailure(error);

--- a/libs/cart/state/src/effects/cart-payment-methods.effects.ts
+++ b/libs/cart/state/src/effects/cart-payment-methods.effects.ts
@@ -3,7 +3,7 @@ import { switchMap, map, catchError } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 
-import { DaffCartPaymentMethod, DaffCartStorageService } from '@daffodil/cart';
+import { DaffCartPaymentMethod, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartPaymentMethodsDriver, DaffCartPaymentMethodsServiceInterface } from '@daffodil/cart/driver';
 
 import {
@@ -18,6 +18,7 @@ export class DaffCartPaymentMethodsEffects<T extends DaffCartPaymentMethod> {
 
   constructor(
     private actions$: Actions,
+    @Inject(DAFF_CART_ERROR_MATCHER) private errorMatcher: Function,
     @Inject(DaffCartPaymentMethodsDriver) private driver: DaffCartPaymentMethodsServiceInterface<T>,
     private storage: DaffCartStorageService
     ) {}
@@ -28,7 +29,7 @@ export class DaffCartPaymentMethodsEffects<T extends DaffCartPaymentMethod> {
     switchMap((action: DaffCartPaymentMethodsLoad) =>
       this.driver.list(this.storage.getCartId()).pipe(
         map((resp: T[]) => new DaffCartPaymentMethodsLoadSuccess(resp)),
-        catchError(error => of(new DaffCartPaymentMethodsLoadFailure('Failed to list cart payment methods')))
+        catchError(error => of(new DaffCartPaymentMethodsLoadFailure(this.errorMatcher(error))))
       )
     )
   )

--- a/libs/cart/state/src/effects/cart-payment.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-payment.effects.spec.ts
@@ -3,6 +3,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Observable, of } from 'rxjs';
 import { hot, cold } from 'jasmine-marbles';
 
+import { DaffStateError } from '@daffodil/core/state';
 import {
   DaffCart,
   DaffCartPaymentMethod,
@@ -103,7 +104,7 @@ describe('Daffodil | Cart | CartPaymentEffects', () => {
 
     describe('and the call to CartPaymentService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to load cart payment';
+        const error: DaffStateError = {code: 'code', message: 'Failed to load cart payment'};
         const response = cold('#', {}, error);
         daffPaymentDriverSpy.get.and.returnValue(response);
         const cartPaymentLoadFailureAction = new DaffCartPaymentLoadFailure(error);
@@ -142,7 +143,7 @@ describe('Daffodil | Cart | CartPaymentEffects', () => {
 
     describe('and the call to CartPaymentService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to update cart payment';
+        const error: DaffStateError = {code: 'code', message: 'Failed to update cart payment'};
         const response = cold('#', {}, error);
         daffPaymentDriverSpy.update.and.returnValue(response);
         const cartPaymentUpdateFailureAction = new DaffCartPaymentUpdateFailure(error);
@@ -181,7 +182,7 @@ describe('Daffodil | Cart | CartPaymentEffects', () => {
 
     describe('and the call to CartPaymentService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to update cart payment and billing address';
+        const error: DaffStateError = {code: 'code', message: 'Failed to update cart payment and billing address'};
         const response = cold('#', {}, error);
         daffPaymentDriverSpy.updateWithBilling.and.returnValue(response);
         const cartPaymentUpdateFailureAction = new DaffCartPaymentUpdateWithBillingFailure(error);
@@ -213,7 +214,7 @@ describe('Daffodil | Cart | CartPaymentEffects', () => {
 
     describe('and the call to CartPaymentService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to remove the cart payment';
+        const error: DaffStateError = {code: 'code', message: 'Failed to remove the cart payment'};
         const response = cold('#', {}, error);
         daffPaymentDriverSpy.remove.and.returnValue(response);
         const cartPaymentRemoveFailureAction = new DaffCartPaymentRemoveFailure(error);

--- a/libs/cart/state/src/effects/cart-payment.effects.ts
+++ b/libs/cart/state/src/effects/cart-payment.effects.ts
@@ -3,7 +3,7 @@ import { switchMap, map, catchError, mapTo } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 
-import { DaffCartPaymentMethod, DaffCart, DaffCartAddress, DaffCartStorageService } from '@daffodil/cart';
+import { DaffCartPaymentMethod, DaffCart, DaffCartAddress, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartPaymentDriver, DaffCartPaymentServiceInterface } from '@daffodil/cart/driver';
 
 import {
@@ -30,6 +30,7 @@ export class DaffCartPaymentEffects<
 > {
   constructor(
     private actions$: Actions,
+    @Inject(DAFF_CART_ERROR_MATCHER) private errorMatcher: Function,
     @Inject(DaffCartPaymentDriver) private driver: DaffCartPaymentServiceInterface<T, V, R>,
     private storage: DaffCartStorageService
   ) {}
@@ -40,7 +41,7 @@ export class DaffCartPaymentEffects<
     switchMap((action: DaffCartPaymentLoad) =>
       this.driver.get(this.storage.getCartId()).pipe(
         map((resp: T) => new DaffCartPaymentLoadSuccess(resp)),
-        catchError(error => of(new DaffCartPaymentLoadFailure('Failed to load cart payment')))
+        catchError(error => of(new DaffCartPaymentLoadFailure(this.errorMatcher(error))))
       )
     )
   )
@@ -51,7 +52,7 @@ export class DaffCartPaymentEffects<
     switchMap((action: DaffCartPaymentUpdate<T>) =>
       this.driver.update(this.storage.getCartId(), action.payload).pipe(
         map((resp: V) => new DaffCartPaymentUpdateSuccess(resp)),
-        catchError(error => of(new DaffCartPaymentUpdateFailure('Failed to update cart payment')))
+        catchError(error => of(new DaffCartPaymentUpdateFailure(this.errorMatcher(error))))
       )
     )
   )
@@ -62,7 +63,7 @@ export class DaffCartPaymentEffects<
     switchMap((action: DaffCartPaymentUpdateWithBilling<T, R>) =>
       this.driver.updateWithBilling(this.storage.getCartId(), action.payment, action.address).pipe(
         map(resp => new DaffCartPaymentUpdateWithBillingSuccess(resp)),
-        catchError(error => of(new DaffCartPaymentUpdateWithBillingFailure('Failed to update cart payment and billing address')))
+        catchError(error => of(new DaffCartPaymentUpdateWithBillingFailure(this.errorMatcher(error))))
       )
     )
   )
@@ -73,7 +74,7 @@ export class DaffCartPaymentEffects<
     switchMap((action: DaffCartPaymentRemove) =>
       this.driver.remove(this.storage.getCartId()).pipe(
         mapTo(new DaffCartPaymentRemoveSuccess()),
-        catchError(error => of(new DaffCartPaymentRemoveFailure('Failed to remove the cart payment')))
+        catchError(error => of(new DaffCartPaymentRemoveFailure(this.errorMatcher(error))))
       )
     )
   )

--- a/libs/cart/state/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-resolver.effects.spec.ts
@@ -28,7 +28,6 @@ describe('DaffCartResolverEffects', () => {
 	let stubCart: DaffCart;
 
   let cartStorageService: jasmine.SpyObj<DaffCartStorageService>;
-  const cartStorageFailureAction = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
   const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
 	beforeEach(() => {
@@ -69,7 +68,8 @@ describe('DaffCartResolverEffects', () => {
       });
 
       it('should indicate cart resolution failure due to cart ID retrieval', () => {
-        const resolveCartFailureAction = new DaffResolveCartFailure('Cart resolution failed while attempting to retrieve the cart ID from storage.');
+        const error = new DaffStorageServiceError('Cart resolution failed while attempting to retrieve the cart ID from storage.');
+        const resolveCartFailureAction = new DaffResolveCartFailure(daffTransformErrorToStateError(error));
         const expected = cold('--b', {
           b: resolveCartFailureAction
         });
@@ -92,9 +92,8 @@ describe('DaffCartResolverEffects', () => {
         });
 
         it('should dispatch DaffResolveCartFailure action', () => {
-          const response = cold('#', {});
-          driver.create.and.returnValue(response);
-          const resolveCartFailureAction = new DaffResolveCartFailure('Cart resolution has failed.');
+          const error = new DaffCartInvalidAPIResponseError('Cart resolution has failed.');
+          const resolveCartFailureAction = new DaffResolveCartFailure(daffTransformErrorToStateError(error));
           const expected = cold('--b', {
             b: resolveCartFailureAction
           });
@@ -129,7 +128,8 @@ describe('DaffCartResolverEffects', () => {
         });
 
         it('should indicate failed cart resolution', () => {
-          const resolveCartFailureAction = new DaffResolveCartFailure('Cart resolution has failed.');
+          const error = new DaffCartInvalidAPIResponseError('Cart resolution has failed.');
+          const resolveCartFailureAction = new DaffResolveCartFailure(daffTransformErrorToStateError(error));
           const expected = cold('--b', {
             b: resolveCartFailureAction,
           });
@@ -178,7 +178,8 @@ describe('DaffCartResolverEffects', () => {
           });
 
           it('should indicate failed cart resolution', () => {
-            const resolveCartFailureAction = new DaffResolveCartFailure('Cart resolution failed after attempting to generate and load a new cart.');
+            const error = new DaffCartInvalidAPIResponseError('Cart resolution failed after attempting to generate and load a new cart.');
+            const resolveCartFailureAction = new DaffResolveCartFailure(daffTransformErrorToStateError(error));
             const expected = cold('--b', {
               b: resolveCartFailureAction,
             });
@@ -195,7 +196,8 @@ describe('DaffCartResolverEffects', () => {
           });
 
           it('should indicate failed cart resolution', () => {
-            const resolveCartFailureAction = new DaffResolveCartFailure('Cart resolution failed after attempting to generate and load a new cart.');
+            const error = new DaffCartNotFoundError('Cart resolution failed after attempting to generate and load a new cart.');
+            const resolveCartFailureAction = new DaffResolveCartFailure(daffTransformErrorToStateError(error));
             const expected = cold('--b', {
               b: resolveCartFailureAction,
             });

--- a/libs/cart/state/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-resolver.effects.spec.ts
@@ -3,14 +3,13 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Observable, of } from 'rxjs';
 import { hot, cold } from 'jasmine-marbles';
 
-import { DaffError, DaffStorageServiceError } from '@daffodil/core';
+import { DaffStorageServiceError } from '@daffodil/core';
 import { daffTransformErrorToStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartStorageService } from '@daffodil/cart';
 import {
   DaffResolveCart,
   DaffResolveCartFailure,
   DaffResolveCartSuccess,
-  DaffCartStorageFailure,
 } from '@daffodil/cart/state';
 import { DaffCartServiceInterface, DaffCartDriver, DaffCartNotFoundError, DaffCartInvalidAPIResponseError } from '@daffodil/cart/driver';
 import {

--- a/libs/cart/state/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-resolver.effects.spec.ts
@@ -3,12 +3,14 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Observable, of } from 'rxjs';
 import { hot, cold } from 'jasmine-marbles';
 
-import { DaffStorageServiceError } from '@daffodil/core';
+import { DaffError, DaffStorageServiceError } from '@daffodil/core';
+import { daffTransformErrorToStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartStorageService } from '@daffodil/cart';
 import {
   DaffResolveCart,
   DaffResolveCartFailure,
   DaffResolveCartSuccess,
+  DaffCartStorageFailure,
 } from '@daffodil/cart/state';
 import { DaffCartServiceInterface, DaffCartDriver, DaffCartNotFoundError, DaffCartInvalidAPIResponseError } from '@daffodil/cart/driver';
 import {
@@ -26,6 +28,7 @@ describe('DaffCartResolverEffects', () => {
 	let stubCart: DaffCart;
 
   let cartStorageService: jasmine.SpyObj<DaffCartStorageService>;
+  const cartStorageFailureAction = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
   const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
 	beforeEach(() => {

--- a/libs/cart/state/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/state/src/effects/cart-resolver.effects.ts
@@ -4,8 +4,9 @@ import { Action } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 import { switchMap, catchError, map, mapTo } from 'rxjs/operators';
 
-import { DaffStorageServiceError } from '@daffodil/core';
-import { DaffCart, DaffCartStorageService } from '@daffodil/cart';
+import { DaffStorageServiceError, DaffError } from '@daffodil/core';
+import { substream } from '@daffodil/core/state';
+import { DaffCart, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartDriver, DaffCartServiceInterface, DaffCartNotFoundError } from '@daffodil/cart/driver';
 
 import {
@@ -22,6 +23,7 @@ import {
 export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
 	constructor(
 		private actions$: Actions,
+    @Inject(DAFF_CART_ERROR_MATCHER) private errorMatcher: Function,
 		private cartStorage: DaffCartStorageService,
 		@Inject(DaffCartDriver) private driver: DaffCartServiceInterface<T>,
 	) {}
@@ -34,18 +36,23 @@ export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
       switchMap(cartId => cartId ? of({ id: cartId }) : this.driver.create()),
       switchMap(({ id }) => this.driver.get(id)),
       map(resp => new DaffResolveCartSuccess(resp)),
-      catchError(error => {
+      catchError((error: DaffError) => {
         switch(true) {
           case error instanceof DaffStorageServiceError:
-            return of(new DaffResolveCartFailure('Cart resolution failed while attempting to retrieve the cart ID from storage.'));
+            error.message = 'Cart resolution failed while attempting to retrieve the cart ID from storage.'
+            return of(new DaffResolveCartFailure(this.errorMatcher(error)));
           case error instanceof DaffCartNotFoundError:
             return this.driver.create().pipe(
               switchMap(({ id }) => this.driver.get(id)),
               map(resp => new DaffResolveCartSuccess(resp)),
-              catchError(() => of(new DaffResolveCartFailure('Cart resolution failed after attempting to generate and load a new cart.')))
+              catchError(() => {
+                error.message = 'Cart resolution failed after attempting to generate and load a new cart.'
+                return of(new DaffResolveCartFailure(this.errorMatcher(error)))
+              })
             );
           default:
-            return of(new DaffResolveCartFailure('Cart resolution has failed.'));
+            error.message = 'Cart resolution has failed.'
+            return of(new DaffResolveCartFailure(this.errorMatcher(error)));
         }
       }),
     ))

--- a/libs/cart/state/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/state/src/effects/cart-resolver.effects.ts
@@ -45,9 +45,9 @@ export class DaffCartResolverEffects<T extends DaffCart = DaffCart> {
             return this.driver.create().pipe(
               switchMap(({ id }) => this.driver.get(id)),
               map(resp => new DaffResolveCartSuccess(resp)),
-              catchError(() => {
-                error.message = 'Cart resolution failed after attempting to generate and load a new cart.'
-                return of(new DaffResolveCartFailure(this.errorMatcher(error)))
+              catchError((innerError: DaffError) => {
+                innerError.message = 'Cart resolution failed after attempting to generate and load a new cart.'
+                return of(new DaffResolveCartFailure(this.errorMatcher(innerError)))
               })
             );
           default:

--- a/libs/cart/state/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/state/src/effects/cart-resolver.effects.ts
@@ -5,7 +5,6 @@ import { Observable, of } from 'rxjs';
 import { switchMap, catchError, map, mapTo } from 'rxjs/operators';
 
 import { DaffStorageServiceError, DaffError } from '@daffodil/core';
-import { substream } from '@daffodil/core/state';
 import { DaffCart, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartDriver, DaffCartServiceInterface, DaffCartNotFoundError } from '@daffodil/cart/driver';
 

--- a/libs/cart/state/src/effects/cart-shipping-address.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-shipping-address.effects.spec.ts
@@ -3,6 +3,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Observable, of } from 'rxjs';
 import { hot, cold } from 'jasmine-marbles';
 
+import { DaffStateError } from '@daffodil/core/state';
 import {
   DaffCart,
   DaffCartAddress,
@@ -91,7 +92,7 @@ describe('Daffodil | Cart | CartShippingAddressEffects', () => {
 
     describe('and the call to CartShippingAddressService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to load cart shipping address';
+        const error: DaffStateError = {code: 'code', message: 'Failed to load cart shipping address'};
         const response = cold('#', {}, error);
         daffShippingAddressDriverSpy.get.and.returnValue(response);
         const cartShippingAddressLoadFailureAction = new DaffCartShippingAddressLoadFailure(error);
@@ -130,7 +131,7 @@ describe('Daffodil | Cart | CartShippingAddressEffects', () => {
 
     describe('and the call to CartShippingAddressService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to update cart shipping address';
+        const error: DaffStateError = {code: 'code', message: 'Failed to update cart shipping address'};
         const response = cold('#', {}, error);
         daffShippingAddressDriverSpy.update.and.returnValue(response);
         const cartCreateFailureAction = new DaffCartShippingAddressUpdateFailure(error);

--- a/libs/cart/state/src/effects/cart-shipping-address.effects.ts
+++ b/libs/cart/state/src/effects/cart-shipping-address.effects.ts
@@ -3,7 +3,7 @@ import { switchMap, map, catchError } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 
-import { DaffCartAddress, DaffCart, DaffCartStorageService } from '@daffodil/cart';
+import { DaffCartAddress, DaffCart, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartShippingAddressDriver, DaffCartShippingAddressServiceInterface } from '@daffodil/cart/driver';
 
 import {
@@ -20,6 +20,7 @@ import {
 export class DaffCartShippingAddressEffects<T extends DaffCartAddress, V extends DaffCart> {
   constructor(
     private actions$: Actions,
+    @Inject(DAFF_CART_ERROR_MATCHER) private errorMatcher: Function,
     @Inject(DaffCartShippingAddressDriver) private driver: DaffCartShippingAddressServiceInterface<T, V>,
     private storage: DaffCartStorageService
   ) {}
@@ -30,7 +31,7 @@ export class DaffCartShippingAddressEffects<T extends DaffCartAddress, V extends
     switchMap((action: DaffCartShippingAddressLoad) =>
       this.driver.get(this.storage.getCartId()).pipe(
         map((resp: T) => new DaffCartShippingAddressLoadSuccess(resp)),
-        catchError(error => of(new DaffCartShippingAddressLoadFailure('Failed to load cart shipping address')))
+        catchError(error => of(new DaffCartShippingAddressLoadFailure(this.errorMatcher(error))))
       )
     )
   )
@@ -41,7 +42,7 @@ export class DaffCartShippingAddressEffects<T extends DaffCartAddress, V extends
     switchMap((action: DaffCartShippingAddressUpdate<T>) =>
       this.driver.update(this.storage.getCartId(), action.payload).pipe(
         map((resp: V) => new DaffCartShippingAddressUpdateSuccess(resp)),
-        catchError(error => of(new DaffCartShippingAddressUpdateFailure('Failed to update cart shipping address')))
+        catchError(error => of(new DaffCartShippingAddressUpdateFailure(this.errorMatcher(error))))
       )
     )
   )

--- a/libs/cart/state/src/effects/cart-shipping-information.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-shipping-information.effects.spec.ts
@@ -3,6 +3,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Observable, of } from 'rxjs';
 import { hot, cold } from 'jasmine-marbles';
 
+import { DaffStateError } from '@daffodil/core/state';
 import {
   DaffCart,
   DaffCartShippingInformation,
@@ -97,7 +98,7 @@ describe('Daffodil | Cart | CartShippingInformationEffects', () => {
 
     describe('and the call to CartShippingInformationService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to load cart shipping information';
+        const error: DaffStateError = {code: 'code', message: 'Failed to load cart shipping information'};
         const response = cold('#', {}, error);
         daffShippingInformationDriverSpy.get.and.returnValue(response);
         const cartShippingInformationLoadFailureAction = new DaffCartShippingInformationLoadFailure(error);
@@ -136,7 +137,7 @@ describe('Daffodil | Cart | CartShippingInformationEffects', () => {
 
     describe('and the call to CartShippingInformationService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to update cart shipping information';
+        const error: DaffStateError = {code: 'code', message: 'Failed to update cart shipping information'};
         const response = cold('#', {}, error);
         daffShippingInformationDriverSpy.update.and.returnValue(response);
         const cartCreateFailureAction = new DaffCartShippingInformationUpdateFailure(error);
@@ -169,7 +170,7 @@ describe('Daffodil | Cart | CartShippingInformationEffects', () => {
 
     describe('and the call to CartShippingInformationService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to delete the cart shipping information';
+        const error: DaffStateError = {code: 'code', message: 'Failed to delete the cart shipping information'};
         const response = cold('#', {}, error);
         daffShippingInformationDriverSpy.delete.and.returnValue(response);
         const cartShippingInformationDeleteFailureAction = new DaffCartShippingInformationDeleteFailure(error);

--- a/libs/cart/state/src/effects/cart-shipping-information.effects.ts
+++ b/libs/cart/state/src/effects/cart-shipping-information.effects.ts
@@ -3,7 +3,7 @@ import { switchMap, map, catchError } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 
-import { DaffCartShippingInformation, DaffCart, DaffCartStorageService } from '@daffodil/cart';
+import { DaffCartShippingInformation, DaffCart, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartShippingInformationDriver, DaffCartShippingInformationServiceInterface } from '@daffodil/cart/driver';
 
 import {
@@ -23,6 +23,7 @@ import {
 export class DaffCartShippingInformationEffects<T extends DaffCartShippingInformation, V extends DaffCart> {
   constructor(
     private actions$: Actions,
+    @Inject(DAFF_CART_ERROR_MATCHER) private errorMatcher: Function,
     @Inject(DaffCartShippingInformationDriver) private driver: DaffCartShippingInformationServiceInterface<T, V>,
     private storage: DaffCartStorageService
   ) {}
@@ -33,7 +34,7 @@ export class DaffCartShippingInformationEffects<T extends DaffCartShippingInform
     switchMap((action: DaffCartShippingInformationLoad) =>
       this.driver.get(this.storage.getCartId()).pipe(
         map((resp: T) => new DaffCartShippingInformationLoadSuccess(resp)),
-        catchError(error => of(new DaffCartShippingInformationLoadFailure('Failed to load cart shipping information')))
+        catchError(error => of(new DaffCartShippingInformationLoadFailure(this.errorMatcher(error))))
       )
     )
   )
@@ -44,7 +45,7 @@ export class DaffCartShippingInformationEffects<T extends DaffCartShippingInform
     switchMap((action: DaffCartShippingInformationUpdate<T>) =>
       this.driver.update(this.storage.getCartId(), action.payload).pipe(
         map((resp: V) => new DaffCartShippingInformationUpdateSuccess(resp)),
-        catchError(error => of(new DaffCartShippingInformationUpdateFailure('Failed to update cart shipping information')))
+        catchError(error => of(new DaffCartShippingInformationUpdateFailure(this.errorMatcher(error))))
       )
     )
   )
@@ -55,7 +56,7 @@ export class DaffCartShippingInformationEffects<T extends DaffCartShippingInform
     switchMap((action: DaffCartShippingInformationDelete<V['shipping_information']>) =>
       this.driver.delete(this.storage.getCartId()).pipe(
         map((resp: V) => new DaffCartShippingInformationDeleteSuccess(resp)),
-        catchError(error => of(new DaffCartShippingInformationDeleteFailure('Failed to delete the cart shipping information')))
+        catchError(error => of(new DaffCartShippingInformationDeleteFailure(this.errorMatcher(error))))
       )
     )
   )

--- a/libs/cart/state/src/effects/cart-shipping-methods.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-shipping-methods.effects.spec.ts
@@ -18,6 +18,7 @@ import {
   DaffCartFactory,
   DaffCartShippingRateFactory,
 } from '@daffodil/cart/testing';
+import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffCartShippingMethodsEffects } from './cart-shipping-methods.effects';
 
@@ -88,7 +89,7 @@ describe('Daffodil | Cart | DaffCartShippingMethodsEffects', () => {
 
     describe('and the call to CartService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to list cart shipping methods';
+        const error: DaffStateError = {code: 'code', message: 'Failed to list cart shipping methods'};
         const response = cold('#', {}, error);
         shippingMethodsDriverSpy.list.and.returnValue(response);
         const cartCreateFailureAction = new DaffCartShippingMethodsLoadFailure(error);

--- a/libs/cart/state/src/effects/cart-shipping-methods.effects.ts
+++ b/libs/cart/state/src/effects/cart-shipping-methods.effects.ts
@@ -3,7 +3,7 @@ import { switchMap, map, catchError } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 
-import { DaffCartShippingRate, DaffCartStorageService } from '@daffodil/cart';
+import { DaffCartShippingRate, DaffCartStorageService, DAFF_CART_ERROR_MATCHER } from '@daffodil/cart';
 import { DaffCartShippingMethodsDriver, DaffCartShippingMethodsServiceInterface } from '@daffodil/cart/driver';
 
 import {
@@ -18,6 +18,7 @@ export class DaffCartShippingMethodsEffects<T extends DaffCartShippingRate> {
 
   constructor(
     private actions$: Actions,
+    @Inject(DAFF_CART_ERROR_MATCHER) private errorMatcher: Function,
     @Inject(DaffCartShippingMethodsDriver) private driver: DaffCartShippingMethodsServiceInterface<T>,
     private storage: DaffCartStorageService
     ) {}
@@ -28,7 +29,7 @@ export class DaffCartShippingMethodsEffects<T extends DaffCartShippingRate> {
     switchMap((action: DaffCartShippingMethodsLoad) =>
       this.driver.list(this.storage.getCartId()).pipe(
         map((resp: T[]) => new DaffCartShippingMethodsLoadSuccess(resp)),
-        catchError(error => of(new DaffCartShippingMethodsLoadFailure('Failed to list cart shipping methods')))
+        catchError(error => of(new DaffCartShippingMethodsLoadFailure(this.errorMatcher(error))))
       )
     )
   )

--- a/libs/cart/state/src/effects/cart.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart.effects.spec.ts
@@ -6,6 +6,7 @@ import { hot, cold } from 'jasmine-marbles';
 import {
   DaffStorageServiceError
 } from '@daffodil/core'
+import { DaffStateError, daffTransformErrorToStateError } from '@daffodil/core/state';
 import {
   DaffCart,
   DaffCartStorageService,
@@ -43,8 +44,8 @@ describe('Daffodil | Cart | CartEffects', () => {
 
   let daffCartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
 
-  const cartStorageFailureAction = new DaffCartStorageFailure('Cart Storage Failed');
-  const throwStorageError = () => { throw new DaffStorageServiceError('message') };
+  const cartStorageFailureAction = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
+  const throwStorageError = () => { throw new DaffStorageServiceError('An error occurred during storage.') };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -95,7 +96,7 @@ describe('Daffodil | Cart | CartEffects', () => {
 
     describe('and the call to CartService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to load cart';
+        const error: DaffStateError = {code: 'code', message: 'Failed to load cart'};
         const response = cold('#', {}, error);
         daffDriverSpy.get.and.returnValue(response);
         const cartLoadFailureAction = new DaffCartLoadFailure(error);
@@ -141,7 +142,7 @@ describe('Daffodil | Cart | CartEffects', () => {
 
     describe('and the call to CartService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to create cart';
+        const error: DaffStateError = {code: 'code', message: 'Failed to create cart'};
         const response = cold('#', {}, error);
         daffDriverSpy.create.and.returnValue(response);
         const cartCreateFailureAction = new DaffCartCreateFailure(error);
@@ -238,7 +239,7 @@ describe('Daffodil | Cart | CartEffects', () => {
 
     describe('and the call to CartService fails', () => {
       beforeEach(() => {
-        const error = 'Failed to add item to cart';
+        const error: DaffStateError = {code: 'code', message: 'Failed to add item to cart'};
         const response = cold('#', {}, error);
         daffDriverSpy.addToCart.and.returnValue(response);
         const addToCartFailureAction = new DaffAddToCartFailure(error);
@@ -270,7 +271,7 @@ describe('Daffodil | Cart | CartEffects', () => {
 
     describe('and the clear call to driver fails', () => {
       beforeEach(() => {
-        const error = 'Failed to clear the cart.';
+        const error: DaffStateError = {code: 'code', message: 'Failed to clear the cart.'};
         const response = cold('#', {}, error);
         daffDriverSpy.clear.and.returnValue(response);
         const cartClearFailureAction = new DaffCartClearFailure(error);

--- a/libs/cart/state/src/facades/cart/cart-facade.interface.ts
+++ b/libs/cart/state/src/facades/cart/cart-facade.interface.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs';
 import { Action } from '@ngrx/store';
 import { Dictionary } from '@ngrx/entity';
 
-import { DaffStoreFacade } from '@daffodil/core/state';
+import { DaffStateError, DaffStoreFacade } from '@daffodil/core/state';
 import { DaffCart, DaffCartOrderResult, DaffCartTotal, DaffConfigurableCartItemAttribute, DaffCompositeCartItemOption } from '@daffodil/cart';
 
 import { DaffCartErrors } from '../../reducers/errors/cart-errors.type';
@@ -222,7 +222,7 @@ export interface DaffCartFacadeInterface<
   canPlaceOrder$: Observable<boolean>;
 
   orderResultLoading$: Observable<boolean>;
-	orderResultErrors$: Observable<string[]>;
+	orderResultErrors$: Observable<DaffStateError[]>;
 	orderResult$: Observable<V>;
 	orderResultId$: Observable<V['orderId']>;
 	orderResultCartId$: Observable<V['cartId']>;

--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -4,7 +4,7 @@ import { StoreModule, combineReducers, Store } from '@ngrx/store';
 import { MockStore } from '@ngrx/store/testing';
 import { cold } from 'jasmine-marbles';
 
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCartOrderResult, DaffCartPaymentMethodIdMap, DaffCart, DaffCartTotalTypeEnum, DaffCartPaymentMethod, DaffConfigurableCartItem, DaffCompositeCartItem, DaffCartItemInputType } from '@daffodil/cart';
 import {
 	initialState, DaffCartReducersState,
@@ -781,7 +781,7 @@ describe('DaffCartFacade', () => {
     });
 
     it('should contain an error upon a failed cart load', () => {
-      const error = 'error';
+      const error: DaffStateError = {code: 'error code', message: 'error message'};
       const expected = cold('a', { a: [error] });
       facade.dispatch(new DaffCartLoadFailure(error));
       expect(facade.cartErrors$).toBeObservable(expected);
@@ -795,7 +795,7 @@ describe('DaffCartFacade', () => {
     });
 
     it('should contain an error upon a failed item load', () => {
-      const error = 'error';
+      const error: DaffStateError = {code: 'error code', message: 'error message'};
       const expected = cold('a', { a: [error] });
       facade.dispatch(new DaffCartItemLoadFailure(error));
       expect(facade.itemErrors$).toBeObservable(expected);
@@ -809,7 +809,7 @@ describe('DaffCartFacade', () => {
     });
 
     it('should contain an error upon a failed billing address load', () => {
-      const error = 'error';
+      const error: DaffStateError = {code: 'error code', message: 'error message'};
       const expected = cold('a', { a: [error] });
       facade.dispatch(new DaffCartBillingAddressLoadFailure(error));
       expect(facade.billingAddressErrors$).toBeObservable(expected);
@@ -823,7 +823,7 @@ describe('DaffCartFacade', () => {
     });
 
     it('should contain an error upon a failed shipping address load', () => {
-      const error = 'error';
+      const error: DaffStateError = {code: 'error code', message: 'error message'};
       const expected = cold('a', { a: [error] });
       facade.dispatch(new DaffCartShippingAddressLoadFailure(error));
       expect(facade.shippingAddressErrors$).toBeObservable(expected);
@@ -837,7 +837,7 @@ describe('DaffCartFacade', () => {
     });
 
     it('should contain an error upon a failed shipping information load', () => {
-      const error = 'error';
+      const error: DaffStateError = {code: 'error code', message: 'error message'};
       const expected = cold('a', { a: [error] });
       facade.dispatch(new DaffCartShippingInformationLoadFailure(error));
       expect(facade.shippingInformationErrors$).toBeObservable(expected);
@@ -851,7 +851,7 @@ describe('DaffCartFacade', () => {
     });
 
     it('should contain an error upon a failed shipping methods load', () => {
-      const error = 'error';
+      const error: DaffStateError = {code: 'error code', message: 'error message'};
       const expected = cold('a', { a: [error] });
       facade.dispatch(new DaffCartShippingMethodsLoadFailure(error));
       expect(facade.shippingMethodsErrors$).toBeObservable(expected);
@@ -865,7 +865,7 @@ describe('DaffCartFacade', () => {
     });
 
     it('should contain an error upon a failed payment load', () => {
-      const error = 'error';
+      const error: DaffStateError = {code: 'error code', message: 'error message'};
       const expected = cold('a', { a: [error] });
       facade.dispatch(new DaffCartPaymentLoadFailure(error));
       expect(facade.paymentErrors$).toBeObservable(expected);
@@ -879,7 +879,7 @@ describe('DaffCartFacade', () => {
     });
 
     it('should contain an error upon a failed payment methods load', () => {
-      const error = 'error';
+      const error: DaffStateError = {code: 'error code', message: 'error message'};
       const expected = cold('a', { a: [error] });
       facade.dispatch(new DaffCartPaymentMethodsLoadFailure(error));
       expect(facade.paymentMethodsErrors$).toBeObservable(expected);
@@ -893,7 +893,7 @@ describe('DaffCartFacade', () => {
     });
 
     it('should contain an error upon a failed coupon list', () => {
-      const error = 'error';
+      const error: DaffStateError = {code: 'error code', message: 'error message'};
       const expected = cold('a', { a: [error] });
       facade.dispatch(new DaffCartCouponListFailure(error));
       expect(facade.couponErrors$).toBeObservable(expected);

--- a/libs/cart/state/src/facades/cart/cart.facade.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.ts
@@ -4,6 +4,7 @@ import { map } from 'rxjs/operators';
 import { Action, Store, select } from '@ngrx/store';
 import { Dictionary } from '@ngrx/entity';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartOrderResult, DaffCartTotal, DaffCartPaymentMethodIdMap, DaffConfigurableCartItemAttribute, DaffCompositeCartItemOption } from '@daffodil/cart';
 
 import { DaffCartReducersState, DaffCartResolveState } from '../../reducers/public_api';
@@ -102,7 +103,7 @@ export class DaffCartFacade<
   canPlaceOrder$: Observable<boolean>;
 
   orderResultLoading$: Observable<boolean>;
-	orderResultErrors$: Observable<string[]>;
+	orderResultErrors$: Observable<DaffStateError[]>;
 	orderResult$: Observable<V>;
 	orderResultId$: Observable<V['orderId']>;
 	orderResultCartId$: Observable<V['cartId']>;

--- a/libs/cart/state/src/injection-tokens/public_api.ts
+++ b/libs/cart/state/src/injection-tokens/public_api.ts
@@ -1,0 +1,1 @@
+export { DaffCartItemStateDebounceTime } from './cart-item-state-debounce-time';

--- a/libs/cart/state/src/public_api.ts
+++ b/libs/cart/state/src/public_api.ts
@@ -4,6 +4,7 @@ export * from './reducers/public_api';
 export * from './guards/public_api';
 export * from './resolvers/public_api';
 export * from './models/public_api';
+export * from './injection-tokens/public_api';
 
 export { DaffCartStateModule } from './cart-state.module'
 

--- a/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCart } from '@daffodil/cart';
 import { DaffCartBillingAddressLoad, DaffCartOperationType, DaffCartReducerState, DaffCartBillingAddressLoadSuccess, DaffCartBillingAddressLoadFailure, DaffCartBillingAddressUpdate, DaffCartBillingAddressUpdateSuccess, DaffCartBillingAddressUpdateFailure, DaffCartAddressUpdate, DaffCartAddressUpdateSuccess, DaffCartAddressUpdateFailure, initialState } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
@@ -67,7 +67,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
   });
 
   describe('when CartBillingAddressLoadFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -80,7 +80,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.BillingAddress]: new Array('firstError')
+          [DaffCartOperationType.BillingAddress]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -139,7 +139,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
   });
 
   describe('when CartBillingAddressUpdateFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -152,11 +152,11 @@ describe('Cart | Reducer | Cart Billing Address', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.BillingAddress]: new Array('firstError')
+          [DaffCartOperationType.BillingAddress]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartBillingAddressUpdateFailure = new DaffCartBillingAddressUpdateFailure(error);
 
@@ -213,7 +213,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
   });
 
   describe('when DaffCartAddressUpdateFailure is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -226,11 +226,11 @@ describe('Cart | Reducer | Cart Billing Address', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.BillingAddress]: new Array('firstError')
+          [DaffCartOperationType.BillingAddress]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartAddressUpdateFailure = new DaffCartAddressUpdateFailure(error);
 

--- a/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartCoupon } from '@daffodil/cart';
 import { DaffCartCouponApply, DaffCartOperationType, DaffCartReducerState, DaffCartCouponApplySuccess, DaffCartCouponApplyFailure, DaffCartCouponList, DaffCartCouponListSuccess, DaffCartCouponListFailure, DaffCartCouponRemove, DaffCartCouponRemoveSuccess, DaffCartCouponRemoveFailure, DaffCartCouponRemoveAll, DaffCartCouponRemoveAllSuccess, DaffCartCouponRemoveAllFailure, initialState } from '@daffodil/cart/state';
 import {
@@ -80,7 +80,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
   });
 
   describe('when CartCouponApplyFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -93,7 +93,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Coupon]: new Array('firstError')
+          [DaffCartOperationType.Coupon]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -153,7 +153,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
   });
 
   describe('when CartCouponListFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -166,7 +166,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Coupon]: new Array('firstError')
+          [DaffCartOperationType.Coupon]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -225,7 +225,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
   });
 
   describe('when CartCouponRemoveFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -238,11 +238,11 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Coupon]: new Array('firstError')
+          [DaffCartOperationType.Coupon]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartCouponRemoveFailure = new DaffCartCouponRemoveFailure(error);
 
@@ -305,7 +305,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
   });
 
   describe('when CartCouponRemoveAllFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -318,11 +318,11 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Coupon]: new Array('firstError')
+          [DaffCartOperationType.Coupon]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartClearFailure = new DaffCartCouponRemoveAllFailure(error);
 

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
@@ -1,19 +1,20 @@
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartItemInputType } from '@daffodil/cart';
-import { 
-	DaffCartItemUpdate, DaffCartOperationType, 
-	DaffCartReducerState, DaffCartItemUpdateSuccess, 
-	DaffCartItemUpdateFailure, DaffCartItemDelete, 
-	DaffCartItemDeleteSuccess, DaffCartItemDeleteFailure, 
-	DaffCartItemAdd, DaffCartItemAddSuccess, 
-	DaffCartItemAddFailure, DaffCartItemLoad, 
-	DaffCartItemLoadSuccess, DaffCartItemLoadFailure, 
-	DaffCartItemList, DaffCartItemListSuccess, 
+import {
+	DaffCartItemUpdate, DaffCartOperationType,
+	DaffCartReducerState, DaffCartItemUpdateSuccess,
+	DaffCartItemUpdateFailure, DaffCartItemDelete,
+	DaffCartItemDeleteSuccess, DaffCartItemDeleteFailure,
+	DaffCartItemAdd, DaffCartItemAddSuccess,
+	DaffCartItemAddFailure, DaffCartItemLoad,
+	DaffCartItemLoadSuccess, DaffCartItemLoadFailure,
+	DaffCartItemList, DaffCartItemListSuccess,
 	DaffCartItemListFailure, initialState,
-	DaffCartItemLoadingState
+	DaffCartItemLoadingState,
+  DaffStatefulCartItem
 } from '@daffodil/cart/state';
 import { DaffStatefulCartItemFactory } from '@daffodil/cart/state/testing';
 import { DaffCartFactory } from '@daffodil/cart/testing';
-import { DaffStatefulCartItem } from '../../models/public_api';
 
 import { cartItemReducer } from './cart-item.reducer';
 
@@ -86,7 +87,7 @@ describe('Cart | Reducer | Cart Item', () => {
   });
 
   describe('when CartItemUpdateFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -99,7 +100,7 @@ describe('Cart | Reducer | Cart Item', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Item]: new Array('firstError')
+          [DaffCartOperationType.Item]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -159,7 +160,7 @@ describe('Cart | Reducer | Cart Item', () => {
   });
 
   describe('when CartItemDeleteFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -172,7 +173,7 @@ describe('Cart | Reducer | Cart Item', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Item]: new Array('firstError')
+          [DaffCartOperationType.Item]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -235,7 +236,7 @@ describe('Cart | Reducer | Cart Item', () => {
   });
 
   describe('when CartItemAddFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -248,11 +249,11 @@ describe('Cart | Reducer | Cart Item', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Item]: new Array('firstError')
+          [DaffCartOperationType.Item]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartItemAddFailure = new DaffCartItemAddFailure(error);
 
@@ -321,7 +322,7 @@ describe('Cart | Reducer | Cart Item', () => {
   });
 
   describe('when CartItemLoadFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -334,11 +335,11 @@ describe('Cart | Reducer | Cart Item', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Item]: new Array('firstError')
+          [DaffCartOperationType.Item]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartItemLoadFailure = new DaffCartItemLoadFailure(error);
 
@@ -401,7 +402,7 @@ describe('Cart | Reducer | Cart Item', () => {
   });
 
   describe('when CartItemListFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -414,11 +415,11 @@ describe('Cart | Reducer | Cart Item', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Item]: new Array('firstError')
+          [DaffCartOperationType.Item]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartItemListFailure = new DaffCartItemListFailure(error);
 

--- a/libs/cart/state/src/reducers/cart-order/cart-order-state.interface.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order-state.interface.ts
@@ -1,8 +1,8 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCartOrderResult } from '@daffodil/cart';
 
 export interface DaffCartOrderReducerState<T extends DaffCartOrderResult = DaffCartOrderResult> {
   cartOrderResult: T;
   loading: DaffLoadingState;
-  errors: string[];
+  errors: DaffStateError[];
 }

--- a/libs/cart/state/src/reducers/cart-order/cart-order.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order.reducer.spec.ts
@@ -1,8 +1,7 @@
 import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
-import { DaffCartPlaceOrder, DaffCartOrderReducerState, DaffCartPlaceOrderSuccess, DaffCartPlaceOrderFailure } from '@daffodil/cart/state';
+import { DaffCartPlaceOrder, DaffCartOrderReducerState, DaffCartPlaceOrderSuccess, DaffCartPlaceOrderFailure, daffCartOrderInitialState as initialState } from '@daffodil/cart/state';
 
 import { daffCartOrderReducer as reducer } from './cart-order.reducer';
-import { daffCartOrderInitialState as initialState } from './cart-order-initial-state';
 
 describe('Cart | Reducer | CartOrder', () => {
   describe('when an unknown action is triggered', () => {

--- a/libs/cart/state/src/reducers/cart-order/cart-order.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCartPlaceOrder, DaffCartOrderReducerState, DaffCartPlaceOrderSuccess, DaffCartPlaceOrderFailure } from '@daffodil/cart/state';
 
 import { daffCartOrderReducer as reducer } from './cart-order.reducer';
@@ -61,7 +61,7 @@ describe('Cart | Reducer | CartOrder', () => {
   });
 
   describe('when CartPlaceOrderFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartOrderReducerState;
 

--- a/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCart } from '@daffodil/cart';
 import { DaffCartPaymentMethodsLoad, DaffCartOperationType, DaffCartReducerState, DaffCartPaymentMethodsLoadSuccess, DaffCartPaymentMethodsLoadFailure, initialState } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
@@ -68,7 +68,7 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
   });
 
   describe('when CartPaymentMethodsLoadFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -81,7 +81,7 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.PaymentMethods]: new Array('firstError')
+          [DaffCartOperationType.PaymentMethods]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 

--- a/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCart } from '@daffodil/cart';
 import { DaffCartPaymentLoad, DaffCartOperationType, DaffCartReducerState, DaffCartPaymentLoadSuccess, DaffCartPaymentLoadFailure, DaffCartPaymentUpdate, DaffCartPaymentUpdateSuccess, DaffCartPaymentUpdateFailure, DaffCartPaymentUpdateWithBilling, DaffCartPaymentUpdateWithBillingSuccess, DaffCartPaymentUpdateWithBillingFailure, DaffCartPaymentRemove, DaffCartPaymentRemoveSuccess, DaffCartPaymentRemoveFailure, DaffCartPaymentMethodAdd, initialState } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
@@ -67,7 +67,7 @@ describe('Cart | Reducer | Cart Payment', () => {
   });
 
   describe('when CartPaymentLoadFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -80,7 +80,7 @@ describe('Cart | Reducer | Cart Payment', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Payment]: new Array('firstError')
+          [DaffCartOperationType.Payment]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -139,7 +139,7 @@ describe('Cart | Reducer | Cart Payment', () => {
   });
 
   describe('when CartPaymentUpdateFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -152,11 +152,11 @@ describe('Cart | Reducer | Cart Payment', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Payment]: new Array('firstError')
+          [DaffCartOperationType.Payment]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartPaymentUpdateFailure = new DaffCartPaymentUpdateFailure(error);
 
@@ -213,7 +213,7 @@ describe('Cart | Reducer | Cart Payment', () => {
   });
 
   describe('when CartPaymentUpdateWithBillingFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -226,11 +226,11 @@ describe('Cart | Reducer | Cart Payment', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Payment]: new Array('firstError')
+          [DaffCartOperationType.Payment]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartPaymentUpdateWithBillingFailure = new DaffCartPaymentUpdateWithBillingFailure(error);
 
@@ -286,7 +286,7 @@ describe('Cart | Reducer | Cart Payment', () => {
   });
 
   describe('when CartPaymentRemoveFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -299,11 +299,11 @@ describe('Cart | Reducer | Cart Payment', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Payment]: new Array('firstError')
+          [DaffCartOperationType.Payment]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartPaymentRemoveFailure = new DaffCartPaymentRemoveFailure(error);
 

--- a/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
@@ -12,6 +12,7 @@ import {
 import {
   DaffCartFactory,
 } from '@daffodil/cart/testing';
+import { DaffStateError } from '@daffodil/core/state';
 
 import { cartResolveReducer as reducer } from './cart-resolve.reducer';
 
@@ -67,7 +68,7 @@ describe('Cart | Reducer | cartResolveReducer', () => {
   });
 
   describe('when ResolveCartActionFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 

--- a/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCart } from '@daffodil/cart';
 import { DaffCartShippingAddressLoad, DaffCartOperationType, DaffCartReducerState, DaffCartShippingAddressLoadSuccess, DaffCartShippingAddressLoadFailure, DaffCartShippingAddressUpdate, DaffCartShippingAddressUpdateSuccess, DaffCartShippingAddressUpdateFailure, DaffCartAddressUpdate, DaffCartAddressUpdateSuccess, DaffCartAddressUpdateFailure, initialState } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
@@ -67,7 +67,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
   });
 
   describe('when CartShippingAddressLoadFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -80,7 +80,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.ShippingAddress]: new Array('firstError')
+          [DaffCartOperationType.ShippingAddress]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -139,7 +139,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
   });
 
   describe('when CartShippingAddressUpdateFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -152,11 +152,11 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.ShippingAddress]: new Array('firstError')
+          [DaffCartOperationType.ShippingAddress]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartShippingAddressUpdateFailure = new DaffCartShippingAddressUpdateFailure(error);
 
@@ -213,7 +213,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
   });
 
   describe('when DaffCartAddressUpdateFailure is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -226,11 +226,11 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.ShippingAddress]: new Array('firstError')
+          [DaffCartOperationType.ShippingAddress]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartAddressUpdateFailure = new DaffCartAddressUpdateFailure(error);
 

--- a/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartShippingInformation } from '@daffodil/cart';
 import { DaffCartShippingInformationLoad, DaffCartOperationType, DaffCartReducerState, DaffCartShippingInformationLoadSuccess, DaffCartShippingInformationLoadFailure, DaffCartShippingInformationUpdate, DaffCartShippingInformationUpdateSuccess, DaffCartShippingInformationUpdateFailure, DaffCartShippingInformationDelete, DaffCartShippingInformationDeleteSuccess, DaffCartShippingInformationDeleteFailure, initialState } from '@daffodil/cart/state';
 import {
@@ -78,7 +78,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
   });
 
   describe('when CartShippingInformationLoadFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -91,7 +91,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.ShippingInformation]: new Array('firstError')
+          [DaffCartOperationType.ShippingInformation]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -150,7 +150,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
   });
 
   describe('when CartShippingInformationUpdateFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -163,11 +163,11 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.ShippingInformation]: new Array('firstError')
+          [DaffCartOperationType.ShippingInformation]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartShippingInformationUpdateFailure = new DaffCartShippingInformationUpdateFailure(error);
 
@@ -231,7 +231,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
   });
 
   describe('when CartShippingInformationDeleteFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -244,11 +244,11 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.ShippingInformation]: new Array('firstError')
+          [DaffCartOperationType.ShippingInformation]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartShippingInformationRemoveFailure = new DaffCartShippingInformationDeleteFailure(error);
 

--- a/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartShippingRate } from '@daffodil/cart';
 import { DaffCartShippingMethodsLoad, DaffCartOperationType, DaffCartReducerState, DaffCartShippingMethodsLoadSuccess, DaffCartShippingMethodsLoadFailure, initialState } from '@daffodil/cart/state';
 import { DaffCartFactory, DaffCartShippingRateFactory } from '@daffodil/cart/testing';
@@ -76,7 +76,7 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
   });
 
   describe('when CartShippingMethodsLoadFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -89,7 +89,7 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.ShippingMethods]: new Array('firstError')
+          [DaffCartOperationType.ShippingMethods]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 

--- a/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError, daffTransformErrorToStateError } from '@daffodil/core/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 
 import { DaffCart } from '@daffodil/cart';
@@ -109,7 +109,7 @@ describe('Cart | Reducer | Cart', () => {
   });
 
   describe('when CartLoadFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -122,7 +122,7 @@ describe('Cart | Reducer | Cart', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Cart]: new Array('firstError')
+          [DaffCartOperationType.Cart]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -185,11 +185,11 @@ describe('Cart | Reducer | Cart', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Cart]: new Array('firstError')
+          [DaffCartOperationType.Cart]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      const cartStorageFailure = new DaffCartStorageFailure('Cart Storage Failed');
+      const cartStorageFailure = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
 
       result = cartReducer(state, cartStorageFailure);
     });
@@ -248,7 +248,7 @@ describe('Cart | Reducer | Cart', () => {
   });
 
   describe('when CartCreateFailureAction is triggered', () => {
-    const error = 'error message';
+    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -261,7 +261,7 @@ describe('Cart | Reducer | Cart', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Cart]: new Array('firstError')
+          [DaffCartOperationType.Cart]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -323,7 +323,7 @@ describe('Cart | Reducer | Cart', () => {
   });
 
   describe('when AddToCartFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -336,11 +336,11 @@ describe('Cart | Reducer | Cart', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Cart]: new Array('firstError')
+          [DaffCartOperationType.Cart]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const addToCartFailure = new DaffAddToCartFailure(error);
 
@@ -403,7 +403,7 @@ describe('Cart | Reducer | Cart', () => {
   });
 
   describe('when CartClearFailureAction is triggered', () => {
-    let error: string;
+    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -416,11 +416,11 @@ describe('Cart | Reducer | Cart', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Cart]: new Array('firstError')
+          [DaffCartOperationType.Cart]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
-      error = 'error';
+      error = {code: 'error code', message: 'error message'};
 
       const cartClearFailure = new DaffCartClearFailure(error);
 

--- a/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
@@ -8,12 +8,17 @@ import { cartReducer } from './cart.reducer';
 
 describe('Cart | Reducer | Cart', () => {
   let cartFactory: DaffCartFactory;
+  let error: DaffStateError;
   let cart: DaffCart;
 
   beforeEach(() => {
     cartFactory = new DaffCartFactory();
 
     cart = cartFactory.create();
+    error = {
+      code: 'error code',
+      message: 'error message'
+    }
   });
 
   describe('when an unknown action is triggered', () => {
@@ -109,7 +114,6 @@ describe('Cart | Reducer | Cart', () => {
   });
 
   describe('when CartLoadFailureAction is triggered', () => {
-    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -141,7 +145,6 @@ describe('Cart | Reducer | Cart', () => {
   });
 
   describe('when ResolveCartFailureAction is triggered', () => {
-    const error = 'error message';
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -154,7 +157,7 @@ describe('Cart | Reducer | Cart', () => {
         },
         errors: {
           ...initialState.errors,
-          [DaffCartOperationType.Cart]: new Array('firstError')
+          [DaffCartOperationType.Cart]: [{code: 'first error code', message: 'first error message'}]
         }
       }
 
@@ -248,7 +251,6 @@ describe('Cart | Reducer | Cart', () => {
   });
 
   describe('when CartCreateFailureAction is triggered', () => {
-    const error: DaffStateError = {code: 'error code', message: 'error message'};
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -323,7 +325,6 @@ describe('Cart | Reducer | Cart', () => {
   });
 
   describe('when AddToCartFailureAction is triggered', () => {
-    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -339,8 +340,6 @@ describe('Cart | Reducer | Cart', () => {
           [DaffCartOperationType.Cart]: [{code: 'first error code', message: 'first error message'}]
         }
       }
-
-      error = {code: 'error code', message: 'error message'};
 
       const addToCartFailure = new DaffAddToCartFailure(error);
 
@@ -403,7 +402,6 @@ describe('Cart | Reducer | Cart', () => {
   });
 
   describe('when CartClearFailureAction is triggered', () => {
-    let error: DaffStateError;
     let result;
     let state: DaffCartReducerState<DaffCart>;
 
@@ -419,8 +417,6 @@ describe('Cart | Reducer | Cart', () => {
           [DaffCartOperationType.Cart]: [{code: 'first error code', message: 'first error message'}]
         }
       }
-
-      error = {code: 'error code', message: 'error message'};
 
       const cartClearFailure = new DaffCartClearFailure(error);
 

--- a/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
@@ -1,8 +1,8 @@
+import { DaffStorageServiceError } from '@daffodil/core';
 import { DaffLoadingState, DaffStateError, daffTransformErrorToStateError } from '@daffodil/core/state';
-import { DaffCartFactory } from '@daffodil/cart/testing';
-
 import { DaffCart } from '@daffodil/cart';
 import { DaffCartLoad, DaffCartOperationType, DaffResolveCart, DaffCartReducerState, DaffCartLoadSuccess, DaffCartLoadFailure, DaffCartStorageFailure, DaffCartCreate, DaffCartCreateSuccess, DaffCartCreateFailure, DaffAddToCart, DaffAddToCartSuccess, DaffAddToCartFailure, DaffCartClear, DaffCartClearSuccess, DaffCartClearFailure, initialState, DaffResolveCartSuccess, DaffResolveCartFailure } from '@daffodil/cart/state';
+import { DaffCartFactory } from '@daffodil/cart/testing';
 
 import { cartReducer } from './cart.reducer';
 

--- a/libs/cart/state/src/reducers/errors/cart-errors.type.ts
+++ b/libs/cart/state/src/reducers/errors/cart-errors.type.ts
@@ -1,5 +1,7 @@
+import { DaffStateError } from '@daffodil/core/state';
+
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 
 export type DaffCartErrors = {
-  [K in DaffCartOperationType]: string[]
+  [K in DaffCartOperationType]: DaffStateError[]
 }

--- a/libs/cart/state/src/reducers/errors/error-state-helpers.ts
+++ b/libs/cart/state/src/reducers/errors/error-state-helpers.ts
@@ -1,8 +1,10 @@
+import { DaffStateError } from '@daffodil/core/state';
+
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartErrors } from './cart-errors.type';
 
 export const initializeErrorAdder = (errorSpace: DaffCartOperationType) =>
-  (errors: DaffCartErrors, error: string) => ({
+  (errors: DaffCartErrors, error: DaffStateError) => ({
     errors: {
       ...errors,
       [errorSpace]: errors[errorSpace].concat(new Array(error))

--- a/libs/cart/state/src/resolvers/cart-resolver.service.spec.ts
+++ b/libs/cart/state/src/resolvers/cart-resolver.service.spec.ts
@@ -5,6 +5,8 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 
+import { DaffStorageServiceError } from '@daffodil/core';
+import { DaffStateError, daffTransformErrorToStateError } from '@daffodil/core/state';
 import { DaffCart } from '@daffodil/cart';
 import {
 	daffCartReducers,
@@ -123,13 +125,14 @@ describe('DaffCartResolver', () => {
     });
 
     describe('when DaffCartStorageFailure is dispatched', () => {
+      const error: DaffStateError = daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.'))
 
       it('should resolve with a DaffCartStorageFailure action', () => {
         cartResolver.resolve().subscribe((resolvedValue) => {
-          expect(resolvedValue).toEqual(new DaffCartStorageFailure('Cart Storage Failed'));
+          expect(resolvedValue).toEqual(new DaffCartStorageFailure(error));
         });
 
-        store.dispatch(new DaffCartStorageFailure('Cart Storage Failed'));
+        store.dispatch(new DaffCartStorageFailure(error));
       });
 
       it('should redirect to the provided DaffCartResolverRedirectUrl', () => {
@@ -137,7 +140,7 @@ describe('DaffCartResolver', () => {
           expect(router.navigateByUrl).toHaveBeenCalledWith(stubUrl);
         });
 
-        store.dispatch(new DaffCartStorageFailure('Cart Storage Failed'));
+        store.dispatch(new DaffCartStorageFailure(error));
       });
     });
   });

--- a/libs/cart/state/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/state/src/selectors/cart/cart.selector.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { StoreModule, combineReducers, Store, select } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartItemInputType, DaffCartTotalTypeEnum } from '@daffodil/cart';
 import {
   DaffCartLoadSuccess,
@@ -57,7 +57,8 @@ describe('Cart | Selector | Cart', () => {
   let orderId: string;
   let cart: DaffCart;
   let loading: DaffCartLoading;
-	let errors: DaffCartErrors;
+  let errors: DaffCartErrors;
+  let error: DaffStateError;
 	const {
     selectCartValue,
 
@@ -155,6 +156,10 @@ describe('Cart | Selector | Cart', () => {
     shippingMethodFactory = TestBed.get(DaffCartShippingRateFactory);
 
     orderId = 'id';
+    error = {
+      code: 'error code',
+      message: 'error message'
+    }
     cart = cartFactory.create({
       items: cartItemFactory.createMany(2),
       shipping_address: cartAddressFactory.create(),
@@ -228,7 +233,7 @@ describe('Cart | Selector | Cart', () => {
     it('should be failed after cart resolution failure', () => {
       const selector = store.pipe(select(selectCartResolved));
       const expected = cold('a', {a: DaffCartResolveState.Failed});
-      store.dispatch(new DaffResolveCartFailure('error'));
+      store.dispatch(new DaffResolveCartFailure(error));
 
       expect(selector).toBeObservable(expected);
     });

--- a/libs/cart/state/src/selectors/cart/cart.selector.ts
+++ b/libs/cart/state/src/selectors/cart/cart.selector.ts
@@ -6,7 +6,7 @@ import {
 } from '@ngrx/store';
 
 import { daffSubtract } from '@daffodil/core';
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffLoadingState, DaffStateError } from '@daffodil/core/state';
 import { daffComparePersonalAddresses } from '@daffodil/geography';
 import { DaffCart, DaffCartTotal, DaffCartOrderResult, DaffCartTotalTypeEnum } from '@daffodil/cart';
 
@@ -170,15 +170,15 @@ export interface DaffCartStateMemoizedSelectors<
 	selectItemMutating: MemoizedSelector<object, boolean>;
 
 	selectCartErrorsObject: MemoizedSelector<object, DaffCartReducerState<T>['errors']>;
-	selectCartErrors: MemoizedSelector<object, string[]>;
-	selectBillingAddressErrors: MemoizedSelector<object, string[]>;
-	selectShippingAddressErrors: MemoizedSelector<object, string[]>;
-	selectShippingInformationErrors: MemoizedSelector<object, string[]>;
-	selectShippingMethodsErrors: MemoizedSelector<object, string[]>;
-	selectPaymentErrors: MemoizedSelector<object, string[]>;
-	selectPaymentMethodsErrors: MemoizedSelector<object, string[]>;
-  selectCouponErrors: MemoizedSelector<object, string[]>;
-	selectItemErrors: MemoizedSelector<object, string[]>;
+	selectCartErrors: MemoizedSelector<object, DaffStateError[]>;
+	selectBillingAddressErrors: MemoizedSelector<object, DaffStateError[]>;
+	selectShippingAddressErrors: MemoizedSelector<object, DaffStateError[]>;
+	selectShippingInformationErrors: MemoizedSelector<object, DaffStateError[]>;
+	selectShippingMethodsErrors: MemoizedSelector<object, DaffStateError[]>;
+	selectPaymentErrors: MemoizedSelector<object, DaffStateError[]>;
+	selectPaymentMethodsErrors: MemoizedSelector<object, DaffStateError[]>;
+  selectCouponErrors: MemoizedSelector<object, DaffStateError[]>;
+	selectItemErrors: MemoizedSelector<object, DaffStateError[]>;
 
 	selectCartId: MemoizedSelector<object, T['id']>;
 	selectCartSubtotal: MemoizedSelector<object, DaffCartTotal['value']>;

--- a/libs/cart/state/testing/src/mock-cart-facade.ts
+++ b/libs/cart/state/testing/src/mock-cart-facade.ts
@@ -2,6 +2,7 @@ import { BehaviorSubject } from 'rxjs';
 import { Action } from '@ngrx/store';
 import { Dictionary } from '@ngrx/entity';
 
+import { DaffStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartTotal, DaffCartItem, DaffCartOrderResult, DaffConfigurableCartItemAttribute, DaffCompositeCartItemOption } from '@daffodil/cart';
 import {
 	DaffCartFacadeInterface,
@@ -94,7 +95,7 @@ export class MockDaffCartFacade implements DaffCartFacadeInterface {
   canPlaceOrder$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   orderResultLoading$ = new BehaviorSubject<boolean>(false);
-	orderResultErrors$ = new BehaviorSubject<string[]>([]);
+	orderResultErrors$ = new BehaviorSubject<DaffStateError[]>([]);
 	orderResult$ = new BehaviorSubject<DaffCartOrderResult>({
     id: null,
     orderId: null,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Cart errors are stored as `string`s.

Fixes: #1107 

## What is the new behavior?
Cart errors are stored as `DaffStateError`s. Effects transform the errors coming out of the driver layer with the injected error matcher function.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Changes the payload type of failure actions from `string` to `DaffStateError`.

## Other information
I'm sorry that this PR is so large. LMK if you want me to break it up into feature slices.