### PR TITLE
feat(product): make DaffProduct.images a required field

### DIFF
--- a/libs/product/src/drivers/magento/transforms/bundled-product-transformers.ts
+++ b/libs/product/src/drivers/magento/transforms/bundled-product-transformers.ts
@@ -41,6 +41,7 @@ function transformMagentoBundledProductItemOption(option: MagentoBundledProductI
 		id: option.id.toString(),
 		name: option.label,
 		price: getPrice(option.product),
+		images: [],
 		discount: getDiscount(option.product),
 		quantity: option.quantity,
 		is_default: option.is_default,

--- a/libs/product/src/drivers/magento/transforms/spec-data/daff-composite-product.json
+++ b/libs/product/src/drivers/magento/transforms/spec-data/daff-composite-product.json
@@ -28,6 +28,7 @@
 					"id": "1",
 					"name": "Option 1",
 					"price": 5,
+					"images": [],
 					"discount": {
 						"amount": 1,
 						"percent": 20
@@ -40,6 +41,7 @@
 					"id": "2",
 					"name": "Option 2",
 					"price": 2,
+					"images": [],
 					"discount": {
 						"amount": 1,
 						"percent": 50

--- a/libs/product/src/drivers/shopify/product.service.ts
+++ b/libs/product/src/drivers/shopify/product.service.ts
@@ -81,7 +81,8 @@ export const GetAProduct = gql`
 export const DaffShopifyProductTransformer = (node: ProductNode) : DaffProduct => {
   return {
     id: node.id,
-    name: node.title
+		name: node.title,
+		images: []
   }
 }
 

--- a/libs/product/src/facades/product/product.facade.spec.ts
+++ b/libs/product/src/facades/product/product.facade.spec.ts
@@ -97,7 +97,7 @@ describe('DaffProductFacade', () => {
 	
 	describe('hasDiscount()', () => {
 		it('should be an observable of whether the given product has discount', () => {
-			const product = {id: '1', name: 'Some Name', discount: { amount: 20, percent: 10 }};
+			const product = {id: '1', name: 'Some Name', images: [], discount: { amount: 20, percent: 10 }};
       const expected = cold('a', { a: true });
       store.dispatch(new DaffProductLoad(product.id));
       store.dispatch(new DaffProductLoadSuccess(product));
@@ -107,7 +107,7 @@ describe('DaffProductFacade', () => {
 	
 	describe('getDiscountAmount()', () => {
 		it('should be an observable of whether the given product has discount', () => {
-			const product = {id: '1', name: 'Some Name', discount: { amount: 20, percent: 10 }};
+			const product = {id: '1', name: 'Some Name', images: [], discount: { amount: 20, percent: 10 }};
       const expected = cold('a', { a: 20 });
       store.dispatch(new DaffProductLoad(product.id));
       store.dispatch(new DaffProductLoadSuccess(product));
@@ -127,7 +127,7 @@ describe('DaffProductFacade', () => {
 	
 	describe('getDiscountPercent()', () => {
 		it('should be an observable of whether the given product has discount', () => {
-			const product = {id: '1', name: 'Some Name', discount: { amount: 20, percent: 10 }};
+			const product = {id: '1', name: 'Some Name', images: [], discount: { amount: 20, percent: 10 }};
       const expected = cold('a', { a: 10 });
       store.dispatch(new DaffProductLoad(product.id));
       store.dispatch(new DaffProductLoadSuccess(product));
@@ -137,7 +137,7 @@ describe('DaffProductFacade', () => {
 	
 	describe('isOutOfStock()', () => {
 		it('should be an observable of whether the given product is out of stock', () => {
-			const product = {id: '1', name: 'Some Name', discount: { amount: 20, percent: 10 }, in_stock: false};
+			const product = {id: '1', name: 'Some Name', images: [], discount: { amount: 20, percent: 10 }, in_stock: false};
       const expected = cold('a', { a: true });
       store.dispatch(new DaffProductLoad(product.id));
       store.dispatch(new DaffProductLoadSuccess(product));

--- a/libs/product/src/models/product.ts
+++ b/libs/product/src/models/product.ts
@@ -18,7 +18,7 @@ export interface DaffProduct {
   name?: string;
   brand?: string;
   description?: string;
-	images?: DaffProductImage[];
+	images: DaffProductImage[];
 	in_stock?: boolean;
 }
 

--- a/libs/product/testing/src/factories/composite-product.factory.spec.ts
+++ b/libs/product/testing/src/factories/composite-product.factory.spec.ts
@@ -32,6 +32,7 @@ describe('Product | Testing | Factories | DaffCompositeProductFactory', () => {
 			expect(result.id).toBeDefined();
       expect(result.url).toBeDefined();
       expect(result.price).toBeDefined();
+      expect(result.images).toBeDefined();
       expect(result.discount.amount).toBeDefined();
       expect(result.discount.percent).toBeDefined();
       expect(result.name).toBeDefined();

--- a/libs/product/testing/src/factories/composite-product.factory.ts
+++ b/libs/product/testing/src/factories/composite-product.factory.ts
@@ -13,6 +13,7 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 	id = faker.random.number({min: 1, max: 10000}).toString();
 	url = faker.random.alphaNumeric(16);
 	price = this.stubPrice;
+	images = [];
 	discount = {
 		amount: this.stubDiscount,
 		percent: this.stubDiscount/this.stubPrice
@@ -32,6 +33,7 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 					id: faker.random.alphaNumeric(10),
 					name: faker.commerce.productMaterial(),
 					price: faker.random.number({min: 1, max: 100}),
+					images: [],
 					discount: {
 						amount: 0,
 						percent: 0
@@ -44,6 +46,7 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 					id: faker.random.alphaNumeric(10),
 					name: faker.commerce.productMaterial(),
 					price: faker.random.number({min: 1, max: 100}),
+					images: [],
 					discount: {
 						amount: 0,
 						percent: 0
@@ -64,6 +67,7 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 					id: faker.random.alphaNumeric(10),
 					name: faker.commerce.productMaterial(),
 					price: faker.random.number({min: 1, max: 100}),
+					images: [],
 					discount: {
 						amount: 0,
 						percent: 0
@@ -76,6 +80,7 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 					id: faker.random.alphaNumeric(10),
 					name: faker.commerce.productMaterial(),
 					price: faker.random.number({min: 1, max: 100}),
+					images: [],
 					discount: {
 						amount: 0,
 						percent: 0

--- a/libs/product/testing/src/factories/configurable-product.factory.spec.ts
+++ b/libs/product/testing/src/factories/configurable-product.factory.spec.ts
@@ -32,6 +32,7 @@ describe('Product | Testing | Factories | DaffConfigurableProductFactory', () =>
 			expect(result.id).toBeDefined();
       expect(result.url).toBeDefined();
       expect(result.price).toBeDefined();
+      expect(result.images).toBeDefined();
       expect(result.name).toBeDefined();
       expect(result.brand).toBeDefined();
 			expect(result.description).toBeDefined();

--- a/libs/product/testing/src/factories/configurable-product.factory.ts
+++ b/libs/product/testing/src/factories/configurable-product.factory.ts
@@ -17,7 +17,8 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 	type = DaffProductTypeEnum.Configurable;
 	id = faker.random.number({min: 1, max: 10000}).toString();
 	url = faker.random.alphaNumeric(16);
-  price = faker.random.number({min: 1, max: 1500});
+	price = faker.random.number({min: 1, max: 1500});
+	images = [];
   name = faker.commerce.productName();
   brand = faker.company.companyName();
 	description = 'Lorem ipsum dolor sit amet, accumsan ullamcorper ei eam. Sint appetere ocurreret no per, et cum lorem disputationi. Sit ut magna delenit, assum vidisse vocibus sed ut. In aperiri malorum accusamus sea, novum mediocritatem ius at. Duo agam probo honestatis ut. Nec regione splendide cu, unum graeco vivendum in duo.'

--- a/libs/product/testing/src/factories/product.factory.spec.ts
+++ b/libs/product/testing/src/factories/product.factory.spec.ts
@@ -32,6 +32,7 @@ describe('Product | Testing | Factories | DaffProductFactory', () => {
 			expect(result.id).toBeDefined();
       expect(result.url).toBeDefined();
       expect(result.price).toBeDefined();
+      expect(result.images).toBeDefined();
       expect(result.discount).toBeDefined();
       expect(result.name).toBeDefined();
       expect(result.brand).toBeDefined(); 

--- a/libs/product/testing/src/factories/product.factory.ts
+++ b/libs/product/testing/src/factories/product.factory.ts
@@ -18,7 +18,8 @@ export class MockProduct implements DaffProduct {
 	discount = {
 		amount: this.stubDiscount,
 		percent: Math.floor((this.stubDiscount/this.stubPrice) * 100)
-	}
+	};
+	images = [];
   name = faker.commerce.productName();
   brand = faker.company.companyName();
   description = 'Lorem ipsum dolor sit amet, accumsan ullamcorper ei eam. Sint appetere ocurreret no per, et cum lorem disputationi. Sit ut magna delenit, assum vidisse vocibus sed ut. In aperiri malorum accusamus sea, novum mediocritatem ius at. Duo agam probo honestatis ut. Nec regione splendide cu, unum graeco vivendum in duo.'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `DaffProduct.images` field is optional, but daffodil should guarantee that this is at least an empty array.

## What is the new behavior?
The `DaffProduct.images` field is now at least an empty array. This removes some of the unnecessary null checking of that field on the app.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```