### PR TITLE
feat(cart): improve CartResolution action hygiene, change resolved state to enum

### DIFF
--- a/libs/cart/state/src/actions/cart.actions.ts
+++ b/libs/cart/state/src/actions/cart.actions.ts
@@ -94,13 +94,13 @@ export class DaffCartClearFailure implements Action {
 }
 
 export class DaffResolveCart implements Action {
-	readonly type = DaffCartActionTypes.ResolveCartAction;
+  readonly type = DaffCartActionTypes.ResolveCartAction;
 }
 
-export class DaffResolveCartSuccess implements Action {
+export class DaffResolveCartSuccess<T extends DaffCart = DaffCart> implements Action {
   readonly type = DaffCartActionTypes.ResolveCartSuccessAction;
 
-  constructor() {}
+  constructor(public payload: T) {}
 }
 
 export class DaffResolveCartFailure implements Action {
@@ -124,5 +124,5 @@ export type DaffCartActions<T extends DaffCart = DaffCart> =
   | DaffCartClearSuccess<T>
   | DaffCartClearFailure
   | DaffResolveCart
-  | DaffResolveCartSuccess
+  | DaffResolveCartSuccess<T>
   | DaffResolveCartFailure;

--- a/libs/cart/state/src/cart-state.module.ts
+++ b/libs/cart/state/src/cart-state.module.ts
@@ -50,7 +50,7 @@ import { DaffCartResolverEffects } from './effects/cart-resolver.effects';
 	providers: [
 		{ provide: DaffCartBillingAddressGuardRedirectUrl, useValue: '/' },
 		{ provide: DaffCartItemsGuardRedirectUrl, useValue: '/' },
-		{ provide: DaffResolvedCartGuardRedirectUrl, useValue: '/' },
+		{ provide: DaffResolvedCartGuardRedirectUrl, useValue: null },
 		{ provide: DaffCartShippingAddressGuardRedirectUrl, useValue: '/' },
 		{ provide: DaffCartShippingMethodGuardRedirectUrl, useValue: '/' },
 		{ provide: DaffCartPaymentMethodGuardRedirectUrl, useValue: '/' },

--- a/libs/cart/state/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-resolver.effects.spec.ts
@@ -136,26 +136,26 @@ describe('DaffCartResolverEffects', () => {
       });
 
       describe('and the cart is not found when attempting to load it', () => {
+        const newCartId = 'newCartId';
+
         beforeEach(() => {
           const response = cold('#', {}, new DaffCartNotFoundError('error'));
           driver.get.withArgs(cartId).and.returnValue(response);
+          driver.create.and.returnValue(of({id: newCartId}));
+        });
+
+        it('should create a new cart', () => {
+          const expected = cold('--b', {
+            b: jasmine.anything(),
+          });
+
+          expect(effects.onResolveCart$).toBeObservable(expected);
+          expect(driver.create).toHaveBeenCalled();
         });
 
         describe('and the driver calls succeed', () => {
           beforeEach(() => {
-            const newCartId = 'newCartId';
-            driver.create.and.returnValue(of({id: newCartId}));
             driver.get.withArgs(newCartId).and.returnValue(of(stubCart));
-          });
-
-          it('should create a new cart', () => {
-            const resolveCartSuccessAction = new DaffResolveCartSuccess(stubCart);
-            const expected = cold('--b', {
-              b: resolveCartSuccessAction,
-            });
-
-            expect(effects.onResolveCart$).toBeObservable(expected);
-            expect(driver.create).toHaveBeenCalled();
           });
 
           it('should indicate successful cart resolution', () => {
@@ -187,7 +187,6 @@ describe('DaffCartResolverEffects', () => {
         describe('and the get call fails', () => {
           beforeEach(() => {
             const response = cold('#', {}, new DaffCartNotFoundError('error'));
-            const newCartId = 'newCartId';
             driver.create.and.returnValue(of({id: newCartId}));
             driver.get.withArgs(newCartId).and.returnValue(response);
           });
@@ -218,7 +217,7 @@ describe('DaffCartResolverEffects', () => {
           expect(driver.create).not.toHaveBeenCalled();
         });
 
-        it('should indicate that a cart has resolved', () => {
+        it('should indicate that a cart has resolved successfully', () => {
           const resolveCartSuccessAction = new DaffResolveCartSuccess(stubCart);
           const expected = cold('--b', {
             b: resolveCartSuccessAction

--- a/libs/cart/state/src/effects/cart.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart.effects.spec.ts
@@ -23,7 +23,8 @@ import {
   DaffCartCreate,
   DaffCartCreateSuccess,
   DaffCartCreateFailure,
-  DaffCartStorageFailure
+  DaffCartStorageFailure,
+  DaffResolveCartSuccess
 } from '@daffodil/cart/state';
 import { DaffCartServiceInterface, DaffCartDriver } from '@daffodil/cart/driver';
 import { DaffCartFactory } from '@daffodil/cart/testing';
@@ -160,6 +161,35 @@ describe('Daffodil | Cart | CartEffects', () => {
 
     beforeEach(() => {
       cartCreateSuccessAction = new DaffCartCreateSuccess({id: mockCart.id});
+      actions$ = hot('--a', { a: cartCreateSuccessAction });
+      expected = cold('---');
+    });
+
+    it('should set the cart ID in storage', () => {
+      expect(effects.storeId$).toBeObservable(expected);
+      expect(daffCartStorageSpy.setCartId).toHaveBeenCalledWith(String(mockCart.id));
+    });
+
+    describe('and the storage service throws an error', () => {
+      beforeEach(() => {
+        daffCartStorageSpy.setCartId.and.callFake(throwStorageError)
+
+        actions$ = hot('--a', { a: cartCreateSuccessAction });
+        expected = cold('--b', { b: cartStorageFailureAction });
+      });
+
+      it('should return a DaffCartStorageFailure', () => {
+        expect(effects.storeId$).toBeObservable(expected);
+      });
+    });
+  });
+
+  describe('when ResolveCartSuccessAction is triggered', () => {
+    let expected;
+    let cartCreateSuccessAction;
+
+    beforeEach(() => {
+      cartCreateSuccessAction = new DaffResolveCartSuccess(mockCart);
       actions$ = hot('--a', { a: cartCreateSuccessAction });
       expected = cold('---');
     });

--- a/libs/cart/state/src/effects/cart.effects.ts
+++ b/libs/cart/state/src/effects/cart.effects.ts
@@ -43,11 +43,9 @@ export class DaffCartEffects<T extends DaffCart> {
     ))
   )
 
-  @Effect({
-    dispatch: false
-  })
+  @Effect()
   storeId$ = this.actions$.pipe(
-    ofType(DaffCartActionTypes.CartCreateSuccessAction),
+    ofType(DaffCartActionTypes.CartCreateSuccessAction, DaffCartActionTypes.ResolveCartSuccessAction),
     switchMap((action: DaffCartCreateSuccess<T>) => of(null).pipe(
       tap(() => {
         this.storage.setCartId(String(action.payload.id))

--- a/libs/cart/state/src/facades/cart/cart-facade.interface.ts
+++ b/libs/cart/state/src/facades/cart/cart-facade.interface.ts
@@ -19,8 +19,6 @@ export interface DaffCartFacadeInterface<
   cart$: Observable<T>;
 
   resolved$: Observable<DaffCartResolveState>;
-  resolveSuccess$: Observable<boolean>;
-  resolveFailure$: Observable<boolean>;
 
   /**
    * The object that holds all the loading states for cart operations.

--- a/libs/cart/state/src/facades/cart/cart-facade.interface.ts
+++ b/libs/cart/state/src/facades/cart/cart-facade.interface.ts
@@ -9,14 +9,18 @@ import { DaffCartErrors } from '../../reducers/errors/cart-errors.type';
 import { DaffCartOperationType } from '../../reducers/cart-operation-type.enum';
 import { DaffCartLoading } from '../../reducers/loading/cart-loading.type';
 import { DaffCartItemStateEnum, DaffStatefulCartItem } from '../../models/stateful-cart-item';
+import { DaffCartResolveState } from '../../reducers/public_api';
 
 export interface DaffCartFacadeInterface<
   T extends DaffCart = DaffCart,
 	V extends DaffCartOrderResult = DaffCartOrderResult,
 	U extends DaffStatefulCartItem = DaffStatefulCartItem
 > extends DaffStoreFacade<Action> {
-  resolved$: Observable<boolean>;
   cart$: Observable<T>;
+
+  resolved$: Observable<DaffCartResolveState>;
+  resolveSuccess$: Observable<boolean>;
+  resolveFailure$: Observable<boolean>;
 
   /**
    * The object that holds all the loading states for cart operations.

--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -6,31 +6,32 @@ import { cold } from 'jasmine-marbles';
 
 import { DaffLoadingState } from '@daffodil/core/state';
 import { DaffCartOrderResult, DaffCartPaymentMethodIdMap, DaffCart, DaffCartTotalTypeEnum, DaffCartPaymentMethod, DaffConfigurableCartItem, DaffCompositeCartItem, DaffCartItemInputType } from '@daffodil/cart';
-import { 
-	initialState, DaffCartReducersState, 
-	DaffCartLoading, DaffCartErrors, 
-	daffCartReducers, DaffCartOperationType, 
-	DaffResolveCartSuccess, DaffCartLoadSuccess, 
-	DaffCartLoad, DaffCartClear, 
-	DaffCartItemLoad, DaffCartItemDelete, 
-	DaffCartBillingAddressLoad, DaffCartBillingAddressUpdate, 
-	DaffCartShippingAddressLoad, DaffCartShippingAddressUpdate, 
-	DaffCartShippingInformationLoad, DaffCartShippingInformationDelete, 
-	DaffCartShippingMethodsLoad, DaffCartPaymentLoad, 
-	DaffCartPaymentRemove, DaffCartPaymentMethodsLoad, 
-	DaffCartCouponList, DaffCartCouponRemoveAll, 
-	DaffCartLoadFailure, DaffCartItemLoadFailure, 
-	DaffCartBillingAddressLoadFailure, DaffCartShippingAddressLoadFailure, 
-	DaffCartShippingInformationLoadFailure, DaffCartShippingMethodsLoadFailure, 
-	DaffCartPaymentLoadFailure, DaffCartPaymentMethodsLoadFailure, 
-	DaffCartCouponListFailure, DaffCartCreateSuccess, 
-	DaffCartItemListSuccess, DaffCartBillingAddressLoadSuccess, 
-	DaffCartShippingAddressLoadSuccess, DaffCartPaymentLoadSuccess, 
-	DaffCartShippingInformationLoadSuccess, DaffCartShippingMethodsLoadSuccess, 
-	DaffCartPaymentMethodsLoadSuccess, DaffCartPlaceOrder, 
+import {
+	initialState, DaffCartReducersState,
+	DaffCartLoading, DaffCartErrors,
+	daffCartReducers, DaffCartOperationType,
+	DaffCartLoadSuccess,
+	DaffCartLoad, DaffCartClear,
+	DaffCartItemLoad, DaffCartItemDelete,
+	DaffCartBillingAddressLoad, DaffCartBillingAddressUpdate,
+	DaffCartShippingAddressLoad, DaffCartShippingAddressUpdate,
+	DaffCartShippingInformationLoad, DaffCartShippingInformationDelete,
+	DaffCartShippingMethodsLoad, DaffCartPaymentLoad,
+	DaffCartPaymentRemove, DaffCartPaymentMethodsLoad,
+	DaffCartCouponList, DaffCartCouponRemoveAll,
+	DaffCartLoadFailure, DaffCartItemLoadFailure,
+	DaffCartBillingAddressLoadFailure, DaffCartShippingAddressLoadFailure,
+	DaffCartShippingInformationLoadFailure, DaffCartShippingMethodsLoadFailure,
+	DaffCartPaymentLoadFailure, DaffCartPaymentMethodsLoadFailure,
+	DaffCartCouponListFailure, DaffCartCreateSuccess,
+	DaffCartItemListSuccess, DaffCartBillingAddressLoadSuccess,
+	DaffCartShippingAddressLoadSuccess, DaffCartPaymentLoadSuccess,
+	DaffCartShippingInformationLoadSuccess, DaffCartShippingMethodsLoadSuccess,
+	DaffCartPaymentMethodsLoadSuccess, DaffCartPlaceOrder,
 	DaffCartPlaceOrderFailure, DaffCartPlaceOrderSuccess,
 	DaffCartItemLoadingState,
-	DaffCartItemAdd
+	DaffCartItemAdd,
+  DaffCartResolveState
 } from '@daffodil/cart/state';
 import {
   DaffCartFactory,
@@ -132,15 +133,23 @@ describe('DaffCartFacade', () => {
   });
 
   describe('resolved$', () => {
-    it('should be false if the cart is not resolved', () => {
-      const expected = cold('a', { a: false });
+    it('should be the resolved state', () => {
+      const expected = cold('a', { a: DaffCartResolveState.Default });
       expect(facade.resolved$).toBeObservable(expected);
     });
+  });
 
-    it('should be true if the cart is resolved', () => {
-      const expected = cold('a', { a: true });
-      facade.dispatch(new DaffResolveCartSuccess());
-      expect(facade.resolved$).toBeObservable(expected);
+  describe('resolveSuccess$', () => {
+    it('should be false', () => {
+      const expected = cold('a', { a: false });
+      expect(facade.resolveSuccess$).toBeObservable(expected);
+    });
+  });
+
+  describe('resolveFailure$', () => {
+    it('should be false', () => {
+      const expected = cold('a', { a: false });
+      expect(facade.resolveFailure$).toBeObservable(expected);
     });
   });
 

--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -139,20 +139,6 @@ describe('DaffCartFacade', () => {
     });
   });
 
-  describe('resolveSuccess$', () => {
-    it('should be false', () => {
-      const expected = cold('a', { a: false });
-      expect(facade.resolveSuccess$).toBeObservable(expected);
-    });
-  });
-
-  describe('resolveFailure$', () => {
-    it('should be false', () => {
-      const expected = cold('a', { a: false });
-      expect(facade.resolveFailure$).toBeObservable(expected);
-    });
-  });
-
   describe('cart$', () => {
     it('should initially be cart with no defined properties', () => {
       const expected = cold('a', { a: initialState.cart });

--- a/libs/cart/state/src/facades/cart/cart.facade.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.ts
@@ -6,7 +6,7 @@ import { Dictionary } from '@ngrx/entity';
 
 import { DaffCart, DaffCartOrderResult, DaffCartTotal, DaffCartPaymentMethodIdMap, DaffConfigurableCartItemAttribute, DaffCompositeCartItemOption } from '@daffodil/cart';
 
-import { DaffCartReducersState } from '../../reducers/public_api';
+import { DaffCartReducersState, DaffCartResolveState } from '../../reducers/public_api';
 import { getDaffCartSelectors } from '../../selectors/public_api';
 import { DaffCartErrors } from '../../reducers/errors/cart-errors.type';
 import { DaffCartOperationType } from '../../reducers/cart-operation-type.enum';
@@ -22,8 +22,11 @@ export class DaffCartFacade<
 	V extends DaffCartOrderResult = DaffCartOrderResult,
 	U extends DaffStatefulCartItem = DaffStatefulCartItem
 > implements DaffCartFacadeInterface<T, V, U> {
-  resolved$: Observable<boolean>;
   cart$: Observable<T>;
+
+  resolved$: Observable<DaffCartResolveState>;
+  resolveSuccess$: Observable<boolean>;
+  resolveFailure$: Observable<boolean>;
 
   loadingObject$: Observable<DaffCartLoading>;
   featureLoading$: Observable<boolean>;
@@ -117,8 +120,11 @@ export class DaffCartFacade<
     @Inject(DaffCartPaymentMethodIdMap) private paymentMethodMap: Object
   ) {
 		const {
-      selectCartResolved,
       selectCartValue,
+
+      selectCartResolved,
+      selectCartResolveSuccess,
+      selectCartResolveFailure,
 
       selectCartLoadingObject,
       selectCartFeatureLoading,
@@ -211,8 +217,11 @@ export class DaffCartFacade<
 		this._selectIsCartItemOutOfStock = selectIsCartItemOutOfStock;
 		this._selectCartItemState = selectCartItemState;
 
-    this.resolved$ = this.store.pipe(select(selectCartResolved));
     this.cart$ = this.store.pipe(select(selectCartValue));
+
+    this.resolved$ = this.store.pipe(select(selectCartResolved));
+    this.resolveSuccess$ = this.store.pipe(select(selectCartResolveSuccess));
+    this.resolveFailure$ = this.store.pipe(select(selectCartResolveFailure));
 
     this.loadingObject$ = this.store.pipe(select(selectCartLoadingObject));
     this.featureLoading$ = this.store.pipe(select(selectCartFeatureLoading));

--- a/libs/cart/state/src/facades/cart/cart.facade.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.ts
@@ -25,8 +25,6 @@ export class DaffCartFacade<
   cart$: Observable<T>;
 
   resolved$: Observable<DaffCartResolveState>;
-  resolveSuccess$: Observable<boolean>;
-  resolveFailure$: Observable<boolean>;
 
   loadingObject$: Observable<DaffCartLoading>;
   featureLoading$: Observable<boolean>;
@@ -123,8 +121,6 @@ export class DaffCartFacade<
       selectCartValue,
 
       selectCartResolved,
-      selectCartResolveSuccess,
-      selectCartResolveFailure,
 
       selectCartLoadingObject,
       selectCartFeatureLoading,
@@ -220,8 +216,6 @@ export class DaffCartFacade<
     this.cart$ = this.store.pipe(select(selectCartValue));
 
     this.resolved$ = this.store.pipe(select(selectCartResolved));
-    this.resolveSuccess$ = this.store.pipe(select(selectCartResolveSuccess));
-    this.resolveFailure$ = this.store.pipe(select(selectCartResolveFailure));
 
     this.loadingObject$ = this.store.pipe(select(selectCartLoadingObject));
     this.featureLoading$ = this.store.pipe(select(selectCartFeatureLoading));

--- a/libs/cart/state/src/guards/billing-address/billing-address.guard.spec.ts
+++ b/libs/cart/state/src/guards/billing-address/billing-address.guard.spec.ts
@@ -7,7 +7,6 @@ import { Router } from '@angular/router';
 
 import { DaffCart } from '@daffodil/cart';
 import {
-  DaffResolveCartSuccess,
   DaffCartLoadSuccess
 } from '@daffodil/cart/state';
 import { daffCartReducers, DaffCartBillingAddressGuardRedirectUrl } from '@daffodil/cart/state';
@@ -44,20 +43,11 @@ describe('Cart | State | Guards | DaffBillingAddressGuard', () => {
 	});
 
 	describe('canActivate', () => {
-    describe('when the cart has not been resolved', () => {
-      it('should not emit', () => {
-        const expected = cold('-');
-
-        expect(service.canActivate()).toBeObservable(expected);
-      });
-    });
-
 		it('should allow activation when there is a billing address', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				billing_address: new DaffCartAddressFactory().create(),
 			});
 			store.dispatch(new DaffCartLoadSuccess(cart));
-			store.dispatch(new DaffResolveCartSuccess());
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -71,7 +61,6 @@ describe('Cart | State | Guards | DaffBillingAddressGuard', () => {
 					billing_address: null,
 				});
         store.dispatch(new DaffCartLoadSuccess(cart));
-        store.dispatch(new DaffResolveCartSuccess());
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/state/src/guards/billing-address/billing-address.guard.ts
+++ b/libs/cart/state/src/guards/billing-address/billing-address.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
-import { tap, filter, switchMapTo, take } from 'rxjs/operators';
+import { tap, take } from 'rxjs/operators';
 
 import { DaffCartFacade } from '../../facades/cart/cart.facade';
 import { DaffCartBillingAddressGuardRedirectUrl } from './billing-address-guard-redirect.token';
@@ -9,7 +9,8 @@ import { DaffCartBillingAddressGuardRedirectUrl } from './billing-address-guard-
 /**
  * A routing guard that will redirect to a given url if the billing address on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartBillingAddressGuardRedirectUrl injection token.
- * The guard will wait until the cart has been resolved before performing the check and emitting.
+ * The guard will not wait until the cart has been resolved before performing the check and emitting.
+ * Ensure that the cart is resolved prior to running this guard with the {@link DaffResolvedCartGuard}.
  */
 @Injectable({
 	providedIn: 'root'
@@ -22,9 +23,7 @@ export class DaffBillingAddressGuard implements CanActivate {
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.resolved$.pipe(
-      filter(resolved => resolved),
-      switchMapTo(this.facade.hasBillingAddress$),
+    return this.facade.hasBillingAddress$.pipe(
       take(1),
 			tap(hasBillingAddress => {
 				if (!hasBillingAddress) {

--- a/libs/cart/state/src/guards/cart-items/cart-items.guard.spec.ts
+++ b/libs/cart/state/src/guards/cart-items/cart-items.guard.spec.ts
@@ -7,7 +7,6 @@ import { Router } from '@angular/router';
 
 import { DaffCart, DaffCartItem } from '@daffodil/cart';
 import {
-  DaffResolveCartSuccess,
   DaffCartLoadSuccess
 } from '@daffodil/cart/state';
 import { daffCartReducers, DaffCartItemsGuardRedirectUrl } from '@daffodil/cart/state';
@@ -57,21 +56,12 @@ describe('Cart | State | Guards | DaffCartItemsGuard', () => {
 	});
 
 	describe('canActivate', () => {
-    describe('when the cart has not been resolved', () => {
-      it('should not emit', () => {
-        const expected = cold('-');
-
-        expect(service.canActivate()).toBeObservable(expected);
-      });
-    });
-
     describe('when there are items in the cart', () => {
       beforeEach(() => {
         store.dispatch(new DaffCartLoadSuccess({
           ...cart,
           items: cartItems
         }));
-        store.dispatch(new DaffResolveCartSuccess());
       });
 
       it('should allow activation', () => {
@@ -89,7 +79,6 @@ describe('Cart | State | Guards | DaffCartItemsGuard', () => {
           ...cart,
           items: []
         }));
-        store.dispatch(new DaffResolveCartSuccess());
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/state/src/guards/cart-items/cart-items.guard.ts
+++ b/libs/cart/state/src/guards/cart-items/cart-items.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
-import { tap, filter, switchMapTo, take, map } from 'rxjs/operators';
+import { tap, take, map } from 'rxjs/operators';
 
 import { DaffCartFacade } from '../../facades/cart/cart.facade';
 import { DaffCartItemsGuardRedirectUrl } from './cart-items-guard-redirect.token';
@@ -10,7 +10,8 @@ import { DaffCartItemsGuardRedirectUrl } from './cart-items-guard-redirect.token
  * A routing guard that will ensure that the cart is not empty before allowing activation of a route.
  * If the cart has items in it, then `canActivate` will emit true. If not, it will emit false and redirect to a specific path.
  * The url is `/` by default but can be overridden with the {@link DaffCartItemsGuardRedirectUrl} injection token.
- * The guard will wait until the cart has been resolved before performing the check and emitting.
+ * The guard will not wait until the cart has been resolved before performing the check and emitting.
+ * Ensure that the cart is resolved prior to running this guard with the {@link DaffResolvedCartGuard}.
  */
 @Injectable({
 	providedIn: 'root'
@@ -23,9 +24,7 @@ export class DaffCartItemsGuard implements CanActivate {
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.resolved$.pipe(
-      filter(resolved => resolved),
-      switchMapTo(this.facade.isCartEmpty$),
+    return this.facade.isCartEmpty$.pipe(
       map(isCartEmpty => !isCartEmpty),
       take(1),
 			tap(hasNonEmptyCart => {

--- a/libs/cart/state/src/guards/payment-method/payment-method.guard.spec.ts
+++ b/libs/cart/state/src/guards/payment-method/payment-method.guard.spec.ts
@@ -8,7 +8,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { DaffCart } from '@daffodil/cart';
 import {
   daffCartReducers,
-  DaffResolveCartSuccess,
   DaffCartLoadSuccess,
   DaffCartPaymentMethodGuardRedirectUrl
 } from '@daffodil/cart/state';
@@ -45,20 +44,11 @@ describe('Cart | State | Guards | DaffPaymentMethodGuard', () => {
 	});
 
 	describe('canActivate', () => {
-		describe('when the cart has not been resolved', () => {
-      it('should not emit', () => {
-        const expected = cold('-');
-
-        expect(service.canActivate()).toBeObservable(expected);
-      });
-    });
-
 		it('should allow activation when there is a payment method', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				payment: new DaffCartPaymentFactory().create(),
 			});
       store.dispatch(new DaffCartLoadSuccess(cart));
-      store.dispatch(new DaffResolveCartSuccess());
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -72,7 +62,6 @@ describe('Cart | State | Guards | DaffPaymentMethodGuard', () => {
 					payment: null,
 				});
         store.dispatch(new DaffCartLoadSuccess(cart));
-				store.dispatch(new DaffResolveCartSuccess());
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/state/src/guards/payment-method/payment-method.guard.ts
+++ b/libs/cart/state/src/guards/payment-method/payment-method.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
-import { tap, filter, switchMapTo, take } from 'rxjs/operators';
+import { tap, take } from 'rxjs/operators';
 
 import { DaffCartFacade } from '../../facades/cart/cart.facade';
 import { DaffCartPaymentMethodGuardRedirectUrl } from './payment-method-guard-redirect.token';
@@ -9,7 +9,8 @@ import { DaffCartPaymentMethodGuardRedirectUrl } from './payment-method-guard-re
 /**
  * A routing guard that will redirect to a given url if the payment method on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartPaymentMethodGuardRedirectUrl injection token.
- * The guard will wait until the cart has been resolved before performing the check and emitting.
+ * The guard will not wait until the cart has been resolved before performing the check and emitting.
+ * Ensure that the cart is resolved prior to running this guard with the {@link DaffResolvedCartGuard}.
  */
 @Injectable({
 	providedIn: 'root'
@@ -22,9 +23,7 @@ export class DaffPaymentMethodGuard implements CanActivate {
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.resolved$.pipe(
-      filter(resolved => resolved),
-      switchMapTo(this.facade.hasPaymentMethod$),
+    return this.facade.hasPaymentMethod$.pipe(
       take(1),
 			tap(hasPaymentMethod => {
 				if (!hasPaymentMethod) {

--- a/libs/cart/state/src/guards/resolved-cart/resolved-cart.guard.spec.ts
+++ b/libs/cart/state/src/guards/resolved-cart/resolved-cart.guard.spec.ts
@@ -6,20 +6,18 @@ import { Router } from '@angular/router';
 
 import { DaffCart } from '@daffodil/cart';
 import {
-  DaffResolveCartSuccess,
-  DaffCartLoadSuccess,
   DaffCartFacade,
   DaffResolveCart
 } from '@daffodil/cart/state';
 import { DaffResolvedCartGuardRedirectUrl } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
-import { DaffCartTestingModule, MockDaffCartFacade } from '@daffodil/cart/state/testing';
+import { DaffCartTestingModule } from '@daffodil/cart/state/testing';
 
 import { DaffResolvedCartGuard } from './resolved-cart.guard';
 
 describe('Cart | State | Guards | DaffResolvedCartGuard', () => {
 	let service: DaffResolvedCartGuard;
-	let facade: MockDaffCartFacade;
+	let facade;
   let router: Router;
 
   let cartFactory: DaffCartFactory;
@@ -39,9 +37,9 @@ describe('Cart | State | Guards | DaffResolvedCartGuard', () => {
 			]
     });
 
-		service = TestBed.get(DaffResolvedCartGuard);
 		facade = TestBed.get(DaffCartFacade);
     router = TestBed.get(Router);
+		service = new DaffResolvedCartGuard(facade, router, stubUrl);
 
     spyOn(facade, 'dispatch');
 
@@ -68,7 +66,7 @@ describe('Cart | State | Guards | DaffResolvedCartGuard', () => {
 
     describe('when the cart has not been resolved', () => {
       beforeEach(() => {
-        facade.resolved$.next(false);
+        facade.resolveSuccess$.next(false);
       });
 
       it('should not emit', () => {
@@ -78,10 +76,9 @@ describe('Cart | State | Guards | DaffResolvedCartGuard', () => {
       });
     });
 
-    describe('when there is a resolved cart with an ID', () => {
+    describe('when there is a successfully resolved cart', () => {
       beforeEach(() => {
-        facade.id$.next(cart.id);
-        facade.resolved$.next(true);
+        facade.resolveSuccess$.next(true);
       });
 
       it('should allow activation', () => {
@@ -91,13 +88,22 @@ describe('Cart | State | Guards | DaffResolvedCartGuard', () => {
       });
     });
 
-
-		describe('when there is not a resolved cart with an ID', () => {
+		describe('when there is a failed cart resolution', () => {
 			beforeEach(() => {
 				spyOn(router, 'navigateByUrl');
-        facade.id$.next(null);
-        facade.resolved$.next(true);
-			});
+        facade.resolveFailure$.next(true);
+      });
+
+      describe('when the redirect URL is not specified', () => {
+        beforeEach(() => {
+          service = new DaffResolvedCartGuard(facade, router, null);
+        });
+
+        it('should not redirect', () => {
+          service.canActivate().subscribe();
+          expect(router.navigateByUrl).not.toHaveBeenCalled();
+        });
+      });
 
 			it('should not allow activation', () => {
 				const expected = cold('(a|)', { a: false });

--- a/libs/cart/state/src/guards/resolved-cart/resolved-cart.guard.spec.ts
+++ b/libs/cart/state/src/guards/resolved-cart/resolved-cart.guard.spec.ts
@@ -7,6 +7,7 @@ import { Router } from '@angular/router';
 import { DaffCart } from '@daffodil/cart';
 import {
   DaffCartFacade,
+  DaffCartResolveState,
   DaffResolveCart
 } from '@daffodil/cart/state';
 import { DaffResolvedCartGuardRedirectUrl } from '@daffodil/cart/state';
@@ -66,7 +67,7 @@ describe('Cart | State | Guards | DaffResolvedCartGuard', () => {
 
     describe('when the cart has not been resolved', () => {
       beforeEach(() => {
-        facade.resolveSuccess$.next(false);
+        facade.resolved$.next(DaffCartResolveState.Default);
       });
 
       it('should not emit', () => {
@@ -78,7 +79,7 @@ describe('Cart | State | Guards | DaffResolvedCartGuard', () => {
 
     describe('when there is a successfully resolved cart', () => {
       beforeEach(() => {
-        facade.resolveSuccess$.next(true);
+        facade.resolved$.next(DaffCartResolveState.Succeeded);
       });
 
       it('should allow activation', () => {
@@ -91,7 +92,7 @@ describe('Cart | State | Guards | DaffResolvedCartGuard', () => {
 		describe('when there is a failed cart resolution', () => {
 			beforeEach(() => {
 				spyOn(router, 'navigateByUrl');
-        facade.resolveFailure$.next(true);
+        facade.resolved$.next(DaffCartResolveState.Failed);
       });
 
       describe('when the redirect URL is not specified', () => {

--- a/libs/cart/state/src/guards/resolved-cart/resolved-cart.guard.ts
+++ b/libs/cart/state/src/guards/resolved-cart/resolved-cart.guard.ts
@@ -6,6 +6,7 @@ import { tap, filter, take, map } from 'rxjs/operators';
 import { DaffCartFacade } from '../../facades/cart/cart.facade';
 import { DaffResolvedCartGuardRedirectUrl } from './resolved-cart-guard-redirect.token';
 import { DaffResolveCart } from '../../actions/public_api';
+import { DaffCartResolveState } from '../../reducers/public_api';
 
 /**
  * A routing guard that will optionally redirect to a given url if the cart is not properly resolved.
@@ -27,12 +28,9 @@ export class DaffResolvedCartGuard implements CanActivate {
   canActivate(): Observable<boolean> {
     this.facade.dispatch(new DaffResolveCart());
 
-    return combineLatest([
-      this.facade.resolveSuccess$,
-      this.facade.resolveFailure$
-    ]).pipe(
-      filter(([success, failure]) => success || failure),
-      map(([success]) => success),
+    return this.facade.resolved$.pipe(
+      filter(resolvedState => resolvedState === DaffCartResolveState.Succeeded || resolvedState === DaffCartResolveState.Failed),
+      map(resolvedState => resolvedState === DaffCartResolveState.Succeeded),
       take(1),
 			tap(success => {
 				if (!success && this.redirectUrl) {

--- a/libs/cart/state/src/guards/shipping-address/shipping-address.guard.spec.ts
+++ b/libs/cart/state/src/guards/shipping-address/shipping-address.guard.spec.ts
@@ -8,7 +8,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { DaffCart } from '@daffodil/cart';
 import {
   daffCartReducers,
-  DaffResolveCartSuccess,
   DaffCartLoadSuccess,
   DaffCartShippingAddressGuardRedirectUrl
 } from '@daffodil/cart/state';
@@ -45,20 +44,11 @@ describe('Cart | State | Guards | DaffShippingAddressGuard', () => {
 	});
 
 	describe('canActivate', () => {
-		describe('when the cart has not been resolved', () => {
-      it('should not emit', () => {
-        const expected = cold('-');
-
-        expect(service.canActivate()).toBeObservable(expected);
-      });
-    });
-
 		it('should allow activation when there is a shipping address', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				shipping_address: new DaffCartAddressFactory().create(),
 			});
       store.dispatch(new DaffCartLoadSuccess(cart));
-      store.dispatch(new DaffResolveCartSuccess());
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -72,7 +62,6 @@ describe('Cart | State | Guards | DaffShippingAddressGuard', () => {
 					shipping_address: null,
 				});
         store.dispatch(new DaffCartLoadSuccess(cart));
-				store.dispatch(new DaffResolveCartSuccess());
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/state/src/guards/shipping-address/shipping-address.guard.ts
+++ b/libs/cart/state/src/guards/shipping-address/shipping-address.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
-import { tap, filter, switchMapTo, take } from 'rxjs/operators';
+import { tap, take } from 'rxjs/operators';
 
 import { DaffCartFacade } from '../../facades/cart/cart.facade';
 import { DaffCartShippingAddressGuardRedirectUrl } from './shipping-address-guard-redirect.token';
@@ -9,7 +9,8 @@ import { DaffCartShippingAddressGuardRedirectUrl } from './shipping-address-guar
 /**
  * A routing guard that will redirect to a given url if the shipping address on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartShippingAddressGuardRedirectUrl injection token.
- * The guard will wait until the cart has been resolved before performing the check and emitting.
+ * The guard will not wait until the cart has been resolved before performing the check and emitting.
+ * Ensure that the cart is resolved prior to running this guard with the {@link DaffResolvedCartGuard}.
  */
 @Injectable({
 	providedIn: 'root'
@@ -22,9 +23,7 @@ export class DaffShippingAddressGuard implements CanActivate {
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.resolved$.pipe(
-      filter(resolved => resolved),
-      switchMapTo(this.facade.hasShippingAddress$),
+    return this.facade.hasShippingAddress$.pipe(
       take(1),
 			tap(hasShippingAddress => {
 				if (!hasShippingAddress) {

--- a/libs/cart/state/src/guards/shipping-method/shipping-method.guard.spec.ts
+++ b/libs/cart/state/src/guards/shipping-method/shipping-method.guard.spec.ts
@@ -8,7 +8,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { DaffCart } from '@daffodil/cart';
 import {
   daffCartReducers,
-  DaffResolveCartSuccess,
   DaffCartLoadSuccess,
   DaffCartShippingMethodGuardRedirectUrl
 } from '@daffodil/cart/state';
@@ -45,20 +44,11 @@ describe('Cart | State | Guards | DaffShippingMethodGuard', () => {
 	});
 
 	describe('canActivate', () => {
-		describe('when the cart has not been resolved', () => {
-      it('should not emit', () => {
-        const expected = cold('-');
-
-        expect(service.canActivate()).toBeObservable(expected);
-      });
-    });
-
 		it('should allow activation when there is a shipping method', () => {
 			const cart: DaffCart = new DaffCartFactory().create({
 				shipping_information: new DaffCartShippingRateFactory().create(),
 			});
       store.dispatch(new DaffCartLoadSuccess(cart));
-      store.dispatch(new DaffResolveCartSuccess());
 			const expected = cold('(a|)', { a: true })
 
 			expect(service.canActivate()).toBeObservable(expected);
@@ -72,7 +62,6 @@ describe('Cart | State | Guards | DaffShippingMethodGuard', () => {
 					shipping_information: null,
 				});
         store.dispatch(new DaffCartLoadSuccess(cart));
-				store.dispatch(new DaffResolveCartSuccess());
 			});
 
 			it('should not allow activation', () => {

--- a/libs/cart/state/src/guards/shipping-method/shipping-method.guard.ts
+++ b/libs/cart/state/src/guards/shipping-method/shipping-method.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
-import { tap, filter, switchMapTo, take } from 'rxjs/operators';
+import { tap, take } from 'rxjs/operators';
 
 import { DaffCartFacade } from '../../facades/cart/cart.facade';
 import { DaffCartShippingMethodGuardRedirectUrl } from './shipping-method-guard-redirect.token';
@@ -9,7 +9,8 @@ import { DaffCartShippingMethodGuardRedirectUrl } from './shipping-method-guard-
 /**
  * A routing guard that will redirect to a given url if the shipping method on the cart is not defined.
  * The url is `/` by default, but can be overridden with the DaffCartShippingMethodGuardRedirectUrl injection token.
- * The guard will wait until the cart has been resolved before performing the check and emitting.
+ * The guard will not wait until the cart has been resolved before performing the check and emitting.
+ * Ensure that the cart is resolved prior to running this guard with the {@link DaffResolvedCartGuard}.
  */
 @Injectable({
 	providedIn: 'root'
@@ -22,9 +23,7 @@ export class DaffShippingMethodGuard implements CanActivate {
 	) {}
 
   canActivate(): Observable<boolean> {
-    return this.facade.resolved$.pipe(
-      filter(resolved => resolved),
-      switchMapTo(this.facade.hasShippingMethod$),
+    return this.facade.hasShippingMethod$.pipe(
       take(1),
 			tap(hasShippingMethod => {
 				if (!hasShippingMethod) {

--- a/libs/cart/state/src/reducers/cart-initial-state.ts
+++ b/libs/cart/state/src/reducers/cart-initial-state.ts
@@ -3,6 +3,7 @@ import { DaffLoadingState } from '@daffodil/core/state';
 import { DaffCartReducerState } from './cart-state.interface';
 import { DaffCartOperationType } from './cart-operation-type.enum';
 import { DaffCartItemLoadingState } from './loading/cart-loading.type';
+import { DaffCartResolveState } from './cart-resolve/cart-resolve-state.enum';
 
 export const initialState: DaffCartReducerState<any> = Object.freeze({
   cart: {
@@ -41,5 +42,5 @@ export const initialState: DaffCartReducerState<any> = Object.freeze({
     [DaffCartOperationType.PaymentMethods]: [],
     [DaffCartOperationType.Coupon]: [],
   },
-  resolved: false
+  resolved: DaffCartResolveState.Default
 });

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -1,10 +1,8 @@
 import { DaffCart } from '@daffodil/cart';
-import { DaffCartItemListSuccess, DaffCartItemLoadSuccess, DaffCartItemUpdateSuccess, DaffCartItemAddSuccess, DaffCartItemDeleteSuccess, DaffCartLoadSuccess, DaffCartClearSuccess } from '@daffodil/cart/state';
+import { DaffCartItemListSuccess, DaffCartItemLoadSuccess, DaffCartItemUpdateSuccess, DaffCartItemAddSuccess, DaffCartItemDeleteSuccess, DaffCartLoadSuccess, DaffCartClearSuccess, DaffCartItemDelete, DaffCartItemStateEnum, DaffCartItemStateReset, DaffCartItemUpdate, DaffResolveCartSuccess, DaffStatefulCartItem } from '@daffodil/cart/state';
 import { DaffCartFactory, DaffCartItemFactory } from '@daffodil/cart/testing';
 import { DaffStatefulCartItemFactory } from '@daffodil/cart/state/testing';
 
-import { DaffCartItemDelete, DaffCartItemStateReset, DaffCartItemUpdate } from '../../actions/public_api';
-import { DaffCartItemStateEnum, DaffStatefulCartItem } from '../../models/stateful-cart-item';
 import { daffCartItemEntitiesAdapter } from './cart-item-entities-reducer-adapter';
 import { daffCartItemEntitiesReducer } from './cart-item-entities.reducer';
 
@@ -27,12 +25,12 @@ describe('Cart | Cart Item Entities Reducer', () => {
       expect(result).toEqual(initialState);
     });
 	});
-	
+
 	describe('when an existing cart item does not have a default daffState', () => {
 		let result;
 		let stubStatefulCartItem: DaffStatefulCartItem;
 		let initialStateWithCartItem;
-		
+
 		beforeEach(() => {
 			stubStatefulCartItem = new DaffStatefulCartItemFactory().create({
 				item_id: 'id'
@@ -57,7 +55,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
 			result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartItemListSuccess);
 			expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
 		});
-		
+
 		it('should retain the existing daffState when a CartItemLoadSuccessAction is triggered', () => {
 			const cartItemLoadSuccess = new DaffCartItemLoadSuccess({
 				...stubStatefulCartItem,
@@ -146,7 +144,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
 				items: cartItems
 			});
       const cartItemUpdateSuccess = new DaffCartItemUpdateSuccess(cart, cartItems[0].item_id);
-      
+
       result = daffCartItemEntitiesReducer(initialState, cartItemUpdateSuccess);
     });
 
@@ -157,7 +155,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     it('sets expected cart item on state', () => {
       expect(result.entities[cartItems[0].item_id].item_id).toEqual(cartItems[0].item_id);
 		});
-		
+
 		it('sets the state of the updated cart item to Updated', () => {
 			expect(result.entities[cartItems[0].item_id].daffState).toEqual(DaffCartItemStateEnum.Updated)
 		});
@@ -186,7 +184,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     it('sets expected cart item on state', () => {
       expect(result.entities[statefulCartItem.item_id].item_id).toEqual(statefulCartItem.item_id);
 		});
-		
+
 		it('sets the new cart item\'s state to New', () => {
 			expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
 		});
@@ -210,7 +208,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
 					qty: statefulCartItem.qty + 1
 				}]
 			});
-      
+
       result = daffCartItemEntitiesReducer({
 				...initialState,
 				entities: {
@@ -218,7 +216,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
 				}
 			}, cartItemAddSuccess);
     });
-		
+
 		it('sets the cart item\'s state to Updated', () => {
 			expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Updated);
 		});
@@ -274,6 +272,31 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
   });
 
+  describe('when ResolveCartSuccessAction is triggered', () => {
+
+    let cart: DaffCart;
+    let cartItems: DaffStatefulCartItem[];
+    let result;
+
+    beforeEach(() => {
+			cartItems = statefulCartItemFactory.createMany(2);
+      cart = new DaffCartFactory().create({
+				items: cartItems
+			});
+      const resolveCartSuccess = new DaffResolveCartSuccess(cart);
+
+      result = daffCartItemEntitiesReducer(initialState, resolveCartSuccess);
+    });
+
+    it('sets expected number of cartItems on state', () => {
+      expect(result.ids.length).toEqual(cartItems.length);
+    });
+
+    it('sets expected cart item on state', () => {
+      expect(result.entities[cartItems[0].item_id]).toEqual(cartItems[0]);
+    });
+  });
+
   describe('when CartClearSuccessAction is triggered', () => {
 
     let cart: DaffCart;
@@ -311,7 +334,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
 				}
 			}
       const cartItemStateReset = new DaffCartItemStateReset();
-      
+
       result = daffCartItemEntitiesReducer(testInitialState, cartItemStateReset);
     });
 
@@ -335,7 +358,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
 				}
 			}
       const cartItemUpdateAction = new DaffCartItemUpdate(stubStatefulCartItem.item_id, { qty: 4 });
-      
+
       result = daffCartItemEntitiesReducer(testInitialState, cartItemUpdateAction);
     });
 
@@ -359,7 +382,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
 				}
 			}
       const cartItemDeleteAction = new DaffCartItemDelete(stubCartItem.item_id);
-      
+
       result = daffCartItemEntitiesReducer(testInitialState, cartItemDeleteAction);
     });
 

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -34,17 +34,18 @@ export function daffCartItemEntitiesReducer<
 			}, state);
 		case DaffCartItemActionTypes.CartItemAddSuccessAction:
 			return adapter.addAll(
-				updateAddedCartItemState<T>(state.entities, <T[]>action.payload.items), 
+				updateAddedCartItemState<T>(state.entities, <T[]>action.payload.items),
 				state
 			);
 		case DaffCartItemActionTypes.CartItemUpdateSuccessAction:
 			return adapter.addAll(
-				updateMutatedCartItemState<T>(<T[]>action.payload.items, action.itemId), 
+				updateMutatedCartItemState<T>(<T[]>action.payload.items, action.itemId),
 				state
 			);
 		case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
 		case DaffCartActionTypes.CartLoadSuccessAction:
-		case DaffCartActionTypes.CartClearSuccessAction:
+		case DaffCartActionTypes.ResolveCartSuccessAction:
+    case DaffCartActionTypes.CartClearSuccessAction:
 			return adapter.addAll(<T[]><unknown>action.payload.items.map(item => ({
 				...item,
 				daffState: getDaffState(state.entities[item.item_id]) || DaffCartItemStateEnum.Default
@@ -86,6 +87,6 @@ function updateAddedCartItemState<T extends DaffStatefulCartItem>(oldCartItems: 
 }
 
 function updateMutatedCartItemState<T extends DaffStatefulCartItem>(cartItems: T[], itemId: T['item_id']): T[] {
-	return cartItems.map(item => item.item_id === itemId ? 
+	return cartItems.map(item => item.item_id === itemId ?
 		{ ...item, daffState: DaffCartItemStateEnum.Updated} : item)
 }

--- a/libs/cart/state/src/reducers/cart-resolve/cart-resolve-state.enum.ts
+++ b/libs/cart/state/src/reducers/cart-resolve/cart-resolve-state.enum.ts
@@ -1,0 +1,6 @@
+export enum DaffCartResolveState {
+  Default = 'default',
+  Resolving = 'resolving',
+  Succeeded = 'succeeded',
+  Failed = 'failed'
+}

--- a/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
@@ -6,7 +6,8 @@ import {
   DaffResolveCartSuccess,
   DaffResolveCartFailure,
   initialState,
-  DaffCartReducerState
+  DaffCartReducerState,
+  DaffCartResolveState
 } from '@daffodil/cart/state';
 import {
   DaffCartFactory,
@@ -35,13 +36,13 @@ describe('Cart | Reducer | cartResolveReducer', () => {
     });
   });
 
-  describe('when ResolveCartActionAction is triggered', () => {
-    it('should set resolved state to false', () => {
+  describe('when ResolveCartAction is triggered', () => {
+    it('should set resolved state to resolving', () => {
       const cartResolveAction: DaffResolveCart = new DaffResolveCart();
 
       const result = reducer(initialState, cartResolveAction);
 
-      expect(result.resolved).toEqual(false);
+      expect(result.resolved).toEqual(DaffCartResolveState.Resolving);
     });
   });
 
@@ -52,16 +53,16 @@ describe('Cart | Reducer | cartResolveReducer', () => {
     beforeEach(() => {
       state = {
         ...initialState,
-        resolved: false
+        resolved: DaffCartResolveState.Resolving
       }
 
-      const cartResolveSuccess = new DaffResolveCartSuccess();
+      const cartResolveSuccess = new DaffResolveCartSuccess(cart);
 
       result = reducer(state, cartResolveSuccess);
     });
 
-    it('should indicate that the cart is resolved', () => {
-      expect(result.resolved).toEqual(true);
+    it('should indicate that the cart resolved successfully', () => {
+      expect(result.resolved).toEqual(DaffCartResolveState.Succeeded);
     });
   });
 
@@ -73,7 +74,7 @@ describe('Cart | Reducer | cartResolveReducer', () => {
     beforeEach(() => {
       state = {
         ...initialState,
-        resolved: false,
+        resolved: DaffCartResolveState.Resolving,
       }
 
       const cartResolveFailure = new DaffResolveCartFailure(error);
@@ -81,8 +82,8 @@ describe('Cart | Reducer | cartResolveReducer', () => {
       result = reducer(state, cartResolveFailure);
     });
 
-    it('should indicate that the cart is resolved', () => {
-      expect(result.resolved).toEqual(true);
+    it('should indicate that the cart failed resolution', () => {
+      expect(result.resolved).toEqual(DaffCartResolveState.Failed);
     });
   });
 });

--- a/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.ts
@@ -6,6 +6,7 @@ import {
 import { initialState } from '../cart-initial-state';
 import { DaffCartReducerState } from '../cart-state.interface';
 import { ActionTypes } from '../action-types.type';
+import { DaffCartResolveState } from './cart-resolve-state.enum';
 
 export function cartResolveReducer<T extends DaffCart = DaffCart>(
   state = initialState,
@@ -15,14 +16,19 @@ export function cartResolveReducer<T extends DaffCart = DaffCart>(
     case DaffCartActionTypes.ResolveCartAction:
       return {
         ...state,
-        resolved: false
+        resolved: DaffCartResolveState.Resolving
       };
 
     case DaffCartActionTypes.ResolveCartSuccessAction:
+      return {
+        ...state,
+        resolved: DaffCartResolveState.Succeeded
+      };
+
     case DaffCartActionTypes.ResolveCartFailureAction:
       return {
         ...state,
-        resolved: true
+        resolved: DaffCartResolveState.Failed
       };
 
     default:

--- a/libs/cart/state/src/reducers/cart-state.interface.ts
+++ b/libs/cart/state/src/reducers/cart-state.interface.ts
@@ -1,4 +1,6 @@
 import { DaffCart } from '@daffodil/cart';
+
+import { DaffCartResolveState } from './cart-resolve/cart-resolve-state.enum';
 import { DaffCartErrors } from './errors/cart-errors.type';
 import { DaffCartLoading } from './loading/cart-loading.type';
 
@@ -6,5 +8,5 @@ export interface DaffCartReducerState<T extends DaffCart = DaffCart> {
   cart: T,
   loading: DaffCartLoading,
   errors: DaffCartErrors,
-  resolved: boolean
+  resolved: DaffCartResolveState
 }

--- a/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
@@ -2,7 +2,7 @@ import { DaffLoadingState } from '@daffodil/core/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 
 import { DaffCart } from '@daffodil/cart';
-import { DaffCartLoad, DaffCartOperationType, DaffResolveCart, DaffCartReducerState, DaffCartLoadSuccess, DaffCartLoadFailure, DaffCartStorageFailure, DaffCartCreate, DaffCartCreateSuccess, DaffCartCreateFailure, DaffAddToCart, DaffAddToCartSuccess, DaffAddToCartFailure, DaffCartClear, DaffCartClearSuccess, DaffCartClearFailure, initialState } from '@daffodil/cart/state';
+import { DaffCartLoad, DaffCartOperationType, DaffResolveCart, DaffCartReducerState, DaffCartLoadSuccess, DaffCartLoadFailure, DaffCartStorageFailure, DaffCartCreate, DaffCartCreateSuccess, DaffCartCreateFailure, DaffAddToCart, DaffAddToCartSuccess, DaffAddToCartFailure, DaffCartClear, DaffCartClearSuccess, DaffCartClearFailure, initialState, DaffResolveCartSuccess, DaffResolveCartFailure } from '@daffodil/cart/state';
 
 import { cartReducer } from './cart.reducer';
 
@@ -77,6 +77,37 @@ describe('Cart | Reducer | Cart', () => {
     });
   });
 
+  describe('when ResolveCartSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartReducerState<DaffCart>;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: {
+          ...initialState.loading,
+          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving
+        }
+      }
+
+      const cartListLoadSuccess = new DaffResolveCartSuccess(cart);
+
+      result = cartReducer(state, cartListLoadSuccess);
+    });
+
+    it('should set cart from action.payload', () => {
+      expect(result.cart).toEqual(cart)
+    });
+
+    it('should indicate that the cart is not loading', () => {
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+    });
+
+    it('should reset the errors in the cart section of state.errors to an empty array', () => {
+      expect(result.errors[DaffCartOperationType.Cart]).toEqual([]);
+    });
+  });
+
   describe('when CartLoadFailureAction is triggered', () => {
     const error = 'error message';
     let result;
@@ -96,6 +127,38 @@ describe('Cart | Reducer | Cart', () => {
       }
 
       const cartListLoadFailure = new DaffCartLoadFailure(error);
+
+      result = cartReducer(state, cartListLoadFailure);
+    });
+
+    it('should indicate that the cart is not loading', () => {
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+    });
+
+    it('should add an error to the cart section of state.errors', () => {
+      expect(result.errors[DaffCartOperationType.Cart].length).toEqual(2);
+    });
+  });
+
+  describe('when ResolveCartFailureAction is triggered', () => {
+    const error = 'error message';
+    let result;
+    let state: DaffCartReducerState<DaffCart>;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: {
+          ...initialState.loading,
+          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving
+        },
+        errors: {
+          ...initialState.errors,
+          [DaffCartOperationType.Cart]: new Array('firstError')
+        }
+      }
+
+      const cartListLoadFailure = new DaffResolveCartFailure(error);
 
       result = cartReducer(state, cartListLoadFailure);
     });

--- a/libs/cart/state/src/reducers/cart/cart.reducer.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.ts
@@ -39,6 +39,7 @@ export function cartReducer<T extends DaffCart>(
     case DaffCartActionTypes.CartClearSuccessAction:
     case DaffCartActionTypes.AddToCartSuccessAction:
     case DaffCartActionTypes.CartCreateSuccessAction:
+    case DaffCartActionTypes.ResolveCartSuccessAction:
       return {
         ...state,
         ...resetErrors(state.errors),
@@ -64,7 +65,7 @@ export function cartReducer<T extends DaffCart>(
     case DaffCartActionTypes.AddToCartFailureAction:
     case DaffCartActionTypes.CartCreateFailureAction:
     case DaffCartActionTypes.CartStorageFailureAction:
-
+    case DaffCartActionTypes.ResolveCartFailureAction:
       return {
         ...state,
         ...addError(state.errors, action.payload),

--- a/libs/cart/state/src/reducers/public_api.ts
+++ b/libs/cart/state/src/reducers/public_api.ts
@@ -4,6 +4,7 @@ export { DaffCartReducersState } from './cart-reducers-state.interface';
 export * from './loading/cart-loading.type';
 export { DaffCartErrors } from './errors/cart-errors.type';
 export { DaffCartOperationType } from './cart-operation-type.enum';
+export { DaffCartResolveState } from './cart-resolve/cart-resolve-state.enum'
 
 export { daffCartReducer } from './cart.reducer';
 export { DaffCartReducerState } from './cart-state.interface';

--- a/libs/cart/state/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/state/src/selectors/cart/cart.selector.spec.ts
@@ -62,8 +62,6 @@ describe('Cart | Selector | Cart', () => {
     selectCartValue,
 
     selectCartResolved,
-    selectCartResolveSuccess,
-    selectCartResolveFailure,
 
     selectCartLoadingObject,
     selectCartFeatureLoading,
@@ -230,40 +228,6 @@ describe('Cart | Selector | Cart', () => {
     it('should be failed after cart resolution failure', () => {
       const selector = store.pipe(select(selectCartResolved));
       const expected = cold('a', {a: DaffCartResolveState.Failed});
-      store.dispatch(new DaffResolveCartFailure('error'));
-
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCartResolveSuccess', () => {
-    it('should initially be false', () => {
-      const selector = store.pipe(select(selectCartResolveSuccess));
-      const expected = cold('a', {a: false});
-
-      expect(selector).toBeObservable(expected);
-    });
-
-    it('should be true after cart resolution success', () => {
-      const selector = store.pipe(select(selectCartResolveSuccess));
-      const expected = cold('a', {a: true});
-      store.dispatch(new DaffResolveCartSuccess(cart));
-
-      expect(selector).toBeObservable(expected);
-    });
-  });
-
-  describe('selectCartResolveFailure', () => {
-    it('should initially be false', () => {
-      const selector = store.pipe(select(selectCartResolveFailure));
-      const expected = cold('a', {a: false});
-
-      expect(selector).toBeObservable(expected);
-    });
-
-    it('should be true after cart resolution failure', () => {
-      const selector = store.pipe(select(selectCartResolveFailure));
-      const expected = cold('a', {a: true});
       store.dispatch(new DaffResolveCartFailure('error'));
 
       expect(selector).toBeObservable(expected);

--- a/libs/cart/state/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/state/src/selectors/cart/cart.selector.spec.ts
@@ -8,29 +8,32 @@ import {
   DaffCartLoadSuccess,
   DaffCartPlaceOrderSuccess,
   DaffResolveCartSuccess,
-	DaffCartBillingAddressLoad, 
-	DaffCartItemLoad, 
-	DaffCartLoad, 
-	DaffCartPaymentLoad, 
-	DaffCartPaymentMethodsLoad, 
-	DaffCartShippingAddressLoad, 
-	DaffCartShippingInformationLoad, 
-	DaffCartShippingMethodsLoad, 
-	DaffCartCouponList, 
-	DaffCartClear, 
-	DaffCartItemDelete, 
-	DaffCartBillingAddressUpdate, 
-	DaffCartShippingAddressUpdate, 
-	DaffCartShippingInformationDelete, 
-	DaffCartPaymentRemove, 
-	DaffCartCouponRemoveAll, 
-	DaffCartReducersState, 
-	DaffCartLoading, 
-	DaffCartErrors, 
-	daffCartReducers, 
+	DaffCartBillingAddressLoad,
+	DaffCartItemLoad,
+	DaffCartLoad,
+	DaffCartPaymentLoad,
+	DaffCartPaymentMethodsLoad,
+	DaffCartShippingAddressLoad,
+	DaffCartShippingInformationLoad,
+	DaffCartShippingMethodsLoad,
+	DaffCartCouponList,
+	DaffCartClear,
+	DaffCartItemDelete,
+	DaffCartBillingAddressUpdate,
+	DaffCartShippingAddressUpdate,
+	DaffCartShippingInformationDelete,
+	DaffCartPaymentRemove,
+	DaffCartCouponRemoveAll,
+	DaffCartReducersState,
+	DaffCartLoading,
+	DaffCartErrors,
+	daffCartReducers,
 	DaffCartOperationType,
 	DaffCartItemAdd,
-	DaffCartItemLoadingState
+	DaffCartItemLoadingState,
+  DaffCartResolveState,
+  DaffResolveCart,
+  DaffResolveCartFailure
 } from '@daffodil/cart/state';
 import {
   DaffCartFactory,
@@ -56,8 +59,11 @@ describe('Cart | Selector | Cart', () => {
   let loading: DaffCartLoading;
 	let errors: DaffCartErrors;
 	const {
-		selectCartResolved,
     selectCartValue,
+
+    selectCartResolved,
+    selectCartResolveSuccess,
+    selectCartResolveFailure,
 
     selectCartLoadingObject,
     selectCartFeatureLoading,
@@ -198,17 +204,67 @@ describe('Cart | Selector | Cart', () => {
   });
 
   describe('selectCartResolved', () => {
-    it('should initially be false', () => {
+    it('should initially be default', () => {
       const selector = store.pipe(select(selectCartResolved));
+      const expected = cold('a', {a: DaffCartResolveState.Default});
+
+      expect(selector).toBeObservable(expected);
+    });
+
+    it('should be resolving after cart resolution has been initiated', () => {
+      const selector = store.pipe(select(selectCartResolved));
+      const expected = cold('a', {a: DaffCartResolveState.Resolving});
+      store.dispatch(new DaffResolveCart());
+
+      expect(selector).toBeObservable(expected);
+    });
+
+    it('should be succeeded after cart resolution success', () => {
+      const selector = store.pipe(select(selectCartResolved));
+      const expected = cold('a', {a: DaffCartResolveState.Succeeded});
+      store.dispatch(new DaffResolveCartSuccess(cart));
+
+      expect(selector).toBeObservable(expected);
+    });
+
+    it('should be failed after cart resolution failure', () => {
+      const selector = store.pipe(select(selectCartResolved));
+      const expected = cold('a', {a: DaffCartResolveState.Failed});
+      store.dispatch(new DaffResolveCartFailure('error'));
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartResolveSuccess', () => {
+    it('should initially be false', () => {
+      const selector = store.pipe(select(selectCartResolveSuccess));
       const expected = cold('a', {a: false});
 
       expect(selector).toBeObservable(expected);
-    })
+    });
 
-    it('it should be true after cart resolution success', () => {
-      const selector = store.pipe(select(selectCartResolved));
+    it('should be true after cart resolution success', () => {
+      const selector = store.pipe(select(selectCartResolveSuccess));
       const expected = cold('a', {a: true});
-      store.dispatch(new DaffResolveCartSuccess());
+      store.dispatch(new DaffResolveCartSuccess(cart));
+
+      expect(selector).toBeObservable(expected);
+    });
+  });
+
+  describe('selectCartResolveFailure', () => {
+    it('should initially be false', () => {
+      const selector = store.pipe(select(selectCartResolveFailure));
+      const expected = cold('a', {a: false});
+
+      expect(selector).toBeObservable(expected);
+    });
+
+    it('should be true after cart resolution failure', () => {
+      const selector = store.pipe(select(selectCartResolveFailure));
+      const expected = cold('a', {a: true});
+      store.dispatch(new DaffResolveCartFailure('error'));
 
       expect(selector).toBeObservable(expected);
     });

--- a/libs/cart/state/src/selectors/cart/cart.selector.ts
+++ b/libs/cart/state/src/selectors/cart/cart.selector.ts
@@ -14,13 +14,17 @@ import { getDaffCartFeatureSelector } from '../cart-feature.selector';
 import { DaffCartReducerState, DaffCartReducersState, DaffCartOperationType } from '../../reducers/public_api';
 import { DaffCartItemLoadingState } from '../../reducers/loading/cart-loading.type';
 import { DaffStatefulCartItem } from '../../models/stateful-cart-item';
+import { DaffCartResolveState } from '../../reducers/cart-resolve/cart-resolve-state.enum';
 
 export interface DaffCartStateMemoizedSelectors<
   T extends DaffCart = DaffCart
 > {
 	selectCartState: MemoizedSelector<object, DaffCartReducerState<T>>;
-	selectCartValue: MemoizedSelector<object, T>;
-  selectCartResolved: MemoizedSelector<object, boolean>;
+  selectCartValue: MemoizedSelector<object, T>;
+
+  selectCartResolved: MemoizedSelector<object, DaffCartResolveState>;
+  selectCartResolveSuccess: MemoizedSelector<object, boolean>;
+  selectCartResolveFailure: MemoizedSelector<object, boolean>;
 
   /**
    * The object that holds all the loading states for cart operations.
@@ -233,10 +237,19 @@ const createCartSelectors = <
 	const selectCartValue = createSelector(
 		selectCartState,
 		(state: DaffCartReducerState<T>) => state.cart
-	);
+  );
+
   const selectCartResolved = createSelector(
 		selectCartState,
 		(state: DaffCartReducerState<T>) => state.resolved
+  );
+  const selectCartResolveSuccess = createSelector(
+		selectCartResolved,
+		resolved => resolved === DaffCartResolveState.Succeeded
+  );
+  const selectCartResolveFailure = createSelector(
+		selectCartResolved,
+		resolved => resolved === DaffCartResolveState.Failed
   );
 
   const selectCartLoadingObject = createSelector(
@@ -605,8 +618,11 @@ const createCartSelectors = <
 
 	return {
 		selectCartState,
-		selectCartValue,
+    selectCartValue,
+
     selectCartResolved,
+    selectCartResolveSuccess,
+    selectCartResolveFailure,
 
     selectCartLoadingObject,
     selectCartFeatureLoading,

--- a/libs/cart/state/src/selectors/cart/cart.selector.ts
+++ b/libs/cart/state/src/selectors/cart/cart.selector.ts
@@ -23,8 +23,6 @@ export interface DaffCartStateMemoizedSelectors<
   selectCartValue: MemoizedSelector<object, T>;
 
   selectCartResolved: MemoizedSelector<object, DaffCartResolveState>;
-  selectCartResolveSuccess: MemoizedSelector<object, boolean>;
-  selectCartResolveFailure: MemoizedSelector<object, boolean>;
 
   /**
    * The object that holds all the loading states for cart operations.
@@ -242,14 +240,6 @@ const createCartSelectors = <
   const selectCartResolved = createSelector(
 		selectCartState,
 		(state: DaffCartReducerState<T>) => state.resolved
-  );
-  const selectCartResolveSuccess = createSelector(
-		selectCartResolved,
-		resolved => resolved === DaffCartResolveState.Succeeded
-  );
-  const selectCartResolveFailure = createSelector(
-		selectCartResolved,
-		resolved => resolved === DaffCartResolveState.Failed
   );
 
   const selectCartLoadingObject = createSelector(
@@ -621,8 +611,6 @@ const createCartSelectors = <
     selectCartValue,
 
     selectCartResolved,
-    selectCartResolveSuccess,
-    selectCartResolveFailure,
 
     selectCartLoadingObject,
     selectCartFeatureLoading,

--- a/libs/cart/state/testing/src/mock-cart-facade.ts
+++ b/libs/cart/state/testing/src/mock-cart-facade.ts
@@ -17,8 +17,6 @@ export class MockDaffCartFacade implements DaffCartFacadeInterface {
   cart$: BehaviorSubject<DaffCart> = new BehaviorSubject(null);
 
   resolved$: BehaviorSubject<DaffCartResolveState> = new BehaviorSubject(DaffCartResolveState.Default);
-  resolveSuccess$: BehaviorSubject<boolean> = new BehaviorSubject(false);
-  resolveFailure$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   loadingObject$: BehaviorSubject<DaffCartLoading> = new BehaviorSubject(null);
   featureLoading$: BehaviorSubject<boolean> = new BehaviorSubject(false);

--- a/libs/cart/state/testing/src/mock-cart-facade.ts
+++ b/libs/cart/state/testing/src/mock-cart-facade.ts
@@ -9,12 +9,16 @@ import {
 	DaffCartOperationType,
 	DaffCartLoading,
 	DaffCartItemStateEnum,
-	DaffStatefulCartItem
+	DaffStatefulCartItem,
+  DaffCartResolveState
 } from '@daffodil/cart/state';
 
 export class MockDaffCartFacade implements DaffCartFacadeInterface {
-  resolved$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   cart$: BehaviorSubject<DaffCart> = new BehaviorSubject(null);
+
+  resolved$: BehaviorSubject<DaffCartResolveState> = new BehaviorSubject(DaffCartResolveState.Default);
+  resolveSuccess$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  resolveFailure$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   loadingObject$: BehaviorSubject<DaffCartLoading> = new BehaviorSubject(null);
   featureLoading$: BehaviorSubject<boolean> = new BehaviorSubject(false);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
- Changes the resolved state to use an enum
- Adds selectors for checking if resolution succeeded or failed and corresponding facade fields
- Changes the resolver effects to no longer use `substream` and to only dispatch resolver related actions
- Changes the cart store ID effect to listen for resolve success as well
- Changes the guards to not wait for cart resolution before emitting
- Changes the resolved cart guard to conditionally redirect based on if the URL has been specified

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The type of the `selectCartResolved` has changed to `DaffCartResolvedState` enum. The type of the `resolved$` facade field has changed in the same way.

## Other information