### PR TITLE
fix(product): allow selectCompositeProductPricesForConfiguration tak…

### DIFF
--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -20,13 +20,13 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * @param id an id for a composite product
 	 * @param configuration a Dictionary of DaffCompositeConfigurationItems
 	 */
-	getPricesForConfiguration(id: string, configuration: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange>;
+	getRequiredItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange>;
 
 	/**
-	 * Get the broadest possible DaffPriceRange for a composite product including optional item prices.
+	 * Get the broadest possible DaffPriceRange for a composite product based on the configuration provided including optional item prices.
 	 * @param id the id of the composite product.
 	 */
-	getPrices(id: string): Observable<DaffPriceRange>;
+	getOptionalItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange>;
 
 	/**
 	 * Get the DaffPriceRange for a composite product based on the current configuration of selected item options in redux state and

--- a/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.spec.ts
@@ -81,7 +81,7 @@ describe('DaffCompositeProductFacade', () => {
     expect(store.dispatch).toHaveBeenCalledTimes(1);
   });
 
-  describe('getPricesForConfiguration', () => {
+  describe('getRequiredItemPricesForConfiguration', () => {
 
     it('should return the expected price range for the configuration provided', () => {
 			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
@@ -112,11 +112,11 @@ describe('DaffCompositeProductFacade', () => {
 			}
 			});
 
-			expect(facade.getPricesForConfiguration(stubCompositeProduct.id, stubConfiguration)).toBeObservable(expected);
+			expect(facade.getRequiredItemPricesForConfiguration(stubCompositeProduct.id, stubConfiguration)).toBeObservable(expected);
 		});
   });
 
-  describe('getPrices', () => {
+  describe('getOptionalItemPricesForConfiguration', () => {
 
     it('should return the broadest price range for a composite product including optional items', () => {
 			const expected = cold('a', { a: {
@@ -142,7 +142,7 @@ describe('DaffCompositeProductFacade', () => {
 			}
 			});
 
-			expect(facade.getPrices(stubCompositeProduct.id)).toBeObservable(expected);
+			expect(facade.getOptionalItemPricesForConfiguration(stubCompositeProduct.id)).toBeObservable(expected);
 		});
   });
 

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -41,12 +41,12 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 	 */
 	hasPriceRange = productPriceRangeHasPriceRange;
 
-	getPricesForConfiguration(id: string, configuration: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductPricesForConfiguration, { id, configuration }));
+	getRequiredItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductRequiredItemPricesForConfiguration, { id, configuration }));
 	}
 
-	getPrices(id: string): Observable<DaffPriceRange> {
-		return this.store.pipe(select(this.selectors.selectCompositeProductPrices, { id }));
+	getOptionalItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange> {
+		return this.store.pipe(select(this.selectors.selectCompositeProductOptionalItemPricesForConfiguration, { id, configuration }));
 	}
 
 	getPricesAsCurrentlyConfigured(id: string): Observable<DaffPriceRange> {

--- a/libs/product/src/models/composite-configuration-item.ts
+++ b/libs/product/src/models/composite-configuration-item.ts
@@ -1,4 +1,4 @@
 export interface DaffCompositeConfigurationItem {
-	qty: number;
-	value: string;
+	qty?: number;
+	value?: string;
 }

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -188,14 +188,48 @@ describe('Composite Product Selectors | integration tests', () => {
 			expect(selector).toBeObservable(expected);
 		});
 
+		it('should return the expected price range when a configuration without quantities is provided', () => {
+			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
+				[stubCompositeProduct.items[0].id]: {
+					value: stubCompositeProduct.items[0].options[1].id
+				},
+				[stubCompositeProduct.items[1].id]: {
+					value: stubCompositeProduct.items[1].options[1].id
+				}
+			}
+			const selector = store.pipe(select(selectCompositeProductRequiredItemPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice01 - stubDiscountAmount01 + 
+						stubPrice11 - stubDiscountAmount11,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01 + stubPrice11
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice01 - stubDiscountAmount01 +
+						stubPrice11 - stubDiscountAmount11,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01 + stubPrice11
+				}
+			}});
+
+			expect(selector).toBeObservable(expected);
+		});
+
 		it('should return the expected price range when a configuration with only quantities is provided', () => {
 			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
 				[stubCompositeProduct.items[0].id]: {
-					value: null,
 					qty: stubQty0
 				},
 				[stubCompositeProduct.items[1].id]: {
-					value: null,
 					qty: stubQty1
 				}
 			}
@@ -330,14 +364,48 @@ describe('Composite Product Selectors | integration tests', () => {
 			expect(selector).toBeObservable(expected);
 		});
 
+		it(`should return the expected price range when a configuration without quantities is provided`, () => {
+			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
+				[stubCompositeProduct.items[0].id]: {
+					value: stubCompositeProduct.items[0].options[1].id
+				},
+				[stubCompositeProduct.items[1].id]: {
+					value: stubCompositeProduct.items[1].options[1].id
+				}
+			}
+			const selector = store.pipe(select(selectCompositeProductOptionalItemPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice01 - stubDiscountAmount01 + 
+						stubPrice11 - stubDiscountAmount11,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01 + stubPrice11
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						stubPrice01 - stubDiscountAmount01 +
+						stubPrice11 - stubDiscountAmount11,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + stubPrice01 + stubPrice11
+				}
+			}});
+
+			expect(selector).toBeObservable(expected);
+		});
+
 		it('should return the expected price range when a configuration with only quantities is provided', () => {
 			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
 				[stubCompositeProduct.items[0].id]: {
-					value: null,
 					qty: stubQty0
 				},
 				[stubCompositeProduct.items[1].id]: {
-					value: null,
 					qty: stubQty1
 				}
 			}

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -24,8 +24,8 @@ describe('Composite Product Selectors | integration tests', () => {
 	let stubCompositeProduct: DaffCompositeProduct;
 	let stubProduct: DaffProduct;
 	const {
-		selectCompositeProductPricesForConfiguration,
-		selectCompositeProductPrices,
+		selectCompositeProductRequiredItemPricesForConfiguration,
+		selectCompositeProductOptionalItemPricesForConfiguration,
 		selectCompositeProductPricesAsCurrentlyConfigured
 	} = getDaffCompositeProductSelectors();
 	const stubPrice00 = 10;
@@ -83,17 +83,17 @@ describe('Composite Product Selectors | integration tests', () => {
 		store.dispatch(new DaffProductLoadSuccess(stubProduct));
 	});
 
-	describe('selectCompositeProductPricesForConfiguration', () => {
+	describe('selectCompositeProductRequiredItemPricesForConfiguration', () => {
 
 		it('should return undefined when the product is not a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductPricesForConfiguration, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductRequiredItemPricesForConfiguration, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 
 		it('should return the broadest price range when no configuration is provided', () => {
-			const selector = store.pipe(select(selectCompositeProductPricesForConfiguration, { id: stubCompositeProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductRequiredItemPricesForConfiguration, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: {
 				minPrice: {
 					discountedPrice: stubCompositeProduct.price + stubPrice00 - stubCompositeProduct.discount.amount - stubDiscountAmount00,
@@ -123,7 +123,7 @@ describe('Composite Product Selectors | integration tests', () => {
 					qty: stubQty1
 				}
 			}
-			const selector = store.pipe(select(selectCompositeProductPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const selector = store.pipe(select(selectCompositeProductRequiredItemPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
 			const expected = cold('a', { a: {
 				minPrice: {
 					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
@@ -161,7 +161,7 @@ describe('Composite Product Selectors | integration tests', () => {
 					qty: stubQty1
 				}
 			}
-			const selector = store.pipe(select(selectCompositeProductPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const selector = store.pipe(select(selectCompositeProductRequiredItemPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
 			const expected = cold('a', { a: {
 				minPrice: {
 					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
@@ -188,7 +188,7 @@ describe('Composite Product Selectors | integration tests', () => {
 			expect(selector).toBeObservable(expected);
 		});
 
-		it('should return the expected price range when a configuration with only quantities is provided', () => {
+		it('should return the expected price range when a configuration with only quantities are provided', () => {
 			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
 				[stubCompositeProduct.items[0].id]: {
 					value: null,
@@ -199,7 +199,7 @@ describe('Composite Product Selectors | integration tests', () => {
 					qty: stubQty1
 				}
 			}
-			const selector = store.pipe(select(selectCompositeProductPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const selector = store.pipe(select(selectCompositeProductRequiredItemPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
 			const expected = cold('a', { a: {
 				minPrice: {
 					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
@@ -210,7 +210,6 @@ describe('Composite Product Selectors | integration tests', () => {
 					},
 					originalPrice: stubCompositeProduct.price + (stubPrice00 * stubQty0)
 				},
-				//this max price doesn't include optional items, but we need it to do that in certain circumstances
 				maxPrice: {
 					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
 						(stubPrice01 - stubDiscountAmount01) * stubQty0,
@@ -226,17 +225,18 @@ describe('Composite Product Selectors | integration tests', () => {
 		});
 	});
 
-	describe('selectCompositeProductPrices', () => {
+	describe('selectCompositeProductOptionalItemPricesForConfiguration', () => {
 
 		it('should return undefined when the product is not a composite product', () => {
-			const selector = store.pipe(select(selectCompositeProductPrices, { id: stubProduct.id }));
+			const selector = store.pipe(select(selectCompositeProductOptionalItemPricesForConfiguration, { id: stubProduct.id }));
 			const expected = cold('a', { a: undefined });
 
 			expect(selector).toBeObservable(expected);
 		});
 		
-		it('should return the broadest price range for a composite product including optional items', () => {
-			const selector = store.pipe(select(selectCompositeProductPrices, { id: stubCompositeProduct.id }));
+		it(`should return the broadest price range for a composite product including optional items
+				when no configuration is provided`, () => {
+			const selector = store.pipe(select(selectCompositeProductOptionalItemPricesForConfiguration, { id: stubCompositeProduct.id }));
 			const expected = cold('a', { a: {
 				minPrice: {
 					discountedPrice: stubCompositeProduct.price + stubPrice00 - stubCompositeProduct.discount.amount - stubDiscountAmount00,
@@ -254,6 +254,112 @@ describe('Composite Product Selectors | integration tests', () => {
 						percent: null
 					},
 					originalPrice: stubCompositeProduct.price + stubPrice01 + stubPrice11
+				}
+			}});
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it(`should return the expected price range including optional items
+				when a partial configuration is provided`, () => {
+			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
+				[stubCompositeProduct.items[0].id]: {
+					value: stubCompositeProduct.items[0].options[0].id,
+					qty: stubQty0
+				}
+			}
+			const selector = store.pipe(select(selectCompositeProductOptionalItemPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + (stubPrice00 - stubDiscountAmount00) * stubQty0,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice00 * stubQty0)
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount +
+						(stubPrice00 - stubDiscountAmount00) * stubQty0 + (stubPrice11 - stubDiscountAmount11),
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice00 * stubQty0) + (stubPrice11)
+				}
+			}});
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it(`should return the expected price range when a full configuration is provided`, () => {
+			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
+				[stubCompositeProduct.items[0].id]: {
+					value: stubCompositeProduct.items[0].options[1].id,
+					qty: stubQty0
+				},
+				[stubCompositeProduct.items[1].id]: {
+					value: stubCompositeProduct.items[1].options[1].id,
+					qty: stubQty1
+				}
+			}
+			const selector = store.pipe(select(selectCompositeProductOptionalItemPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice01 - stubDiscountAmount01) * stubQty0 + 
+						(stubPrice11 - stubDiscountAmount11) * stubQty1,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice01 * stubQty0) + (stubPrice11 * stubQty1)
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice01 - stubDiscountAmount01) * stubQty0 +
+						(stubPrice11 - stubDiscountAmount11) * stubQty1,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice01 * stubQty0) + (stubPrice11 * stubQty1)
+				}
+			}});
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('should return the expected price range when a configuration with only quantities are provided', () => {
+			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
+				[stubCompositeProduct.items[0].id]: {
+					value: null,
+					qty: stubQty0
+				},
+				[stubCompositeProduct.items[1].id]: {
+					value: null,
+					qty: stubQty1
+				}
+			}
+			const selector = store.pipe(select(selectCompositeProductOptionalItemPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice00 - stubDiscountAmount00) * stubQty0,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice00 * stubQty0)
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice01 - stubDiscountAmount01) * stubQty0 + (stubPrice11 - stubDiscountAmount11) * stubQty1,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice01 * stubQty0) + (stubPrice11 * stubQty1)
 				}
 			}});
 

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -187,6 +187,43 @@ describe('Composite Product Selectors | integration tests', () => {
 
 			expect(selector).toBeObservable(expected);
 		});
+
+		it('should return the expected price range when a configuration with only quantities is provided', () => {
+			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
+				[stubCompositeProduct.items[0].id]: {
+					value: null,
+					qty: stubQty0
+				},
+				[stubCompositeProduct.items[1].id]: {
+					value: null,
+					qty: stubQty1
+				}
+			}
+			const selector = store.pipe(select(selectCompositeProductPricesForConfiguration, { id: stubCompositeProduct.id, configuration: stubConfiguration }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice00 - stubDiscountAmount00) * stubQty0,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice00 * stubQty0)
+				},
+				//this max price doesn't include optional items, but we need it to do that in certain circumstances
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice01 - stubDiscountAmount01) * stubQty0,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice01 * stubQty0)
+				}
+			}});
+
+			expect(selector).toBeObservable(expected);
+		});
 	});
 
 	describe('selectCompositeProductPrices', () => {

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -188,7 +188,7 @@ describe('Composite Product Selectors | integration tests', () => {
 			expect(selector).toBeObservable(expected);
 		});
 
-		it('should return the expected price range when a configuration with only quantities are provided', () => {
+		it('should return the expected price range when a configuration with only quantities is provided', () => {
 			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
 				[stubCompositeProduct.items[0].id]: {
 					value: null,
@@ -330,7 +330,7 @@ describe('Composite Product Selectors | integration tests', () => {
 			expect(selector).toBeObservable(expected);
 		});
 
-		it('should return the expected price range when a configuration with only quantities are provided', () => {
+		it('should return the expected price range when a configuration with only quantities is provided', () => {
 			const stubConfiguration: Dictionary<DaffCompositeConfigurationItem> = {
 				[stubCompositeProduct.items[0].id]: {
 					value: null,

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -215,7 +215,7 @@ function getAppliedOptionsForConfiguration(product: DaffCompositeProduct, config
 		...acc,
 		[item.id]: configuration[item.id] ? {
 			...item.options.find(option => option.id === configuration[item.id].value),
-			quantity: configuration[item.id].qty
+			quantity: (configuration[item.id].qty === null || configuration[item.id].qty === undefined) ? 1 : configuration[item.id].qty
 		} : null
 }), {})
 }
@@ -227,5 +227,5 @@ function appliedOptionHasId(appliedOption: DaffCompositeProductItemOption): bool
 
 //todo: use optional chaining when possible
 function appliedOptionHasQty(appliedOption: DaffCompositeProductItemOption): boolean {
-	return appliedOption && !!appliedOption.quantity;
+	return appliedOption && appliedOption.quantity !== null;
 }

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -138,16 +138,14 @@ function getMinPricesForConfiguration(product: DaffCompositeProduct, appliedOpti
 			acc, 
 			appliedOptionHasId(appliedOptions[item.id]) ? 
 				daffMultiply(getDiscountedPrice(appliedOptions[item.id]), appliedOptions[item.id].quantity) : 
-				appliedOptionHasQty(appliedOptions[item.id]) ? 
-					getMinimumRequiredCompositeItemDiscountedPrice(item, appliedOptions[item.id].quantity) : getMinimumRequiredCompositeItemDiscountedPrice(item, 1)
+				getMinimumRequiredCompositeItemDiscountedPrice(item, getOptionQty(appliedOptions[item.id]))
 		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },
 		originalPrice: product.items.reduce((acc, item) => daffAdd(
 			acc, 
 			appliedOptionHasId(appliedOptions[item.id]) ? 
 				daffMultiply(appliedOptions[item.id].price, appliedOptions[item.id].quantity) : 
-				appliedOptionHasQty(appliedOptions[item.id]) ? 
-					getMinimumRequiredCompositeItemPrice(item, appliedOptions[item.id].quantity) : getMinimumRequiredCompositeItemPrice(item, 1)
+				getMinimumRequiredCompositeItemPrice(item, getOptionQty(appliedOptions[item.id]))
 		), product.price)
 	}
 }
@@ -163,16 +161,14 @@ function getMaxPricesForConfiguration(product: DaffCompositeProduct, appliedOpti
 			acc, 
 			appliedOptionHasId(appliedOptions[item.id]) ? 
 				daffMultiply(getDiscountedPrice(appliedOptions[item.id]), appliedOptions[item.id].quantity) : 
-				appliedOptionHasQty(appliedOptions[item.id]) ?
-					getMaximumRequiredCompositeItemDiscountedPrice(item, appliedOptions[item.id].quantity) : getMaximumRequiredCompositeItemDiscountedPrice(item, 1)
+				getMaximumRequiredCompositeItemDiscountedPrice(item, getOptionQty(appliedOptions[item.id]))
 		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },
 		originalPrice: product.items.reduce((acc, item) => daffAdd(
 			acc,
 			appliedOptionHasId(appliedOptions[item.id]) ? 
 				daffMultiply(appliedOptions[item.id].price, appliedOptions[item.id].quantity) : 
-				appliedOptionHasQty(appliedOptions[item.id]) ? 
-					getMaximumRequiredCompositeItemPrice(item, appliedOptions[item.id].quantity) : getMaximumRequiredCompositeItemPrice(item, 1)
+				getMaximumRequiredCompositeItemPrice(item, getOptionQty(appliedOptions[item.id]))
 		), product.price)
 	}
 }
@@ -192,7 +188,8 @@ function getMaxPricesForConfigurationIncludingOptionalItems(product: DaffComposi
 			appliedOptionHasId(appliedOptions[item.id]) ? 
 				daffMultiply(getDiscountedPrice(appliedOptions[item.id]), appliedOptions[item.id].quantity) :
 				appliedOptionHasQty(appliedOptions[item.id]) ?
-					daffMultiply(Math.max(...item.options.map(getDiscountedPrice)), appliedOptions[item.id].quantity) : Math.max(...item.options.map(getDiscountedPrice))
+					daffMultiply(Math.max(...item.options.map(getDiscountedPrice)), appliedOptions[item.id].quantity) : 
+					Math.max(...item.options.map(getDiscountedPrice))
 		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },
 		originalPrice: (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
@@ -200,7 +197,8 @@ function getMaxPricesForConfigurationIncludingOptionalItems(product: DaffComposi
 			appliedOptionHasId(appliedOptions[item.id]) ? 
 				daffMultiply(appliedOptions[item.id].price, appliedOptions[item.id].quantity) : 
 				appliedOptionHasQty(appliedOptions[item.id]) ?
-					daffMultiply(Math.max(...item.options.map(option => option.price)), appliedOptions[item.id].quantity) : Math.max(...item.options.map(option => option.price))
+					daffMultiply(Math.max(...item.options.map(option => option.price)), appliedOptions[item.id].quantity) : 
+					Math.max(...item.options.map(option => option.price))
 		), product.price)
 	}
 }
@@ -223,6 +221,10 @@ function getAppliedOptionsForConfiguration(product: DaffCompositeProduct, config
 //todo: use optional chaining when possible
 function appliedOptionHasId(appliedOption: DaffCompositeProductItemOption): boolean {
 	return appliedOption && !!appliedOption.id;
+}
+
+function getOptionQty(appliedOption: DaffCompositeProductItemOption): number {
+	return appliedOptionHasQty(appliedOption) ? appliedOption.quantity : 1;
 }
 
 //todo: use optional chaining when possible

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -11,10 +11,10 @@ import {
 import { Dictionary } from '@ngrx/entity';
 
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
-	getPricesForConfiguration(id: string, configuration: Dictionary<DaffCompositeConfigurationItem>): BehaviorSubject<DaffPriceRange> {
+	getRequiredItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): BehaviorSubject<DaffPriceRange> {
 		return new BehaviorSubject(null);
 	}
-	getPrices(id: string): BehaviorSubject<DaffPriceRange> {
+	getOptionalItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): BehaviorSubject<DaffPriceRange> {
 		return new BehaviorSubject(null);
 	}
 	getPricesAsCurrentlyConfigured(id: string): BehaviorSubject<DaffPriceRange> {


### PR DESCRIPTION
…e a configuration of quantities without a chosen option

BREAKING CHANGE: The `selectCompositeProductPricesForConfiguration` selector is now `selectCompositeProductRequiredItemPricesForConfiguration`, and the `selectCompositeProductPrices` is now `selectCompositeProductOptionalItemPricesForConfiguration`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Composite products items cannot retrieve prices that include optional item prices when an item qty configuration needs to be provided without selecting an item option. This is needed for the non-one, unchangeable quantity scenario. 

## What is the new behavior?
Composite products with fixed quantities can retrieve ranged prices with the fixed quantity as the configuration. 

The `selectCompositeProductPrices` selector needed to change to `selectCompositeProductOptionalItemPricesForConfiguration`, because that selector now needs to be able to take a configuration (so far, the only usecase for this is the non-one, unchangeable quantity scenario).

Both the `selectCompositeProductRequiredItemPricesForConfiguration` and `selectCompositeProductOptionalItemPricesForConfiguration` selectors can now take a configuration of quantities set without option ids, like this: 

```
selectCompositeProductRequiredItemPricesForConfiguration('productId', {
   someItemId: {
      qty: 12
   }
}
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```