### PR TITLE
fix(core): queued apollo mutation errors prevent subsequent requests

### DIFF
--- a/libs/core/graphql/src/apollo/queued-apollo.service.ts
+++ b/libs/core/graphql/src/apollo/queued-apollo.service.ts
@@ -3,7 +3,7 @@ import { Apollo } from 'apollo-angular';
 import { R } from 'apollo-angular/types';
 import { MutationOptions } from 'apollo-client';
 import { FetchResult } from 'apollo-link';
-import { Observable, Subscriber } from 'rxjs';
+import { Observable, Subscriber, Subscription } from 'rxjs';
 
 /**
  * A service that will queue mutate calls to Apollo.
@@ -39,25 +39,30 @@ export class DaffQueuedApollo {
           // emit the outer observable
           subscriber.next(response);
           subscriber.complete();
-          sub.unsubscribe();
 
-          // process the queue
-          this.queue.shift();
-          // TODO: optional chaining
-          if (this.queue[0]) this.queue[0]();
+          this.finishRequestSubscription(sub);
         },
         error => {
           subscriber.error(error)
-          sub.unsubscribe();
+          this.finishRequestSubscription(sub);
         },
         () => {
           subscriber.complete()
-          sub.unsubscribe();
+          this.finishRequestSubscription(sub);
         }
       )
     });
 
     // start the queue if previously empty
     if (this.queue.length === 1) this.queue[0]();
+  }
+
+  private finishRequestSubscription(requestSubscription: Subscription): void {
+    requestSubscription.unsubscribe();
+
+    // process queue
+    this.queue.shift();
+    // TODO: optional chaining
+    if (this.queue[0]) this.queue[0]();
   }
 }

--- a/libs/core/graphql/src/apollo/queued-apollo.service.ts
+++ b/libs/core/graphql/src/apollo/queued-apollo.service.ts
@@ -26,6 +26,7 @@ export class DaffQueuedApollo {
    * The request will not actually be queued until the returned observable is subscribed.
    * If the queue is empty, the request will be sent when it enters the queue.
    * Otherwise, it will be sent when it reaches the front of the queue.
+   * The observable will complete after it emits once.
    * @param options Mutation options.
    */
   mutate<T, V = R>(options: MutationOptions<T, V>): Observable<FetchResult<T>> {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A queued mutation that threw an error would not cause the mutation queued to be processed and therefore subsequent requests would never be sent.


## What is the new behavior?
The mutation queued will be processed for all observable events (emit, error, and complete) and subsequent requests will be processed when all prior requests complete in any way.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information