### PR TITLE
fix(product): out of stock item options result in a price bug for non…

### DIFF
--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
@@ -181,7 +181,17 @@ describe('Product | Composite Product Entities Reducer', () => {
 			const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
 			result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
 
-			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id]).toEqual({ value: null, qty: null });
+			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id].value).toEqual(null);
+		});
+
+		it('should set the default option qty to the default qty when the default option is out of stock', () => {
+			compositeProduct.items[0].options[0].is_default = false;
+			compositeProduct.items[0].options[1].is_default = true;
+			compositeProduct.items[0].options[1].in_stock = false;
+			const productLoadSuccess = new DaffProductLoadSuccess(compositeProduct);
+			result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
+
+			expect(result.entities[compositeProduct.id].items[compositeProduct.items[0].id].qty).toEqual(compositeProduct.items[0].options[1].quantity);
 		});
 
 		it(`should set the default option to null when the default item option is not defined`, () => {

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -70,15 +70,16 @@ function buildCompositeProductAppliedOptionsEntity(product: DaffCompositeProduct
 
 /**
  * Sets the default item option to the specified default option if it is in stock.
- * Does not set a default option if a default is not specified or if the default is out of stock.
+ * Does not set a default option if a default is not specified.
+ * Does not set a default option but does set a default qty if the default is out of stock.
  * @param item a DaffCompositeProductItem
  */
 function getDefaultOption(item: DaffCompositeProductItem): DaffCompositeConfigurationItem {
 	const defaultOptionIndex = item.options.findIndex(option => option.is_default);
 
-	if(defaultOptionIndex > -1 && item.options[defaultOptionIndex].in_stock) {
+	if(defaultOptionIndex > -1) {
 		return {
-			value: item.options[defaultOptionIndex].id,
+			value: item.options[defaultOptionIndex].in_stock ? item.options[defaultOptionIndex].id : null,
 			qty: item.options[defaultOptionIndex].quantity
 		}
 	} else {

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.spec.ts
@@ -57,7 +57,6 @@ describe('Composite Product Selectors | integration tests', () => {
 		stubCompositeProduct.items[0].options[0].price = stubPrice00;
 		stubCompositeProduct.items[0].options[0].quantity = stubQty0;
 		stubCompositeProduct.items[0].options[1].price = stubPrice01;
-		stubCompositeProduct.items[0].options[0].quantity = stubQty1;
 		stubCompositeProduct.items[0].options[0].discount = {
 			amount: stubDiscountAmount00,
 			percent: null
@@ -70,6 +69,7 @@ describe('Composite Product Selectors | integration tests', () => {
 		stubCompositeProduct.items[1].options[0].is_default = false;
 		stubCompositeProduct.items[1].options[0].price = stubPrice10;
 		stubCompositeProduct.items[1].options[1].price = stubPrice11;
+		stubCompositeProduct.items[1].options[0].quantity = stubQty1;
 		stubCompositeProduct.items[1].options[0].discount = {
 			amount: stubDiscountAmount10,
 			percent: null
@@ -479,6 +479,35 @@ describe('Composite Product Selectors | integration tests', () => {
 						percent: null
 					},
 					originalPrice: stubCompositeProduct.price + (stubPrice01 * stubQty0) + (stubPrice11 * stubQty1)
+				}
+			}});
+
+			expect(selector).toBeObservable(expected);
+		});
+		
+		it('should return a price range that reflects the expected option quantity when the default item option is out of stock', () => {
+			stubCompositeProduct.items[0].options[0].in_stock = false;
+			store.dispatch(new DaffProductLoadSuccess(stubCompositeProduct));
+
+			const selector = store.pipe(select(selectCompositeProductPricesAsCurrentlyConfigured, { id: stubCompositeProduct.id }));
+			const expected = cold('a', { a: {
+				minPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice00 - stubDiscountAmount00) * stubQty0,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice00 * stubQty0)
+				},
+				maxPrice: {
+					discountedPrice: stubCompositeProduct.price - stubCompositeProduct.discount.amount + 
+						(stubPrice01 - stubDiscountAmount01) * stubQty0,
+					discount: {
+						amount: null,
+						percent: null
+					},
+					originalPrice: stubCompositeProduct.price + (stubPrice01 * stubQty0)
 				}
 			}});
 

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -47,6 +47,7 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			}
 
 			const appliedOptions = props.configuration ? getAppliedOptionsForConfiguration(<DaffCompositeProduct>product, props.configuration) : {};
+			console.log(appliedOptions);
 			return {
 				minPrice: getMinPricesForConfiguration(<DaffCompositeProduct>product, appliedOptions),
 				maxPrice: getMaxPricesForConfiguration(<DaffCompositeProduct>product, appliedOptions)
@@ -209,6 +210,7 @@ function getMaxPricesForConfigurationIncludingOptionalItems(product: DaffComposi
  * @param configuration a Dictionary<DaffCompositeConfigurationItem> used to build the appliedOptions object.
  */
 function getAppliedOptionsForConfiguration(product: DaffCompositeProduct, configuration: Dictionary<DaffCompositeConfigurationItem>): Dictionary<DaffCompositeProductItemOption> {
+	console.log(configuration);
 	return (<DaffCompositeProduct>product).items.reduce((acc, item) => ({
 		...acc,
 		[item.id]: configuration[item.id] ? {

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -47,7 +47,6 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 			}
 
 			const appliedOptions = props.configuration ? getAppliedOptionsForConfiguration(<DaffCompositeProduct>product, props.configuration) : {};
-			console.log(appliedOptions);
 			return {
 				minPrice: getMinPricesForConfiguration(<DaffCompositeProduct>product, appliedOptions),
 				maxPrice: getMaxPricesForConfiguration(<DaffCompositeProduct>product, appliedOptions)
@@ -210,7 +209,6 @@ function getMaxPricesForConfigurationIncludingOptionalItems(product: DaffComposi
  * @param configuration a Dictionary<DaffCompositeConfigurationItem> used to build the appliedOptions object.
  */
 function getAppliedOptionsForConfiguration(product: DaffCompositeProduct, configuration: Dictionary<DaffCompositeConfigurationItem>): Dictionary<DaffCompositeProductItemOption> {
-	console.log(configuration);
 	return (<DaffCompositeProduct>product).items.reduce((acc, item) => ({
 		...acc,
 		[item.id]: configuration[item.id] ? {


### PR DESCRIPTION
…-one, unchangeable item option quantity products

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
For a composite product with item options that have non-one, unchangeable quantities, if the default option is out of stock, the prices shown will not be multiplied by the option quantity as they should be.

## What is the new behavior?
For this scenario, the prices returned will be a price range based on the quantity of the default option.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```