### PR TITLE
feat(authorizenet): add new production token to authorizenet package 

### DIFF
--- a/libs/authorizenet/src/drivers/interfaces/authorize-net-config.interface.ts
+++ b/libs/authorizenet/src/drivers/interfaces/authorize-net-config.interface.ts
@@ -4,11 +4,9 @@ export const DaffAuthorizeNetConfigToken = new InjectionToken('DaffAuthorizeNetC
 
 /**
  * An interface for providing @daffodil/authorizenet with needed configurations specific to your authorizenet
- * endpoint. The production flag will switch between the sandbox and production endpoint depending on the value
- * given.
+ * endpoint.
  */
 export interface DaffAuthorizeNetConfig {
 	clientKey: string;
 	apiLoginID: string;
-	production: boolean;
 }

--- a/libs/authorizenet/src/drivers/magento/transformers/authorize-net-transformer.spec.ts
+++ b/libs/authorizenet/src/drivers/magento/transformers/authorize-net-transformer.spec.ts
@@ -13,8 +13,7 @@ describe('AuthorizeNet | Drivers | Magento | Transformers', () => {
 	}
 	const stubAuthData: DaffAuthorizeNetConfig = {
 		apiLoginID: 'apiLoginID',
-		clientKey: 'clientKey',
-		production: false
+		clientKey: 'clientKey'
 	};
 	
 	describe('transformMagentoAuthorizeNetRequest', () => {

--- a/libs/authorizenet/src/effects/authorize-net.effects.spec.ts
+++ b/libs/authorizenet/src/effects/authorize-net.effects.spec.ts
@@ -47,8 +47,7 @@ describe('DaffAuthorizeNetEffects', () => {
 	let authorizeNetPaymentService: MockAuthorizeNetDriver;
 	const stubConfig: DaffAuthorizeNetConfig = {
 		clientKey: 'clientKey',
-		apiLoginID: 'apiLoginID',
-		production: false
+		apiLoginID: 'apiLoginID'
 	}
 	let stubAddress: DaffCartAddress;
 	const acceptJsLoadingServiceSpy = jasmine.createSpyObj('DaffAcceptJsLoadingService', ['load', 'getAccept']);

--- a/libs/authorizenet/src/index.ts
+++ b/libs/authorizenet/src/index.ts
@@ -1,1 +1,1 @@
-export * from 'public_api';
+export * from './public_api';

--- a/libs/authorizenet/src/index.ts
+++ b/libs/authorizenet/src/index.ts
@@ -1,14 +1,1 @@
-export * from './actions/authorizenet.actions';
-
-export { DaffAuthorizeNetCreditCard } from './models/request/credit-card';
-export { DaffAuthorizeNetFacade } from './facades/authorize-net.facade';
-export { DaffAuthorizeNetFacadeInterface } from './facades/authorize-net-facade.interface';
-export { DaffAuthorizeNetTokenRequest } from './models/request/authorize-net-token-request';
-
-export * from './selectors/authorize-net.selector';
-export { DaffAuthorizeNetReducersState } from './reducers/authorize-net-reducers.interface';
-export { daffAuthorizeNetReducers } from './reducers/authorize-net.reducers';
-export { DaffAuthorizeNetReducerState } from './reducers/authorize-net/authorize-net-reducer.interface';
-export { daffAuthorizeNetReducer } from './reducers/authorize-net/authorize-net.reducer';
-export { DaffAuthorizeNetModule } from './authorize-net.module';
-export * from './drivers/public_api';
+export * from 'public_api';

--- a/libs/authorizenet/src/public_api.ts
+++ b/libs/authorizenet/src/public_api.ts
@@ -1,0 +1,17 @@
+export * from './actions/authorizenet.actions';
+
+export { DaffAuthorizeNetCreditCard } from './models/request/credit-card';
+export { DaffAuthorizeNetFacade } from './facades/authorize-net.facade';
+export { DaffAuthorizeNetFacadeInterface } from './facades/authorize-net-facade.interface';
+export { DaffAuthorizeNetTokenRequest } from './models/request/authorize-net-token-request';
+
+export * from './selectors/authorize-net.selector';
+export { DaffAuthorizeNetReducersState } from './reducers/authorize-net-reducers.interface';
+export { daffAuthorizeNetReducers } from './reducers/authorize-net.reducers';
+export { DaffAuthorizeNetReducerState } from './reducers/authorize-net/authorize-net-reducer.interface';
+export { daffAuthorizeNetReducer } from './reducers/authorize-net/authorize-net.reducer';
+export { DaffAuthorizeNetModule } from './authorize-net.module';
+export * from './drivers/public_api';
+
+export { DaffAcceptJsLoadingService } from './services/accept-js-loading.service';
+export { DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION } from './services/accept-js-production.token';

--- a/libs/authorizenet/src/services/accept-js-loading.service.spec.ts
+++ b/libs/authorizenet/src/services/accept-js-loading.service.spec.ts
@@ -1,41 +1,45 @@
 import { TestBed } from '@angular/core/testing';
 
+import { DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION } from '@daffodil/authorizenet';
+
 import { DaffAcceptJsLoadingService } from './accept-js-loading.service';
-import { DaffAuthorizeNetConfig, DaffAuthorizeNetConfigToken } from '../drivers/public_api';
 
 describe('DaffAcceptJsLoadingService', () => {
-  let service: DaffAcceptJsLoadingService;
-	const stubConfig: DaffAuthorizeNetConfig = {
-		clientKey: 'clientKey',
-		apiLoginID: 'apiLoginID',
-		production: false
-	}
+	let service: DaffAcceptJsLoadingService;
+	let production: boolean;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        DaffAcceptJsLoadingService,
-				{ provide: DaffAuthorizeNetConfigToken, useValue: stubConfig }
-			]
-    });
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			providers: [
+				DaffAcceptJsLoadingService,
+				{
+					provide: DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION,
+					useFactory: () => production,
+				},
+			],
+		});
 
-    service = TestBed.get(DaffAcceptJsLoadingService);
-  });
+		production = false;
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+		service = TestBed.get(DaffAcceptJsLoadingService);
 	});
-		
+
+	it('should be created', () => {
+		expect(service).toBeTruthy();
+	});
+
 	it(`throws an error when acceptJs has not been loaded
 			should load the acceptJs library into the document`, () => {
 		expect(() => {
-			service.getAccept()
+			service.getAccept();
 		}).toThrowError();
 
 		service.load();
 		setTimeout(() => {
 			const scripts = document.getElementsByTagName('script');
-			expect(scripts[scripts.length-1].src).toEqual('https://jstest.authorize.net/v1/Accept.js');
+			expect(scripts[scripts.length - 1].src).toEqual(
+				'https://jstest.authorize.net/v1/Accept.js',
+			);
 		});
 		expect(true).toBeTruthy();
 	});

--- a/libs/authorizenet/src/services/accept-js-loading.service.ts
+++ b/libs/authorizenet/src/services/accept-js-loading.service.ts
@@ -1,8 +1,7 @@
 import { Inject, Injectable } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-
+import { DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION } from './accept-js-production.token';
 import { AcceptType } from '../models/acceptJs/accept';
-import { DaffAuthorizeNetConfig, DaffAuthorizeNetConfigToken } from '../drivers/public_api';
 
 const ACCEPT_JS_SANDBOX_URL = 'https://jstest.authorize.net/v1/Accept.js';
 const ACCEPT_JS_PRODUCTION_URL = 'https://js.authorize.net/v1/Accept.js';
@@ -10,21 +9,23 @@ const ACCEPT_JS_PRODUCTION_URL = 'https://js.authorize.net/v1/Accept.js';
 export declare var Accept: AcceptType;
 
 @Injectable({
-	providedIn: 'root'
+	providedIn: 'root',
 })
 export class DaffAcceptJsLoadingService {
-
-  constructor(
-		@Inject(DaffAuthorizeNetConfigToken) private config: DaffAuthorizeNetConfig,
-		@Inject(DOCUMENT) private doc
-	){}
+	constructor(
+		@Inject(DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION) private production: boolean,
+		@Inject(DOCUMENT) private doc,
+	) {}
 
 	load(): void {
-		if(typeof Accept === 'undefined') {
+		if (typeof Accept === 'undefined') {
 			const acceptJsScript = this.doc.createElement('script');
 			acceptJsScript.async = true;
 			acceptJsScript.setAttribute('type', 'text/javascript');
-			acceptJsScript.setAttribute('src', this.config.production ? ACCEPT_JS_PRODUCTION_URL : ACCEPT_JS_SANDBOX_URL);
+			acceptJsScript.setAttribute(
+				'src',
+				this.production ? ACCEPT_JS_PRODUCTION_URL : ACCEPT_JS_SANDBOX_URL,
+			);
 			acceptJsScript.setAttribute('charset', 'utf-8');
 			this.doc.body.appendChild(acceptJsScript);
 		}

--- a/libs/authorizenet/src/services/accept-js-production.token.ts
+++ b/libs/authorizenet/src/services/accept-js-production.token.ts
@@ -1,0 +1,12 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * A token that represents the version to use for Accept.JS calls
+ * By default, we assume you're using the sandbox (false) for safety purposes.
+ */
+export const DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION = new InjectionToken<
+	boolean
+>('DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION', {
+	providedIn: 'root',
+	factory: () => false,
+});

--- a/libs/authorizenet/src/services/accept-js-production.token.ts
+++ b/libs/authorizenet/src/services/accept-js-production.token.ts
@@ -2,8 +2,8 @@ import { InjectionToken } from '@angular/core';
 
 /**
  * A token that represents the version to use for Accept.JS calls.
- * A true configures the package to use the production AcceptJs endpoint, 
- * and a false value configures it to use the Sandbox AcceptJs endpoint. 
+ * A "true" value configures the package to use the production AcceptJs endpoint, 
+ * and a "false" value configures it to use the Sandbox AcceptJs endpoint. 
  * By default, we assume you're using the sandbox (false).
  */
 export const DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION = new InjectionToken<

--- a/libs/authorizenet/src/services/accept-js-production.token.ts
+++ b/libs/authorizenet/src/services/accept-js-production.token.ts
@@ -1,8 +1,10 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * A token that represents the version to use for Accept.JS calls
- * By default, we assume you're using the sandbox (false) for safety purposes.
+ * A token that represents the version to use for Accept.JS calls.
+ * A true configures the package to use the production AcceptJs endpoint, 
+ * and a false value configures it to use the Sandbox AcceptJs endpoint. 
+ * By default, we assume you're using the sandbox (false).
  */
 export const DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION = new InjectionToken<
 	boolean


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```
This splits off a single commit from #1160 that didn't make sense for that PR.

## What is the current behavior?
Currently, the authorize.net loader service depends on a configuration from the driver. This is a mistake.

Fixes: N/A


## What is the new behavior?
This adds a configuration (an injectable) outside of the scope of the driver that can be used to configure the acceptjs endpoint.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information