### PR TITLE
fix(product): configurable product selectable attributes include out …

### DIFF
--- a/libs/product/src/facades/configurable-product/configurable-product.facade.spec.ts
+++ b/libs/product/src/facades/configurable-product/configurable-product.facade.spec.ts
@@ -276,8 +276,8 @@ describe('DaffConfigurableProductFacade', () => {
 					],
 					[stubConfigurableProduct.configurableAttributes[2].code]: [
 						stubConfigurableProduct.configurableAttributes[2].values[0].value,
-						stubConfigurableProduct.configurableAttributes[2].values[1].value,
-						stubConfigurableProduct.configurableAttributes[2].values[2].value
+						stubConfigurableProduct.configurableAttributes[2].values[2].value,
+						stubConfigurableProduct.configurableAttributes[2].values[1].value
 					]
 				}
 			});

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.integration.spec.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.integration.spec.ts
@@ -150,7 +150,7 @@ describe('Configurable Product Selectors | integration tests', () => {
 			a: {
 				color: ['0', '1', '2'],
 				size: ['0', '1', '2'],
-				material: ['0', '1', '2']
+				material: ['0', '2', '1']
 			} 
 		});
 

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.ts
@@ -223,7 +223,6 @@ const createConfigurableProductSelectors = (): DaffConfigurableProductMemoizedSe
 				return {};
 			}
 			const appliedAttributes: DaffConfigurableProductEntityAttribute[] = selectConfigurableProductAppliedAttributes.projector(appliedAttributesEntities, { id: props.id });
-			if(appliedAttributes.length === 0) return selectAllConfigurableProductAttributes.projector(products, { id: props.id });
 			
 			const selectableAttributes = initializeSelectableAttributes(product.configurableAttributes);
 

--- a/libs/product/src/selectors/configurable-product/configurable-product.selectors.unit.spec.ts
+++ b/libs/product/src/selectors/configurable-product/configurable-product.selectors.unit.spec.ts
@@ -376,7 +376,28 @@ describe('Configurable Product Selectors | unit tests', () => {
 				a: {
 					color: ['0', '1', '2'],
 					size: ['0', '1', '2'],
-					material: ['0', '1', '2']
+					material: ['0', '2', '1']
+				}
+			});
+
+			expect(selector).toBeObservable(expected);
+		});
+
+		it('returns expected dictionary when variants are out of stock', () => {
+			stubConfigurableProduct.variants = stubConfigurableProduct.variants.map(variant => {
+				if(variant.appliedAttributes['material'] === '1') {
+					variant.in_stock = false;
+				}
+
+				return variant;
+			});
+			store.dispatch(new DaffProductLoadSuccess(stubConfigurableProduct));
+			const selector = store.pipe(select(selectSelectableConfigurableProductAttributes, { id: stubConfigurableProduct.id }));
+			const expected = cold('a', {
+				a: {
+					color: ['0', '1', '2'],
+					size: ['0', '1', '2'],
+					material: ['0', '2']
 				}
 			});
 


### PR DESCRIPTION
…of stock variants

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `selectSelectableConfigurableProductAttributes` selector returns all attributes when no attributes are selected. This introduces a bug when all variants with a particular attribute option are out of stock. That attribute, which should be unselectable, is added in with all the other attributes.

## What is the new behavior?
The `selectSelectableConfigurableProductAttributes` selector goes through the same process of determining what attributes are "selectable" even when no attributes have been selected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```