### PR TITLE
feat(core): swap persistence to server error on server by default

### DIFF
--- a/libs/core/src/storage/persistence.interface.ts
+++ b/libs/core/src/storage/persistence.interface.ts
@@ -1,6 +1,8 @@
 import { InjectionToken, inject, PLATFORM_ID } from '@angular/core';
 
 import { DaffLocalStorageService } from './localstorage/localstorage.service';
+import { isPlatformBrowser } from '@angular/common';
+import { DaffServerErrorStorageService } from './server-error/public_api';
 
 export interface DaffPersistenceService {
   setItem(key : string, value: any): void;
@@ -11,5 +13,7 @@ export interface DaffPersistenceService {
 
 export const DaffPersistenceServiceToken = new InjectionToken<DaffPersistenceService>('DaffPersistenceService', {
   providedIn: 'root',
-  factory: () => new DaffLocalStorageService(inject<string>(PLATFORM_ID)),
+  factory: () => isPlatformBrowser(inject<string>(PLATFORM_ID)) 
+    ? new DaffLocalStorageService(inject<string>(PLATFORM_ID)) 
+    : new DaffServerErrorStorageService(),
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, if you try to DI the persistence token on the server without providing something to replace localstorage, we throw an error when the service is constructed.

Fixes: N/A


## What is the new behavior?
Now, by default, we'll use the server-error service so that don't get construction time errors.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information