### PR TITLE
fix(category): default sort option transformer cannot set read only property '0'

### DIFF
--- a/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.spec.ts
@@ -100,8 +100,18 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 				sort_fields: sort_fields,
 				products: products,
 				total_count: stubCategoryPageConfigurationState.total_products
-			}
-		});
+      }
+    });
+
+    describe('when the sort options are immutable', () => {
+      beforeEach(() => {
+        Object.freeze(sort_fields.options);
+      });
+
+      it('should complete successfully', () => {
+        expect(service.transform(completeCategoryResponse)).toBeTruthy();
+      });
+    });
 
 		describe('when the filter type is select', () => {
 

--- a/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.ts
+++ b/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.ts
@@ -8,6 +8,7 @@ import { MagentoCompleteCategoryResponse } from '../models/complete-category-res
 import { DaffCategoryFromToFilterSeparator } from '../../../models/requests/filter-request';
 import { DaffCategoryFilterType } from '../../../models/category-filter-base';
 import { DaffCategoryRequest } from '../../../models/requests/category-request';
+import { coerceDefaultSortOptionFirst } from './pure/sort-default-option-first';
 
 @Injectable({
   providedIn: 'root'
@@ -22,7 +23,7 @@ export class DaffMagentoCategoryPageConfigTransformerService {
 			total_pages: categoryResponse.page_info.total_pages,
 			total_products: categoryResponse.total_count,
       filters: categoryResponse.aggregates.map(this.transformAggregate.bind(this)),
-			sort_options: this.makeDefaultOptionFirst(categoryResponse.sort_fields).options,
+			sort_options: coerceDefaultSortOptionFirst(categoryResponse.sort_fields).options,
 			product_ids: categoryResponse.products.map(product => product.sku)
     }
   }
@@ -53,16 +54,5 @@ export class DaffMagentoCategoryPageConfigTransformerService {
 
 	private transformRangeValue(value: string): string {
 		return value.replace('_', DaffCategoryFromToFilterSeparator);
-	}
-
-	private makeDefaultOptionFirst(sort_fields: MagentoSortFields): MagentoSortFields {
-		sort_fields.options.forEach((sort, index) => {
-			if(sort_fields.default === sort.value) {
-				const temp = sort_fields.options[0];
-				sort_fields.options[0] = sort;
-				sort_fields.options[index] = temp;
-			}
-		})
-		return sort_fields;
 	}
 }

--- a/libs/category/src/drivers/magento/transformers/pure/sort-default-option-first.ts
+++ b/libs/category/src/drivers/magento/transformers/pure/sort-default-option-first.ts
@@ -1,0 +1,14 @@
+import { MagentoSortFields } from '../../models/sort-fields'
+
+export function coerceDefaultSortOptionFirst(sort_fields: MagentoSortFields): MagentoSortFields {
+  const index = sort_fields.options.findIndex(option => sort_fields.default === option.value)
+
+  return {
+    ...sort_fields,
+    options: [
+      sort_fields.options[index],
+      ...sort_fields.options.slice(0, index),
+      ...sort_fields.options.slice(index + 1)
+    ]
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The category loading fails, I think when the default option is first.


## What is the new behavior?
It succeeds.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information