### PR TITLE
feat(authorizenet): transform errors to state with error matcher

### DIFF
--- a/libs/authorizenet/state/src/actions/authorizenet.actions.ts
+++ b/libs/authorizenet/state/src/actions/authorizenet.actions.ts
@@ -2,6 +2,7 @@ import { Action } from '@ngrx/store';
 
 import { DaffCartAddress } from '@daffodil/cart';
 import { DaffAuthorizeNetTokenRequest } from '@daffodil/authorizenet';
+import { DaffStateError } from '@daffodil/core/state';
 
 export enum DaffAuthorizeNetActionTypes {
   UpdatePaymentAction = '[Daff-Authorize-Net] Update Payment',
@@ -43,7 +44,7 @@ export class DaffAuthorizeNetUpdatePaymentSuccess implements Action {
 export class DaffAuthorizeNetUpdatePaymentFailure implements Action {
 	readonly type = DaffAuthorizeNetActionTypes.UpdatePaymentFailureAction;
 
-	constructor(public payload: string) { }
+	constructor(public payload: DaffStateError) { }
 }
 
 export class DaffLoadAcceptJs implements Action {
@@ -63,7 +64,7 @@ export class DaffLoadAcceptJsSuccess implements Action {
 export class DaffLoadAcceptJsFailure implements Action {
 	readonly type = DaffAuthorizeNetActionTypes.LoadAcceptJsFailureAction;
 
-	constructor(public payload: string) {};
+	constructor(public payload: DaffStateError) {};
 }
 
 export type DaffAuthorizeNetActions<

--- a/libs/authorizenet/state/src/effects/authorize-net.effects.ts
+++ b/libs/authorizenet/state/src/effects/authorize-net.effects.ts
@@ -1,12 +1,12 @@
 import { Injectable, Inject } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { switchMap, catchError, map, tap } from 'rxjs/operators';
+import { switchMap, catchError, map, tap, mapTo } from 'rxjs/operators';
 import { Observable, of } from 'rxjs';
 
-import { DaffCartPaymentActionTypes, DaffCartPaymentUpdateWithBilling } from '@daffodil/cart/state';
-import { backoff } from '@daffodil/core';
+import { DaffCartPaymentActionTypes, DaffCartPaymentUpdateWithBilling, DaffCartPaymentUpdateWithBillingFailure } from '@daffodil/cart/state';
+import { backoff, DaffError } from '@daffodil/core';
 import { substream } from '@daffodil/core/state';
-import { DaffAcceptJsLoadingService, DaffAuthorizeNetTokenRequest } from '@daffodil/authorizenet';
+import { DaffAcceptJsLoadingService, DaffAuthorizeNetTokenRequest, DAFF_AUTHORIZENET_ERROR_MATCHER } from '@daffodil/authorizenet';
 import { DaffAuthorizeNetDriver, DaffAuthorizeNetService, DaffAuthorizeNetPaymentId } from '@daffodil/authorizenet/driver';
 
 import {
@@ -26,6 +26,7 @@ export class DaffAuthorizeNetEffects<T extends DaffAuthorizeNetTokenRequest = Da
     private actions$: Actions,
 		@Inject(DaffAuthorizeNetDriver) private driver: DaffAuthorizeNetService<T>,
 		@Inject(DaffAuthorizeNetPaymentId) private authorizeNetPaymentId: string,
+		@Inject(DAFF_AUTHORIZENET_ERROR_MATCHER) private errorMatcher: Function,
 		private acceptJsLoadingService: DaffAcceptJsLoadingService
 	) {}
 
@@ -41,8 +42,8 @@ export class DaffAuthorizeNetEffects<T extends DaffAuthorizeNetTokenRequest = Da
 					},
 					action.address
 				)),
-        catchError((error: Error) =>
-          of(new DaffAuthorizeNetUpdatePaymentFailure(error.message))
+        catchError((error: DaffError) =>
+          of(new DaffAuthorizeNetUpdatePaymentFailure(this.errorMatcher(error)))
         )
 			)
 		)
@@ -54,7 +55,7 @@ export class DaffAuthorizeNetEffects<T extends DaffAuthorizeNetTokenRequest = Da
 			[DaffAuthorizeNetActionTypes.UpdatePaymentAction, DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingSuccessAction],
 			DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingFailureAction
 		),
-		map((actions: Actions[]) => new DaffAuthorizeNetUpdatePaymentSuccess())
+		mapTo(new DaffAuthorizeNetUpdatePaymentSuccess())
 	)
 
 	@Effect()
@@ -63,7 +64,13 @@ export class DaffAuthorizeNetEffects<T extends DaffAuthorizeNetTokenRequest = Da
 			[DaffAuthorizeNetActionTypes.UpdatePaymentAction, DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingFailureAction],
 			DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingSuccessAction
 		),
-		map((actions: Actions[]) => new DaffAuthorizeNetUpdatePaymentFailure('The payment method has failed to update the cart.'))
+    map(([updatePaymentAction, updatePaymentFailureAction]: [DaffAuthorizeNetUpdatePayment, DaffCartPaymentUpdateWithBillingFailure]) =>
+      // TODO: change once cart failure actions use DaffStateError
+      new DaffAuthorizeNetUpdatePaymentFailure(this.errorMatcher({
+        code: 'DaffCartPaymentUpdateWithBillingFailure placeholder code',
+        message: updatePaymentFailureAction.payload
+      }))
+    )
 	)
 
 	@Effect()
@@ -73,8 +80,8 @@ export class DaffAuthorizeNetEffects<T extends DaffAuthorizeNetTokenRequest = Da
 		switchMap(() => of(null).pipe(
 			map(() => this.acceptJsLoadingService.getAccept()),
 			backoff(maxTries, ms),
-			map(() => new DaffLoadAcceptJsSuccess()),
-			catchError(() => of(new DaffLoadAcceptJsFailure('Accept Js has failed to load.')))
+			mapTo(new DaffLoadAcceptJsSuccess()),
+			catchError((error: DaffError) => of(new DaffLoadAcceptJsFailure(this.errorMatcher(error))))
 		))
 	)
 }

--- a/libs/authorizenet/state/src/facades/authorize-net-facade.interface.ts
+++ b/libs/authorizenet/state/src/facades/authorize-net-facade.interface.ts
@@ -1,11 +1,11 @@
 import { Action } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
-import { DaffStoreFacade } from '@daffodil/core/state';
+import { DaffStateError, DaffStoreFacade } from '@daffodil/core/state';
 
 export interface DaffAuthorizeNetFacadeInterface extends DaffStoreFacade<Action> {
   isAcceptJsLoaded$: Observable<boolean>;
   loading$: Observable<boolean>;
-  paymentError$: Observable<string>;
-  acceptJsLoadError$: Observable<string>;
+  paymentError$: Observable<DaffStateError>;
+  acceptJsLoadError$: Observable<DaffStateError>;
 }

--- a/libs/authorizenet/state/src/facades/authorize-net.facade.spec.ts
+++ b/libs/authorizenet/state/src/facades/authorize-net.facade.spec.ts
@@ -6,12 +6,14 @@ import { cold } from 'jasmine-marbles';
 import { DaffCartPaymentMethodAdd } from '@daffodil/cart/state';
 import { MAGENTO_AUTHORIZE_NET_PAYMENT_ID } from '@daffodil/authorizenet/driver/magento';
 import { daffAuthorizeNetReducers, DaffAuthorizeNetUpdatePaymentFailure, DaffLoadAcceptJsFailure, DAFF_AUTHORIZENET_STORE_FEATURE_KEY } from '@daffodil/authorizenet/state';
+import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffAuthorizeNetFacade } from './authorize-net.facade';
 
 describe('DaffAuthorizeNetFacade', () => {
   let store: MockStore<any>;
   let facade: DaffAuthorizeNetFacade;
+  let mockError: DaffStateError;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -27,6 +29,11 @@ describe('DaffAuthorizeNetFacade', () => {
 
     store = TestBed.get(Store);
     facade = TestBed.get(DaffAuthorizeNetFacade);
+
+    mockError = {
+      code: 'code',
+      message: 'error'
+    };
   });
 
   it('should be created', () => {
@@ -67,9 +74,8 @@ describe('DaffAuthorizeNetFacade', () => {
   describe('paymentError$', () => {
 
     it('should return the current error message', () => {
-      const stubError = 'error message';
-      const expected = cold('a', { a: stubError});
-      store.dispatch(new DaffAuthorizeNetUpdatePaymentFailure(stubError));
+      const expected = cold('a', { a: mockError});
+      store.dispatch(new DaffAuthorizeNetUpdatePaymentFailure(mockError));
       expect(facade.paymentError$).toBeObservable(expected);
     });
   })
@@ -77,9 +83,8 @@ describe('DaffAuthorizeNetFacade', () => {
   describe('acceptJsLoadError$', () => {
 
     it('should return the acceptJsLoad error message', () => {
-      const stubError = 'error message';
-      const expected = cold('a', { a: stubError});
-      store.dispatch(new DaffLoadAcceptJsFailure(stubError));
+      const expected = cold('a', { a: mockError});
+      store.dispatch(new DaffLoadAcceptJsFailure(mockError));
       expect(facade.acceptJsLoadError$).toBeObservable(expected);
     });
   })

--- a/libs/authorizenet/state/src/facades/authorize-net.facade.ts
+++ b/libs/authorizenet/state/src/facades/authorize-net.facade.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 import { Action, Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
+import { DaffStateError } from '@daffodil/core/state';
+
 import { daffAuthorizeNetSelectors } from '../selectors/authorize-net.selector';
 import { DaffAuthorizeNetReducersState } from '../reducers/authorize-net-reducers.interface';
 import { DaffAuthorizeNetFacadeInterface } from './authorize-net-facade.interface';
@@ -13,8 +15,8 @@ export class DaffAuthorizeNetFacade implements DaffAuthorizeNetFacadeInterface {
 
 	isAcceptJsLoaded$: Observable<boolean>;
   loading$: Observable<boolean>;
-  paymentError$: Observable<string>;
-  acceptJsLoadError$: Observable<string>;
+  paymentError$: Observable<DaffStateError>;
+  acceptJsLoadError$: Observable<DaffStateError>;
 
   constructor(private store: Store<DaffAuthorizeNetReducersState>) {
 		const {

--- a/libs/authorizenet/state/src/reducers/authorize-net/authorize-net-reducer.interface.ts
+++ b/libs/authorizenet/state/src/reducers/authorize-net/authorize-net-reducer.interface.ts
@@ -1,6 +1,8 @@
+import { DaffStateError } from '@daffodil/core/state';
+
 export interface DaffAuthorizeNetReducerState {
 	isAcceptLoaded: boolean;
-	paymentError: string;
-	acceptJsLoadError: string;
+	paymentError: DaffStateError;
+	acceptJsLoadError: DaffStateError;
 	loading: boolean;
 }

--- a/libs/authorizenet/state/src/reducers/authorize-net/authorize-net.reducer.spec.ts
+++ b/libs/authorizenet/state/src/reducers/authorize-net/authorize-net.reducer.spec.ts
@@ -1,6 +1,7 @@
 import { DaffAuthorizeNetUpdatePaymentSuccess, DaffAuthorizeNetUpdatePaymentFailure, DaffAuthorizeNetUpdatePayment, DaffLoadAcceptJsSuccess, DaffLoadAcceptJsFailure, DaffAuthorizeNetReducerState } from '@daffodil/authorizenet/state';
 import { DaffCartAddress } from '@daffodil/cart';
 import { DaffCartAddressFactory } from '@daffodil/cart/testing';
+import { DaffStateError } from '@daffodil/core/state';
 
 import { daffAuthorizeNetReducer } from './authorize-net.reducer';
 
@@ -73,9 +74,14 @@ describe('AuthorizeNet | AuthorizeNet Reducer', () => {
 
   describe('when DaffAuthorizeNetUpdatePaymentFailure is triggered', () => {
     let result: DaffAuthorizeNetReducerState;
+    let mockError: DaffStateError;
 
     beforeEach(() => {
-      const tokenResponseLoadFailure: DaffAuthorizeNetUpdatePaymentFailure = new DaffAuthorizeNetUpdatePaymentFailure('error');
+      mockError = {
+        code: 'error code',
+        message: 'error message'
+      };
+      const tokenResponseLoadFailure: DaffAuthorizeNetUpdatePaymentFailure = new DaffAuthorizeNetUpdatePaymentFailure(mockError);
 
       result = daffAuthorizeNetReducer(initialState, tokenResponseLoadFailure);
     });
@@ -85,7 +91,7 @@ describe('AuthorizeNet | AuthorizeNet Reducer', () => {
 		});
 
     it('sets payment error state to the action payload', () => {
-      expect(result.paymentError).toEqual('error');
+      expect(result.paymentError).toEqual(mockError);
 		});
 	});
 
@@ -109,9 +115,14 @@ describe('AuthorizeNet | AuthorizeNet Reducer', () => {
 
   describe('when DaffLoadAcceptJsFailure is triggered', () => {
     let result: DaffAuthorizeNetReducerState;
+    let mockError: DaffStateError;
 
     beforeEach(() => {
-      const loadAcceptJsFailure: DaffLoadAcceptJsFailure = new DaffLoadAcceptJsFailure('error');
+      mockError = {
+        code: 'error code',
+        message: 'error message'
+      };
+      const loadAcceptJsFailure: DaffLoadAcceptJsFailure = new DaffLoadAcceptJsFailure(mockError);
 
       result = daffAuthorizeNetReducer(initialState, loadAcceptJsFailure);
     });
@@ -121,7 +132,7 @@ describe('AuthorizeNet | AuthorizeNet Reducer', () => {
 		});
 
     it('sets acceptJsLoad error state to the action payload', () => {
-      expect(result.acceptJsLoadError).toEqual('error');
+      expect(result.acceptJsLoadError).toEqual(mockError);
 		});
 	});
 });

--- a/libs/authorizenet/state/src/selectors/authorize-net.selector.spec.ts
+++ b/libs/authorizenet/state/src/selectors/authorize-net.selector.spec.ts
@@ -5,12 +5,14 @@ import { cold } from 'jasmine-marbles';
 import { DaffCartPaymentMethodAdd } from '@daffodil/cart/state';
 import { MAGENTO_AUTHORIZE_NET_PAYMENT_ID } from '@daffodil/authorizenet/driver/magento';
 import { DaffAuthorizeNetReducersState, daffAuthorizeNetReducers, DaffAuthorizeNetUpdatePaymentFailure, DaffLoadAcceptJsFailure, DAFF_AUTHORIZENET_STORE_FEATURE_KEY } from '@daffodil/authorizenet/state';
+import { DaffStateError } from '@daffodil/core/state';
 
 import { daffAuthorizeNetSelectors } from './authorize-net.selector';
 
 describe('DaffAuthorizeNetSelectors', () => {
 
-	let store: Store<DaffAuthorizeNetReducersState>;
+  let store: Store<DaffAuthorizeNetReducersState>;
+  let mockError: DaffStateError;
 	const {
 		selectAuthorizeNetState,
 		selectIsAcceptJsLoaded,
@@ -29,6 +31,11 @@ describe('DaffAuthorizeNetSelectors', () => {
     });
 
     store = TestBed.get(Store);
+
+    mockError = {
+      code: 'code',
+      message: 'error'
+    };
 
 		store.dispatch(new DaffCartPaymentMethodAdd({
 			method: MAGENTO_AUTHORIZE_NET_PAYMENT_ID,
@@ -72,10 +79,10 @@ describe('DaffAuthorizeNetSelectors', () => {
   describe('selectError', () => {
 
     it('selects the error message state', () => {
-			store.dispatch(new DaffAuthorizeNetUpdatePaymentFailure('error'));
+			store.dispatch(new DaffAuthorizeNetUpdatePaymentFailure(mockError));
 
       const selector = store.pipe(select(selectPaymentError));
-      const expected = cold('a', { a: 'error' });
+      const expected = cold('a', { a: mockError });
       expect(selector).toBeObservable(expected);
     });
   });
@@ -83,10 +90,10 @@ describe('DaffAuthorizeNetSelectors', () => {
   describe('selectAcceptJsLoadError', () => {
 
     it('selects the error message state', () => {
-			store.dispatch(new DaffLoadAcceptJsFailure('load error'));
+			store.dispatch(new DaffLoadAcceptJsFailure(mockError));
 
       const selector = store.pipe(select(selectAcceptJsLoadError));
-      const expected = cold('a', { a: 'load error' });
+      const expected = cold('a', { a: mockError });
       expect(selector).toBeObservable(expected);
     });
   });

--- a/libs/authorizenet/state/src/selectors/authorize-net.selector.ts
+++ b/libs/authorizenet/state/src/selectors/authorize-net.selector.ts
@@ -1,5 +1,7 @@
 import { createSelector, createFeatureSelector, MemoizedSelector } from '@ngrx/store';
 
+import { DaffStateError } from '@daffodil/core/state';
+
 import { DaffAuthorizeNetReducersState } from '../reducers/authorize-net-reducers.interface';
 import { DaffAuthorizeNetReducerState } from '../reducers/authorize-net/authorize-net-reducer.interface';
 import { DAFF_AUTHORIZENET_STORE_FEATURE_KEY } from '../reducers/authorizenet-store-feature-key';
@@ -8,8 +10,8 @@ export interface DaffAuthorizeNetMemoizedSelectors {
 	selectAuthorizeNetFeatureState: MemoizedSelector<object, DaffAuthorizeNetReducersState>;
 	selectAuthorizeNetState: MemoizedSelector<object, DaffAuthorizeNetReducerState> ;
 	selectLoading: MemoizedSelector<object, boolean>;
-	selectPaymentError: MemoizedSelector<object, string>;
-	selectAcceptJsLoadError: MemoizedSelector<object, string>;
+	selectPaymentError: MemoizedSelector<object, DaffStateError>;
+	selectAcceptJsLoadError: MemoizedSelector<object, DaffStateError>;
 	selectIsAcceptJsLoaded: MemoizedSelector<object, boolean>;
 }
 

--- a/libs/authorizenet/state/testing/src/mock-authorize-net-facade.ts
+++ b/libs/authorizenet/state/testing/src/mock-authorize-net-facade.ts
@@ -2,12 +2,13 @@ import { Action } from '@ngrx/store';
 import { BehaviorSubject } from 'rxjs';
 
 import { DaffAuthorizeNetFacadeInterface } from '@daffodil/authorizenet/state';
+import { DaffStateError } from '@daffodil/core/state';
 
 export class MockDaffAuthorizeNetFacade implements DaffAuthorizeNetFacadeInterface {
   isAcceptJsLoaded$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
-  paymentError$: BehaviorSubject<string> = new BehaviorSubject(null);
-  acceptJsLoadError$: BehaviorSubject<string> = new BehaviorSubject(null);
+  paymentError$: BehaviorSubject<DaffStateError> = new BehaviorSubject(null);
+  acceptJsLoadError$: BehaviorSubject<DaffStateError> = new BehaviorSubject(null);
 
   dispatch(action: Action) {};
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Anet state errors are just strings.


## What is the new behavior?
Anet state errors are the `DaffStateError` object.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The type of state errors and their corresponding selectors and facade fields have changed.

## Other information