### PR TITLE
fix(cart): cart item state is set incorrectly in cart item reducers

### DIFF
--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -1,6 +1,6 @@
 import { DaffCart } from '@daffodil/cart';
 import { DaffCartItemListSuccess, DaffCartItemLoadSuccess, DaffCartItemUpdateSuccess, DaffCartItemAddSuccess, DaffCartItemDeleteSuccess, DaffCartLoadSuccess, DaffCartClearSuccess } from '@daffodil/cart/state';
-import { DaffCartFactory } from '@daffodil/cart/testing';
+import { DaffCartFactory, DaffCartItemFactory } from '@daffodil/cart/testing';
 import { DaffStatefulCartItemFactory } from '@daffodil/cart/state/testing';
 
 import { DaffCartItemDelete, DaffCartItemStateReset, DaffCartItemUpdate } from '../../actions/public_api';
@@ -11,7 +11,7 @@ import { daffCartItemEntitiesReducer } from './cart-item-entities.reducer';
 describe('Cart | Cart Item Entities Reducer', () => {
 
 	let statefulCartItemFactory: DaffStatefulCartItemFactory;
-	const initialState = daffCartItemEntitiesAdapter().getInitialState({ daffState: DaffCartItemStateEnum.Default });
+	const initialState = daffCartItemEntitiesAdapter().getInitialState();
 
   beforeEach(() => {
     statefulCartItemFactory = new DaffStatefulCartItemFactory();
@@ -26,7 +26,75 @@ describe('Cart | Cart Item Entities Reducer', () => {
 
       expect(result).toEqual(initialState);
     });
-  });
+	});
+	
+	describe('when an existing cart item does not have a default daffState', () => {
+		let result;
+		let stubStatefulCartItem: DaffStatefulCartItem;
+		let initialStateWithCartItem;
+		
+		beforeEach(() => {
+			stubStatefulCartItem = new DaffStatefulCartItemFactory().create({
+				item_id: 'id'
+			});
+			initialStateWithCartItem = {
+				...initialState,
+				entities: {
+					[stubStatefulCartItem.item_id]: {
+						...stubStatefulCartItem,
+						daffState: DaffCartItemStateEnum.New
+					}
+				}
+			};
+		});
+
+		it('should retain the existing daffState when a CartItemListSuccessAction is triggered', () => {
+      const cartItemListSuccess = new DaffCartItemListSuccess([{
+				...stubStatefulCartItem,
+				daffState: DaffCartItemStateEnum.Default
+			}]);
+
+			result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartItemListSuccess);
+			expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+		});
+		
+		it('should retain the existing daffState when a CartItemLoadSuccessAction is triggered', () => {
+			const cartItemLoadSuccess = new DaffCartItemLoadSuccess({
+				...stubStatefulCartItem,
+				daffState: DaffCartItemStateEnum.Default
+			});
+
+			result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartItemLoadSuccess);
+			expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+		});
+
+		it('should retain the existing daffState when a CartItemDeleteSuccessAction is triggered', () => {
+      const cartItemDeleteSuccess = new DaffCartItemDeleteSuccess(new DaffCartFactory().create({
+				items: [new DaffCartItemFactory().create({ item_id: stubStatefulCartItem.item_id })]
+			}));
+
+			result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartItemDeleteSuccess);
+			expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+		});
+
+		it('should retain the existing daffState when a CartLoadSuccessAction is triggered', () => {
+      const cartLoadSuccess = new DaffCartLoadSuccess(new DaffCartFactory().create({
+				items: [new DaffCartItemFactory().create({ item_id: stubStatefulCartItem.item_id })]
+			}));
+
+			result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartLoadSuccess);
+			expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+		});
+
+		it('should retain the existing daffState when a CartClearSuccessAction is triggered', () => {
+      const cartClearSuccess = new DaffCartClearSuccess(new DaffCartFactory().create({
+				items: [new DaffCartItemFactory().create({ item_id: stubStatefulCartItem.item_id })]
+			}));
+
+			result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartClearSuccess);
+			expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+		});
+	});
 
   describe('when CartItemListSuccessAction is triggered', () => {
 

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -120,7 +120,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
 		});
 		
 		it('sets the new cart item\'s state to New', () => {
-			expect(result.entities[statefulCartItem.item_id].state).toEqual(DaffCartItemStateEnum.New);
+			expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
 		});
   });
 
@@ -248,7 +248,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('resets the state of all the cart items to default', () => {
-      expect(result.entities[stubCartItem.item_id].state).toEqual(DaffCartItemStateEnum.Default);
+      expect(result.entities[stubCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Default);
     });
   });
 
@@ -272,7 +272,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('sets the updating cart item state to mutating', () => {
-      expect(result.entities[stubStatefulCartItem.item_id].state).toEqual(DaffCartItemStateEnum.Mutating);
+      expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Mutating);
     });
   });
 
@@ -296,7 +296,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('sets the cart item state to mutating', () => {
-      expect(result.entities[stubCartItem.item_id].state).toEqual(DaffCartItemStateEnum.Mutating);
+      expect(result.entities[stubCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Mutating);
     });
   });
 });

--- a/libs/cart/state/testing/src/factories/stateful-cart-item.factory.ts
+++ b/libs/cart/state/testing/src/factories/stateful-cart-item.factory.ts
@@ -5,7 +5,7 @@ import { DaffMockCartItem } from '@daffodil/cart/testing';
 import { DaffStatefulCartItem, DaffCartItemStateEnum } from '@daffodil/cart/state';
 
 export class DaffMockStatefulCartItem extends DaffMockCartItem implements DaffStatefulCartItem {
-	daffState: DaffCartItemStateEnum.Default;
+	daffState = DaffCartItemStateEnum.Default;
 }
 
 @Injectable({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The cart item state reducers aren't correct, and sometimes even set "state" on the cart item entity instead of "daffState".

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Notes
The reason the tests were passing before is because the `DaffCartItemStateFactory` was setting the `daffState` incorrectly. I fixed the factory here.