### PR TITLE
feat(navigation): injectable category tree query depth in magento driver

### DIFF
--- a/libs/navigation/src/drivers/injection-tokens/category-tree-query-depth.token.ts
+++ b/libs/navigation/src/drivers/injection-tokens/category-tree-query-depth.token.ts
@@ -1,0 +1,8 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * The maximum depth of category children that the navigation driver will query.
+ * Defaults to 3.
+ */
+export const DaffNavigationCategoryTreeQueryDepth =
+  new InjectionToken<number>('DaffNavigationCategoryTreeQueryDepth', {factory: () => 3});

--- a/libs/navigation/src/drivers/injection-tokens/category-tree-query-depth.token.ts
+++ b/libs/navigation/src/drivers/injection-tokens/category-tree-query-depth.token.ts
@@ -1,8 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-/**
- * The maximum depth of category children that the navigation driver will query.
- * Defaults to 3.
- */
-export const DaffNavigationCategoryTreeQueryDepth =
-  new InjectionToken<number>('DaffNavigationCategoryTreeQueryDepth', {factory: () => 3});

--- a/libs/navigation/src/drivers/interfaces/navigation-config.interface.ts
+++ b/libs/navigation/src/drivers/interfaces/navigation-config.interface.ts
@@ -1,0 +1,12 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * The maximum depth of category children that the navigation driver will query.
+ * Defaults to 3.
+ */
+export const MAGENTO_NAVIGATION_TREE_QUERY_DEPTH =
+  new InjectionToken<number>('MAGENTO_NAVIGATION_TREE_QUERY_DEPTH', {factory: () => 3});
+
+export interface MagentoNavigationDriverConfiguration {
+  navigationTreeQueryDepth: number;
+}

--- a/libs/navigation/src/drivers/magento/interfaces/category-node.ts
+++ b/libs/navigation/src/drivers/magento/interfaces/category-node.ts
@@ -1,6 +1,7 @@
 import { CategoryProductNode } from './category-product-node';
 
 export interface CategoryNode {
+  __typename?: string;
   id: string;
   name?: string;
   include_in_menu: boolean;

--- a/libs/navigation/src/drivers/magento/interfaces/category-product-node.ts
+++ b/libs/navigation/src/drivers/magento/interfaces/category-product-node.ts
@@ -1,3 +1,4 @@
 export interface CategoryProductNode {
+  __typename?: string;
   total_count: number;
 }

--- a/libs/navigation/src/drivers/magento/navigation-driver.module.ts
+++ b/libs/navigation/src/drivers/magento/navigation-driver.module.ts
@@ -5,6 +5,7 @@ import { DaffNavigationDriver } from '../injection-tokens/navigation-driver.toke
 import { DaffMagentoNavigationService } from './navigation.service';
 import { DaffNavigationTransformer } from '../injection-tokens/navigation-transformer.token';
 import { DaffMagentoNavigationTransformerService } from './transformers/navigation-transformer';
+import { MagentoNavigationDriverConfiguration, MAGENTO_NAVIGATION_TREE_QUERY_DEPTH } from '../interfaces/navigation-config.interface';
 
 @NgModule({
   imports: [
@@ -12,7 +13,7 @@ import { DaffMagentoNavigationTransformerService } from './transformers/navigati
   ]
 })
 export class DaffNavigationMagentoDriverModule {
-  static forRoot(): ModuleWithProviders<DaffNavigationMagentoDriverModule> {
+  static forRoot(config: MagentoNavigationDriverConfiguration): ModuleWithProviders<DaffNavigationMagentoDriverModule> {
     return {
       ngModule: DaffNavigationMagentoDriverModule,
       providers: [
@@ -23,6 +24,10 @@ export class DaffNavigationMagentoDriverModule {
         {
           provide: DaffNavigationTransformer,
           useExisting: DaffMagentoNavigationTransformerService
+        },
+        {
+          provide: MAGENTO_NAVIGATION_TREE_QUERY_DEPTH,
+          useValue: config.navigationTreeQueryDepth
         }
       ]
     };

--- a/libs/navigation/src/drivers/magento/navigation-driver.module.ts
+++ b/libs/navigation/src/drivers/magento/navigation-driver.module.ts
@@ -7,13 +7,17 @@ import { DaffNavigationTransformer } from '../injection-tokens/navigation-transf
 import { DaffMagentoNavigationTransformerService } from './transformers/navigation-transformer';
 import { MagentoNavigationDriverConfiguration, MAGENTO_NAVIGATION_TREE_QUERY_DEPTH } from '../interfaces/navigation-config.interface';
 
+export const MAGENTO_NAVIGATION_DEFAULT_CONFIGURATION: MagentoNavigationDriverConfiguration = {
+  navigationTreeQueryDepth: 3
+}
+
 @NgModule({
   imports: [
     CommonModule
   ]
 })
 export class DaffNavigationMagentoDriverModule {
-  static forRoot(config: MagentoNavigationDriverConfiguration): ModuleWithProviders<DaffNavigationMagentoDriverModule> {
+  static forRoot(config: MagentoNavigationDriverConfiguration = MAGENTO_NAVIGATION_DEFAULT_CONFIGURATION): ModuleWithProviders<DaffNavigationMagentoDriverModule> {
     return {
       ngModule: DaffNavigationMagentoDriverModule,
       providers: [

--- a/libs/navigation/src/drivers/magento/navigation.service.spec.ts
+++ b/libs/navigation/src/drivers/magento/navigation.service.spec.ts
@@ -2,19 +2,26 @@ import { TestBed } from '@angular/core/testing';
 import {
   ApolloTestingModule,
   ApolloTestingController,
+  APOLLO_TESTING_CACHE,
 } from 'apollo-angular/testing';
+import { addTypenameToDocument } from 'apollo-utilities';
+import { schema } from '@daffodil/driver/magento';
+import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory';
 
 import { DaffNavigationTreeFactory } from '@daffodil/navigation/testing';
 
 import { DaffMagentoNavigationService } from './navigation.service';
-import { GetCategoryTree } from './queries/get-category-tree';
+import { getCategoryTree } from './queries/get-category-tree';
 import { DaffNavigationTransformer } from '../injection-tokens/navigation-transformer.token';
 import { DaffMagentoNavigationTransformerService } from './transformers/navigation-transformer';
+import { DaffNavigationCategoryTreeQueryDepth } from '../injection-tokens/category-tree-query-depth.token';
 
 describe('Driver | Magento | Navigation | NavigationService', () => {
   let navigationService: DaffMagentoNavigationService;
   let navigationTreeFactory: DaffNavigationTreeFactory;
   let controller: ApolloTestingController;
+
+  const queryDepth = 1;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -23,7 +30,20 @@ describe('Driver | Magento | Navigation | NavigationService', () => {
       ],
       providers: [
         DaffMagentoNavigationService,
-        { provide: DaffNavigationTransformer, useExisting: DaffMagentoNavigationTransformerService }
+        { provide: DaffNavigationTransformer, useExisting: DaffMagentoNavigationTransformerService },
+        {
+          provide: DaffNavigationCategoryTreeQueryDepth,
+          useValue: queryDepth
+        },
+        {
+					provide: APOLLO_TESTING_CACHE,
+					useValue: new InMemoryCache({
+						addTypename: true,
+						fragmentMatcher: new IntrospectionFragmentMatcher({
+							introspectionQueryResultData: schema,
+						}),
+					}),
+				}
       ]
     });
 
@@ -38,7 +58,7 @@ describe('Driver | Magento | Navigation | NavigationService', () => {
   });
 
   describe('get | getting a single navigation', () => {
-    it('should return an observable single navigation', () => {
+    it('should return an observable single navigation', done => {
       const navigation = navigationTreeFactory.create();
 
       navigationService.get(navigation.id).subscribe((result) => {
@@ -46,19 +66,23 @@ describe('Driver | Magento | Navigation | NavigationService', () => {
         expect(result.name).toEqual(navigation.name);
         expect(result.total_products).toEqual(navigation.total_products);
         expect(result.children_count).toEqual(navigation.children_count);
+        done();
       });
 
-      const op = controller.expectOne(GetCategoryTree);
+      const op = controller.expectOne(addTypenameToDocument(getCategoryTree(queryDepth)));
 
       expect(op.operation.variables.filters).toEqual({ ids: { eq: navigation.id}});
 
       op.flush({
         data: {
           categoryList: [{
+            __typename: 'CategoryTree',
             id: navigation.id,
             name: navigation.name,
             include_in_menu: true,
+            level: 0,
             products: {
+              __typename: 'typename',
               total_count: navigation.total_products
             },
             children_count: navigation.children_count,

--- a/libs/navigation/src/drivers/magento/navigation.service.spec.ts
+++ b/libs/navigation/src/drivers/magento/navigation.service.spec.ts
@@ -14,7 +14,7 @@ import { DaffMagentoNavigationService } from './navigation.service';
 import { getCategoryTree } from './queries/get-category-tree';
 import { DaffNavigationTransformer } from '../injection-tokens/navigation-transformer.token';
 import { DaffMagentoNavigationTransformerService } from './transformers/navigation-transformer';
-import { DaffNavigationCategoryTreeQueryDepth } from '../injection-tokens/category-tree-query-depth.token';
+import { MAGENTO_NAVIGATION_TREE_QUERY_DEPTH } from '../interfaces/navigation-config.interface';
 
 describe('Driver | Magento | Navigation | NavigationService', () => {
   let navigationService: DaffMagentoNavigationService;
@@ -32,7 +32,7 @@ describe('Driver | Magento | Navigation | NavigationService', () => {
         DaffMagentoNavigationService,
         { provide: DaffNavigationTransformer, useExisting: DaffMagentoNavigationTransformerService },
         {
-          provide: DaffNavigationCategoryTreeQueryDepth,
+          provide: MAGENTO_NAVIGATION_TREE_QUERY_DEPTH,
           useValue: queryDepth
         },
         {

--- a/libs/navigation/src/drivers/magento/navigation.service.ts
+++ b/libs/navigation/src/drivers/magento/navigation.service.ts
@@ -4,24 +4,27 @@ import { map } from 'rxjs/operators';
 import { Apollo } from 'apollo-angular';
 
 import { DaffNavigationServiceInterface } from '../interfaces/navigation-service.interface';
-import { GetCategoryTree } from './queries/get-category-tree';
+import { getCategoryTree } from './queries/get-category-tree';
 import { GetCategoryTreeResponse } from './interfaces/get-category-tree-response';
 import { DaffNavigationTransformer } from '../injection-tokens/navigation-transformer.token';
 import { DaffNavigationTransformerInterface } from '../interfaces/navigation-transformer.interface';
 import { DaffNavigationTree } from '../../models/navigation-tree';
+import { DaffNavigationCategoryTreeQueryDepth } from '../injection-tokens/category-tree-query-depth.token';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DaffMagentoNavigationService implements DaffNavigationServiceInterface<DaffNavigationTree> {
-  
+
   constructor(
     private apollo: Apollo,
-    @Inject(DaffNavigationTransformer) private transformer: DaffNavigationTransformerInterface<DaffNavigationTree>) {}
+    @Inject(DaffNavigationTransformer) private transformer: DaffNavigationTransformerInterface<DaffNavigationTree>,
+    @Inject(DaffNavigationCategoryTreeQueryDepth) private categoryTreeQueryDepth: number
+  ) {}
 
   get(categoryId: string): Observable<DaffNavigationTree> {
     return this.apollo.query<GetCategoryTreeResponse>({
-      query: GetCategoryTree,
+      query: getCategoryTree(this.categoryTreeQueryDepth),
       variables: {
         filters: { ids: { eq: categoryId } }
       }

--- a/libs/navigation/src/drivers/magento/navigation.service.ts
+++ b/libs/navigation/src/drivers/magento/navigation.service.ts
@@ -9,7 +9,7 @@ import { GetCategoryTreeResponse } from './interfaces/get-category-tree-response
 import { DaffNavigationTransformer } from '../injection-tokens/navigation-transformer.token';
 import { DaffNavigationTransformerInterface } from '../interfaces/navigation-transformer.interface';
 import { DaffNavigationTree } from '../../models/navigation-tree';
-import { DaffNavigationCategoryTreeQueryDepth } from '../injection-tokens/category-tree-query-depth.token';
+import { MAGENTO_NAVIGATION_TREE_QUERY_DEPTH } from '../interfaces/navigation-config.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -19,7 +19,7 @@ export class DaffMagentoNavigationService implements DaffNavigationServiceInterf
   constructor(
     private apollo: Apollo,
     @Inject(DaffNavigationTransformer) private transformer: DaffNavigationTransformerInterface<DaffNavigationTree>,
-    @Inject(DaffNavigationCategoryTreeQueryDepth) private categoryTreeQueryDepth: number
+    @Inject(MAGENTO_NAVIGATION_TREE_QUERY_DEPTH) private categoryTreeQueryDepth: number
   ) {}
 
   get(categoryId: string): Observable<DaffNavigationTree> {

--- a/libs/navigation/src/drivers/magento/queries/fragments/category-node.spec.ts
+++ b/libs/navigation/src/drivers/magento/queries/fragments/category-node.spec.ts
@@ -1,0 +1,203 @@
+import { TestBed } from '@angular/core/testing';
+import { schema } from '@daffodil/driver/magento';
+import { Apollo } from 'apollo-angular';
+import { ApolloTestingController, ApolloTestingModule, APOLLO_TESTING_CACHE } from 'apollo-angular/testing';
+import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory';
+import { ApolloQueryResult } from 'apollo-client';
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+import { Observable } from 'rxjs';
+import { addTypenameToDocument } from 'apollo-utilities';
+
+import { CategoryNode } from '../../interfaces/category-node';
+import { getCategoryNodeFragment } from './category-node';
+
+const generateMagentoCategoryTree = (): CategoryNode => ({
+  __typename: 'CategoryTree',
+  id: 'id',
+  name: 'name',
+  include_in_menu: true,
+  level: 0,
+  products: {
+    __typename: 'typename',
+    total_count: 1
+  },
+  children_count: 0,
+  children: []
+})
+
+describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
+  let apollo: Apollo;
+  let controller: ApolloTestingController;
+
+  let childlessNavigationTree: CategoryNode;
+  let depth1NavigationTree: CategoryNode;
+  let depth3NavigationTree: CategoryNode;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ApolloTestingModule
+      ],
+      providers: [
+        {
+					provide: APOLLO_TESTING_CACHE,
+					useValue: new InMemoryCache({
+						addTypename: true,
+						fragmentMatcher: new IntrospectionFragmentMatcher({
+							introspectionQueryResultData: schema,
+						}),
+					}),
+				}
+      ]
+    });
+
+    apollo = TestBed.get(Apollo);
+    controller = TestBed.get(ApolloTestingController);
+
+    childlessNavigationTree = generateMagentoCategoryTree();
+    delete childlessNavigationTree.children;
+    delete childlessNavigationTree.children_count;
+    depth1NavigationTree = {
+      ...generateMagentoCategoryTree(),
+      children_count: 1,
+      children: [childlessNavigationTree]
+    };
+    depth3NavigationTree = {
+      ...generateMagentoCategoryTree(),
+      children_count: 1,
+      children: [{
+        ...generateMagentoCategoryTree(),
+        children_count: 1,
+        children: [{
+          ...generateMagentoCategoryTree(),
+          children_count: 1,
+          children: [childlessNavigationTree]
+        }]
+      }]
+    };
+  });
+
+  describe('when the depth is 0', () => {
+    let query: DocumentNode;
+    let response: Observable<ApolloQueryResult<CategoryNode>>;
+
+    beforeEach(() => {
+      const fragment = getCategoryNodeFragment(0);
+
+      query = gql`
+        query TestQuery {
+          ...recursiveCategoryNode
+        }
+        ${fragment}
+      `;
+
+      response = apollo.query({query});
+    });
+
+    it('should successfully query a childless response', done => {
+      response.subscribe(resp => {
+        expect(resp.data).toEqual(childlessNavigationTree);
+        done();
+      });
+
+      const op = controller.expectOne(addTypenameToDocument(query));
+
+      op.flush({
+        data: childlessNavigationTree
+      })
+    });
+
+    it('should not successfully query a childful response', done => {
+      response.subscribe(resp => {
+        expect(resp.data.children).toBeFalsy();
+        done();
+      });
+
+      const op = controller.expectOne(addTypenameToDocument(query));
+
+      op.flush({
+        data: depth3NavigationTree
+      })
+    });
+  });
+
+  describe('when the depth is 1', () => {
+    let query: DocumentNode;
+    let response: Observable<ApolloQueryResult<CategoryNode>>;
+
+    beforeEach(() => {
+      const fragment = getCategoryNodeFragment(1);
+
+      query = gql`
+        query TestQuery {
+          ...recursiveCategoryNode
+        }
+        ${fragment}
+      `;
+
+      response = apollo.query({query});
+    });
+
+    it('should successfully query a 1 child response', done => {
+      response.subscribe(resp => {
+        expect(resp.data).toEqual(depth1NavigationTree);
+        done();
+      });
+
+      const op = controller.expectOne(addTypenameToDocument(query));
+
+      op.flush({
+        data: depth1NavigationTree
+      })
+    });
+
+    it('should not successfully query a depth 3 response', done => {
+      response.subscribe(resp => {
+        expect(resp.data.children[0].children).toBeFalsy();
+        done();
+      });
+
+      const op = controller.expectOne(addTypenameToDocument(query));
+
+      op.flush({
+        data: depth3NavigationTree
+      })
+    });
+  });
+
+  describe('when the depth is 3', () => {
+    let query: DocumentNode;
+    let response: Observable<ApolloQueryResult<CategoryNode>>;
+
+    beforeEach(() => {
+      const fragment = getCategoryNodeFragment(3);
+
+      query = gql`
+        query TestQuery {
+          ...recursiveCategoryNode
+        }
+        ${fragment}
+      `;
+
+      response = apollo.query({query});
+    });
+
+    it('should successfully query a 3 child response', done => {
+      response.subscribe(resp => {
+        expect(resp.data).toEqual(depth3NavigationTree);
+        done();
+      });
+
+      const op = controller.expectOne(addTypenameToDocument(query));
+
+      op.flush({
+        data: depth3NavigationTree
+      })
+    });
+  });
+
+  afterEach(() => {
+    controller.verify();
+  });
+});

--- a/libs/navigation/src/drivers/magento/queries/fragments/category-node.ts
+++ b/libs/navigation/src/drivers/magento/queries/fragments/category-node.ts
@@ -1,0 +1,38 @@
+import { DocumentNode } from 'graphql';
+import gql from 'graphql-tag';
+
+/**
+ * A category tree fragment with no nested children.
+ */
+export const categoryNodeFragment = gql`
+  fragment categoryNode on CategoryTree {
+    id
+    level
+    name
+    include_in_menu
+    products {
+      total_count
+    }
+  }
+`
+
+/**
+ * Generates a category tree fragment with the specified number of nested child category trees.
+ * @param depth The maximum depth to which category children should be added to the fragment.
+ */
+export function getCategoryNodeFragment(depth: number = 3): DocumentNode {
+  const fragmentBody = new Array(depth).fill(null).reduce(acc => `
+    ...categoryNode
+    children_count
+    children {
+      ${acc}
+    }
+  `, '...categoryNode')
+
+  return gql`
+    fragment recursiveCategoryNode on CategoryTree {
+      ${fragmentBody}
+    }
+    ${categoryNodeFragment}
+  `
+}

--- a/libs/navigation/src/drivers/magento/queries/get-category-tree.ts
+++ b/libs/navigation/src/drivers/magento/queries/get-category-tree.ts
@@ -1,113 +1,18 @@
 import gql from 'graphql-tag';
 
-export const GetCategoryTree = gql`
-  query GetCategoryTree($filters: CategoryFilterInput!){
-    categoryList(filters: $filters) {
-      id
-      name
-      include_in_menu
-      products {
-        total_count
-      }
-      children_count
-      children {
-        id
-        level
-        name
-        include_in_menu
-        products {
-          total_count
-        }
-        path
-        children_count
-        children {
-          id
-          level
-          name
-          include_in_menu
-          products {
-            total_count
-          }
-          path
-          children_count
-          children {
-            id
-            level
-            name
-            include_in_menu
-            products {
-              total_count
-            }
-            path
-            children_count
-            children {
-              id
-              level
-              name
-              include_in_menu
-              products {
-                total_count
-              }
-              path
-              children_count
-              children {
-                id
-                level
-                name
-                include_in_menu
-                products {
-                  total_count
-                }
-                path
-                children_count
-                children {
-                  id
-                  level
-                  name
-                  include_in_menu
-                  products {
-                    total_count
-                  }
-                  path
-                  children_count
-                  children {
-                    id
-                    level
-                    name
-                    include_in_menu
-                    products {
-                      total_count
-                    }
-                    path
-                    children_count
-                    children {
-                      id
-                      level
-                      name
-                      include_in_menu
-                      products {
-                        total_count
-                      }
-                      path
-                      children_count
-                      children {
-                        id
-                        level
-                        name
-                        include_in_menu
-                        products {
-                          total_count
-                        }
-                        path
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+import { getCategoryNodeFragment } from './fragments/category-node';
+
+/**
+ * Generates a category tree query with the specified number of nested child category tree fragments.
+ * @param depth The maximum depth to which category children should be added to the fragment.
+ */
+export function getCategoryTree(depth: number = 3) {
+  return gql`
+    query GetCategoryTree($filters: CategoryFilterInput!){
+      categoryList(filters: $filters) {
+        ...recursiveCategoryNode
       }
     }
-  }
-`;
+    ${getCategoryNodeFragment(depth)}
+  `;
+}

--- a/libs/navigation/src/drivers/magento/transformers/navigation-transformer.ts
+++ b/libs/navigation/src/drivers/magento/transformers/navigation-transformer.ts
@@ -16,9 +16,8 @@ export class DaffMagentoNavigationTransformerService implements DaffNavigationTr
       name: node.name,
       total_products: node.products.total_count,
       children_count: node.children_count,
-      children: node.children.filter((child) => child.include_in_menu).map((child) => {
-        return this.transform(child);
-      })
+      // TODO: optional chaining
+      children: node.children && node.children.filter(child => child.include_in_menu).map(child => this.transform(child))
     };
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The navigation tree query depth is hardcoded and unconfigurable.


## What is the new behavior?
The navigation tree query depth is configurable by an injection token.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The implementation is non trivial. In order to handle a configurable number of nested fragments, they had to be generated dynamically with different names. The fragment name must be returned separately from the fragment so it can be referenced dynamically in the enclosing gql doc. This resulted in an interface and a couple functions for generating the fragments.