### PR TITLE
feat(cart): resolve success on server side storage error

### DIFF
--- a/libs/cart/state/src/cart-state.server.module.ts
+++ b/libs/cart/state/src/cart-state.server.module.ts
@@ -2,6 +2,9 @@ import { NgModule } from '@angular/core';
 
 import { DaffPersistenceServiceToken, DaffServerErrorStorageService } from '@daffodil/core';
 
+/**
+ * A cart state module that should be loaded into SSR contexts.
+ */
 @NgModule({
 	providers: [
 		{

--- a/libs/cart/state/src/cart-state.server.module.ts
+++ b/libs/cart/state/src/cart-state.server.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+
+import { DaffPersistenceServiceToken, DaffServerErrorStorageService } from '@daffodil/core';
+
+@NgModule({
+	providers: [
+		{
+      provide: DaffPersistenceServiceToken,
+      useExisting: DaffServerErrorStorageService
+    }
+	]
+})
+export class DaffCartStateServerModule { }

--- a/libs/cart/state/src/public_api.ts
+++ b/libs/cart/state/src/public_api.ts
@@ -6,6 +6,7 @@ export * from './resolvers/public_api';
 export * from './models/public_api';
 
 export { DaffCartStateModule } from './cart-state.module'
+export { DaffCartStateServerModule } from './cart-state.server.module'
 
 export { DaffCartFacade } from './facades/cart/cart.facade';
 export { DaffCartFacadeInterface } from './facades/cart/cart-facade.interface';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When cart resolution throws storage errors in SSR, the resolve effect dispatches a resolve failure. This causes the resolve guard to emit `false`. This will cause  an app to never render any pages that are guarded by the cart resolve guard in SSR.

## What is the new behavior?
The resolve effect will return resolve success in response to the new server side storage error. This will cause the resolve cart guard to emit `true` in SSR contexts. Also adds a server side state module.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information