### PR TITLE
test(cart,order): allow discount to be equal to price in item factories

### DIFF
--- a/libs/cart/testing/src/factories/cart-item/cart-item.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart-item/cart-item.factory.spec.ts
@@ -42,8 +42,8 @@ describe('Cart | Testing | Factories | CartItemFactory', () => {
       expect(result.in_stock).not.toBeNull();
     });
 
-    it('should set total_discount to be less than price', () => {
-      expect(result.total_discount).toBeLessThan(result.price);
+    it('should set total_discount to be less than or equal to price', () => {
+      expect(result.total_discount).toBeLessThanOrEqual(result.price);
     });
   });
 });

--- a/libs/order/testing/src/factories/order-item.factory.spec.ts
+++ b/libs/order/testing/src/factories/order-item.factory.spec.ts
@@ -58,8 +58,8 @@ describe('Order | Testing | Factories | OrderItemFactory', () => {
       expect(result.type).not.toBeNull();
     });
 
-    it('should set total_discount to be less than price', () => {
-      expect(result.discount_amount).toBeLessThan(result.price);
+    it('should set total_discount to be less than or equal to price', () => {
+      expect(result.discount_amount).toBeLessThanOrEqual(result.price);
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The factories allow for the discount to be the same as the price. The tests assert that the discount is strictly less than the price and will therefor occasionally fail when they are equal.


## What is the new behavior?
The tests allow for discounts less than or equal to the price.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I think allowing for discounts equal to the price is the behavior we want since items can be free by some discounts.