### PR TITLE
perf(navigation): cut navigation query call time significantly.

### DIFF
--- a/libs/navigation/driver/magento/src/models/category-node.ts
+++ b/libs/navigation/driver/magento/src/models/category-node.ts
@@ -1,11 +1,9 @@
-import { CategoryProductNode } from './category-product-node';
-
 export interface CategoryNode {
   __typename?: string;
   id: string;
   name?: string;
   include_in_menu: boolean;
-  products?: CategoryProductNode;
+  product_count: number;
   level?: number;
   children_count?: number;
 	children?: CategoryNode[];

--- a/libs/navigation/driver/magento/src/models/category-product-node.ts
+++ b/libs/navigation/driver/magento/src/models/category-product-node.ts
@@ -1,4 +1,0 @@
-export interface CategoryProductNode {
-  __typename?: string;
-  total_count: number;
-}

--- a/libs/navigation/driver/magento/src/models/public_api.ts
+++ b/libs/navigation/driver/magento/src/models/public_api.ts
@@ -1,3 +1,2 @@
 export { CategoryNode, MagentoBreadcrumb } from './category-node';
-export { CategoryProductNode } from './category-product-node';
 export { GetCategoryTreeResponse } from './get-category-tree-response';

--- a/libs/navigation/driver/magento/src/navigation.service.spec.ts
+++ b/libs/navigation/driver/magento/src/navigation.service.spec.ts
@@ -85,10 +85,7 @@ describe('Driver | Magento | Navigation | NavigationService', () => {
             name: navigation.name,
             include_in_menu: true,
             level: 0,
-            products: {
-              __typename: 'typename',
-              total_count: navigation.total_products
-            },
+            product_count: navigation.total_products,
             children_count: navigation.children_count,
 						children: [],
 						breadcrumbs: []

--- a/libs/navigation/driver/magento/src/queries/fragments/category-node.spec.ts
+++ b/libs/navigation/driver/magento/src/queries/fragments/category-node.spec.ts
@@ -19,10 +19,7 @@ const generateMagentoCategoryTree = (): CategoryNode => ({
   name: 'name',
   include_in_menu: true,
   level: 0,
-  products: {
-    __typename: 'typename',
-    total_count: 1
-  },
+  product_count: 10,
   children_count: 0,
 	children: [],
 	breadcrumbs: []
@@ -208,7 +205,7 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
 			'name',
 			'include_in_menu',
 			'breadcrumbs',
-			'products',
+			'product_count',
 			'children_count',
 			'children'
 		];

--- a/libs/navigation/driver/magento/src/queries/fragments/category-node.ts
+++ b/libs/navigation/driver/magento/src/queries/fragments/category-node.ts
@@ -15,9 +15,7 @@ const categoryNodeFragment = `
 		category_level
 		category_url_key
 	}
-	products {
-		total_count
-	}
+	product_count
 `
 
 /**

--- a/libs/navigation/driver/magento/src/transformers/navigation-transformer.spec.ts
+++ b/libs/navigation/driver/magento/src/transformers/navigation-transformer.spec.ts
@@ -26,17 +26,13 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
       id: '1',
       name: 'Root Category',
       include_in_menu: true,
-      products: {
-        total_count: 10
-      },
+      product_count: 10,
       children_count: 0,
       children: [{
         id: '2',
         include_in_menu: false,
         name: 'Subcategory',
-        products: {
-          total_count: 10
-        },
+        product_count: 10,
         children_count: 0,
 				children: [],
 				breadcrumbs: [{
@@ -67,17 +63,13 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
       id: '1',
       name: 'Root Category',
       include_in_menu: true,
-      products: {
-        total_count: 10
-      },
+      product_count: 10,
       children_count: 1,
       children: [{
         id: '2',
         include_in_menu: true,
         name: 'Subcategory',
-        products: {
-          total_count: 10
-        },
+        product_count: 10,
         children_count: 0,
 				children: [],
 				breadcrumbs: [{

--- a/libs/navigation/driver/magento/src/transformers/navigation-transformer.ts
+++ b/libs/navigation/driver/magento/src/transformers/navigation-transformer.ts
@@ -15,8 +15,8 @@ export class DaffMagentoNavigationTransformerService implements DaffNavigationTr
       id: node.id,
       path: node.id,
       name: node.name,
-      total_products: node.products.total_count,
-			children_count: node.children_count,
+      total_products: node.product_count,
+      children_count: node.children_count,
 			//todo: use optional chaining when possible
 			breadcrumbs: node.breadcrumbs ? 
 				node.breadcrumbs


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
We are incurring a sequence of nested database calls unnecessarily. 

Fixes: N/A


## What is the new behavior?
Instead, we use the cached products_count value in order to compute the total products in a given category
This on average, cuts this call time from ~3s to about ~1s.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information