### PR TITLE
fix(category): stop category load on DaffCategoryLoadSuccess

### DIFF
--- a/libs/category/src/reducers/category/category.reducer.spec.ts
+++ b/libs/category/src/reducers/category/category.reducer.spec.ts
@@ -516,6 +516,35 @@ describe('Category | Category Reducer', () => {
 		});
   });
 
+  describe('when CategoryLoadSuccessAction is triggered', () => {
+
+    let result: DaffCategoryReducerState<DaffCategoryRequest, DaffCategoryPageConfigurationState<DaffCategoryRequest>>;
+    let state: DaffCategoryReducerState<DaffCategoryRequest, DaffCategoryPageConfigurationState<DaffCategoryRequest>>;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        categoryLoading: true,
+        productsLoading: true,
+      }
+
+      const categoryLoadSuccess = new DaffCategoryLoadSuccess({ category: category, categoryPageConfigurationState: categoryPageConfigurationState, products: null });
+      result = daffCategoryReducer(state, categoryLoadSuccess);
+    });
+
+    it('sets categoryLoading to false', () => {
+      expect(result.categoryLoading).toEqual(false);
+    });
+
+    it('sets productsLoading to false', () => {
+      expect(result.productsLoading).toEqual(false);
+    });
+
+    it('sets categoryPageConfigurationState from the payload', () => {
+      expect(result.categoryPageConfigurationState).toEqual(categoryPageConfigurationState);
+    });
+  });
+
   describe('when CategoryPageLoadSuccessAction is triggered', () => {
 
     let result: DaffCategoryReducerState<DaffCategoryRequest, DaffCategoryPageConfigurationState<DaffCategoryRequest>>;

--- a/libs/category/src/reducers/category/category.reducer.ts
+++ b/libs/category/src/reducers/category/category.reducer.ts
@@ -98,7 +98,8 @@ export function daffCategoryReducer<T extends DaffCategoryRequest, U extends Daf
 			}
     // This reducer cannot spread over state, because this would wipe out the applied filters on state. Applied filters are not
     // set here for reasons stated above.
-    case DaffCategoryActionTypes.CategoryPageLoadSuccessAction:
+		case DaffCategoryActionTypes.CategoryLoadSuccessAction:
+		case DaffCategoryActionTypes.CategoryPageLoadSuccessAction:
       return {
         ...state,
 				categoryLoading: false,

--- a/libs/category/src/resolvers/category-page/category-page.resolver.spec.ts
+++ b/libs/category/src/resolvers/category-page/category-page.resolver.spec.ts
@@ -16,7 +16,7 @@ import { DaffCategoryReducersState } from '../../reducers/category-reducers.inte
 import { DaffCategory } from '../../models/category';
 import { daffCategoryReducers } from '../../reducers/category-reducers';
 import { DaffDefaultCategoryPageSize } from './default-category-page-size.token';
-import { DaffCategoryLoad, DaffCategoryLoadSuccess, DaffCategoryLoadFailure } from '../../actions/category.actions';
+import { DaffCategoryPageLoad, DaffCategoryPageLoadSuccess, DaffCategoryPageLoadFailure } from '../../actions/category.actions';
 
 describe('DaffCategoryPageResolver', () => {
 	const actions$: Observable<any> = null;
@@ -53,20 +53,20 @@ describe('DaffCategoryPageResolver', () => {
 			route = TestBed.get(ActivatedRoute);
 		}));
 
-		it('should dispatch a DaffCategoryLoad action with the correct category id', () => {
+		it('should dispatch a DaffCategoryPageLoad action with the correct category id', () => {
 			spyOn(store, 'dispatch');
 			categoryResolver.resolve( route.snapshot );
 			expect(store.dispatch).toHaveBeenCalledWith(
-				new DaffCategoryLoad({ id: '123', page_size: 12 })
+				new DaffCategoryPageLoad({ id: '123', page_size: 12 })
 			);
 		});
 
-		it('should resolve when DaffCategoryLoadSuccess is dispatched', () => {
+		it('should resolve when DaffCategoryPageLoadSuccess is dispatched', () => {
 			categoryResolver.resolve(route.snapshot).subscribe(value => {
 				expect(value).toEqual(true);
 			});
 
-			store.dispatch(new DaffCategoryLoadSuccess({
+			store.dispatch(new DaffCategoryPageLoadSuccess({
 				products: [new DaffProductFactory().create()],
 				category: stubCategory,
 				categoryPageConfigurationState: new DaffCategoryPageConfigurationStateFactory().create()
@@ -78,7 +78,7 @@ describe('DaffCategoryPageResolver', () => {
 				expect(value).toEqual(true);
 			});
 
-			store.dispatch(new DaffCategoryLoadFailure(null));
+			store.dispatch(new DaffCategoryPageLoadFailure(null));
 		});
 
 		it('should not resolve without a category load success or failure', () => {
@@ -116,11 +116,11 @@ describe('DaffCategoryPageResolver', () => {
 			route = TestBed.get(ActivatedRoute);
 		}));
 
-		it('should dispatch a DaffCategoryLoad action with the correct category id', () => {
+		it('should dispatch a DaffCategoryPageLoad action with the correct category id', () => {
 			spyOn(store, 'dispatch');
 			categoryResolver.resolve( route.snapshot );
 			expect(store.dispatch).toHaveBeenCalledWith(
-				new DaffCategoryLoad({ id: '123', page_size: 12 })
+				new DaffCategoryPageLoad({ id: '123', page_size: 12 })
 			);
 		});
 

--- a/libs/category/src/resolvers/category-page/category-page.resolver.ts
+++ b/libs/category/src/resolvers/category-page/category-page.resolver.ts
@@ -6,7 +6,7 @@ import { ActionsSubject, Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs'
 import { mapTo, take } from 'rxjs/operators';
 
-import { DaffCategoryActionTypes, DaffCategoryLoad } from '../../actions/category.actions';
+import { DaffCategoryActionTypes, DaffCategoryPageLoad } from '../../actions/category.actions';
 import { DaffCategoryReducersState } from '../../reducers/category-reducers.interface';
 import { DaffDefaultCategoryPageSize } from './default-category-page-size.token';
 
@@ -26,12 +26,12 @@ export class DaffCategoryPageResolver implements Resolve<Observable<boolean>> {
 	) {}
 	
 	resolve(route: ActivatedRouteSnapshot): Observable<boolean> {
-		this.store.dispatch(new DaffCategoryLoad({
+		this.store.dispatch(new DaffCategoryPageLoad({
       id: route.paramMap.get('id'), page_size: this.defaultCategoryPageSize
 		}));
 
 		return isPlatformBrowser(this.platformId) ? of(true) : this.dispatcher.pipe(
-			ofType(DaffCategoryActionTypes.CategoryLoadSuccessAction, DaffCategoryActionTypes.CategoryLoadFailureAction),
+			ofType(DaffCategoryActionTypes.CategoryPageLoadSuccessAction, DaffCategoryActionTypes.CategoryPageLoadFailureAction),
 			mapTo(true),
 			take(1)
 		);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The category page resolver uses DaffCategoryLoad actions when it should use DaffCategoryPageLoad actions. The DaffCategoryLoad action causes an infinite loading state.

## What is the new behavior?
The category page resolver now uses DaffCategoryPageLoad actions, and the DaffCategoryLoadSuccess will stop the category loading state.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```