### PR TITLE
fix(navigation): the getCategoryNodeFragment magento query does not work

### DIFF
--- a/libs/navigation/src/drivers/magento/queries/fragments/category-node.spec.ts
+++ b/libs/navigation/src/drivers/magento/queries/fragments/category-node.spec.ts
@@ -199,7 +199,7 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
 	
 	//todo: remove this test when this bug is fixed: https://github.com/magento/magento2/issues/31086
 	//This test only exists to test the workaround.
-	it('should return the expected fragment', () => {
+	it('should not use nested fragments', () => {
 		const expectedFields = [
 			'id',
 			'level',

--- a/libs/navigation/src/drivers/magento/queries/fragments/category-node.spec.ts
+++ b/libs/navigation/src/drivers/magento/queries/fragments/category-node.spec.ts
@@ -171,7 +171,7 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
     let response: Observable<ApolloQueryResult<CategoryNode>>;
 
     beforeEach(() => {
-      const fragment = getCategoryNodeFragment(3);
+			const fragment = getCategoryNodeFragment(3);
 
       query = gql`
         query TestQuery {
@@ -195,7 +195,23 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
         data: depth3NavigationTree
       })
     });
-  });
+	});
+	
+	it('should return the expected fragment', () => {
+		const expectedFields = [
+			'id',
+			'level',
+			'name',
+			'include_in_menu',
+			'products',
+			'children_count',
+			'children'
+		];
+
+		(<any>getCategoryNodeFragment(3).definitions[0]).selectionSet.selections.forEach((selection, index) => {
+			expect(selection.name.value).toEqual(expectedFields[index]);
+		});
+	});
 
   afterEach(() => {
     controller.verify();

--- a/libs/navigation/src/drivers/magento/queries/fragments/category-node.spec.ts
+++ b/libs/navigation/src/drivers/magento/queries/fragments/category-node.spec.ts
@@ -197,6 +197,8 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
     });
 	});
 	
+	//todo: remove this test when this bug is fixed: https://github.com/magento/magento2/issues/31086
+	//This test only exists to test the workaround.
 	it('should return the expected fragment', () => {
 		const expectedFields = [
 			'id',

--- a/libs/navigation/src/drivers/magento/queries/fragments/category-node.ts
+++ b/libs/navigation/src/drivers/magento/queries/fragments/category-node.ts
@@ -4,16 +4,14 @@ import gql from 'graphql-tag';
 /**
  * A category tree fragment with no nested children.
  */
-export const categoryNodeFragment = gql`
-  fragment categoryNode on CategoryTree {
-    id
-    level
-    name
-    include_in_menu
-    products {
-      total_count
-    }
-  }
+const categoryNodeFragment = `
+	id
+	level
+	name
+	include_in_menu
+	products {
+		total_count
+	}
 `
 
 /**
@@ -22,17 +20,16 @@ export const categoryNodeFragment = gql`
  */
 export function getCategoryNodeFragment(depth: number = 3): DocumentNode {
   const fragmentBody = new Array(depth).fill(null).reduce(acc => `
-    ...categoryNode
+    ${categoryNodeFragment}
     children_count
     children {
       ${acc}
     }
-  `, '...categoryNode')
+  `, categoryNodeFragment)
 
   return gql`
     fragment recursiveCategoryNode on CategoryTree {
       ${fragmentBody}
     }
-    ${categoryNodeFragment}
   `
 }

--- a/libs/navigation/src/drivers/magento/queries/fragments/category-node.ts
+++ b/libs/navigation/src/drivers/magento/queries/fragments/category-node.ts
@@ -18,6 +18,7 @@ const categoryNodeFragment = `
  * Generates a category tree fragment with the specified number of nested child category trees.
  * @param depth The maximum depth to which category children should be added to the fragment.
  */
+//todo: use nested fragments when this bug is fixed: https://github.com/magento/magento2/issues/31086
 export function getCategoryNodeFragment(depth: number = 3): DocumentNode {
   const fragmentBody = new Array(depth).fill(null).reduce(acc => `
     ${categoryNodeFragment}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The magento navigation query has a small problem that prevents it from working. Apparently you can't pass a fragment string into another function like this:
```
export function getCategoryNodeFragment(depth: number = 3): DocumentNode {
  const fragmentBody = new Array(depth).fill(null).reduce(acc => `
    ...categoryNode
    children_count
    children {
      ${acc}
    }
  `, '...categoryNode')

  return gql`
    fragment recursiveCategoryNode on CategoryTree {
      ${fragmentBody}
    }
    ${categoryNodeFragment}
  `
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```