### PR TITLE
fix(category): category breadcrumbs return from magento in alphabetic…

### DIFF
--- a/libs/category/src/drivers/magento/transformers/category-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-transformer.service.spec.ts
@@ -28,8 +28,10 @@ describe('DaffMagentoCategoryTransformerService', () => {
 
   describe('transform', () => {
 
-    it('should return a DaffCategory', () => {
-      const magentoCategory: MagentoCategory = {
+		let magentoCategory: MagentoCategory;
+
+		beforeEach(() => {
+			magentoCategory = {
         id: stubCategory.id,
 				name: stubCategory.name,
 				description: stubCategory.description,
@@ -56,50 +58,31 @@ describe('DaffMagentoCategoryTransformerService', () => {
 				},
         children_count: stubCategory.children_count
       }
+		});
 
+    it('should return a DaffCategory', () => {
       expect(service.transform(magentoCategory)).toEqual(stubCategory);
 		});
 
     it('should return breadcrumbs in order of category_level', () => {
-      const magentoCategory: MagentoCategory = {
-        id: stubCategory.id,
-				name: stubCategory.name,
-				description: stubCategory.description,
-        breadcrumbs: [{
-          category_id: 3,
-          category_name: 'category3',
-          category_level: 3,
-          category_url_key: 'urlKey3'
-				},
-				{
-          category_id: 1,
-          category_name: 'category1',
-          category_level: 1,
-          category_url_key: 'urlKey1'
-				},
-				{
-          category_id: 2,
-          category_name: 'category2',
-          category_level: 2,
-          category_url_key: 'urlKey2'
-				}],
-				products: {
-					items: [{
-						__typename: 'simple',
-						id: 1,
-						name: 'name',
-						sku: stubCategory.product_ids[0],
-						url_key: 'url_key',
-						image: null,
-						price_range: null,
-            thumbnail: {
-              url: 'url',
-              label: 'label'
-            }
-					}]
-				},
-        children_count: stubCategory.children_count
-			}
+      magentoCategory.breadcrumbs = [{
+				category_id: 3,
+				category_name: 'category3',
+				category_level: 3,
+				category_url_key: 'urlKey3'
+			},
+			{
+				category_id: 1,
+				category_name: 'category1',
+				category_level: 1,
+				category_url_key: 'urlKey1'
+			},
+			{
+				category_id: 2,
+				category_name: 'category2',
+				category_level: 2,
+				category_url_key: 'urlKey2'
+			}];
 			const expectedBreadcrumbs: DaffCategoryBreadcrumb[] = [{
 				categoryId: 1,
 				categoryName: 'category1',

--- a/libs/category/src/drivers/magento/transformers/category-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-transformer.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
+import { DaffCategoryBreadcrumb } from '@daffodil/category';
 import { DaffCategoryFactory } from '@daffodil/category/testing';
 
 import { DaffMagentoCategoryTransformerService } from './category-transformer.service';
@@ -57,6 +58,68 @@ describe('DaffMagentoCategoryTransformerService', () => {
       }
 
       expect(service.transform(magentoCategory)).toEqual(stubCategory);
+		});
+
+    it('should return breadcrumbs in order of category_level', () => {
+      const magentoCategory: MagentoCategory = {
+        id: stubCategory.id,
+				name: stubCategory.name,
+				description: stubCategory.description,
+        breadcrumbs: [{
+          category_id: 3,
+          category_name: 'category3',
+          category_level: 3,
+          category_url_key: 'urlKey3'
+				},
+				{
+          category_id: 1,
+          category_name: 'category1',
+          category_level: 1,
+          category_url_key: 'urlKey1'
+				},
+				{
+          category_id: 2,
+          category_name: 'category2',
+          category_level: 2,
+          category_url_key: 'urlKey2'
+				}],
+				products: {
+					items: [{
+						__typename: 'simple',
+						id: 1,
+						name: 'name',
+						sku: stubCategory.product_ids[0],
+						url_key: 'url_key',
+						image: null,
+						price_range: null,
+            thumbnail: {
+              url: 'url',
+              label: 'label'
+            }
+					}]
+				},
+        children_count: stubCategory.children_count
+			}
+			const expectedBreadcrumbs: DaffCategoryBreadcrumb[] = [{
+				categoryId: 1,
+				categoryName: 'category1',
+				categoryLevel: 1,
+				categoryUrlKey: 'urlKey1'
+			},
+			{
+				categoryId: 2,
+				categoryName: 'category2',
+				categoryLevel: 2,
+				categoryUrlKey: 'urlKey2'
+			},
+			{
+				categoryId: 3,
+				categoryName: 'category3',
+				categoryLevel: 3,
+				categoryUrlKey: 'urlKey3'
+			}];
+
+      expect(service.transform(magentoCategory).breadcrumbs).toEqual(expectedBreadcrumbs);
     });
   });
 });

--- a/libs/category/src/drivers/magento/transformers/category-transformer.service.ts
+++ b/libs/category/src/drivers/magento/transformers/category-transformer.service.ts
@@ -14,7 +14,8 @@ export class DaffMagentoCategoryTransformerService {
       id: category.id,
 			name: category.name,
 			description: category.description,
-      children_count: category.children_count,
+			children_count: category.children_count,
+			//todo: use optional chaining when possible
 			breadcrumbs: category.breadcrumbs ? 
 				category.breadcrumbs
 					.map(breadcrumb => this.transformBreadcrumb(breadcrumb))

--- a/libs/category/src/drivers/magento/transformers/category-transformer.service.ts
+++ b/libs/category/src/drivers/magento/transformers/category-transformer.service.ts
@@ -15,7 +15,11 @@ export class DaffMagentoCategoryTransformerService {
 			name: category.name,
 			description: category.description,
       children_count: category.children_count,
-			breadcrumbs: category.breadcrumbs ? category.breadcrumbs.map(breadcrumb => this.transformBreadcrumb(breadcrumb)) : null,
+			breadcrumbs: category.breadcrumbs ? 
+				category.breadcrumbs
+					.map(breadcrumb => this.transformBreadcrumb(breadcrumb))
+					.sort((a, b) => a.categoryLevel - b.categoryLevel) : 
+				null,
 			product_ids: category.products.items.map(product => product.sku),
 			total_products: category.products.items.length
     }


### PR DESCRIPTION
…al order instead of by order of category level

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Magento returns category breadcrumbs in alphabetical order instead of category_level order, so they end up in an unexpected order in the front end.

## What is the new behavior?
The daffodil magento category transformer now sorts the breadcrumbs in order of category_level.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```