### PR TITLE
feat(all): provide mock facade in root and with useExisting

### DIFF
--- a/libs/authorizenet/state/testing/src/authorize-net-testing.module.ts
+++ b/libs/authorizenet/state/testing/src/authorize-net-testing.module.ts
@@ -6,7 +6,7 @@ import { MockDaffAuthorizeNetFacade } from './mock-authorize-net-facade';
 
 @NgModule({
   providers: [
-		{ provide: DaffAuthorizeNetFacade, useClass: MockDaffAuthorizeNetFacade }
+		{ provide: DaffAuthorizeNetFacade, useExisting: MockDaffAuthorizeNetFacade }
 	]
 })
 export class DaffAuthorizeNetTestingModule {}

--- a/libs/authorizenet/state/testing/src/mock-authorize-net-facade.ts
+++ b/libs/authorizenet/state/testing/src/mock-authorize-net-facade.ts
@@ -1,9 +1,11 @@
 import { Action } from '@ngrx/store';
 import { BehaviorSubject } from 'rxjs';
+import { Injectable } from '@angular/core';
 
 import { DaffAuthorizeNetFacadeInterface } from '@daffodil/authorizenet/state';
 import { DaffStateError } from '@daffodil/core/state';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffAuthorizeNetFacade implements DaffAuthorizeNetFacadeInterface {
   isAcceptJsLoaded$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);

--- a/libs/cart/state/testing/src/cart-testing.module.ts
+++ b/libs/cart/state/testing/src/cart-testing.module.ts
@@ -6,7 +6,7 @@ import { MockDaffCartFacade } from './mock-cart-facade';
 
 @NgModule({
   providers: [
-		{ provide: DaffCartFacade, useClass: MockDaffCartFacade }
+		{ provide: DaffCartFacade, useExisting: MockDaffCartFacade }
 	]
 })
 export class DaffCartTestingModule { }

--- a/libs/cart/state/testing/src/mock-cart-facade.ts
+++ b/libs/cart/state/testing/src/mock-cart-facade.ts
@@ -1,6 +1,7 @@
 import { BehaviorSubject } from 'rxjs';
 import { Action } from '@ngrx/store';
 import { Dictionary } from '@ngrx/entity';
+import { Injectable } from '@angular/core';
 
 import { DaffStateError } from '@daffodil/core/state';
 import { DaffCart, DaffCartTotal, DaffCartItem, DaffCartOrderResult, DaffConfigurableCartItemAttribute, DaffCompositeCartItemOption } from '@daffodil/cart';
@@ -14,6 +15,7 @@ import {
   DaffCartResolveState
 } from '@daffodil/cart/state';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffCartFacade implements DaffCartFacadeInterface {
   cart$: BehaviorSubject<DaffCart> = new BehaviorSubject(null);
 

--- a/libs/category/testing/src/helpers/category-testing.module.ts
+++ b/libs/category/testing/src/helpers/category-testing.module.ts
@@ -6,7 +6,7 @@ import { MockDaffCategoryFacade } from './mock-category-facade';
 
 @NgModule({
   providers: [
-		{ provide: DaffCategoryFacade, useClass: MockDaffCategoryFacade }
+		{ provide: DaffCategoryFacade, useExisting: MockDaffCategoryFacade }
 	]
 })
 export class DaffCategoryTestingModule { }

--- a/libs/category/testing/src/helpers/mock-category-facade.ts
+++ b/libs/category/testing/src/helpers/mock-category-facade.ts
@@ -1,17 +1,19 @@
 import { BehaviorSubject } from 'rxjs';
 import { Action } from '@ngrx/store';
+import { Injectable } from '@angular/core';
 
 import { DaffProduct } from '@daffodil/product';
-import { 
-	DaffCategoryFacadeInterface, 
-	DaffCategory, 
-	DaffCategoryPageConfigurationState, 
-	DaffCategoryFilter, 
-	DaffCategorySortOption, 
-	DaffCategoryAppliedFilter, 
-	DaffSortDirectionEnum 
+import {
+	DaffCategoryFacadeInterface,
+	DaffCategory,
+	DaffCategoryPageConfigurationState,
+	DaffCategoryFilter,
+	DaffCategorySortOption,
+	DaffCategoryAppliedFilter,
+	DaffSortDirectionEnum
 } from '@daffodil/category';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffCategoryFacade implements DaffCategoryFacadeInterface {
 
   category$: BehaviorSubject<DaffCategory> = new BehaviorSubject(null);
@@ -30,7 +32,7 @@ export class MockDaffCategoryFacade implements DaffCategoryFacadeInterface {
   productsLoading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 	errors$: BehaviorSubject<string[]> = new BehaviorSubject([]);
 	isCategoryEmpty$: BehaviorSubject<boolean> = new BehaviorSubject(true);
-	
+
 	getCategoryById(id: string): BehaviorSubject<DaffCategory> {
 		return new BehaviorSubject(null);
 	};

--- a/libs/contact/testing/src/helpers/contact-testing.module.ts
+++ b/libs/contact/testing/src/helpers/contact-testing.module.ts
@@ -6,7 +6,7 @@ import { MockDaffContactFacade } from './mock-contact-facade';
 
 @NgModule({
 	providers: [
-		{ provide: DaffContactFacade, useClass: MockDaffContactFacade }
+		{ provide: DaffContactFacade, useExisting: MockDaffContactFacade }
 	]
 })
 export class DaffContactTestingModule { }

--- a/libs/contact/testing/src/helpers/mock-contact-facade.ts
+++ b/libs/contact/testing/src/helpers/mock-contact-facade.ts
@@ -1,8 +1,10 @@
 import { Action } from '@ngrx/store';
 import { BehaviorSubject } from 'rxjs';
+import { Injectable } from '@angular/core';
 
 import { DaffContactFacadeInterface } from '@daffodil/contact';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffContactFacade implements DaffContactFacadeInterface {
   success$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   error$: BehaviorSubject<string[]> = new BehaviorSubject([]);

--- a/libs/geography/state/testing/src/geography-testing.module.ts
+++ b/libs/geography/state/testing/src/geography-testing.module.ts
@@ -6,7 +6,7 @@ import { MockDaffGeographyFacade } from './mock-geography-facade';
 
 @NgModule({
   providers: [
-		{ provide: DaffGeographyFacade, useClass: MockDaffGeographyFacade }
+		{ provide: DaffGeographyFacade, useExisting: MockDaffGeographyFacade }
 	]
 })
 export class DaffGeographyTestingModule {}

--- a/libs/geography/state/testing/src/mock-geography-facade.ts
+++ b/libs/geography/state/testing/src/mock-geography-facade.ts
@@ -4,7 +4,9 @@ import { Dictionary } from '@ngrx/entity';
 
 import { DaffCountry } from '@daffodil/geography';
 import { DaffGeographyFacadeInterface } from '@daffodil/geography/state';
+import { Injectable } from '@angular/core';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffGeographyFacade implements DaffGeographyFacadeInterface {
   loading$: BehaviorSubject<boolean> = new BehaviorSubject(null);
   errors$: BehaviorSubject<string[]> = new BehaviorSubject([]);

--- a/libs/geography/state/testing/src/mock-geography-facade.ts
+++ b/libs/geography/state/testing/src/mock-geography-facade.ts
@@ -1,10 +1,10 @@
 import { BehaviorSubject } from 'rxjs';
 import { Action } from '@ngrx/store';
 import { Dictionary } from '@ngrx/entity';
+import { Injectable } from '@angular/core';
 
 import { DaffCountry } from '@daffodil/geography';
 import { DaffGeographyFacadeInterface } from '@daffodil/geography/state';
-import { Injectable } from '@angular/core';
 
 @Injectable({providedIn: 'root'})
 export class MockDaffGeographyFacade implements DaffGeographyFacadeInterface {

--- a/libs/navigation/state/testing/src/mock-navigation.facade.ts
+++ b/libs/navigation/state/testing/src/mock-navigation.facade.ts
@@ -1,4 +1,5 @@
 import { BehaviorSubject } from 'rxjs';
+import { Injectable } from '@angular/core';
 
 import { DaffGenericNavigationTree } from '@daffodil/navigation';
 import { DaffNavigationFacadeInterface } from '@daffodil/navigation/state';
@@ -7,6 +8,7 @@ import { DaffNavigationFacadeInterface } from '@daffodil/navigation/state';
  * A mock of the DaffNavigationFacade used to remove any interaction with the ngrx store.
  * This mock should be imported into tests using the DaffNavigationTestingModule.
  */
+@Injectable({providedIn: 'root'})
 export class MockDaffNavigationFacade<T extends DaffGenericNavigationTree<T>> implements DaffNavigationFacadeInterface<T> {
   loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   tree$: BehaviorSubject<T> = new BehaviorSubject(null);

--- a/libs/navigation/state/testing/src/navigation-testing.module.ts
+++ b/libs/navigation/state/testing/src/navigation-testing.module.ts
@@ -14,7 +14,7 @@ import { MockDaffNavigationFacade } from './mock-navigation.facade';
     CommonModule
   ],
   providers: [
-    { provide: DaffNavigationFacade, useClass: MockDaffNavigationFacade }
+    { provide: DaffNavigationFacade, useExisting: MockDaffNavigationFacade }
   ]
 })
 export class DaffNavigationTestingModule {}

--- a/libs/newsletter/testing/src/helpers/mock-newsletter-facade.ts
+++ b/libs/newsletter/testing/src/helpers/mock-newsletter-facade.ts
@@ -1,8 +1,10 @@
 import { BehaviorSubject } from 'rxjs';
 import { Action } from '@ngrx/store';
+import { Injectable } from '@angular/core';
 
 import { DaffNewsletterFacadeInterface } from '@daffodil/newsletter';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffNewsletterFacade implements DaffNewsletterFacadeInterface {
   success$ : BehaviorSubject<boolean> = new BehaviorSubject(false);
   error$: BehaviorSubject<string> = new BehaviorSubject(null);

--- a/libs/newsletter/testing/src/helpers/newsletter-testing.module.ts
+++ b/libs/newsletter/testing/src/helpers/newsletter-testing.module.ts
@@ -6,7 +6,7 @@ import { MockDaffNewsletterFacade } from './mock-newsletter-facade';
 
 @NgModule({
   providers: [
-		{ provide: DaffNewsletterFacade, useClass: MockDaffNewsletterFacade }
+		{ provide: DaffNewsletterFacade, useExisting: MockDaffNewsletterFacade }
 	]
 })
 export class DaffNewsletterTestingModule { }

--- a/libs/order/state/testing/src/mock-order-facade.ts
+++ b/libs/order/state/testing/src/mock-order-facade.ts
@@ -1,10 +1,12 @@
 import { BehaviorSubject } from 'rxjs';
 import { Action } from '@ngrx/store';
 import { Dictionary } from '@ngrx/entity';
+import { Injectable } from '@angular/core';
 
 import { DaffOrder, DaffOrderTotal } from '@daffodil/order';
 import { DaffOrderFacadeInterface } from '@daffodil/order/state';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffOrderFacade implements DaffOrderFacadeInterface {
   loading$: BehaviorSubject<boolean> = new BehaviorSubject(null);
   errors$: BehaviorSubject<string[]> = new BehaviorSubject([]);

--- a/libs/order/state/testing/src/order-testing.module.ts
+++ b/libs/order/state/testing/src/order-testing.module.ts
@@ -6,7 +6,7 @@ import { MockDaffOrderFacade } from './mock-order-facade';
 
 @NgModule({
   providers: [
-		{ provide: DaffOrderFacade, useClass: MockDaffOrderFacade }
+		{ provide: DaffOrderFacade, useExisting: MockDaffOrderFacade }
 	]
 })
 export class DaffOrderTestingModule {}

--- a/libs/paypal/testing/src/helpers/mock-paypal-facade.ts
+++ b/libs/paypal/testing/src/helpers/mock-paypal-facade.ts
@@ -1,8 +1,10 @@
 import { BehaviorSubject } from 'rxjs';
 import { Action } from '@ngrx/store';
+import { Injectable } from '@angular/core';
 
 import { DaffPaypalFacadeInterface, DaffPaypalTokenResponse } from '@daffodil/paypal';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffPaypalFacade implements DaffPaypalFacadeInterface {
   loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 	paypalTokenResponse$: BehaviorSubject<DaffPaypalTokenResponse> = new BehaviorSubject(null);

--- a/libs/paypal/testing/src/helpers/paypal-testing.module.ts
+++ b/libs/paypal/testing/src/helpers/paypal-testing.module.ts
@@ -6,7 +6,7 @@ import { MockDaffPaypalFacade } from './mock-paypal-facade';
 
 @NgModule({
   providers: [
-		{ provide: DaffPaypalFacade, useClass: MockDaffPaypalFacade }
+		{ provide: DaffPaypalFacade, useExisting: MockDaffPaypalFacade }
 	]
 })
 export class DaffPaypalTestingModule { }

--- a/libs/product/testing/src/helpers/mock-best-sellers.facade.ts
+++ b/libs/product/testing/src/helpers/mock-best-sellers.facade.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Action } from '@ngrx/store';
+import { BehaviorSubject } from 'rxjs';
+
+import { DaffStoreFacade } from '@daffodil/core/state';
+import { DaffProduct } from '@daffodil/product';
+
+@Injectable({providedIn: 'root'})
+export class MockDaffBestSellersFacade implements DaffStoreFacade<Action> {
+  loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  bestSellers$: BehaviorSubject<DaffProduct[]> = new BehaviorSubject([]);
+
+  dispatch(action: Action) {}
+}

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -1,15 +1,17 @@
 import { BehaviorSubject } from 'rxjs';
+import { Dictionary } from '@ngrx/entity';
+import { Injectable } from '@angular/core';
 
-import { 
-	DaffCompositeProductFacadeInterface, 
-	DaffCompositeProductItemOption, 
-	DaffCompositeProduct, 
+import {
+	DaffCompositeProductFacadeInterface,
+	DaffCompositeProductItemOption,
+	DaffCompositeProduct,
 	DaffCompositeProductItem,
 	DaffPriceRange,
 	DaffCompositeConfigurationItem
 } from '@daffodil/product';
-import { Dictionary } from '@ngrx/entity';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
 	getRequiredItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): BehaviorSubject<DaffPriceRange> {
 		return new BehaviorSubject(null);

--- a/libs/product/testing/src/helpers/mock-configurable-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-configurable-product-facade.ts
@@ -1,8 +1,10 @@
 import { BehaviorSubject } from 'rxjs';
 import { Dictionary } from '@ngrx/entity';
+import { Injectable } from '@angular/core';
 
 import { DaffConfigurableProductFacadeInterface, DaffConfigurableProductVariant } from '@daffodil/product';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffConfigurableProductFacade implements DaffConfigurableProductFacadeInterface {
 	getAllAttributes(id: string): BehaviorSubject<Dictionary<string[]>> {
 		return new BehaviorSubject({});

--- a/libs/product/testing/src/helpers/mock-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-product-facade.ts
@@ -1,7 +1,9 @@
 import { BehaviorSubject } from 'rxjs';
+import { Injectable } from '@angular/core';
 
 import { DaffProduct, DaffProductFacadeInterface } from '@daffodil/product';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffProductFacade implements DaffProductFacadeInterface {
 	loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 	/**

--- a/libs/product/testing/src/helpers/mock-product-grid-facade.ts
+++ b/libs/product/testing/src/helpers/mock-product-grid-facade.ts
@@ -1,7 +1,9 @@
 import { BehaviorSubject } from 'rxjs';
+import { Injectable } from '@angular/core';
 
 import { DaffProduct, DaffProductGridFacadeInterface } from '@daffodil/product';
 
+@Injectable({providedIn: 'root'})
 export class MockDaffProductGridFacade implements DaffProductGridFacadeInterface {
 	loading$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 	products$: BehaviorSubject<DaffProduct[]> = new BehaviorSubject([]);

--- a/libs/product/testing/src/helpers/product-testing.module.ts
+++ b/libs/product/testing/src/helpers/product-testing.module.ts
@@ -1,17 +1,19 @@
 import { NgModule } from '@angular/core';
-import { DaffProductFacade, DaffProductGridFacade, DaffConfigurableProductFacade, DaffCompositeProductFacade } from '@daffodil/product';
+import { DaffProductFacade, DaffProductGridFacade, DaffConfigurableProductFacade, DaffCompositeProductFacade, DaffBestSellersFacade } from '@daffodil/product';
 
 import { MockDaffProductFacade } from './mock-product-facade';
 import { MockDaffProductGridFacade } from './mock-product-grid-facade';
 import { MockDaffConfigurableProductFacade } from './mock-configurable-product-facade';
 import { MockDaffCompositeProductFacade } from './mock-composite-product-facade';
+import { MockDaffBestSellersFacade } from './mock-best-sellers.facade';
 
 @NgModule({
 	providers: [
-		{ provide: DaffProductFacade, useClass: MockDaffProductFacade },
-		{ provide: DaffProductGridFacade, useClass: MockDaffProductGridFacade },
-		{ provide: DaffConfigurableProductFacade, useClass: MockDaffConfigurableProductFacade },
-		{ provide: DaffCompositeProductFacade, useClass: MockDaffCompositeProductFacade },
+		{ provide: DaffProductFacade, useExisting: MockDaffProductFacade },
+		{ provide: DaffProductGridFacade, useExisting: MockDaffProductGridFacade },
+		{ provide: DaffConfigurableProductFacade, useExisting: MockDaffConfigurableProductFacade },
+		{ provide: DaffCompositeProductFacade, useExisting: MockDaffCompositeProductFacade },
+		{ provide: DaffBestSellersFacade, useExisting: MockDaffBestSellersFacade },
 	]
 })
 export class DaffProductTestingModule { }

--- a/libs/product/testing/src/index.ts
+++ b/libs/product/testing/src/index.ts
@@ -12,5 +12,6 @@ export { DaffProductTestingModule } from './helpers/product-testing.module';
 export { MockDaffProductGridFacade } from './helpers/mock-product-grid-facade';
 export { MockDaffConfigurableProductFacade } from './helpers/mock-configurable-product-facade';
 export { MockDaffCompositeProductFacade } from './helpers/mock-composite-product-facade';
+export { MockDaffBestSellersFacade } from './helpers/mock-best-sellers.facade';
 
 export * from './factories/magento/public_api';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When a mock facade is injected in a test in the following way:
```ts
facade = TestBed.inject(MockDaffCartFacade)
```
it causes a different instance to be injected into the test that is present in the SUT. It also fails unless you provide the mock facade in the providers.

## What is the new behavior?
When a mock facade is injected into the test in the above way (which is how we should do it after the ng10 upgrade) it works as expected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is in preparation for the ng10 upgrade