### PR TITLE
fix(cart): cart item states get reset when DaffCartItemUpdateSuccess …

### DIFF
--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -92,6 +92,19 @@ describe('Cart | Cart Item Entities Reducer', () => {
 			result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartClearSuccess);
 			expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
 		});
+
+		it('should retain the existing daffState when a CartItemUpdateSuccessAction is triggered', () => {
+			const cartItem = new DaffCartItemFactory().create();
+			const cartItemUpdateSuccess = new DaffCartItemUpdateSuccess(new DaffCartFactory().create({
+				items: [
+					stubStatefulCartItem,
+					cartItem
+				]
+			}), cartItem.item_id);
+			result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartItemUpdateSuccess);
+
+			expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+		});
 	});
 
   describe('when CartItemListSuccessAction is triggered', () => {
@@ -136,7 +149,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
 
     let cart: DaffCart;
     let cartItems: DaffStatefulCartItem[];
-    let result;
+		let result;
 
     beforeEach(() => {
 			cartItems = statefulCartItemFactory.createMany(2);

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -39,7 +39,7 @@ export function daffCartItemEntitiesReducer<
 			);
 		case DaffCartItemActionTypes.CartItemUpdateSuccessAction:
 			return adapter.addAll(
-				updateMutatedCartItemState<T>(<T[]>action.payload.items, action.itemId),
+				updateMutatedCartItemState<T>(<T[]>action.payload.items, state.entities, action.itemId),
 				state
 			);
 		case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
@@ -86,7 +86,8 @@ function updateAddedCartItemState<T extends DaffStatefulCartItem>(oldCartItems: 
 	})
 }
 
-function updateMutatedCartItemState<T extends DaffStatefulCartItem>(cartItems: T[], itemId: T['item_id']): T[] {
-	return cartItems.map(item => item.item_id === itemId ?
-		{ ...item, daffState: DaffCartItemStateEnum.Updated} : item)
+function updateMutatedCartItemState<T extends DaffStatefulCartItem>(responseItems: T[], stateItems: Dictionary<T>, itemId: T['item_id']): T[] {
+	return responseItems.map(item => item.item_id === itemId ?
+		{ ...item, daffState: DaffCartItemStateEnum.Updated} : 
+		{ ...item, daffState: getDaffState(stateItems[item.item_id]) || DaffCartItemStateEnum.Default })
 }


### PR DESCRIPTION
…actions are dispatched

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When DaffCartItemUpdateSuccess actions are dispatched, the cart item states are reset to default.

## What is the new behavior?
Cart item states of existing cart items are retained upon DaffCartItemUpdateSuccess actions.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```