### PR TITLE
feat(all): change ID type to string and generate IDs with uuid

### DIFF
--- a/apps/demo/src/app/cart/components/add-to-cart-notification/components/add-to-cart-notification/add-to-cart-notification.component.ts
+++ b/apps/demo/src/app/cart/components/add-to-cart-notification/components/add-to-cart-notification/add-to-cart-notification.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
 import { DaffProduct, getDaffProductSelectors } from '@daffodil/product';
+import { DaffCartItem } from '@daffodil/cart';
 
 import * as fromDemoAddToCartNotification from '../../reducers/index';
 import { CloseAddToCartNotification } from '../../actions/add-to-cart-notification.actions';
-import { switchMap } from 'rxjs/operators';
 
 import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
 
@@ -18,12 +19,12 @@ import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
 export class AddToCartNotificationComponent implements OnInit {
   faCheck = faCheck;
   faTimes = faTimes;
-  
+
   open$: Observable<boolean>;
   productQty$: Observable<number>;
   cartItemCount$: Observable<number>;
   loading$: Observable<boolean>;
-  productId$: Observable<string>;
+  productId$: Observable<DaffCartItem['product_id']>;
   product$: Observable<DaffProduct>;
 
   constructor(private store: Store<fromDemoAddToCartNotification.State>) { }

--- a/apps/demo/src/app/cart/components/add-to-cart-notification/reducers/add-to-cart-notification.reducer.ts
+++ b/apps/demo/src/app/cart/components/add-to-cart-notification/reducers/add-to-cart-notification.reducer.ts
@@ -1,3 +1,4 @@
+import { DaffCartItem } from '@daffodil/cart';
 import { DaffCartActionTypes, DaffCartActions, DaffAddToCart } from '@daffodil/cart/state';
 
 import { AddToCartNotificationActionTypes, AddToCartNotificationActions } from '../actions/add-to-cart-notification.actions';
@@ -5,7 +6,7 @@ import { AddToCartNotificationActionTypes, AddToCartNotificationActions } from '
 export interface State {
   open: boolean,
   productQty: number,
-  productId: string,
+  productId: DaffCartItem['product_id'],
   loading: boolean
 }
 

--- a/apps/demo/src/app/cart/components/add-to-cart-notification/reducers/index.ts
+++ b/apps/demo/src/app/cart/components/add-to-cart-notification/reducers/index.ts
@@ -1,5 +1,6 @@
 import { ActionReducerMap, createSelector, createFeatureSelector, MemoizedSelector } from '@ngrx/store';
 
+import { DaffCartItem } from '@daffodil/cart';
 import { getDaffCartSelectors } from '@daffodil/cart/state';
 
 import * as fromDemoAddToCartNotification from './add-to-cart-notification.reducer';
@@ -35,7 +36,7 @@ export const selectProductQty: MemoizedSelector<object, number> = createSelector
   fromDemoAddToCartNotification.getProductQty
 );
 
-export const selectProductId: MemoizedSelector<object, string> = createSelector(
+export const selectProductId: MemoizedSelector<object, DaffCartItem['product_id']> = createSelector(
   addToCartNotificationStateSelector,
   fromDemoAddToCartNotification.getProductId
 )

--- a/apps/demo/src/app/core/sidebar/components/sidebar-list/sidebar-list.component.ts
+++ b/apps/demo/src/app/core/sidebar/components/sidebar-list/sidebar-list.component.ts
@@ -16,7 +16,7 @@ export class SidebarListComponent {
     return this.level + 1;
   }
 
-  getNavigationPath(path: string) {
+  getNavigationPath(path: DaffNavigationTree['path']) {
     return '/' + path;
   }
 }

--- a/apps/demo/src/app/drivers/in-memory/backend/backend.service.spec.ts
+++ b/apps/demo/src/app/drivers/in-memory/backend/backend.service.spec.ts
@@ -77,7 +77,7 @@ describe('Driver | In Memory | InMemoryService', () => {
 
       beforeEach(() => {
         returnedValue = 'returnedValue';
-        spyOn(service.productTestingService, 'get').and.returnValue(returnedValue);;
+        spyOn(service.productTestingService, 'get').and.returnValue(returnedValue);
         reqInfo = {
           collectionName: 'products'
         }
@@ -102,7 +102,7 @@ describe('Driver | In Memory | InMemoryService', () => {
 
       beforeEach(() => {
         returnedValue = 'returnedValue';
-        spyOn(service.navigationTestingService, 'get').and.returnValue(returnedValue);;
+        spyOn(service.navigationTestingService, 'get').and.returnValue(returnedValue);
         reqInfo = {
           collectionName: 'navigation'
         }

--- a/libs/cart/driver/in-memory/src/backend/cart-address/cart-address.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-address/cart-address.service.ts
@@ -18,7 +18,7 @@ export class DaffInMemoryBackendCartAddressService implements DaffInMemoryDataSe
   }
 
   private getCart(reqInfo: RequestInfo): DaffCart {
-    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, Number(reqInfo.id))
+    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id)
   }
 
   private updateAddress(reqInfo: RequestInfo): DaffCart {

--- a/libs/cart/driver/in-memory/src/backend/cart-billing-address/cart-billing-address.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-billing-address/cart-billing-address.service.ts
@@ -26,7 +26,7 @@ export class DaffInMemoryBackendCartBillingAddressService implements DaffInMemor
   }
 
   private getCart(reqInfo: RequestInfo): DaffCart {
-    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, Number(reqInfo.id))
+    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id)
   }
 
   private getBillingAddress(reqInfo): DaffCartAddress {

--- a/libs/cart/driver/in-memory/src/backend/cart-coupon/cart-coupon.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-coupon/cart-coupon.service.ts
@@ -51,7 +51,7 @@ export class DaffInMemoryBackendCartCouponService implements DaffInMemoryDataSer
   }
 
   private getCart(reqInfo: RequestInfo): DaffCart {
-    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, Number(reqInfo.id))
+    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id)
   }
 
   private listCoupons(reqInfo): DaffCartCoupon[] {

--- a/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.spec.ts
@@ -155,7 +155,7 @@ describe('DaffInMemoryBackendCartItemsService', () => {
     });
 
     it('should remove the cart item from the cart', () => {
-      expect(result.body.items.find(({item_id}) => String(itemId) === String(item_id))).toBeFalsy();
+      expect(result.body.items.find(({item_id}) => itemId === item_id)).toBeFalsy();
     });
   });
 });

--- a/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
@@ -81,13 +81,13 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
   private getItem(reqInfo: RequestInfo, itemId: DaffCartItem['item_id']): DaffCartItem {
     const cart = this.getCart(reqInfo);
 
-    return cart.items.find(({item_id}) => String(item_id) === String(itemId))
+    return cart.items.find(({item_id}) => itemId === item_id)
   }
 
   private updateItem(reqInfo: RequestInfo, itemId: DaffCartItem['item_id']): DaffCart {
     const cart = this.getCart(reqInfo);
     const item = reqInfo.utils.getJsonBody(reqInfo.req);
-    const itemIndex = cart.items.findIndex(({item_id}) => String(itemId) === String(item_id))
+    const itemIndex = cart.items.findIndex(({item_id}) => itemId === item_id)
 
     cart.items[itemIndex] = {
       ...cart.items[itemIndex],
@@ -114,7 +114,7 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
 
   private deleteItem(reqInfo: RequestInfo, itemId: DaffCartItem['item_id']): DaffCart {
     const cart = this.getCart(reqInfo);
-    const itemIndex = cart.items.findIndex(({item_id}) => String(itemId) === String(item_id));
+    const itemIndex = cart.items.findIndex(({item_id}) => itemId === item_id);
 
 		cart.items.splice(itemIndex, 1);
 		cart.items = Object.assign([], cart.items);

--- a/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
@@ -63,7 +63,7 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
   }
 
   private getCart(reqInfo: RequestInfo): DaffCart {
-    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, Number(reqInfo.id))
+    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id)
   }
 
   private transformItemInput(itemInput: DaffCartItemInput) {

--- a/libs/cart/driver/in-memory/src/backend/cart-payment-methods/cart-payment-methods.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-payment-methods/cart-payment-methods.service.ts
@@ -19,7 +19,7 @@ export class DaffInMemoryBackendCartPaymentMethodsService implements DaffInMemor
   }
 
   private getCart(reqInfo: RequestInfo): DaffCart {
-    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, Number(reqInfo.id))
+    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id)
   }
 
   private listPaymentMethods(reqInfo): DaffCartPaymentMethod[] {

--- a/libs/cart/driver/in-memory/src/backend/cart-payment/cart-payment.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-payment/cart-payment.service.ts
@@ -33,7 +33,7 @@ export class DaffInMemoryBackendCartPaymentService implements DaffInMemoryDataSe
   }
 
   private getCart(reqInfo: RequestInfo): DaffCart {
-    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, Number(reqInfo.id))
+    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id)
   }
 
   private getPayment(reqInfo): DaffCartPaymentMethod {

--- a/libs/cart/driver/in-memory/src/backend/cart-root.service.integration.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-root.service.integration.spec.ts
@@ -69,7 +69,7 @@ describe('DaffInMemoryBackendCartRootService | Integration', () => {
     mockShippingMethod = cartShippingMethodFactory.create();
     mockShippingInformation = {
       ...cartShippingMethodFactory.create(),
-      address_id: 0
+      address_id: null
     };
     cartId = mockCart.id;
     itemId = mockCartItem.item_id;
@@ -521,7 +521,7 @@ describe('DaffInMemoryBackendCartRootService | Integration', () => {
     beforeEach(done => {
       newShippingInformation = {
         ...cartShippingMethodFactory.create(),
-        address_id: 5
+        address_id: null
       };
 
       httpClient.put<any>(`/api/cart-shipping-information/${cartId}/`, newShippingInformation).subscribe(res => {

--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-address/cart-shipping-address.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-address/cart-shipping-address.service.ts
@@ -26,7 +26,7 @@ export class DaffInMemoryBackendCartShippingAddressService implements DaffInMemo
   }
 
   private getCart(reqInfo: RequestInfo): DaffCart {
-    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, Number(reqInfo.id))
+    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id)
   }
 
   private getShippingAddress(reqInfo): DaffCartAddress {

--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-information/cart-shipping-information.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-information/cart-shipping-information.service.spec.ts
@@ -38,7 +38,7 @@ describe('DaffInMemoryBackendCartShippingInformationService', () => {
     mockCart = cartFactory.create();
     mockCartShippingInformation = {
       ...cartShippingInformationFactory.create(),
-      address_id: 0
+      address_id: null
     };
     mockCart.shipping_information = mockCartShippingInformation;
     collection = [mockCart];
@@ -85,7 +85,7 @@ describe('DaffInMemoryBackendCartShippingInformationService', () => {
     beforeEach(() => {
       newShippingInformation = {
         ...cartShippingInformationFactory.create(),
-        address_id: 5
+        address_id: null
       };
       reqInfoStub.url = cartUrl;
       reqInfoStub.req.body = newShippingInformation;

--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-information/cart-shipping-information.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-information/cart-shipping-information.service.ts
@@ -33,7 +33,7 @@ export class DaffInMemoryBackendCartShippingInformationService implements DaffIn
   }
 
   private getCart(reqInfo: RequestInfo): DaffCart {
-    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, Number(reqInfo.id))
+    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id)
   }
 
   private getShippingInformation(reqInfo): DaffCartShippingInformation {

--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-methods/cart-shipping-methods.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-methods/cart-shipping-methods.service.ts
@@ -19,7 +19,7 @@ export class DaffInMemoryBackendCartShippingMethodsService implements DaffInMemo
   }
 
   private getCart(reqInfo: RequestInfo): DaffCart {
-    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, Number(reqInfo.id))
+    return reqInfo.utils.findById<DaffCart>(reqInfo.collection, reqInfo.id)
   }
 
   private listShippingMethods(reqInfo): DaffCartShippingRate[] {

--- a/libs/cart/driver/in-memory/src/drivers/cart-item/cart-item.service.ts
+++ b/libs/cart/driver/in-memory/src/drivers/cart-item/cart-item.service.ts
@@ -39,7 +39,7 @@ export class DaffInMemoryCartItemService implements DaffCartItemServiceInterface
     return this.http.put<Partial<DaffCart>>(`${this.url}/${cartId}/${itemId}`, item);
   }
 
-  delete(cartId: string, itemId: string): Observable<Partial<DaffCart>> {
+  delete(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<Partial<DaffCart>> {
     return this.http.delete<Partial<DaffCart>>(`${this.url}/${cartId}/${itemId}`);
   }
 }

--- a/libs/cart/driver/in-memory/src/drivers/cart-shipping-information/cart-shipping-information.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/drivers/cart-shipping-information/cart-shipping-information.service.spec.ts
@@ -42,7 +42,7 @@ describe('Driver | In Memory | Cart | CartShippingInformationService', () => {
     mockCart = cartFactory.create();
     mockCartShippingInfo = {
       ...cartShippingRateFactory.create(),
-      address_id: 0
+      address_id: null
     };
     mockCart.shipping_information = mockCartShippingInfo;
     cartId = mockCart.id;

--- a/libs/cart/driver/magento/src/cart-address.service.ts
+++ b/libs/cart/driver/magento/src/cart-address.service.ts
@@ -37,11 +37,11 @@ export class DaffMagentoCartAddressService implements DaffCartAddressServiceInte
     public cartAddressInputTransformer: DaffMagentoCartAddressInputTransformer,
   ) {}
 
-  update(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  update(cartId: DaffCart['id'], address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return address.email ? this.updateAddressWithEmail(cartId, address) : this.updateAddress(cartId, address)
   }
 
-  private updateAddress(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  private updateAddress(cartId: DaffCart['id'], address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoUpdateAddressResponse>({
       mutation: updateAddress(this.extraCartFragments),
       variables: {
@@ -54,7 +54,7 @@ export class DaffMagentoCartAddressService implements DaffCartAddressServiceInte
     )
   }
 
-  private updateAddressWithEmail(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  private updateAddressWithEmail(cartId: DaffCart['id'], address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoUpdateAddressWithEmailResponse>({
       mutation: updateAddressWithEmail(this.extraCartFragments),
       variables: {

--- a/libs/cart/driver/magento/src/cart-billing-address.service.ts
+++ b/libs/cart/driver/magento/src/cart-billing-address.service.ts
@@ -41,7 +41,7 @@ export class DaffMagentoCartBillingAddressService implements DaffCartBillingAddr
     public billingAddressInputTransformer: DaffMagentoBillingAddressInputTransformer
   ) {}
 
-  get(cartId: string): Observable<DaffCartAddress> {
+  get(cartId: DaffCart['id']): Observable<DaffCartAddress> {
     return this.apollo.query<MagentoGetBillingAddressResponse>({
       query: getBillingAddress(this.extraCartFragments),
       variables: {cartId}
@@ -56,11 +56,11 @@ export class DaffMagentoCartBillingAddressService implements DaffCartBillingAddr
     )
   }
 
-  update(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  update(cartId: DaffCart['id'], address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return address.email ? this.updateAddressWithEmail(cartId, address) : this.updateAddress(cartId, address)
   }
 
-  private updateAddress(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  private updateAddress(cartId: DaffCart['id'], address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoUpdateBillingAddressResponse>({
       mutation: updateBillingAddress(this.extraCartFragments),
       variables: {
@@ -73,7 +73,7 @@ export class DaffMagentoCartBillingAddressService implements DaffCartBillingAddr
     )
   }
 
-  private updateAddressWithEmail(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  private updateAddressWithEmail(cartId: DaffCart['id'], address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoUpdateBillingAddressWithEmailResponse>({
       mutation: updateBillingAddressWithEmail(this.extraCartFragments),
       variables: {

--- a/libs/cart/driver/magento/src/cart-item.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart-item.service.spec.ts
@@ -222,7 +222,7 @@ describe('Driver | Magento | Cart | CartItemService', () => {
     });
 
     it('should return the correct value', done => {
-      service.get(cartId, Number(mockDaffCartItem.item_id)).subscribe(result => {
+      service.get(cartId, mockDaffCartItem.item_id).subscribe(result => {
         expect(result).toEqual(jasmine.objectContaining(mockDaffCartItem));
         done();
       });
@@ -293,7 +293,7 @@ describe('Driver | Magento | Cart | CartItemService', () => {
     });
 
     it('should return the correct value', done => {
-      service.update(cartId, Number(mockDaffCartItem.item_id), mockDaffCartItem).subscribe(result => {
+      service.update(cartId, mockDaffCartItem.item_id, mockDaffCartItem).subscribe(result => {
         expect(result.items[0].qty).toEqual(qty);
         done();
       });
@@ -317,9 +317,9 @@ describe('Driver | Magento | Cart | CartItemService', () => {
     });
 
     it('should return the cart without the cart item', done => {
-      service.delete(cartId, Number(mockDaffCartItem.item_id)).subscribe(result => {
+      service.delete(cartId, mockDaffCartItem.item_id).subscribe(result => {
         expect(result.items.find(({item_id}) =>
-          Number(item_id) === Number(mockDaffCartItem.item_id)
+          item_id === mockDaffCartItem.item_id
         )).toBeFalsy();
         done();
       });

--- a/libs/cart/driver/magento/src/cart-item.service.ts
+++ b/libs/cart/driver/magento/src/cart-item.service.ts
@@ -43,7 +43,7 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
     public cartItemUpdateInputTransformer: DaffMagentoCartItemUpdateInputTransformer
   ) {}
 
-  list(cartId: string): Observable<DaffCartItem[]> {
+  list(cartId: DaffCart['id']): Observable<DaffCartItem[]> {
     return this.apollo.query<MagentoListCartItemsResponse>({
       query: listCartItems(this.extraCartFragments),
       variables: {cartId}
@@ -52,13 +52,13 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
     )
   }
 
-  get(cartId: string, itemId: number): Observable<DaffCartItem> {
+  get(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<DaffCartItem> {
     return this.list(cartId).pipe(
       map(items => items.find(item => Number(item.item_id) === itemId))
     )
   }
 
-  add(cartId: string, cartItemInput: DaffCartItemInput): Observable<Partial<DaffCart>> {
+  add(cartId: DaffCart['id'], cartItemInput: DaffCartItemInput): Observable<Partial<DaffCart>> {
 		switch(cartItemInput.type) {
 			case (DaffCartItemInputType.Composite):
 				return this.addBundledProduct(cartId, <DaffCompositeCartItemInput>cartItemInput);
@@ -69,7 +69,7 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
 		}
   }
 
-  update(cartId: string, itemId: number, changes: Partial<DaffCartItem>): Observable<Partial<DaffCart>> {
+  update(cartId: DaffCart['id'], itemId: DaffCartItem['item_id'], changes: Partial<DaffCartItem>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoUpdateCartItemResponse>({
       mutation: updateCartItem(this.extraCartFragments),
       variables: {
@@ -84,7 +84,7 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
     )
   }
 
-  delete(cartId: string, itemId: number): Observable<Partial<DaffCart>> {
+  delete(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoRemoveCartItemResponse>({
       mutation: removeCartItem(this.extraCartFragments),
       variables: {
@@ -96,7 +96,7 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
     )
   }
 
-	private addBundledProduct(cartId: string, cartItemInput: DaffCompositeCartItemInput): Observable<Partial<DaffCart>> {
+	private addBundledProduct(cartId: DaffCart['id'], cartItemInput: DaffCompositeCartItemInput): Observable<Partial<DaffCart>> {
 		const bundleInput = transformCompositeCartItem(cartItemInput);
 		return this.mutationQueue.mutate<MagentoAddBundleCartItemResponse>({
       mutation: addBundleCartItem(this.extraCartFragments),
@@ -110,7 +110,7 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
     )
 	}
 
-	private addConfigurableProduct(cartId: string, cartItemInput: DaffConfigurableCartItemInput): Observable<Partial<DaffCart>> {
+	private addConfigurableProduct(cartId: DaffCart['id'], cartItemInput: DaffConfigurableCartItemInput): Observable<Partial<DaffCart>> {
 		const configurableInput: MagentoConfigurableCartItemInput = transformConfigurableCartItem(cartItemInput);
 		return this.mutationQueue.mutate<MagentoAddConfigurableCartItemResponse>({
       mutation: addConfigurableCartItem(this.extraCartFragments),
@@ -124,7 +124,7 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
     )
 	}
 
-	private addSimpleProduct(cartId: string, cartItemInput: DaffCartItemInput): Observable<Partial<DaffCart>> {
+	private addSimpleProduct(cartId: DaffCart['id'], cartItemInput: DaffCartItemInput): Observable<Partial<DaffCart>> {
 		return this.mutationQueue.mutate<MagentoAddSimpleCartItemResponse>({
       mutation: addSimpleCartItem(this.extraCartFragments),
       variables: {

--- a/libs/cart/driver/magento/src/cart-item.service.ts
+++ b/libs/cart/driver/magento/src/cart-item.service.ts
@@ -54,7 +54,7 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
 
   get(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<DaffCartItem> {
     return this.list(cartId).pipe(
-      map(items => items.find(item => Number(item.item_id) === itemId))
+      map(items => items.find(item => item.item_id === itemId))
     )
   }
 

--- a/libs/cart/driver/magento/src/cart-order.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart-order.service.spec.ts
@@ -65,8 +65,8 @@ describe('Driver | Magento | Cart | CartOrderService', () => {
     describe('when the call to the Magento API is successful', () => {
       it('should return the order and cart ID', done => {
         service.placeOrder(cartId, mockDaffCartPayment).subscribe(result => {
-          expect(String(result.orderId)).toEqual(String(orderNumber));
-          expect(String(result.cartId)).toEqual(String(cartId));
+          expect(result.orderId).toEqual(orderNumber);
+          expect(result.cartId).toEqual(cartId);
           done();
         });
 

--- a/libs/cart/driver/magento/src/cart-payment-methods.service.ts
+++ b/libs/cart/driver/magento/src/cart-payment-methods.service.ts
@@ -4,7 +4,7 @@ import { DocumentNode } from 'graphql';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { DaffCartPaymentMethod } from '@daffodil/cart';
+import { DaffCartPaymentMethod, DaffCart } from '@daffodil/cart';
 import { DaffCartPaymentMethodsServiceInterface } from '@daffodil/cart/driver';
 
 import { listPaymentMethods } from './queries/public_api';
@@ -25,7 +25,7 @@ export class DaffMagentoCartPaymentMethodsService implements DaffCartPaymentMeth
     public paymentTransformer: DaffMagentoCartPaymentTransformer
   ) {}
 
-  list(cartId: string): Observable<DaffCartPaymentMethod[]> {
+  list(cartId: DaffCart['id']): Observable<DaffCartPaymentMethod[]> {
     return this.apollo.query<MagentoListPaymentMethodsResponse>({
       query: listPaymentMethods(this.extraCartFragments),
       variables: {cartId}

--- a/libs/cart/driver/magento/src/cart-payment.service.ts
+++ b/libs/cart/driver/magento/src/cart-payment.service.ts
@@ -45,7 +45,7 @@ export class DaffMagentoCartPaymentService implements DaffCartPaymentServiceInte
     @Inject(DAFF_CART_MAGENTO_EXTRA_CART_FRAGMENTS) public extraCartFragments: DocumentNode[],
   ) {}
 
-  get(cartId: string): Observable<DaffCartPaymentMethod> {
+  get(cartId: DaffCart['id']): Observable<DaffCartPaymentMethod> {
     return this.apollo.query<MagentoGetSelectedPaymentMethodResponse>({
       query: getSelectedPaymentMethod(this.extraCartFragments),
       variables: {cartId}
@@ -54,7 +54,7 @@ export class DaffMagentoCartPaymentService implements DaffCartPaymentServiceInte
     );
   }
 
-  update(cartId: string, payment: Partial<DaffCartPaymentMethod>): Observable<Partial<DaffCart>> {
+  update(cartId: DaffCart['id'], payment: Partial<DaffCartPaymentMethod>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoSetSelectedPaymentMethodResponse>({
       mutation: setSelectedPaymentMethod(this.extraCartFragments),
       variables: {
@@ -66,13 +66,13 @@ export class DaffMagentoCartPaymentService implements DaffCartPaymentServiceInte
     )
   }
 
-  updateWithBilling(cartId: string, payment: Partial<DaffCartPaymentMethod>, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  updateWithBilling(cartId: DaffCart['id'], payment: Partial<DaffCartPaymentMethod>, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return address.email
       ? this.updateWithBillingAddressAndEmail(cartId, payment, address)
       : this.updateWithBillingAddress(cartId, payment, address)
   }
 
-  remove(cartId: string): Observable<void> {
+  remove(cartId: DaffCart['id']): Observable<void> {
     return this.mutationQueue.mutate({
       mutation: setSelectedPaymentMethod(this.extraCartFragments),
       variables: {
@@ -84,7 +84,7 @@ export class DaffMagentoCartPaymentService implements DaffCartPaymentServiceInte
     )
   }
 
-  private updateWithBillingAddress(cartId: string, payment: Partial<DaffCartPaymentMethod>, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  private updateWithBillingAddress(cartId: DaffCart['id'], payment: Partial<DaffCartPaymentMethod>, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoSetSelectedPaymentMethodWithBillingResponse>({
       mutation: setSelectedPaymentMethodWithBilling(this.extraCartFragments),
       variables: {
@@ -98,7 +98,7 @@ export class DaffMagentoCartPaymentService implements DaffCartPaymentServiceInte
     )
   }
 
-  private updateWithBillingAddressAndEmail(cartId: string, payment: Partial<DaffCartPaymentMethod>, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  private updateWithBillingAddressAndEmail(cartId: DaffCart['id'], payment: Partial<DaffCartPaymentMethod>, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoSetSelectedPaymentMethodWithBillingAndEmailResponse>({
       mutation: setSelectedPaymentMethodWithBillingAndEmail(this.extraCartFragments),
       variables: {

--- a/libs/cart/driver/magento/src/cart-shipping-address.service.ts
+++ b/libs/cart/driver/magento/src/cart-shipping-address.service.ts
@@ -41,7 +41,7 @@ export class DaffMagentoCartShippingAddressService implements DaffCartShippingAd
     public shippingAddressInputTransformer: DaffMagentoShippingAddressInputTransformer
   ) {}
 
-  get(cartId: string): Observable<DaffCartAddress> {
+  get(cartId: DaffCart['id']): Observable<DaffCartAddress> {
     return this.apollo.query<MagentoGetShippingAddressResponse>({
       query: getShippingAddress(this.extraCartFragments),
       variables: {cartId}
@@ -56,11 +56,11 @@ export class DaffMagentoCartShippingAddressService implements DaffCartShippingAd
     )
   }
 
-  update(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  update(cartId: DaffCart['id'], address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return address.email ? this.updateAddressWithEmail(cartId, address) : this.updateAddress(cartId, address)
   }
 
-  private updateAddress(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  private updateAddress(cartId: DaffCart['id'], address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoUpdateShippingAddressResponse>({
       mutation: updateShippingAddress(this.extraCartFragments),
       variables: {
@@ -73,7 +73,7 @@ export class DaffMagentoCartShippingAddressService implements DaffCartShippingAd
     )
   }
 
-  private updateAddressWithEmail(cartId: string, address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
+  private updateAddressWithEmail(cartId: DaffCart['id'], address: Partial<DaffCartAddress>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoUpdateShippingAddressWithEmailResponse>({
       mutation: updateShippingAddressWithEmail(this.extraCartFragments),
       variables: {

--- a/libs/cart/driver/magento/src/cart-shipping-information.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart-shipping-information.service.spec.ts
@@ -96,7 +96,7 @@ describe('Driver | Magento | Cart | CartShippingInformationService', () => {
 		}
     mockDaffCartShippingInformation = {
       ...daffCartShippingRateFactory.create(),
-      address_id: 0
+      address_id: null
     };
     mockMagentoShippingAddress = magentoShippingAddressFactory.create();
 

--- a/libs/cart/driver/magento/src/cart-shipping-information.service.ts
+++ b/libs/cart/driver/magento/src/cart-shipping-information.service.ts
@@ -36,7 +36,7 @@ export class DaffMagentoCartShippingInformationService implements DaffCartShippi
     public shippingMethodInputTransformer: DaffMagentoShippingMethodInputTransformer,
   ) {}
 
-  get(cartId: string): Observable<DaffCartShippingRate> {
+  get(cartId: DaffCart['id']): Observable<DaffCartShippingRate> {
     return this.apollo.query<MagentoGetSelectedShippingMethodResponse>({
       query: getSelectedShippingMethod(this.extraCartFragments),
       variables: {cartId}
@@ -48,7 +48,7 @@ export class DaffMagentoCartShippingInformationService implements DaffCartShippi
     );
   }
 
-  update(cartId: string, shippingInfo: Partial<DaffCartShippingRate>): Observable<Partial<DaffCart>> {
+  update(cartId: DaffCart['id'], shippingInfo: Partial<DaffCartShippingRate>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoSetSelectedShippingMethodResponse>({
       mutation: setSelectedShippingMethod(this.extraCartFragments),
       variables: {
@@ -76,7 +76,7 @@ export class DaffMagentoCartShippingInformationService implements DaffCartShippi
     )
   }
 
-  delete(cartId: string, id?: string | number): Observable<Partial<DaffCart>> {
+  delete(cartId: DaffCart['id'], id?: DaffCartShippingRate['id']): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoSetSelectedShippingMethodResponse>({
       mutation: setSelectedShippingMethod(this.extraCartFragments),
       variables: {

--- a/libs/cart/driver/magento/src/cart-shipping-methods.service.ts
+++ b/libs/cart/driver/magento/src/cart-shipping-methods.service.ts
@@ -4,7 +4,7 @@ import { DocumentNode } from 'graphql';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { DaffCartShippingRate } from '@daffodil/cart';
+import { DaffCartShippingRate, DaffCart } from '@daffodil/cart';
 import { DaffCartShippingMethodsServiceInterface } from '@daffodil/cart/driver';
 
 import { listShippingMethods } from './queries/public_api';
@@ -25,7 +25,7 @@ export class DaffMagentoCartShippingMethodsService implements DaffCartShippingMe
     public shippingRateTransformer: DaffMagentoCartShippingRateTransformer
   ) {}
 
-  list(cartId: string): Observable<DaffCartShippingRate[]> {
+  list(cartId: DaffCart['id']): Observable<DaffCartShippingRate[]> {
     return this.apollo.query<MagentoListShippingMethodsResponse>({
       query: listShippingMethods(this.extraCartFragments),
       variables: {cartId}

--- a/libs/cart/driver/magento/src/cart.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart.service.spec.ts
@@ -77,12 +77,12 @@ describe('Driver | Magento | Cart | CartService', () => {
     mockMagentoCartItem = magentoCartItemFactory.create();
     mockDaffCartItem = daffCartItemFactory.create();
 
-    mockMagentoCartItem.id = String(mockDaffCartItem.item_id);
+    mockMagentoCartItem.id = mockDaffCartItem.item_id;
     cartId = mockDaffCart.id;
     mockMagentoCart.items = [mockMagentoCartItem];
     mockDaffCart.items = [mockDaffCartItem];
     mockCreateCartResponse = {
-      createEmptyCart: String(cartId)
+      createEmptyCart: cartId
     };
     mockCartResponse = {
 			__typename: 'Cart',
@@ -156,7 +156,7 @@ describe('Driver | Magento | Cart | CartService', () => {
   describe('create | creates the cart', () => {
     it('should return an observable with the cart ID', done => {
       service.create().subscribe(result => {
-        expect(String(result.id)).toEqual(String(cartId));
+        expect(result.id).toEqual(cartId);
         done();
       });
 

--- a/libs/cart/driver/magento/src/cart.service.ts
+++ b/libs/cart/driver/magento/src/cart.service.ts
@@ -35,7 +35,7 @@ export class DaffMagentoCartService implements DaffCartServiceInterface<DaffCart
     @Inject(DAFF_CART_MAGENTO_EXTRA_CART_FRAGMENTS) public extraCartFragments: DocumentNode[],
   ) {}
 
-  get(cartId: string): Observable<DaffCart> {
+  get(cartId: DaffCart['id']): Observable<DaffCart> {
     return this.apollo.query<MagentoGetCartResponse>({
       query: getCart(this.extraCartFragments),
       variables: {cartId}
@@ -45,7 +45,7 @@ export class DaffMagentoCartService implements DaffCartServiceInterface<DaffCart
     );
   }
 
-  create(): Observable<{id: string}> {
+  create(): Observable<{id: DaffCart['id']}> {
     return this.mutationQueue.mutate<MagentoCreateCartResponse>({mutation: createCart}).pipe(
       map(result => ({id: result.data.createEmptyCart}))
     )
@@ -55,7 +55,7 @@ export class DaffMagentoCartService implements DaffCartServiceInterface<DaffCart
     throw new Error('Method is deprecated. Use DaffCartItemServiceInterface#add instead.');
   }
 
-  clear(cartId: string): Observable<Partial<DaffCart>> {
+  clear(cartId: DaffCart['id']): Observable<Partial<DaffCart>> {
     return this.cartItemDriver.list(cartId).pipe(
       switchMap(items =>
         forkJoin(...items.map(item =>

--- a/libs/cart/driver/magento/src/models/responses/cart.ts
+++ b/libs/cart/driver/magento/src/models/responses/cart.ts
@@ -10,7 +10,7 @@ import { MagentoShippingAddress } from './shipping-address';
  * An object for defining what the cart service requests and retrieves from a magento backend.
  */
 export interface MagentoCart {
-  id: number;
+  id: string;
   email: string;
   billing_address: MagentoCartAddress;
   shipping_addresses: MagentoShippingAddress[];

--- a/libs/cart/driver/magento/src/queries/responses/create-cart.ts
+++ b/libs/cart/driver/magento/src/queries/responses/create-cart.ts
@@ -1,3 +1,5 @@
+import { MagentoCart } from '../../models/public_api';
+
 export interface MagentoCreateCartResponse {
-  createEmptyCart: string;
+  createEmptyCart: MagentoCart['id'];
 }

--- a/libs/cart/driver/magento/src/transforms/inputs/cart-address.service.ts
+++ b/libs/cart/driver/magento/src/transforms/inputs/cart-address.service.ts
@@ -15,7 +15,7 @@ export class DaffMagentoCartAddressInputTransformer {
       firstname: cartAddress.firstname,
       lastname: cartAddress.lastname,
       postcode: cartAddress.postcode,
-      region: String(cartAddress.region),
+      region: cartAddress.region,
       save_in_address_book: false,
       street: [cartAddress.street],
       telephone: cartAddress.telephone,

--- a/libs/cart/driver/magento/src/transforms/inputs/cart-item-input-transformers.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/inputs/cart-item-input-transformers.spec.ts
@@ -36,7 +36,7 @@ describe('Driver | Magento | Cart | Transformers | MagentoCartItemInput', () => 
     });
 
     it('should return an object with the correct values', () => {
-      expect(transformedCartItem.sku).toEqual(String(mockDaffCartItemInput.productId));
+      expect(transformedCartItem.sku).toEqual(mockDaffCartItemInput.productId);
       expect(transformedCartItem.quantity).toEqual(mockDaffCartItemInput.qty);
     });
   });
@@ -59,7 +59,7 @@ describe('Driver | Magento | Cart | Transformers | MagentoCartItemInput', () => 
 
     it('should return an object with the correct values', () => {
 			transformedCartItem = transformCompositeCartItem(mockDaffCompositeCartItemInput);
-      expect(transformedCartItem.input.sku).toEqual(String(mockDaffCompositeCartItemInput.productId));
+      expect(transformedCartItem.input.sku).toEqual(mockDaffCompositeCartItemInput.productId);
       expect(transformedCartItem.input.quantity).toEqual(mockDaffCompositeCartItemInput.qty);
       expect(transformedCartItem.options[0].id).toEqual(Number(mockDaffCompositeCartItemInput.options[0].code));
       expect(transformedCartItem.options[0].quantity).toEqual(mockDaffCompositeCartItemInput.options[0].quantity);
@@ -87,9 +87,9 @@ describe('Driver | Magento | Cart | Transformers | MagentoCartItemInput', () => 
 
     it('should return an object with the correct values', () => {
 			transformedCartItem = transformConfigurableCartItem(mockDaffConfigurableCartItemInput);
-      expect(transformedCartItem.parentSku).toEqual(String(mockDaffConfigurableCartItemInput.productId));
+      expect(transformedCartItem.parentSku).toEqual(mockDaffConfigurableCartItemInput.productId);
 			expect(transformedCartItem.data.quantity).toEqual(mockDaffConfigurableCartItemInput.qty);
-			expect(transformedCartItem.data.sku).toEqual(String(mockDaffConfigurableCartItemInput.variantId));
+			expect(transformedCartItem.data.sku).toEqual(mockDaffConfigurableCartItemInput.variantId);
 		});
   });
 });

--- a/libs/cart/driver/magento/src/transforms/inputs/cart-item-input-transformers.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/inputs/cart-item-input-transformers.spec.ts
@@ -36,7 +36,7 @@ describe('Driver | Magento | Cart | Transformers | MagentoCartItemInput', () => 
     });
 
     it('should return an object with the correct values', () => {
-      expect(transformedCartItem.sku).toEqual(mockDaffCartItemInput.productId);
+      expect(transformedCartItem.sku).toEqual(String(mockDaffCartItemInput.productId));
       expect(transformedCartItem.quantity).toEqual(mockDaffCartItemInput.qty);
     });
   });
@@ -59,7 +59,7 @@ describe('Driver | Magento | Cart | Transformers | MagentoCartItemInput', () => 
 
     it('should return an object with the correct values', () => {
 			transformedCartItem = transformCompositeCartItem(mockDaffCompositeCartItemInput);
-      expect(transformedCartItem.input.sku).toEqual(mockDaffCompositeCartItemInput.productId);
+      expect(transformedCartItem.input.sku).toEqual(String(mockDaffCompositeCartItemInput.productId));
       expect(transformedCartItem.input.quantity).toEqual(mockDaffCompositeCartItemInput.qty);
       expect(transformedCartItem.options[0].id).toEqual(Number(mockDaffCompositeCartItemInput.options[0].code));
       expect(transformedCartItem.options[0].quantity).toEqual(mockDaffCompositeCartItemInput.options[0].quantity);
@@ -87,7 +87,7 @@ describe('Driver | Magento | Cart | Transformers | MagentoCartItemInput', () => 
 
     it('should return an object with the correct values', () => {
 			transformedCartItem = transformConfigurableCartItem(mockDaffConfigurableCartItemInput);
-      expect(transformedCartItem.parentSku).toEqual(mockDaffConfigurableCartItemInput.productId);
+      expect(transformedCartItem.parentSku).toEqual(String(mockDaffConfigurableCartItemInput.productId));
 			expect(transformedCartItem.data.quantity).toEqual(mockDaffConfigurableCartItemInput.qty);
 			expect(transformedCartItem.data.sku).toEqual(String(mockDaffConfigurableCartItemInput.variantId));
 		});

--- a/libs/cart/driver/magento/src/transforms/inputs/cart-item-input-transformers.ts
+++ b/libs/cart/driver/magento/src/transforms/inputs/cart-item-input-transformers.ts
@@ -12,13 +12,13 @@ export function transformCompositeCartItem(item: DaffCompositeCartItemInput): Ma
 export function transformSimpleCartItem(item: DaffCartItemInput): MagentoCartItemInput {
 	return {
 		quantity: item.qty,
-		sku: item.productId
+		sku: String(item.productId)
 	}
 }
 
 export function transformConfigurableCartItem(item: DaffConfigurableCartItemInput): MagentoConfigurableCartItemInput {
 	return {
-		parentSku: item.productId,
+		parentSku: String(item.productId),
 		data: {
 			quantity: item.qty,
 			sku: String(item.variantId)

--- a/libs/cart/driver/magento/src/transforms/inputs/cart-item-input-transformers.ts
+++ b/libs/cart/driver/magento/src/transforms/inputs/cart-item-input-transformers.ts
@@ -12,16 +12,16 @@ export function transformCompositeCartItem(item: DaffCompositeCartItemInput): Ma
 export function transformSimpleCartItem(item: DaffCartItemInput): MagentoCartItemInput {
 	return {
 		quantity: item.qty,
-		sku: String(item.productId)
+		sku: item.productId
 	}
 }
 
 export function transformConfigurableCartItem(item: DaffConfigurableCartItemInput): MagentoConfigurableCartItemInput {
 	return {
-		parentSku: String(item.productId),
+		parentSku: item.productId,
 		data: {
 			quantity: item.qty,
-			sku: String(item.variantId)
+			sku: item.variantId
 		},
 	}
 }

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-coupon-response.service.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-coupon-response.service.spec.ts
@@ -77,7 +77,7 @@ describe('Driver | Magento | Cart | Transformer | CartCouponResponse', () => {
       });
 
       it('should return an object with the correct values', () => {
-        expect(String(transformedCart.id)).toEqual(String(id));
+        expect(transformedCart.id).toEqual(id);
         expect(transformedCart.subtotal).toEqual(subtotal);
         expect(transformedCart.grand_total).toEqual(grand_total);
       });

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-item/bundle-cart-item-transformer.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-item/bundle-cart-item-transformer.spec.ts
@@ -14,7 +14,7 @@ describe('transformMagentoBundleCartItem', () => {
 	});
 
 	it('should return the expected composite product', () => {
-		expect(transformedCartItem.options[0].option_id).toEqual(stubMagentoBundleCartItem.bundle_options[0].values[0].id);
+		expect(transformedCartItem.options[0].option_id).toEqual(String(stubMagentoBundleCartItem.bundle_options[0].values[0].id));
 		expect(transformedCartItem.options[0].option_label).toEqual(stubMagentoBundleCartItem.bundle_options[0].label);
 		expect(transformedCartItem.options[0].value_label).toEqual(stubMagentoBundleCartItem.bundle_options[0].values[0].label);
 	});

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-item/bundle-cart-item-transformer.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-item/bundle-cart-item-transformer.ts
@@ -17,7 +17,7 @@ export function transformMagentoBundleCartItem(bundleCartItem: MagentoBundleCart
 
 function transformBundleCartItemOption(option: MagentoBundleCartItem['bundle_options'][0]): DaffCompositeCartItemOption {
 	return {
-		option_id: option.values[0].id,
+		option_id: String(option.values[0].id),
 		option_label: option.label,
 		value_label: option.values[0].label
 	}

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-item/simple-cart-item-transformer.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-item/simple-cart-item-transformer.ts
@@ -29,6 +29,6 @@ export function transformMagentoSimpleCartItem(cartItem: MagentoCartItem): DaffC
 		in_stock: cartItem.product.stock_status === MagentoProductStockStatusEnum.InStock,
 
 		// TODO: implement
-		parent_item_id: 0
+		parent_item_id: null
 	} : null
 }

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-shipping-information.service.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-shipping-information.service.spec.ts
@@ -39,7 +39,7 @@ describe('Driver | Magento | Cart | Transformer | MagentoShippingInformation', (
 
     mockDaffShippingInformation = {
       ...daffCartShippingInformationFactory.create(),
-      address_id: 0
+      address_id: null
     };
     mockMagentoShippingMethod = magentoCartShippingMethodFactory.create();
 

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-shipping-information.service.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-shipping-information.service.ts
@@ -21,7 +21,7 @@ export class DaffMagentoCartShippingInformationTransformer {
     return shippingMethod ? {
       ...this.shippingRateTransformer.transform(shippingMethod),
       // TODO: implement
-      address_id: 0
+      address_id: null
     } : null
   }
 }

--- a/libs/cart/driver/magento/src/transforms/outputs/cart.service.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart.service.spec.ts
@@ -144,7 +144,7 @@ describe('Driver | Magento | Cart | Transformer | MagentoCart', () => {
       });
 
       it('should return an object with the correct values', () => {
-        expect(String(transformedCart.id)).toEqual(String(id));
+        expect(transformedCart.id).toEqual(id);
         expect(transformedCart.subtotal).toEqual(subtotal);
         expect(transformedCart.grand_total).toEqual(grand_total);
       });

--- a/libs/cart/driver/magento/testing/src/factories/cart-item/bundle-cart-item.factory.ts
+++ b/libs/cart/driver/magento/testing/src/factories/cart-item/bundle-cart-item.factory.ts
@@ -12,13 +12,13 @@ export class MockMagentoBundleCartItem extends MockMagentoCartItem implements Ma
   __typename = MagentoCartItemTypeEnum.Bundle;
   bundle_options = [
 		{
-			id: faker.random.number({min: 1, max: 1000}),
+			id: faker.random.uuid(),
 			type: 'radio',
 			label: faker.random.word(),
 			price: faker.random.number({min: 1, max: 99}),
 			quantity: 1,
 			values: [{
-				id: faker.random.number({min:1, max: 1000}),
+				id: faker.random.uuid(),
 				label: faker.random.word(),
 				price: faker.random.number({min: 1, max: 99}),
 				quantity: 1

--- a/libs/cart/driver/magento/testing/src/factories/cart-item/cart-item.factory.ts
+++ b/libs/cart/driver/magento/testing/src/factories/cart-item/cart-item.factory.ts
@@ -13,7 +13,7 @@ import { MagentoMoneyFactory } from '@daffodil/driver/magento/testing';
 
 export class MockMagentoCartItem implements MagentoCartItem {
 	__typename = MagentoCartItemTypeEnum.Simple;
-  id = faker.random.number({min: 1, max: 1000});
+  id = faker.random.uuid();
   prices = {
 		__typename: 'CartItemPrices',
     price: this.money(),

--- a/libs/cart/driver/magento/testing/src/factories/cart.factory.ts
+++ b/libs/cart/driver/magento/testing/src/factories/cart.factory.ts
@@ -8,7 +8,7 @@ import { MagentoMoneyFactory } from '@daffodil/driver/magento/testing';
 
 export class MockMagentoCart implements MagentoCart {
 	__typename = 'Cart';
-  id = faker.random.number({min: 1, max: 1000});
+  id = faker.random.uuid();
   prices = {
 		__typename: 'CartPrices',
     subtotal_excluding_tax: this.money(),

--- a/libs/cart/driver/testing/src/drivers/cart-item/cart-item.service.ts
+++ b/libs/cart/driver/testing/src/drivers/cart-item/cart-item.service.ts
@@ -37,7 +37,7 @@ export class DaffTestingCartItemService implements DaffCartItemServiceInterface 
     return of(this.cartFactory.create());
   }
 
-  delete(cartId: string, itemId: string): Observable<Partial<DaffCart>> {
+  delete(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<Partial<DaffCart>> {
     return of(this.cartFactory.create());
   }
 }

--- a/libs/cart/driver/testing/src/drivers/cart-order/cart-order.service.spec.ts
+++ b/libs/cart/driver/testing/src/drivers/cart-order/cart-order.service.spec.ts
@@ -52,9 +52,9 @@ describe('Driver | Testing | Cart | CartOrderService', () => {
   describe('placeOrder | placing an order and getting an order result', () => {
     it('should return the order ID and not throw an error', () => {
       const expected = cold('(a|)', {a: jasmine.objectContaining({
-        id: jasmine.any(Number),
-        orderId: jasmine.any(Number),
-        cartId: jasmine.any(Number),
+        id: jasmine.truthy(),
+        orderId: jasmine.truthy(),
+        cartId: jasmine.truthy(),
       })});
       expect(service.placeOrder(cartId, mockCartPayment)).toBeObservable(expected);
     });

--- a/libs/cart/driver/testing/src/drivers/cart-order/cart-order.service.ts
+++ b/libs/cart/driver/testing/src/drivers/cart-order/cart-order.service.ts
@@ -13,8 +13,8 @@ import {
 export class DaffTestingCartOrderService implements DaffCartOrderServiceInterface {
   placeOrder(cartId: DaffCart['id'], payment?: DaffCartPaymentMethod): Observable<DaffCartOrderResult> {
     return of({
-      id: faker.random.number(999999),
-      orderId: faker.random.number(999999),
+      id: faker.random.uuid(),
+      orderId: faker.random.uuid(),
       cartId,
     });
   }

--- a/libs/cart/driver/testing/src/drivers/cart-shipping-information/cart-shipping-information.service.spec.ts
+++ b/libs/cart/driver/testing/src/drivers/cart-shipping-information/cart-shipping-information.service.spec.ts
@@ -37,7 +37,7 @@ describe('Driver | Testing | Cart | CartShippingInformationService', () => {
     mockCart = cartFactory.create();
     mockCartShippingInfo = {
       ...cartShippingRateFactory.create(),
-      address_id: 0
+      address_id: null
     };
     mockCart.shipping_information = mockCartShippingInfo;
     cartId = mockCart.id;

--- a/libs/cart/driver/testing/src/drivers/cart/cart.service.spec.ts
+++ b/libs/cart/driver/testing/src/drivers/cart/cart.service.spec.ts
@@ -42,7 +42,7 @@ describe('Driver | Testing | Cart | CartService', () => {
   describe('create | creating a cart', () => {
     it('should return a cart ID and not throw an error', () => {
       const expected = cold('(a|)', {a: jasmine.objectContaining({
-        id: jasmine.any(Number)
+        id: jasmine.truthy()
       })});
       expect(service.create()).toBeObservable(expected);
     });

--- a/libs/cart/driver/testing/src/drivers/cart/cart.service.ts
+++ b/libs/cart/driver/testing/src/drivers/cart/cart.service.ts
@@ -14,7 +14,7 @@ export class DaffTestingCartService implements DaffCartServiceInterface {
     private cartFactory: DaffCartFactory
   ) {}
 
-  get(id: number | string): Observable<DaffCart> {
+  get(id: DaffCart['id']): Observable<DaffCart> {
     return of(this.cartFactory.create());
   }
 
@@ -22,7 +22,7 @@ export class DaffTestingCartService implements DaffCartServiceInterface {
     return of(this.cartFactory.create());
   }
 
-  clear(id: number | string): Observable<DaffCart> {
+  clear(id: DaffCart['id']): Observable<DaffCart> {
     return of(this.cartFactory.create());
   }
 

--- a/libs/cart/src/models/cart-coupon.ts
+++ b/libs/cart/src/models/cart-coupon.ts
@@ -1,5 +1,7 @@
+import { ID } from '@daffodil/core';
+
 export interface DaffCartCoupon {
-  coupon_id?: string | number;
+  coupon_id?: ID;
   code: string;
   description?: string;
 }

--- a/libs/cart/src/models/cart-item-input.ts
+++ b/libs/cart/src/models/cart-item-input.ts
@@ -1,4 +1,5 @@
 import { DaffProduct } from '@daffodil/product';
+import { ID } from '@daffodil/core';
 
 export enum DaffCartItemInputType {
 	Simple = 'simple',
@@ -29,5 +30,5 @@ export interface DaffCompositeCartItemInputOption {
 
 export interface DaffConfigurableCartItemInput extends DaffCartItemInput {
 	type: DaffCartItemInputType.Configurable;
-	variantId: string | number;
+	variantId: ID;
 }

--- a/libs/cart/src/models/cart-item.ts
+++ b/libs/cart/src/models/cart-item.ts
@@ -2,14 +2,16 @@ import {
   DaffProductImage,
   DaffProduct
 } from '@daffodil/product';
+import { ID } from '@daffodil/core';
+
 import { DaffCartItemInputType } from './cart-item-input';
 
 export interface DaffCartItem {
-	item_id: number | string;
+	item_id: ID;
 	type: DaffCartItemInputType;
   image?: DaffProductImage;
   product_id: DaffProduct['id'];
-  parent_item_id: number;
+  parent_item_id: ID;
   sku: string;
   name: string;
   qty: number;

--- a/libs/cart/src/models/cart-order-result.ts
+++ b/libs/cart/src/models/cart-order-result.ts
@@ -1,12 +1,14 @@
+import { ID } from '@daffodil/core';
+
 /**
  * The result of placing an order for a cart.
  * Stores a reference to a cart and order object.
  */
 export interface DaffCartOrderResult {
-  cartId: string | number;
-  orderId: string | number;
+  cartId: ID;
+  orderId: ID;
   /**
    * @deprecated Use DaffCartOrderResult#orderId instead.
    */
-  id?: string | number;
+  id?: ID;
 }

--- a/libs/cart/src/models/cart-shipping-info.ts
+++ b/libs/cart/src/models/cart-shipping-info.ts
@@ -1,5 +1,7 @@
+import { ID } from '@daffodil/core';
+
 import { DaffCartShippingRate } from './cart-shipping-rate';
 
 export interface DaffCartShippingInformation extends DaffCartShippingRate {
-	address_id: string | number;
+	address_id: ID;
 }

--- a/libs/cart/src/models/cart-shipping-rate.ts
+++ b/libs/cart/src/models/cart-shipping-rate.ts
@@ -1,5 +1,7 @@
+import { ID } from '@daffodil/core';
+
 export interface DaffCartShippingRate {
-  id: string | number;
+  id: ID;
   carrier: string;
   carrier_title: string;
   method_code: string;

--- a/libs/cart/src/models/cart.ts
+++ b/libs/cart/src/models/cart.ts
@@ -1,3 +1,5 @@
+import { ID } from '@daffodil/core';
+
 import { DaffCartItem } from './cart-item';
 import { DaffCartAddress } from './cart-address';
 import { DaffCartPaymentMethod } from './cart-payment';
@@ -7,7 +9,7 @@ import { DaffCartTotal } from './cart-total';
 import { DaffCartShippingRate } from './cart-shipping-rate';
 
 export interface DaffCart {
-	id: number | string;
+	id: ID;
 	/**
 	 * @deprecated use totals instead
 	 */

--- a/libs/cart/state/src/actions/cart.actions.ts
+++ b/libs/cart/state/src/actions/cart.actions.ts
@@ -2,6 +2,7 @@ import { Action } from '@ngrx/store';
 
 import { DaffStateError } from '@daffodil/core/state';
 import { DaffCart } from '@daffodil/cart';
+import { DaffProduct } from '@daffodil/product';
 
 export enum DaffCartActionTypes {
   CartStorageFailureAction = '[DaffCart] Cart Storage Failure Action',
@@ -64,7 +65,7 @@ export class DaffCartCreateFailure implements Action {
 export class DaffAddToCart implements Action {
   readonly type = DaffCartActionTypes.AddToCartAction;
 
-  constructor(public payload: {productId: string, qty: number}) {}
+  constructor(public payload: {productId: DaffProduct['id'], qty: number}) {}
 }
 
 export class DaffAddToCartSuccess implements Action {

--- a/libs/cart/state/src/effects/cart-address.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-address.effects.spec.ts
@@ -63,7 +63,7 @@ describe('Daffodil | Cart | CartAddressEffects', () => {
 
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
     driverUpdateSpy = spyOn(daffAddressDriver, 'update');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {

--- a/libs/cart/state/src/effects/cart-billing-address.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-billing-address.effects.spec.ts
@@ -61,7 +61,7 @@ describe('Daffodil | Cart | CartBillingAddressEffects', () => {
     driverGetSpy = spyOn(daffBillingAddressDriver, 'get');
     driverUpdateSpy = spyOn(daffBillingAddressDriver, 'update');
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {

--- a/libs/cart/state/src/effects/cart-coupon.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-coupon.effects.spec.ts
@@ -69,7 +69,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
     driverRemoveSpy = spyOn(daffDriver, 'remove');
     driverRemoveAllSpy = spyOn(daffDriver, 'removeAll');
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {

--- a/libs/cart/state/src/effects/cart-item.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-item.effects.spec.ts
@@ -82,7 +82,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
     driverUpdateSpy = spyOn(daffCartItemDriver, 'update');
     driverDeleteSpy = spyOn(daffCartItemDriver, 'delete');
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {

--- a/libs/cart/state/src/effects/cart-order.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-order.effects.spec.ts
@@ -66,7 +66,7 @@ describe('Cart | Effect | CartOrderEffects', () => {
 
     driverPlaceOrderSpy = spyOn(cartOrderDriver, 'placeOrder');
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {

--- a/libs/cart/state/src/effects/cart-payment-methods.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-payment-methods.effects.spec.ts
@@ -59,7 +59,7 @@ describe('Daffodil | Cart | DaffCartPaymentMethodsEffects', () => {
 
     driverListSpy = spyOn(paymentMethodsDriver, 'list');
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {

--- a/libs/cart/state/src/effects/cart-payment.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-payment.effects.spec.ts
@@ -84,7 +84,7 @@ describe('Daffodil | Cart | CartPaymentEffects', () => {
     driverUpdateWithBillingSpy = spyOn(daffPaymentDriver, 'updateWithBilling');
     driverRemoveSpy = spyOn(daffPaymentDriver, 'remove');
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {

--- a/libs/cart/state/src/effects/cart-shipping-address.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-shipping-address.effects.spec.ts
@@ -68,7 +68,7 @@ describe('Daffodil | Cart | CartShippingAddressEffects', () => {
     driverGetSpy = spyOn(daffShippingAddressDriver, 'get');
     driverUpdateSpy = spyOn(daffShippingAddressDriver, 'update');
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {

--- a/libs/cart/state/src/effects/cart-shipping-information.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-shipping-information.effects.spec.ts
@@ -76,7 +76,7 @@ describe('Daffodil | Cart | CartShippingInformationEffects', () => {
     driverUpdateSpy = spyOn(daffShippingInformationDriver, 'update');
     driverDeleteSpy = spyOn(daffShippingInformationDriver, 'delete');
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {

--- a/libs/cart/state/src/effects/cart-shipping-methods.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-shipping-methods.effects.spec.ts
@@ -63,7 +63,7 @@ describe('Daffodil | Cart | DaffCartShippingMethodsEffects', () => {
 
     driverListSpy = spyOn(shippingMethodsDriver, 'list');
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {

--- a/libs/cart/state/src/effects/cart.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart.effects.spec.ts
@@ -78,7 +78,7 @@ describe('Daffodil | Cart | CartEffects', () => {
     driverAddToCartSpy = spyOn(driver, 'addToCart');
     setCartIdSpy = spyOn(daffCartStorageService, 'setCartId');
     getCartIdSpy = spyOn(daffCartStorageService, 'getCartId');
-    getCartIdSpy.and.returnValue(String(mockCart.id));
+    getCartIdSpy.and.returnValue(mockCart.id);
   });
 
   it('should be created', () => {
@@ -176,7 +176,7 @@ describe('Daffodil | Cart | CartEffects', () => {
 
     it('should set the cart ID in storage', () => {
       expect(effects.storeId$).toBeObservable(expected);
-      expect(setCartIdSpy).toHaveBeenCalledWith(String(mockCart.id));
+      expect(setCartIdSpy).toHaveBeenCalledWith(mockCart.id);
     });
 
     describe('and the storage service throws an error', () => {
@@ -205,7 +205,7 @@ describe('Daffodil | Cart | CartEffects', () => {
 
     it('should set the cart ID in storage', () => {
       expect(effects.storeId$).toBeObservable(expected);
-      expect(setCartIdSpy).toHaveBeenCalledWith(String(mockCart.id));
+      expect(setCartIdSpy).toHaveBeenCalledWith(mockCart.id);
     });
 
     describe('and the storage service throws an error', () => {

--- a/libs/cart/state/src/effects/cart.effects.ts
+++ b/libs/cart/state/src/effects/cart.effects.ts
@@ -74,7 +74,7 @@ export class DaffCartEffects<T extends DaffCart> {
   addToCart$ = this.actions$.pipe(
     ofType(DaffCartActionTypes.AddToCartAction),
     switchMap((action: DaffAddToCart) =>
-      this.driver.addToCart(action.payload.productId, action.payload.qty).pipe(
+      this.driver.addToCart(String(action.payload.productId), action.payload.qty).pipe(
         map((resp: T) => new DaffAddToCartSuccess(resp)),
         catchError(error => of(new DaffAddToCartFailure(this.errorMatcher(error))))
       )

--- a/libs/cart/state/src/effects/cart.effects.ts
+++ b/libs/cart/state/src/effects/cart.effects.ts
@@ -49,7 +49,7 @@ export class DaffCartEffects<T extends DaffCart> {
     ofType(DaffCartActionTypes.CartCreateSuccessAction, DaffCartActionTypes.ResolveCartSuccessAction),
     switchMap((action: DaffCartCreateSuccess<T>) => of(null).pipe(
       tap(() => {
-        this.storage.setCartId(String(action.payload.id))
+        this.storage.setCartId(action.payload.id)
       }),
       switchMapTo(EMPTY),
       catchError(error => of(new DaffCartStorageFailure(this.errorMatcher(error)))),
@@ -74,7 +74,7 @@ export class DaffCartEffects<T extends DaffCart> {
   addToCart$ = this.actions$.pipe(
     ofType(DaffCartActionTypes.AddToCartAction),
     switchMap((action: DaffAddToCart) =>
-      this.driver.addToCart(String(action.payload.productId), action.payload.qty).pipe(
+      this.driver.addToCart(action.payload.productId, action.payload.qty).pipe(
         map((resp: T) => new DaffAddToCartSuccess(resp)),
         catchError(error => of(new DaffAddToCartFailure(this.errorMatcher(error))))
       )

--- a/libs/cart/state/src/facades/cart/cart-facade.interface.ts
+++ b/libs/cart/state/src/facades/cart/cart-facade.interface.ts
@@ -176,7 +176,7 @@ export interface DaffCartFacadeInterface<
   paymentMethodsErrors$: Observable<DaffCartErrors[DaffCartOperationType.PaymentMethods]>;
   couponErrors$: Observable<DaffCartErrors[DaffCartOperationType.Coupon]>;
 
-  id$: Observable<DaffCart['id']>;
+  id$: Observable<T['id']>;
   subtotal$: Observable<DaffCartTotal['value']>;
   grandTotal$: Observable<DaffCartTotal['value']>;
   subtotalExcludingTax$: Observable<DaffCartTotal['value']>;
@@ -186,21 +186,21 @@ export interface DaffCartFacadeInterface<
   discountTotals$: Observable<DaffCartTotal[]>;
   totalTax$: Observable<DaffCartTotal['value']>;
   shippingTotal$: Observable<DaffCartTotal['value']>;
-  coupons$: Observable<DaffCart['coupons']>;
-	items$: Observable<DaffCart['items']>;
+  coupons$: Observable<T['coupons']>;
+	items$: Observable<T['items']>;
 	/**
 	 * The total number of cart items, taking into account the quantity of each cart item.
 	 */
   totalItems$: Observable<number>;
   hasOutOfStockItems$: Observable<boolean>;
   itemDictionary$: Observable<Dictionary<U>>;
-  billingAddress$: Observable<DaffCart['billing_address']>;
-  shippingAddress$: Observable<DaffCart['shipping_address']>;
-  payment$: Observable<DaffCart['payment']>;
-  totals$: Observable<DaffCart['totals']>;
-  shippingInformation$: Observable<DaffCart['shipping_information']>;
-  availableShippingMethods$: Observable<DaffCart['available_shipping_methods']>;
-  availablePaymentMethods$: Observable<DaffCart['available_payment_methods']>;
+  billingAddress$: Observable<T['billing_address']>;
+  shippingAddress$: Observable<T['shipping_address']>;
+  payment$: Observable<T['payment']>;
+  totals$: Observable<T['totals']>;
+  shippingInformation$: Observable<T['shipping_information']>;
+  availableShippingMethods$: Observable<T['available_shipping_methods']>;
+  availablePaymentMethods$: Observable<T['available_payment_methods']>;
   /**
    * The user-defined platform-agnostic payment identifier that corresponds to the cart's current (platform-specific) payment method.
    * Define the mapping with the `DaffCartPaymentMethodIdMap` injection token.

--- a/libs/cart/state/src/facades/cart/cart.facade.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.ts
@@ -69,7 +69,7 @@ export class DaffCartFacade<
   paymentMethodsErrors$: Observable<DaffCartErrors[DaffCartOperationType.PaymentMethods]>;
   couponErrors$: Observable<DaffCartErrors[DaffCartOperationType.Coupon]>;
 
-  id$: Observable<DaffCart['id']>;
+  id$: Observable<T['id']>;
   subtotal$: Observable<DaffCartTotal['value']>;
   grandTotal$: Observable<DaffCartTotal['value']>;
   subtotalExcludingTax$: Observable<DaffCartTotal['value']>;
@@ -79,18 +79,18 @@ export class DaffCartFacade<
   discountTotals$: Observable<DaffCartTotal[]>;
   totalTax$: Observable<DaffCartTotal['value']>;
   shippingTotal$: Observable<DaffCartTotal['value']>;
-  coupons$: Observable<DaffCart['coupons']>;
-  items$: Observable<DaffCart['items']>;
+  coupons$: Observable<T['coupons']>;
+  items$: Observable<T['items']>;
   totalItems$: Observable<number>;
   hasOutOfStockItems$: Observable<boolean>;
   itemDictionary$: Observable<Dictionary<U>>;
-  billingAddress$: Observable<DaffCart['billing_address']>;
-  shippingAddress$: Observable<DaffCart['shipping_address']>;
-  payment$: Observable<DaffCart['payment']>;
-  totals$: Observable<DaffCart['totals']>;
-  shippingInformation$: Observable<DaffCart['shipping_information']>;
-  availableShippingMethods$: Observable<DaffCart['available_shipping_methods']>;
-  availablePaymentMethods$: Observable<DaffCart['available_payment_methods']>;
+  billingAddress$: Observable<T['billing_address']>;
+  shippingAddress$: Observable<T['shipping_address']>;
+  payment$: Observable<T['payment']>;
+  totals$: Observable<T['totals']>;
+  shippingInformation$: Observable<T['shipping_information']>;
+  availableShippingMethods$: Observable<T['available_shipping_methods']>;
+  availablePaymentMethods$: Observable<T['available_payment_methods']>;
   paymentId$: Observable<any>;
 
   isCartEmpty$: Observable<boolean>;

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities-reducer-adapter.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities-reducer-adapter.ts
@@ -8,5 +8,5 @@ import { DaffStatefulCartItem } from '../../models/stateful-cart-item';
 export const daffCartItemEntitiesAdapter = (() => {
 	let cache;
   return <T extends DaffStatefulCartItem>(): EntityAdapter<T> =>
-    cache = cache || createEntityAdapter<T>({selectId: item => String(item.item_id)});
+    cache = cache || createEntityAdapter<T>({selectId: item => item.item_id});
 })();

--- a/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.spec.ts
+++ b/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.spec.ts
@@ -60,7 +60,7 @@ describe('selectCartItemEntitiesState', () => {
 
       it('selects cart item ids', () => {
 				const selector = store.pipe(select(selectCartItemIds));
-				const expected = cold('a', { a: [String(mockCartItems[0].item_id), String(mockCartItems[1].item_id)] });
+				const expected = cold('a', { a: [mockCartItems[0].item_id, mockCartItems[1].item_id] });
 
 				expect(selector).toBeObservable(expected);
       });

--- a/libs/cart/state/testing/src/mock-cart-facade.ts
+++ b/libs/cart/state/testing/src/mock-cart-facade.ts
@@ -107,15 +107,15 @@ export class MockDaffCartFacade implements DaffCartFacadeInterface {
 	orderResultCartId$ = new BehaviorSubject<DaffCartOrderResult['cartId']>(null);
 	hasOrderResult$ = new BehaviorSubject<boolean>(false);
 
-	getCartItemDiscountedTotal(itemId: string | number): BehaviorSubject<number> {
+	getCartItemDiscountedTotal(itemId: DaffCartItem['item_id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	}
 
-	getConfiguredCartItemAttributes(itemId: string | number): BehaviorSubject<DaffConfigurableCartItemAttribute[]> {
+	getConfiguredCartItemAttributes(itemId: DaffCartItem['item_id']): BehaviorSubject<DaffConfigurableCartItemAttribute[]> {
 		return new BehaviorSubject([]);
 	}
 
-	getCompositeCartItemOptions(itemId: string | number): BehaviorSubject<DaffCompositeCartItemOption[]> {
+	getCompositeCartItemOptions(itemId: DaffCartItem['item_id']): BehaviorSubject<DaffCompositeCartItemOption[]> {
 		return new BehaviorSubject([]);
 	}
 

--- a/libs/cart/testing/src/factories/cart-item/cart-item.factory.ts
+++ b/libs/cart/testing/src/factories/cart-item/cart-item.factory.ts
@@ -7,10 +7,10 @@ import { DaffProductImageFactory } from '@daffodil/product/testing';
 import { DaffProductImage } from '@daffodil/product';
 
 export class DaffMockCartItem implements DaffCartItem {
-	item_id = faker.random.number({min: 1, max: 1000});
+	item_id = faker.random.uuid();
 	type = DaffCartItemInputType.Simple;
-  product_id = String(faker.random.number({min: 1, max: 1000}));
-	parent_item_id = faker.random.number({min: 1, max: 1000});
+  product_id = faker.random.uuid();
+	parent_item_id = faker.random.uuid();
 	image = <DaffProductImage>new DaffProductImageFactory().create();
   sku = 'sku';
   name = 'Product Name';

--- a/libs/cart/testing/src/factories/cart-shipping-rate.factory.ts
+++ b/libs/cart/testing/src/factories/cart-shipping-rate.factory.ts
@@ -5,7 +5,7 @@ import { DaffCartShippingRate } from '@daffodil/cart';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockCartShippingRate implements DaffCartShippingRate {
-    id = faker.random.number({min: 1, max: 1000});
+    id = faker.random.uuid();
     carrier = 'Birds Inc.';
     carrier_title = 'laden';
     method_code = faker.random.word();

--- a/libs/cart/testing/src/factories/cart.factory.ts
+++ b/libs/cart/testing/src/factories/cart.factory.ts
@@ -5,7 +5,7 @@ import { DaffCart, DaffCartTotalTypeEnum } from '@daffodil/cart';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockCart implements DaffCart {
-  id = faker.random.number({min: 1, max: 1000});
+  id = faker.random.uuid();
   subtotal = 10000;
   grand_total = 15000;
   coupons = [];

--- a/libs/category/src/drivers/magento/models/category.ts
+++ b/libs/category/src/drivers/magento/models/category.ts
@@ -1,7 +1,7 @@
 import { MagentoProduct } from '@daffodil/product';
 
 export interface MagentoCategory {
-  id: string;
+  id: number;
 	name?: string;
 	description?: string;
   breadcrumbs?: MagentoBreadcrumb[];

--- a/libs/category/src/drivers/magento/transformers/applied-filter-transformer.service.ts
+++ b/libs/category/src/drivers/magento/transformers/applied-filter-transformer.service.ts
@@ -3,16 +3,17 @@ import { Injectable } from '@angular/core';
 import { MagentoCategoryFilters, MagentoCategoryFilterActionEnum } from '../models/requests/filters';
 import { DaffCategoryFilterRequest, DaffCategoryFromToFilterSeparator } from '../../../models/requests/filter-request';
 import { DaffCategoryFilterType } from '../../../models/category-filter-base';
+import { DaffCategory } from '../../../models/category';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DaffMagentoAppliedFiltersTransformService {
 
-  transform(categoryId: string, daffFilters: DaffCategoryFilterRequest[]): MagentoCategoryFilters {
+  transform(categoryId: DaffCategory['id'], daffFilters: DaffCategoryFilterRequest[]): MagentoCategoryFilters {
 		const magentoFilters: MagentoCategoryFilters = {
 			category_id: {
-				[MagentoCategoryFilterActionEnum.Equal]: categoryId
+				[MagentoCategoryFilterActionEnum.Equal]: String(categoryId)
 			}
 		};
 
@@ -38,12 +39,12 @@ export class DaffMagentoAppliedFiltersTransformService {
 
 		return magentoFilters;
 	}
-	
+
 	/**
 	 * Returns an In action for Equal type and a Match action for Match type.
 	 */
 	private getFilterAction(type: DaffCategoryFilterType): MagentoCategoryFilterActionEnum {
-		return type === DaffCategoryFilterType.Equal 
+		return type === DaffCategoryFilterType.Equal
 			? MagentoCategoryFilterActionEnum.In
 			: MagentoCategoryFilterActionEnum.Match;
 	}

--- a/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.spec.ts
@@ -20,7 +20,9 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 
   let service: DaffMagentoCategoryPageConfigTransformerService;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
-  const stubCategory: DaffCategory = categoryFactory.create();
+  const stubCategory: DaffCategory = categoryFactory.create({
+    id: '1'
+  });
 
   const categoryPageConfigurationStateFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
   const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest> = categoryPageConfigurationStateFactory.create();
@@ -52,10 +54,10 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 
 		beforeEach(() => {
 			category = {
-        id: stubCategory.id,
+        id: Number(stubCategory.id),
         name: stubCategory.name,
         breadcrumbs: [{
-          category_id: stubCategory.breadcrumbs[0].categoryId,
+          category_id: Number(stubCategory.breadcrumbs[0].categoryId),
           category_name: stubCategory.breadcrumbs[0].categoryName,
           category_level: stubCategory.breadcrumbs[0].categoryLevel,
           category_url_key: stubCategory.breadcrumbs[0].categoryUrlKey

--- a/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.ts
+++ b/libs/category/src/drivers/magento/transformers/category-page-config-transformer.service.ts
@@ -17,7 +17,7 @@ export class DaffMagentoCategoryPageConfigTransformerService {
 
   transform(categoryResponse: MagentoCompleteCategoryResponse): DaffCategoryPageConfigurationState<DaffCategoryRequest> {
 		return {
-      id: categoryResponse.category.id,
+      id: String(categoryResponse.category.id),
       page_size: categoryResponse.page_info.page_size,
       current_page: categoryResponse.page_info.current_page,
 			total_pages: categoryResponse.page_info.total_pages,

--- a/libs/category/src/drivers/magento/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-response-transform.service.spec.ts
@@ -20,7 +20,9 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
 
   let service: DaffMagentoCategoryResponseTransformService;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
-  const stubCategory: DaffCategory = categoryFactory.create();
+  const stubCategory: DaffCategory = categoryFactory.create({
+    id: '1'
+  });
   const categoryPageConfigurationStateFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
   const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest> = categoryPageConfigurationStateFactory.create();
   const productFactory: DaffProductFactory = new DaffProductFactory();
@@ -55,10 +57,10 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
       magentoProductTransformerServiceSpy.transformMany.and.returnValue(stubProducts);
 
       const category: MagentoCategory = {
-        id: stubCategory.id,
+        id: Number(stubCategory.id),
         name: stubCategory.name,
         breadcrumbs: [{
-          category_id: stubCategory.breadcrumbs[0].categoryId,
+          category_id: Number(stubCategory.breadcrumbs[0].categoryId),
           category_name: stubCategory.breadcrumbs[0].categoryName,
           category_level: stubCategory.breadcrumbs[0].categoryLevel,
           category_url_key: stubCategory.breadcrumbs[0].categoryUrlKey

--- a/libs/category/src/drivers/magento/transformers/category-transformer.service.spec.ts
+++ b/libs/category/src/drivers/magento/transformers/category-transformer.service.spec.ts
@@ -11,7 +11,9 @@ describe('DaffMagentoCategoryTransformerService', () => {
 
   let service: DaffMagentoCategoryTransformerService;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
-	const stubCategory: DaffCategory = categoryFactory.create();
+	const stubCategory: DaffCategory = categoryFactory.create({
+    id: '1'
+  });
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -32,15 +34,15 @@ describe('DaffMagentoCategoryTransformerService', () => {
 
 		beforeEach(() => {
 			magentoCategory = {
-        id: stubCategory.id,
-				name: stubCategory.name,
-				description: stubCategory.description,
+        id: Number(stubCategory.id),
+        name: stubCategory.name,
         breadcrumbs: [{
-          category_id: stubCategory.breadcrumbs[0].categoryId,
+          category_id: Number(stubCategory.breadcrumbs[0].categoryId),
           category_name: stubCategory.breadcrumbs[0].categoryName,
           category_level: stubCategory.breadcrumbs[0].categoryLevel,
           category_url_key: stubCategory.breadcrumbs[0].categoryUrlKey
 				}],
+        description: stubCategory.description,
 				products: {
 					items: [{
 						__typename: 'simple',
@@ -84,19 +86,19 @@ describe('DaffMagentoCategoryTransformerService', () => {
 				category_url_key: 'urlKey2'
 			}];
 			const expectedBreadcrumbs: DaffCategoryBreadcrumb[] = [{
-				categoryId: 1,
+				categoryId: '1',
 				categoryName: 'category1',
 				categoryLevel: 1,
 				categoryUrlKey: 'urlKey1'
 			},
 			{
-				categoryId: 2,
+				categoryId: '2',
 				categoryName: 'category2',
 				categoryLevel: 2,
 				categoryUrlKey: 'urlKey2'
 			},
 			{
-				categoryId: 3,
+				categoryId: '3',
 				categoryName: 'category3',
 				categoryLevel: 3,
 				categoryUrlKey: 'urlKey3'

--- a/libs/category/src/drivers/magento/transformers/category-transformer.service.ts
+++ b/libs/category/src/drivers/magento/transformers/category-transformer.service.ts
@@ -11,15 +11,15 @@ export class DaffMagentoCategoryTransformerService {
 
   transform(category: MagentoCategory): DaffCategory {
     return {
-      id: category.id,
+      id: String(category.id),
 			name: category.name,
 			description: category.description,
 			children_count: category.children_count,
 			//todo: use optional chaining when possible
-			breadcrumbs: category.breadcrumbs ? 
+			breadcrumbs: category.breadcrumbs ?
 				category.breadcrumbs
 					.map(breadcrumb => this.transformBreadcrumb(breadcrumb))
-					.sort((a, b) => a.categoryLevel - b.categoryLevel) : 
+					.sort((a, b) => a.categoryLevel - b.categoryLevel) :
 				null,
 			product_ids: category.products.items.map(product => product.sku),
 			total_products: category.products.items.length
@@ -28,7 +28,7 @@ export class DaffMagentoCategoryTransformerService {
 
   private transformBreadcrumb(breadcrumb: MagentoBreadcrumb): DaffCategoryBreadcrumb {
     return {
-      categoryId: breadcrumb.category_id,
+      categoryId: String(breadcrumb.category_id),
       categoryName: breadcrumb.category_name,
       categoryLevel: breadcrumb.category_level,
       categoryUrlKey: breadcrumb.category_url_key

--- a/libs/category/src/facades/category-facade.interface.ts
+++ b/libs/category/src/facades/category-facade.interface.ts
@@ -87,17 +87,17 @@ export interface DaffCategoryFacadeInterface<
 	 * Get a category by the provided Id.
 	 * @param id
 	 */
-	getCategoryById(id: string): Observable<V>;
+	getCategoryById(id: V['id']): Observable<V>;
 
 	/**
 	 * Get products by a category Id.
 	 * @param categoryId
 	 */
-	getProductsByCategory(categoryId: string): Observable<W[]>;
+	getProductsByCategory(categoryId: V['id']): Observable<W[]>;
 
 	/**
 	 * Get products by a category Id.
 	 * @param categoryId
 	 */
-	getTotalProductsByCategory(categoryId: string): Observable<number>;
+	getTotalProductsByCategory(categoryId: V['id']): Observable<number>;
 }

--- a/libs/category/src/facades/category.facade.ts
+++ b/libs/category/src/facades/category.facade.ts
@@ -23,13 +23,13 @@ import { DaffCategoryFacadeInterface } from './category-facade.interface';
   providedIn: DaffCategoryModule
 })
 export class DaffCategoryFacade<
-	T extends DaffCategoryRequest = DaffCategoryRequest, 
-	V extends DaffGenericCategory<V> = DaffCategory, 
+	T extends DaffCategoryRequest = DaffCategoryRequest,
+	V extends DaffGenericCategory<V> = DaffCategory,
 	U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
 	W extends DaffProduct = DaffProduct
 > implements DaffCategoryFacadeInterface<T, V, U, W> {
 	private categorySelectors = getDaffCategorySelectors<T, V, U, W>();
-	
+
 	/**
    * The currently selected category.
    */
@@ -94,28 +94,28 @@ export class DaffCategoryFacade<
 	 * Is the category page empty of products.
 	 */
 	isCategoryEmpty$: Observable<boolean>;
-	
+
 	/**
 	 * Get a category by the provided Id.
-	 * @param id 
+	 * @param id
 	 */
-	getCategoryById(id: string): Observable<V> {
+	getCategoryById(id: V['id']): Observable<V> {
 		return this.store.pipe(select(this.categorySelectors.selectCategory, {id: id}));
 	}
 
 	/**
 	 * Get products by a category Id.
-	 * @param categoryId 
+	 * @param categoryId
 	 */
-	getProductsByCategory(categoryId: string): Observable<W[]> {
+	getProductsByCategory(categoryId: V['id']): Observable<W[]> {
 		return this.store.pipe(select(this.categorySelectors.selectProductsByCategory, {id: categoryId}))
 	}
 
 	/**
 	 * Get products by a category Id.
-	 * @param categoryId 
+	 * @param categoryId
 	 */
-	getTotalProductsByCategory(categoryId: string): Observable<number> {
+	getTotalProductsByCategory(categoryId: V['id']): Observable<number> {
 		return this.store.pipe(select(this.categorySelectors.selectTotalProductsByCategory, {id: categoryId}))
 	}
 

--- a/libs/category/src/models/category-breadcrumb.ts
+++ b/libs/category/src/models/category-breadcrumb.ts
@@ -1,5 +1,7 @@
+import { ID } from '@daffodil/core';
+
 export interface DaffCategoryBreadcrumb {
-  categoryId: number;
+  categoryId: ID;
   categoryName: string;
   categoryLevel: number;
   categoryUrlKey: string;

--- a/libs/category/src/models/generic-category.ts
+++ b/libs/category/src/models/generic-category.ts
@@ -1,10 +1,12 @@
+import { ID } from '@daffodil/core';
+
 import { DaffCategoryBreadcrumb } from './category-breadcrumb';
 
 /**
  * The DaffGenericCategory should be used only in extension when defining a new model.
  */
 export interface DaffGenericCategory<T extends DaffGenericCategory<T>> {
-  id: string;
+  id: ID;
 	name: string;
 	description?: string;
   children_count?: number;

--- a/libs/category/src/models/requests/category-request.ts
+++ b/libs/category/src/models/requests/category-request.ts
@@ -1,3 +1,5 @@
+import { ID } from '@daffodil/core';
+
 import { DaffCategoryFilterRequest } from './filter-request';
 
 export enum DaffSortDirectionEnum {
@@ -6,7 +8,7 @@ export enum DaffSortDirectionEnum {
 }
 
 export interface DaffCategoryRequest {
-  id: string;
+  id: ID;
   filter_requests?: DaffCategoryFilterRequest[];
   applied_sort_option?: string;
   applied_sort_direction?: DaffSortDirectionEnum;

--- a/libs/category/src/selectors/category.selector.ts
+++ b/libs/category/src/selectors/category.selector.ts
@@ -13,8 +13,8 @@ import { getDaffCategoryEntitiesSelectors } from './category-entities/category-e
 import { DaffCategory } from '../models/category';
 
 export interface DaffCategoryMemoizedSelectors<
-	T extends DaffCategoryRequest = DaffCategoryRequest, 
-	V extends DaffGenericCategory<V> = DaffCategory, 
+	T extends DaffCategoryRequest = DaffCategoryRequest,
+	V extends DaffGenericCategory<V> = DaffCategory,
 	U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
 	W extends DaffProduct = DaffProduct
 > extends
@@ -34,9 +34,9 @@ const createCategorySelectors = <T extends DaffCategoryRequest, V extends DaffGe
 	const {
 		selectCategoryEntities
 	} = getDaffCategoryEntitiesSelectors<T, V, U>();
-	const { 
-		selectSelectedCategoryId, 
-		selectCategoryPageProductIds 
+	const {
+		selectSelectedCategoryId,
+		selectCategoryPageProductIds
 	} = getDaffCategoryPageSelectors<T, V, U>();
 	/**
 	 * Combinatoric Category Selectors
@@ -44,7 +44,7 @@ const createCategorySelectors = <T extends DaffCategoryRequest, V extends DaffGe
 	const selectSelectedCategory = createSelector(
 		selectCategoryEntities,
 		selectSelectedCategoryId,
-		(entities: Dictionary<V>, selectedCategoryId: string) => entities[selectedCategoryId]
+		(entities: Dictionary<V>, selectedCategoryId: V['id']) => entities[selectedCategoryId]
 	);
 
 	const selectCategoryPageProducts = createSelector(
@@ -89,11 +89,11 @@ const createCategorySelectors = <T extends DaffCategoryRequest, V extends DaffGe
 export const getDaffCategorySelectors = (() => {
 	let cache;
 	return <
-		T extends DaffCategoryRequest = DaffCategoryRequest, 
-		V extends DaffGenericCategory<V> = DaffCategory, 
-		U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>, 
+		T extends DaffCategoryRequest = DaffCategoryRequest,
+		V extends DaffGenericCategory<V> = DaffCategory,
+		U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
 		W extends DaffProduct = DaffProduct
-	>(): DaffCategoryMemoizedSelectors<T, V, U, W> => cache = cache 
-		? cache 
+	>(): DaffCategoryMemoizedSelectors<T, V, U, W> => cache = cache
+		? cache
 		: createCategorySelectors<T, V, U, W>();
 })();

--- a/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
+++ b/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
@@ -5,7 +5,7 @@ import { DaffCategoryPageConfigurationState, DaffCategoryFilterType, DaffCategor
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockCategoryPageConfigurationState implements DaffCategoryPageConfigurationState<DaffCategoryRequest> {
-  id = faker.random.uuid();;
+  id = faker.random.uuid();
   page_size = 20;
   current_page = 1;
   filters = [{

--- a/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
+++ b/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
@@ -5,7 +5,7 @@ import { DaffCategoryPageConfigurationState, DaffCategoryFilterType, DaffCategor
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockCategoryPageConfigurationState implements DaffCategoryPageConfigurationState<DaffCategoryRequest> {
-  id = String(faker.random.number({min: 1, max: 100}));
+  id = faker.random.uuid();;
   page_size = 20;
   current_page = 1;
   filters = [{

--- a/libs/category/testing/src/factories/category.factory.ts
+++ b/libs/category/testing/src/factories/category.factory.ts
@@ -5,11 +5,11 @@ import { DaffCategory } from '@daffodil/category';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockCategory implements DaffCategory {
-  id = faker.random.number({min: 1, max: 10000}).toString();
+  id = faker.random.uuid();
 	name = faker.commerce.productMaterial();
 	description = faker.random.words(Math.floor(Math.random() * 20));
   breadcrumbs = [{
-    categoryId: faker.random.number({min: 1, max: 100}),
+    categoryId: String(faker.random.number({min: 1, max: 100})),
     categoryName: faker.commerce.productMaterial(),
     categoryLevel: faker.random.number({min: 1, max: 5}),
     categoryUrlKey: faker.commerce.productMaterial()

--- a/libs/category/testing/src/helpers/mock-category-facade.ts
+++ b/libs/category/testing/src/helpers/mock-category-facade.ts
@@ -33,13 +33,13 @@ export class MockDaffCategoryFacade implements DaffCategoryFacadeInterface {
 	errors$: BehaviorSubject<string[]> = new BehaviorSubject([]);
 	isCategoryEmpty$: BehaviorSubject<boolean> = new BehaviorSubject(true);
 
-	getCategoryById(id: string): BehaviorSubject<DaffCategory> {
+	getCategoryById(id: DaffCategory['id']): BehaviorSubject<DaffCategory> {
 		return new BehaviorSubject(null);
 	};
-	getProductsByCategory(categoryId: string): BehaviorSubject<DaffProduct[]> {
+	getProductsByCategory(categoryId: DaffCategory['id']): BehaviorSubject<DaffProduct[]> {
 		return new BehaviorSubject([]);
 	};
-	getTotalProductsByCategory(categoryId: string): BehaviorSubject<number> {
+	getTotalProductsByCategory(categoryId: DaffCategory['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
   dispatch(action: Action) {};

--- a/libs/category/testing/src/inmemory-backend/category.service.ts
+++ b/libs/category/testing/src/inmemory-backend/category.service.ts
@@ -63,8 +63,8 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
       };
     });
 	}
-	
-	private getTotalPages(allIds: string[], pageSize: number) {
+
+	private getTotalPages(allIds: DaffProduct['id'][], pageSize: number) {
 		return Math.ceil(allIds.length/pageSize);
 	}
 
@@ -76,7 +76,7 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
 		return tempIds;
 	}
 
-	private generateProductIdSubset(products: DaffProduct[]): string[] {
+	private generateProductIdSubset(products: DaffProduct[]): DaffProduct['id'][] {
 		return randomSubset(products).map(product => product.id);
 	}
 

--- a/libs/checkout/src/models/order/order-address.ts
+++ b/libs/checkout/src/models/order/order-address.ts
@@ -22,7 +22,7 @@ export interface DaffOrderAddress extends DaffAddress {
   street: string;
   city: string;
   region: string;
-  region_id: number;
+  region_id: string;
   postcode: string;
   country_id: string; //todo: ISO code
   telephone: string;

--- a/libs/checkout/testing/src/order/factories/order.factory.ts
+++ b/libs/checkout/testing/src/order/factories/order.factory.ts
@@ -8,7 +8,7 @@ import { DaffModelFactory } from '@daffodil/core/testing';
  * @deprecated
  */
 export class MockOrder implements DaffOrder {
-  id = faker.random.number({min: 1, max: 1000});
+  id = faker.random.uuid();
   created_at = new Date();
   updated_at = new Date();
   store_to_base_rate = faker.random.number({min: 1, max: 1000});

--- a/libs/checkout/testing/src/shipping/factories/shipping-option.factory.ts
+++ b/libs/checkout/testing/src/shipping/factories/shipping-option.factory.ts
@@ -6,7 +6,7 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 import * as faker from 'faker/locale/en_US';
 
 export class MockShippingOption implements ShippingOption {
-  id = faker.random.number().toString();
+  id = faker.random.uuid();
   text = faker.company.companyName() + ' ' + faker.commerce.productAdjective() + ' Shipping'
 }
 

--- a/libs/core/src/types/id.type.ts
+++ b/libs/core/src/types/id.type.ts
@@ -1,1 +1,1 @@
-export type ID = string | number;
+export type ID = string;

--- a/libs/geography/driver/magento/src/transforms/responses/subdivision.service.spec.ts
+++ b/libs/geography/driver/magento/src/transforms/responses/subdivision.service.spec.ts
@@ -29,7 +29,9 @@ describe('Driver | Magento | Geography | Transformer | Subdivision', () => {
 
     daffSubdivisionFactory = TestBed.inject(DaffSubdivisionFactory);
 
-    mockDaffSubdivision = daffSubdivisionFactory.create();
+    mockDaffSubdivision = daffSubdivisionFactory.create({
+      id: '1'
+    });
     mockMagentoRegion = {
       id: Number(mockDaffSubdivision.id),
       name: mockDaffSubdivision.name,

--- a/libs/geography/src/models/address.ts
+++ b/libs/geography/src/models/address.ts
@@ -1,3 +1,5 @@
+import { ID } from '@daffodil/core';
+
 /**
  * A basic model of an address
  */
@@ -5,14 +7,14 @@ export interface DaffAddress {
 	street: string;
 	street2?: string;
   city: string;
-  region: string | number;
+  region: ID;
   /**
    * Use DaffAddress#region instead.
    *
    * @deprecated
    */
-  region_id?: string | number;
-  country?: string;
-  country_id?: string | number;
+  region_id?: ID;
+  country?: ID;
+  country_id?: ID;
   postcode: string;
 }

--- a/libs/geography/src/models/country.ts
+++ b/libs/geography/src/models/country.ts
@@ -1,3 +1,5 @@
+import { ID } from '@daffodil/core';
+
 import { DaffSubdivision } from './subdivision';
 
 /**
@@ -5,7 +7,7 @@ import { DaffSubdivision } from './subdivision';
  * See: ISO-3166
  */
 export interface DaffCountry {
-	id: string;
+	id: ID;
 	name: string;
 	name_en: string;
 	alpha2: string;

--- a/libs/geography/src/models/subdivision.ts
+++ b/libs/geography/src/models/subdivision.ts
@@ -1,9 +1,11 @@
+import { ID } from "@daffodil/core";
+
 /**
  * The subdivisions of a country as per ISO-3166-2
  * For the United States this is commonly termed as "States"
  */
 export interface DaffSubdivision {
-  id: string;
+  id: ID;
   name: string;
   iso_3166_2: string;
 }

--- a/libs/geography/src/models/subdivision.ts
+++ b/libs/geography/src/models/subdivision.ts
@@ -1,4 +1,4 @@
-import { ID } from "@daffodil/core";
+import { ID } from '@daffodil/core';
 
 /**
  * The subdivisions of a country as per ISO-3166-2

--- a/libs/geography/state/src/facades/geography/geography-facade.interface.ts
+++ b/libs/geography/state/src/facades/geography/geography-facade.interface.ts
@@ -9,7 +9,7 @@ export interface DaffGeographyFacadeInterface<T extends DaffCountry = DaffCountr
   loading$: Observable<boolean>;
   errors$: Observable<string[]>;
   countries$: Observable<T[]>;
-  countryIds$: Observable<(string | number)[]>;
+  countryIds$: Observable<T['id'][]>;
   countryCount$: Observable<number>;
   countryEntities$: Observable<Dictionary<T>>;
 

--- a/libs/geography/state/src/facades/geography/geography.facade.ts
+++ b/libs/geography/state/src/facades/geography/geography.facade.ts
@@ -19,7 +19,7 @@ export class DaffGeographyFacade<T extends DaffCountry = DaffCountry> implements
   errors$: Observable<string[]>;
 
   countries$: Observable<T[]>;
-  countryIds$: Observable<(string | number)[]>;
+  countryIds$: Observable<T['id'][]>;
   countryCount$: Observable<number>;
   countryEntities$: Observable<Dictionary<T>>;
 

--- a/libs/geography/state/src/selectors/country-entities.selector.ts
+++ b/libs/geography/state/src/selectors/country-entities.selector.ts
@@ -11,14 +11,14 @@ import {
 } from '../reducers/public_api';
 import { getDaffGeographyFeatureStateSelector } from './geography-feature.selector';
 
-export interface DaffCountryEntitySelectors<T extends DaffCountry> {
+export interface DaffCountryEntitySelectors<T extends DaffCountry = DaffCountry> {
   selectCountryEntitiesState: MemoizedSelector<object, DaffCountryEntityState<T>>;
-  selectCountryIds: MemoizedSelector<object, string[] | number[]>;
+  selectCountryIds: MemoizedSelector<object, T['id'][] | number[]>;
   selectCountryEntities: MemoizedSelector<object, Dictionary<T>>;
   selectAllCountries: MemoizedSelector<object, T[]>;
   selectCountryTotal: MemoizedSelector<object, number>;
-  selectCountry: MemoizedSelectorWithProps<object, {id: string | number}, T>;
-  selectCountrySubdivisions: MemoizedSelectorWithProps<object, {id: string | number}, T['subdivisions']>;
+  selectCountry: MemoizedSelectorWithProps<object, {id: T['id']}, T>;
+  selectCountrySubdivisions: MemoizedSelectorWithProps<object, {id: T['id']}, T['subdivisions']>;
   selectIsCountryFullyLoaded: MemoizedSelector<object, boolean>;
 }
 

--- a/libs/geography/state/src/selectors/country-entities.selector.ts
+++ b/libs/geography/state/src/selectors/country-entities.selector.ts
@@ -13,7 +13,7 @@ import { getDaffGeographyFeatureStateSelector } from './geography-feature.select
 
 export interface DaffCountryEntitySelectors<T extends DaffCountry = DaffCountry> {
   selectCountryEntitiesState: MemoizedSelector<object, DaffCountryEntityState<T>>;
-  selectCountryIds: MemoizedSelector<object, T['id'][] | number[]>;
+  selectCountryIds: MemoizedSelector<object, T['id'][]>;
   selectCountryEntities: MemoizedSelector<object, Dictionary<T>>;
   selectAllCountries: MemoizedSelector<object, T[]>;
   selectCountryTotal: MemoizedSelector<object, number>;

--- a/libs/geography/state/testing/src/mock-geography-facade.ts
+++ b/libs/geography/state/testing/src/mock-geography-facade.ts
@@ -11,7 +11,7 @@ export class MockDaffGeographyFacade implements DaffGeographyFacadeInterface {
   loading$: BehaviorSubject<boolean> = new BehaviorSubject(null);
   errors$: BehaviorSubject<string[]> = new BehaviorSubject([]);
   countries$: BehaviorSubject<DaffCountry[]> = new BehaviorSubject([]);
-  countryIds$: BehaviorSubject<(string | number)[]> = new BehaviorSubject([]);
+  countryIds$: BehaviorSubject<DaffCountry['id'][]> = new BehaviorSubject([]);
   countryCount$: BehaviorSubject<number> = new BehaviorSubject(null);
   countryEntities$: BehaviorSubject<Dictionary<DaffCountry>> = new BehaviorSubject(null);
 

--- a/libs/geography/testing/src/factories/country.factory.ts
+++ b/libs/geography/testing/src/factories/country.factory.ts
@@ -6,7 +6,7 @@ import { DaffCountry } from '@daffodil/geography';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockCountry implements DaffCountry {
-  id = faker.random.uuid();;
+  id = faker.random.uuid();
   name = faker.random.word();
 	name_en = faker.random.word();
 	alpha2 = faker.random.alphaNumeric(2);

--- a/libs/geography/testing/src/factories/country.factory.ts
+++ b/libs/geography/testing/src/factories/country.factory.ts
@@ -6,7 +6,7 @@ import { DaffCountry } from '@daffodil/geography';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockCountry implements DaffCountry {
-  id = String(faker.random.number({min: 1, max: 1000}));
+  id = faker.random.uuid();;
   name = faker.random.word();
 	name_en = faker.random.word();
 	alpha2 = faker.random.alphaNumeric(2);

--- a/libs/geography/testing/src/factories/subdivision.factory.ts
+++ b/libs/geography/testing/src/factories/subdivision.factory.ts
@@ -6,7 +6,7 @@ import { DaffSubdivision } from '@daffodil/geography';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockSubdivision implements DaffSubdivision {
-  id = String(faker.random.number({min: 1, max: 1000}));
+  id = faker.random.uuid();;
   name = faker.random.word();
 	iso_3166_2 = faker.random.alphaNumeric(2);
 }

--- a/libs/geography/testing/src/factories/subdivision.factory.ts
+++ b/libs/geography/testing/src/factories/subdivision.factory.ts
@@ -6,7 +6,7 @@ import { DaffSubdivision } from '@daffodil/geography';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockSubdivision implements DaffSubdivision {
-  id = faker.random.uuid();;
+  id = faker.random.uuid();
   name = faker.random.word();
 	iso_3166_2 = faker.random.alphaNumeric(2);
 }

--- a/libs/navigation/driver/in-memory/src/navigation.service.ts
+++ b/libs/navigation/driver/in-memory/src/navigation.service.ts
@@ -13,7 +13,7 @@ export class DaffInMemoryNavigationService implements DaffNavigationServiceInter
 
   constructor(private http: HttpClient) {}
 
-  get(navigationId: string): Observable<DaffNavigationTree> {
+  get(navigationId: DaffNavigationTree['id']): Observable<DaffNavigationTree> {
     return this.http.get<DaffNavigationTree>(this.url + navigationId);
   }
 }

--- a/libs/navigation/driver/magento/src/models/category-node.ts
+++ b/libs/navigation/driver/magento/src/models/category-node.ts
@@ -1,6 +1,6 @@
 export interface CategoryNode {
   __typename?: string;
-  id: string;
+  id: number;
   name?: string;
   include_in_menu: boolean;
   product_count: number;

--- a/libs/navigation/driver/magento/src/transformers/navigation-transformer.spec.ts
+++ b/libs/navigation/driver/magento/src/transformers/navigation-transformer.spec.ts
@@ -23,13 +23,13 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
 
   it('should transform a CategoryNode into a DaffNavigationTree', () => {
     const categoryNode: CategoryNode = {
-      id: '1',
+      id: 1,
       name: 'Root Category',
       include_in_menu: true,
       product_count: 10,
       children_count: 0,
       children: [{
-        id: '2',
+        id: 2,
         include_in_menu: false,
         name: 'Subcategory',
         product_count: 10,
@@ -60,13 +60,13 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
 
   it('should filter out categories (and necessarily their children) that are include_in_menu false', () => {
     const categoryNode: CategoryNode = {
-      id: '1',
+      id: 1,
       name: 'Root Category',
       include_in_menu: true,
       product_count: 10,
       children_count: 1,
       children: [{
-        id: '2',
+        id: 2,
         include_in_menu: true,
         name: 'Subcategory',
         product_count: 10,
@@ -95,7 +95,7 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
         children: [],
 				children_count: 0,
 				breadcrumbs: [{
-					categoryId: 1,
+					categoryId: '1',
 					categoryLevel: 1,
 					categoryName: 'name',
 					categoryUrlKey: 'url'

--- a/libs/navigation/driver/magento/src/transformers/navigation-transformer.ts
+++ b/libs/navigation/driver/magento/src/transformers/navigation-transformer.ts
@@ -11,17 +11,18 @@ import { CategoryNode, MagentoBreadcrumb } from '../models/category-node';
 export class DaffMagentoNavigationTransformerService implements DaffNavigationTransformerInterface<DaffNavigationTree> {
 
   transform(node: CategoryNode): DaffNavigationTree {
+    const id = String(node.id);
     return {
-      id: node.id,
-      path: node.id,
+      id,
+      path: id,
       name: node.name,
       total_products: node.product_count,
       children_count: node.children_count,
 			//todo: use optional chaining when possible
-			breadcrumbs: node.breadcrumbs ? 
+			breadcrumbs: node.breadcrumbs ?
 				node.breadcrumbs
 					.map(breadcrumb => this.transformBreadcrumb(breadcrumb))
-					.sort((a, b) => a.categoryLevel - b.categoryLevel) : 
+					.sort((a, b) => a.categoryLevel - b.categoryLevel) :
 				[],
       // TODO: optional chaining
       children: node.children && node.children.filter(child => child.include_in_menu).map(child => this.transform(child))
@@ -30,7 +31,7 @@ export class DaffMagentoNavigationTransformerService implements DaffNavigationTr
 
   private transformBreadcrumb(breadcrumb: MagentoBreadcrumb): DaffNavigationBreadcrumb {
     return {
-      categoryId: breadcrumb.category_id,
+      categoryId: String(breadcrumb.category_id),
       categoryName: breadcrumb.category_name,
       categoryLevel: breadcrumb.category_level,
       categoryUrlKey: breadcrumb.category_url_key

--- a/libs/navigation/driver/src/interfaces/navigation-service.interface.ts
+++ b/libs/navigation/driver/src/interfaces/navigation-service.interface.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { DaffGenericNavigationTree } from '@daffodil/navigation';
 
 export interface DaffNavigationServiceInterface<T extends DaffGenericNavigationTree<T>> {
-  get(categoryId: string): Observable<T>;
+  get(categoryId: T['id']): Observable<T>;
 }
 
 export const DaffNavigationDriver =

--- a/libs/navigation/src/models/generic-navigation-tree.ts
+++ b/libs/navigation/src/models/generic-navigation-tree.ts
@@ -1,12 +1,14 @@
+import { ID } from '@daffodil/core';
+
 import { DaffNavigationBreadcrumb } from './navigation-breadcrumb';
 
 /**
  * The DaffGenericNavigationTree should be used only in extension when defining a new model.
  */
 export interface DaffGenericNavigationTree<T extends DaffGenericNavigationTree<T>> {
-  id: string;
+  id: ID;
   name: string;
-  path: string;
+  path: ID;
   children_count?: number;
   total_products?: number;
 	children?: T[];

--- a/libs/navigation/src/models/navigation-breadcrumb.ts
+++ b/libs/navigation/src/models/navigation-breadcrumb.ts
@@ -1,5 +1,7 @@
+import { DaffNavigationTree } from './navigation-tree';
+
 export interface DaffNavigationBreadcrumb {
-  categoryId: number;
+  categoryId: DaffNavigationTree['id'];
   categoryName: string;
   categoryLevel: number;
   categoryUrlKey: string;

--- a/libs/navigation/testing/src/factories/navigation-tree.factory.ts
+++ b/libs/navigation/testing/src/factories/navigation-tree.factory.ts
@@ -5,7 +5,7 @@ import { DaffNavigationTree } from '@daffodil/navigation';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockNavigationTree implements DaffNavigationTree {
-  id = '1';
+  id = faker.random.uuid();
   name = '';
   path = faker.commerce.department().toString().toLowerCase();
   total_products = faker.random.number({min: 1, max: 10});
@@ -18,35 +18,41 @@ export class MockNavigationTree implements DaffNavigationTree {
       ? [...Array(faker.random.number({min:1, max:3}))].map(() => this.fakeTree(depth - 1))
       : [];
 
-    return depth <= 0
-      ? {
-        id: faker.random.number({min:1, max:10000}).toString(),
+    if (depth <= 0) {
+      const id = faker.random.uuid();
+
+      return {
+        id,
         name: faker.commerce.department(),
         path: faker.commerce.department().toString().toLowerCase(),
         total_products: faker.random.number({min: 1, max: 20}),
         children: [],
 				children_count: 0,
 				breadcrumbs: [{
-					categoryId: 1,
+					categoryId: id,
 					categoryName: '',
 					categoryLevel: 1,
 					categoryUrlKey: faker.commerce.productMaterial()
 				}]
       }
-      : {
-        id: faker.random.number({min:1, max:10000}).toString(),
+    } else {
+      const id = faker.random.uuid();
+
+      return {
+        id,
         name: faker.commerce.department(),
         path: faker.commerce.department().toString().toLowerCase(),
         total_products: faker.random.number({min: 1, max: 20}),
         children: children,
 				children_count: children.length,
 				breadcrumbs: [{
-					categoryId: 1,
+					categoryId: id,
 					categoryName: '',
 					categoryLevel: 1,
 					categoryUrlKey: faker.commerce.productMaterial()
 				}]
       }
+    }
   }
 }
 

--- a/libs/order/driver/magento/2.4.0/src/order.service.spec.ts
+++ b/libs/order/driver/magento/2.4.0/src/order.service.spec.ts
@@ -50,6 +50,7 @@ import {
   getGuestOrders,
   MagentoGetGuestOrdersResponse
 } from '@daffodil/order/driver/magento/2.4.0';
+import { DaffCart } from '@daffodil/cart';
 
 import { DaffOrderMagentoService } from './order.service';
 
@@ -69,7 +70,7 @@ describe('Order | Driver | Magento | 2.4.0 | OrderService', () => {
   let daffOrderShippingMethodFactory: DaffOrderShippingMethodFactory;
   let daffOrderTotalFactory: DaffOrderTotalFactory;
 
-  let cartId: string;
+  let cartId: DaffCart['id'];
   let orderId: DaffOrder['id'];
   let mockDaffOrder: DaffOrder;
   let mockDaffOrderAddress: DaffOrderAddress;

--- a/libs/order/driver/magento/2.4.0/src/order.service.spec.ts
+++ b/libs/order/driver/magento/2.4.0/src/order.service.spec.ts
@@ -131,10 +131,14 @@ describe('Order | Driver | Magento | 2.4.0 | OrderService', () => {
     daffOrderShippingMethodFactory = TestBed.inject(DaffOrderShippingMethodFactory);
     daffOrderTotalFactory = TestBed.inject(DaffOrderTotalFactory);
 
-    mockDaffOrderAddress = daffOrderAddressFactory.create();
+    mockDaffOrderAddress = daffOrderAddressFactory.create({
+      order_id: '2',
+    });
     mockDaffOrderCoupon = daffOrderCouponFactory.create();
     mockDaffOrderPayment = daffOrderPaymentFactory.create({
       created_at: null,
+      order_id: '2',
+      payment_id: '6',
       updated_at: null,
     });
     mockDaffOrderItem = daffOrderItemFactory.create({
@@ -144,6 +148,8 @@ describe('Order | Driver | Magento | 2.4.0 | OrderService', () => {
         label: null
       },
       parent_item_id: null,
+      product_id: '4',
+      order_id: '2',
       item_id: null
     });
     mockDaffOrderShipmentItem = daffOrderShipmentItemFactory.create({
@@ -203,6 +209,8 @@ describe('Order | Driver | Magento | 2.4.0 | OrderService', () => {
       shipping_method: null
     });
     mockDaffOrder = daffOrderFactory.create({
+      id: '2',
+      customer_id: '1',
       totals: jasmine.arrayContaining([
         mockDaffOrderGrandTotal,
         mockDaffOrderSubTotal,
@@ -231,7 +239,7 @@ describe('Order | Driver | Magento | 2.4.0 | OrderService', () => {
       order_id: String(mockDaffOrderItem.order_id),
       created_at: mockDaffOrderItem.created_at,
       updated_at: mockDaffOrderItem.updated_at,
-      product_id: mockDaffOrderItem.product_id,
+      product_id: Number(mockDaffOrderItem.product_id),
       sku: mockDaffOrderItem.sku,
       name: mockDaffOrderItem.name,
       weight: mockDaffOrderItem.weight,

--- a/libs/order/driver/magento/2.4.0/src/order.service.ts
+++ b/libs/order/driver/magento/2.4.0/src/order.service.ts
@@ -49,7 +49,7 @@ export class DaffOrderMagentoService implements DaffOrderServiceInterface {
     return this.list(cartId).pipe(
       map(orders => {
         for (const order of orders) {
-          if (String(order.id) === String(orderId)) {
+          if (order.id === orderId) {
             return order
           }
         }

--- a/libs/order/driver/magento/2.4.0/src/transforms/responses/order.spec.ts
+++ b/libs/order/driver/magento/2.4.0/src/transforms/responses/order.spec.ts
@@ -91,10 +91,14 @@ describe('Order | Driver | Magento | 2.4.0 | Transformer | Order', () => {
     daffOrderShippingMethodFactory = TestBed.inject(DaffOrderShippingMethodFactory);
     daffOrderTotalFactory = TestBed.inject(DaffOrderTotalFactory);
 
-    mockDaffOrderAddress = daffOrderAddressFactory.create();
+    mockDaffOrderAddress = daffOrderAddressFactory.create({
+      order_id: '2',
+    });
     mockDaffOrderCoupon = daffOrderCouponFactory.create();
     mockDaffOrderPayment = daffOrderPaymentFactory.create({
       created_at: null,
+      order_id: '2',
+      payment_id: '6',
       updated_at: null,
     });
     mockDaffOrderItem = daffOrderItemFactory.create({
@@ -104,6 +108,8 @@ describe('Order | Driver | Magento | 2.4.0 | Transformer | Order', () => {
         label: null
       },
       parent_item_id: null,
+      product_id: '4',
+      order_id: '2',
       item_id: null
     });
     mockDaffOrderShipmentItem = daffOrderShipmentItemFactory.create({
@@ -163,6 +169,8 @@ describe('Order | Driver | Magento | 2.4.0 | Transformer | Order', () => {
       shipping_method: null
     });
     mockDaffOrder = daffOrderFactory.create({
+      id: '2',
+      customer_id: '1',
       totals: jasmine.arrayContaining([
         mockDaffOrderGrandTotal,
         mockDaffOrderSubTotal,
@@ -188,7 +196,7 @@ describe('Order | Driver | Magento | 2.4.0 | Transformer | Order', () => {
       order_id: String(mockDaffOrderItem.order_id),
       created_at: mockDaffOrderItem.created_at,
       updated_at: mockDaffOrderItem.updated_at,
-      product_id: mockDaffOrderItem.product_id,
+      product_id: Number(mockDaffOrderItem.product_id),
       sku: mockDaffOrderItem.sku,
       name: mockDaffOrderItem.name,
       weight: mockDaffOrderItem.weight,

--- a/libs/order/driver/magento/2.4.0/src/transforms/responses/order.ts
+++ b/libs/order/driver/magento/2.4.0/src/transforms/responses/order.ts
@@ -77,10 +77,10 @@ function transformItem(item: MagentoGraycoreOrderItem): DaffOrderItem {
       id: null,
       label: null
     },
-    order_id: Number(item.order_id),
+    order_id: item.order_id,
     created_at: item.created_at,
     updated_at: item.updated_at,
-    product_id: item.product_id,
+    product_id: String(item.product_id),
     parent_item_id: null,
     sku: item.sku,
     name: item.name,
@@ -99,7 +99,7 @@ function transformItem(item: MagentoGraycoreOrderItem): DaffOrderItem {
 
 function transformAddress(address: MagentoGraycoreOrderAddress): DaffOrderAddress {
   return {
-    order_id: address.order_id,
+    order_id: String(address.order_id),
     prefix: address.prefix,
     suffix: address.suffix,
     firstname: address.firstname,
@@ -147,8 +147,8 @@ function transformShipment(shipment: MagentoGraycoreOrderShipment): DaffOrderShi
 
 function transformPayment(payment: MagentoGraycoreOrderPayment): DaffOrderPayment {
   return {
-    payment_id: payment.payment_id,
-    order_id: payment.order_id,
+    payment_id: String(payment.payment_id),
+    order_id: String(payment.order_id),
     created_at: null,
     updated_at: null,
     method: payment.method,
@@ -178,8 +178,8 @@ export function daffMagentoTransformOrder(order: MagentoGraycoreOrder): DaffOrde
   return {
     extra_attributes: order,
 
-    id: order.order_number,
-    customer_id: order.customer_id,
+    id: String(order.order_number),
+    customer_id: String(order.customer_id),
     created_at: order.created_at,
     updated_at: order.updated_at,
     status: order.status,

--- a/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
+++ b/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
@@ -246,7 +246,7 @@ export class MagentoOrderTestDataFactory {
       updated_at: null
     });
     // magento order IDs are strings, and the type mismatch will cause the equality check to fail
-    mockDaffOrder.id = String(mockDaffOrder.id);
+    mockDaffOrder.id = mockDaffOrder.id;
     mockDaffOrderAddress.order_id = mockDaffOrder.id;
     mockDaffOrderPayment.order_id = mockDaffOrder.id;
     mockDaffOrderItem.order_id = mockDaffOrder.id;
@@ -371,8 +371,8 @@ export class MagentoOrderTestDataFactory {
       telephone: mockDaffOrderAddress.telephone,
       street: [mockDaffOrderAddress.street, mockDaffOrderAddress.street2],
       city: mockDaffOrderAddress.city,
-      region_id: String(mockDaffOrderAddress.region),
-      region: String(mockDaffOrderAddress.region),
+      region_id: mockDaffOrderAddress.region,
+      region: mockDaffOrderAddress.region,
       country_code: mockDaffOrderAddress.country,
       postcode: mockDaffOrderAddress.postcode,
       company: null,
@@ -396,7 +396,7 @@ export class MagentoOrderTestDataFactory {
     };
     mockMagentoOrderPayment = {
       __typename: 'OrderPaymentMethod',
-      name: String(mockDaffOrderPayment.payment_id),
+      name: mockDaffOrderPayment.payment_id,
       type: mockDaffOrderPayment.method,
       additional_data: [
         {
@@ -510,8 +510,8 @@ export class MagentoOrderTestDataFactory {
     };
     mockMagentoOrder = {
       __typename: 'GraycoreGuestOrder',
-      id: String(mockDaffOrder.id),
-      number: String(mockDaffOrder.id),
+      id: mockDaffOrder.id,
+      number: mockDaffOrder.id,
       order_date: mockDaffOrder.created_at,
       carrier: mockDaffOrderShipment.carrier,
       shipping_method: mockDaffOrderShipment.method,

--- a/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
+++ b/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
@@ -245,7 +245,6 @@ export class MagentoOrderTestDataFactory {
       customer_id: null,
       updated_at: null
     });
-    // magento order IDs are strings, and the type mismatch will cause the equality check to fail
     mockDaffOrder.id = mockDaffOrder.id;
     mockDaffOrderAddress.order_id = mockDaffOrder.id;
     mockDaffOrderPayment.order_id = mockDaffOrder.id;

--- a/libs/order/driver/magento/2.4.1/src/order.service.spec.ts
+++ b/libs/order/driver/magento/2.4.1/src/order.service.spec.ts
@@ -14,6 +14,7 @@ import {
 } from '@daffodil/order/driver';
 import { MagentoOrder, MagentoGetGuestOrdersResponse, getGuestOrders } from '@daffodil/order/driver/magento/2.4.1';
 import { schema } from '@daffodil/driver/magento';
+import { DaffCart } from '@daffodil/cart';
 
 import { MagentoOrderTestDataFactory } from './helpers/public_api';
 import { DaffOrderMagentoService } from './order.service';
@@ -23,7 +24,7 @@ describe('Order | Driver | Magento | 2.4.1 | OrderService', () => {
   let controller: ApolloTestingController;
   let testDataFactory: MagentoOrderTestDataFactory;
 
-  let cartId: string;
+  let cartId: DaffCart['id'];
   let orderId: DaffOrder['id'];
   let mockDaffOrder: DaffOrder;
   let mockMagentoOrder: MagentoOrder;

--- a/libs/order/driver/magento/2.4.1/src/order.service.ts
+++ b/libs/order/driver/magento/2.4.1/src/order.service.ts
@@ -49,7 +49,7 @@ export class DaffOrderMagentoService implements DaffOrderServiceInterface {
     return this.list(cartId).pipe(
       map(orders => {
         for (const order of orders) {
-          if (String(order.id) === String(orderId)) {
+          if (order.id === orderId) {
             return order
           }
         }

--- a/libs/order/src/models/order-item.ts
+++ b/libs/order/src/models/order-item.ts
@@ -1,4 +1,6 @@
+import { ID } from '@daffodil/core';
 import { DaffProductImage } from '@daffodil/product';
+
 import { DaffOrder } from './order';
 
 export enum DaffOrderItemType {
@@ -9,7 +11,7 @@ export enum DaffOrderItemType {
 
 export interface DaffOrderItem {
   type: DaffOrderItemType;
-  item_id: number;
+  item_id: ID;
   qty_ordered: number;
   qty_canceled: number;
   qty_fulfilled: number;
@@ -17,8 +19,8 @@ export interface DaffOrderItem {
   order_id: DaffOrder['id'];
   created_at: string;
   updated_at: string;
-  product_id: number;
-  parent_item_id: number;
+  product_id: ID;
+  parent_item_id: ID;
   sku: string;
   name: string;
   weight: number;

--- a/libs/order/src/models/order-payment.ts
+++ b/libs/order/src/models/order-payment.ts
@@ -1,7 +1,9 @@
+import { ID } from '@daffodil/core';
+
 import { DaffOrder } from './order';
 
 export interface DaffOrderCreditCardPayment {
-  payment_id: number | string;
+  payment_id: ID;
   order_id: DaffOrder['id'];
   created_at: string;
   updated_at: string;

--- a/libs/order/src/models/order.ts
+++ b/libs/order/src/models/order.ts
@@ -1,3 +1,5 @@
+import { ID } from '@daffodil/core';
+
 import { DaffOrderItem } from './order-item';
 import { DaffOrderAddress } from './order-address';
 import { DaffOrderPayment } from './order-payment';
@@ -8,8 +10,8 @@ import { DaffOrderInvoice } from './order-invoice';
 import { DaffOrderCredit } from './order-credit';
 
 export interface DaffOrder {
-  id: number | string;
-  customer_id: number | string;
+  id: ID;
+  customer_id: ID;
   created_at: string;
   updated_at: string;
   status: string;

--- a/libs/order/state/src/facades/order/order-facade.interface.ts
+++ b/libs/order/state/src/facades/order/order-facade.interface.ts
@@ -9,7 +9,7 @@ export interface DaffOrderFacadeInterface<T extends DaffOrder = DaffOrder> exten
   loading$: Observable<boolean>;
   errors$: Observable<string[]>;
   orders$: Observable<T[]>;
-  orderIds$: Observable<(string | number)[]>;
+  orderIds$: Observable<T['id'][]>;
   orderCount$: Observable<number>;
   orderEntities$: Observable<Dictionary<T>>;
 

--- a/libs/order/state/src/facades/order/order.facade.ts
+++ b/libs/order/state/src/facades/order/order.facade.ts
@@ -20,7 +20,7 @@ export class DaffOrderFacade<T extends DaffOrder = DaffOrder> implements DaffOrd
   errors$: Observable<string[]>;
 
   orders$: Observable<T[]>;
-  orderIds$: Observable<(string | number)[]>;
+  orderIds$: Observable<T['id'][]>;
   orderCount$: Observable<number>;
   orderEntities$: Observable<Dictionary<T>>;
 

--- a/libs/order/state/src/selectors/order-entities.selector.ts
+++ b/libs/order/state/src/selectors/order-entities.selector.ts
@@ -15,7 +15,7 @@ export interface DaffOrderEntitySelectors<T extends DaffOrder = DaffOrder> {
   /**
    * Selector for order IDs.
    */
-  selectOrderIds: MemoizedSelector<object, string[] | number[]>;
+  selectOrderIds: MemoizedSelector<object, T['id'][]>;
   /**
    * Selector for order entities.
    */

--- a/libs/order/state/testing/src/mock-order-facade.ts
+++ b/libs/order/state/testing/src/mock-order-facade.ts
@@ -12,7 +12,7 @@ export class MockDaffOrderFacade implements DaffOrderFacadeInterface {
   errors$: BehaviorSubject<string[]> = new BehaviorSubject([]);
 
   orders$: BehaviorSubject<DaffOrder[]> = new BehaviorSubject([]);
-  orderIds$: BehaviorSubject<(string | number)[]> = new BehaviorSubject([]);
+  orderIds$: BehaviorSubject<DaffOrder['id'][]> = new BehaviorSubject([]);
   orderCount$: BehaviorSubject<number> = new BehaviorSubject(null);
   orderEntities$: BehaviorSubject<Dictionary<DaffOrder>> = new BehaviorSubject({});
 

--- a/libs/order/testing/src/factories/order-address.factory.ts
+++ b/libs/order/testing/src/factories/order-address.factory.ts
@@ -6,7 +6,7 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 import { MockDaffPersonalAddress } from '@daffodil/geography/testing';
 
 export class MockOrderAddress extends MockDaffPersonalAddress implements DaffOrderAddress {
-  order_id = faker.random.number({min: 1, max: 1000});
+  order_id = faker.random.uuid();
 }
 
 @Injectable({

--- a/libs/order/testing/src/factories/order-item.factory.ts
+++ b/libs/order/testing/src/factories/order-item.factory.ts
@@ -6,20 +6,20 @@ import { DaffOrderItem, DaffOrderItemType } from '@daffodil/order';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockOrderItem implements DaffOrderItem {
-  item_id = faker.random.number({min: 1, max: 1000});
+  item_id = faker.random.uuid();
   image = {
     url: faker.image.imageUrl(),
-    id: String(faker.random.number({min: 1, max: 1000})),
+    id: faker.random.uuid(),
     label: faker.random.word()
   };
-  order_id = faker.random.number({min: 1, max: 1000});
+  order_id = faker.random.uuid();
   qty_ordered = faker.random.number({min: 1, max: 1000});
   qty_canceled = faker.random.number({min: 1, max: 1000});
   qty_fulfilled = faker.random.number({min: 1, max: 1000});
   created_at = faker.date.past().toString();
   updated_at = faker.date.past().toString();
-  product_id = faker.random.number({min: 1, max: 1000});
-  parent_item_id = faker.random.number({min: 1, max: 1000});
+  product_id = faker.random.uuid();
+  parent_item_id = faker.random.uuid();
   sku = faker.random.alphaNumeric(20);
   name = faker.random.word();
   weight = faker.random.number({min: 1, max: 1000});

--- a/libs/order/testing/src/factories/order-payment.factory.ts
+++ b/libs/order/testing/src/factories/order-payment.factory.ts
@@ -5,23 +5,23 @@ import { DaffOrderPayment } from '@daffodil/order';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockOrderPayment implements DaffOrderPayment {
-    payment_id = faker.random.number({min: 1, max: 1000});
-    order_id = faker.random.number({min: 1, max: 1000});
-    created_at = faker.date.past().toString();
-    updated_at = faker.date.past().toString();
-    method = 'card';
-    cc_type = 'visa';
-    cc_last4 = faker.random.number({min: 1000, max: 9999}).toString();
-    cc_owner = 'owner';
-    cc_exp_month = 'month';
-    cc_exp_year = 'year';
+  payment_id = faker.random.uuid();
+  order_id = faker.random.uuid();
+  created_at = faker.date.past().toString();
+  updated_at = faker.date.past().toString();
+  method = 'card';
+  cc_type = 'visa';
+  cc_last4 = faker.random.number({min: 1000, max: 9999}).toString();
+  cc_owner = 'owner';
+  cc_exp_month = 'month';
+  cc_exp_year = 'year';
 }
 
 @Injectable({
-    providedIn: 'root'
+  providedIn: 'root'
 })
 export class DaffOrderPaymentFactory extends DaffModelFactory<DaffOrderPayment>{
-    constructor(){
-        super(MockOrderPayment);
-      }
+  constructor() {
+    super(MockOrderPayment);
+  }
 }

--- a/libs/order/testing/src/factories/order-shipping-rate.factory.ts
+++ b/libs/order/testing/src/factories/order-shipping-rate.factory.ts
@@ -5,9 +5,9 @@ import { DaffOrderShippingMethod } from '@daffodil/order';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockOrderShippingMethod implements DaffOrderShippingMethod {
-  rate_id = faker.random.number({min: 1, max: 1000});
-  address_id = faker.random.number({min: 1, max: 1000});
-  order_id = faker.random.number({min: 1, max: 1000});
+  rate_id = faker.random.uuid();
+  address_id = faker.random.uuid();
+  order_id = faker.random.uuid();
   created_at = faker.date.past().toString();
   updated_at = faker.date.past().toString();
   carrier = faker.random.word();

--- a/libs/order/testing/src/factories/order.factory.ts
+++ b/libs/order/testing/src/factories/order.factory.ts
@@ -5,8 +5,8 @@ import { DaffOrder } from '@daffodil/order';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockOrder implements DaffOrder {
-  id = faker.random.number({min: 1, max: 1000});
-  customer_id = faker.random.number({min: 1, max: 1000});
+  id = faker.random.uuid();
+  customer_id = faker.random.uuid();
   created_at = faker.date.past().toString();
   updated_at = faker.date.past().toString();
   status = faker.random.word();

--- a/libs/paypal/package.json
+++ b/libs/paypal/package.json
@@ -25,6 +25,7 @@
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@daffodil/core": "0.0.0-PLACEHOLDER",
+    "@daffodil/cart": "0.0.0-PLACEHOLDER",
     "@ngrx/effects": "0.0.0-PLACEHOLDER",
     "@ngrx/entity": "0.0.0-PLACEHOLDER",
     "@ngrx/store": "0.0.0-PLACEHOLDER",
@@ -37,6 +38,7 @@
     "@apollo/client": "0.0.0-PLACEHOLDER"
   },
   "devDependencies": {
+    "@daffodil/cart": "0.0.0-PLACEHOLDER",
     "@daffodil/core": "0.0.0-PLACEHOLDER"
   }
 }

--- a/libs/paypal/src/drivers/magento/models/request/magento-paypal-token-request.ts
+++ b/libs/paypal/src/drivers/magento/models/request/magento-paypal-token-request.ts
@@ -1,7 +1,9 @@
+import { ID } from '@daffodil/core';
+
 import { MagentoPaypalUrlsRequest } from './magento-paypal-urls';
 
 export interface MagentoPaypalTokenRequest {
-	cart_id: string;
+	cart_id: ID;
 	code: string;
 	urls: MagentoPaypalUrlsRequest;
 	express_button?: boolean;

--- a/libs/paypal/src/drivers/magento/models/request/magento-paypal-token-request.ts
+++ b/libs/paypal/src/drivers/magento/models/request/magento-paypal-token-request.ts
@@ -1,9 +1,7 @@
-import { ID } from '@daffodil/core';
-
 import { MagentoPaypalUrlsRequest } from './magento-paypal-urls';
 
 export interface MagentoPaypalTokenRequest {
-	cart_id: ID;
+	cart_id: string;
 	code: string;
 	urls: MagentoPaypalUrlsRequest;
 	express_button?: boolean;

--- a/libs/paypal/src/models/paypal-token-request.ts
+++ b/libs/paypal/src/models/paypal-token-request.ts
@@ -1,3 +1,5 @@
+import { DaffCart } from '@daffodil/cart';
+
 export interface DaffPaypalTokenRequest {
-	cartId: string;
+	cartId: DaffCart['id'];
 }

--- a/libs/paypal/tsconfig.json
+++ b/libs/paypal/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "@daffodil/*": [
+        "dist/*"
+      ],
+      "@daffodil/paypal": [
+        "libs/paypal/src"
+      ],
+      "@daffodil/paypal/testing": [
+        "libs/paypal/testing/src"
+      ],
+    }
+  }
+}

--- a/libs/paypal/tsconfig.spec.json
+++ b/libs/paypal/tsconfig.spec.json
@@ -1,31 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc/libs/paypal",
     "types": [
       "jasmine",
       "node"
     ],
-    "paths": {
-      "@daffodil/core": [
-        "dist/core"
-      ],
-      "@daffodil/core/testing": [
-        "dist/core/testing"
-      ],
-      "@daffodil/core/graphql": [
-        "dist/core/graphql"
-      ],
-      "@daffodil/core/state": [
-        "dist/core/state"
-      ],
-      "@daffodil/paypal": [
-        "libs/paypal/src/index.ts"
-      ],
-      "@daffodil/paypal/testing": [
-        "libs/paypal/testing/src/index.ts"
-      ]
-    }
   },
   "files": [
     "test.ts"

--- a/libs/product/src/drivers/interfaces/product-service.interface.ts
+++ b/libs/product/src/drivers/interfaces/product-service.interface.ts
@@ -16,8 +16,8 @@ export interface DaffProductServiceInterface<T extends DaffProduct = DaffProduct
   getBestSellers(): Observable<T[]>;
   /**
    * Get a product by Id.
-   * 
+   *
    * @param productId - A string of the product ID.
    */
-  get(productId: string): Observable<T>;
+  get(productId: T['id']): Observable<T>;
 }

--- a/libs/product/src/drivers/magento/product.service.ts
+++ b/libs/product/src/drivers/magento/product.service.ts
@@ -23,7 +23,7 @@ export class DaffMagentoProductService implements DaffProductServiceInterface {
    * Get an Observable of a DaffProduct by id.
    * @param productId a product Id
    */
-  get(productId: string): Observable<DaffProduct> {
+  get(productId: DaffProduct['id']): Observable<DaffProduct> {
     return this.apollo.query<any>({
 			query: GetProductQuery,
 			variables: {

--- a/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/src/facades/composite-product/composite-product-facade.interface.ts
@@ -20,26 +20,26 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	 * @param id an id for a composite product
 	 * @param configuration a Dictionary of DaffCompositeConfigurationItems
 	 */
-	getRequiredItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange>;
+	getRequiredItemPricesForConfiguration(id: DaffCompositeProduct['id'], configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange>;
 
 	/**
 	 * Get the broadest possible DaffPriceRange for a composite product based on the configuration provided including optional item prices.
 	 * @param id the id of the composite product.
 	 */
-	getOptionalItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange>;
+	getOptionalItemPricesForConfiguration(id: DaffCompositeProduct['id'], configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange>;
 
 	/**
 	 * Get the DaffPriceRange for a composite product based on the current configuration of selected item options in redux state and
 	 * excluding unselected, optional item prices.
 	 * @param id the id of the composite product.
 	 */
-	getPricesAsCurrentlyConfigured(id: string): Observable<DaffPriceRange>;
+	getPricesAsCurrentlyConfigured(id: DaffCompositeProduct['id']): Observable<DaffPriceRange>;
 
 	/**
 	 * Returns the applied options for a composite product.
 	 * @param id the id of the composite product.
 	 */
-	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption>>;
+	getAppliedOptions(id: DaffCompositeProduct['id']): Observable<Dictionary<DaffCompositeProductItemOption>>;
 
 	/**
 	 * Returns whether the item of a composite product is required.

--- a/libs/product/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/src/facades/composite-product/composite-product.facade.ts
@@ -9,7 +9,6 @@ import { DaffProduct } from '../../models/product';
 import { getDaffProductSelectors } from '../../selectors/public_api';
 import { DaffCompositeProductFacadeInterface } from './composite-product-facade.interface';
 import { DaffCompositeProductItemOption, DaffCompositeProductItem } from '../../models/composite-product-item';
-import { DaffCompositeProduct } from '../../models/composite-product';
 import { DaffPriceRange } from '../../models/prices';
 import { DaffCompositeConfigurationItem } from '../../models/composite-configuration-item';
 import { productPriceRangeHasDiscount, productPriceRangeHasPriceRange } from '../helpers';
@@ -17,14 +16,14 @@ import { productPriceRangeHasDiscount, productPriceRangeHasPriceRange } from '..
 /**
  * A facade for interacting with the composite product state.
  * Exposes many parts of the state for easy access and allows dispatching of actions.
- * 
+ *
  * See the <a href="docs/api/product/DaffCompositeProductFacadeInterface">DaffCompositeProductFacadeInterface docs</a> for more details.
  */
 @Injectable({
   providedIn: DaffProductModule
 })
 export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> implements DaffCompositeProductFacadeInterface {
-	
+
 	constructor(private store: Store<DaffProductReducersState<T>>) {}
 
 	selectors = getDaffProductSelectors<T>();
@@ -41,23 +40,23 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 	 */
 	hasPriceRange = productPriceRangeHasPriceRange;
 
-	getRequiredItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange> {
+	getRequiredItemPricesForConfiguration(id: T['id'], configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange> {
 		return this.store.pipe(select(this.selectors.selectCompositeProductRequiredItemPricesForConfiguration, { id, configuration }));
 	}
 
-	getOptionalItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange> {
+	getOptionalItemPricesForConfiguration(id: T['id'], configuration?: Dictionary<DaffCompositeConfigurationItem>): Observable<DaffPriceRange> {
 		return this.store.pipe(select(this.selectors.selectCompositeProductOptionalItemPricesForConfiguration, { id, configuration }));
 	}
 
-	getPricesAsCurrentlyConfigured(id: string): Observable<DaffPriceRange> {
+	getPricesAsCurrentlyConfigured(id: T['id']): Observable<DaffPriceRange> {
 		return this.store.pipe(select(this.selectors.selectCompositeProductPricesAsCurrentlyConfigured, { id }));
 	}
 
-	getAppliedOptions(id: string): Observable<Dictionary<DaffCompositeProductItemOption>> {
+	getAppliedOptions(id: T['id']): Observable<Dictionary<DaffCompositeProductItemOption>> {
 		return this.store.pipe(select(this.selectors.selectCompositeProductAppliedOptions, { id }));
 	}
 
-	isItemRequired(id: DaffCompositeProduct['id'], item_id: DaffCompositeProductItem['id']) {
+	isItemRequired(id: T['id'], item_id: DaffCompositeProductItem['id']) {
 		return this.store.pipe(select(this.selectors.selectIsCompositeProductItemRequired, { id, item_id }));
 	}
 

--- a/libs/product/src/facades/configurable-product/configurable-product-facade.interface.ts
+++ b/libs/product/src/facades/configurable-product/configurable-product-facade.interface.ts
@@ -3,7 +3,7 @@ import { Action } from '@ngrx/store';
 import { Dictionary } from '@ngrx/entity';
 
 import { DaffStoreFacade } from '@daffodil/core/state';
-import { DaffConfigurableProductVariant } from '../../models/configurable-product';
+import { DaffConfigurableProductVariant, DaffConfigurableProduct } from '../../models/configurable-product';
 
 /**
  * An interface for a facade that accesses configurable product state.
@@ -15,78 +15,78 @@ export interface DaffConfigurableProductFacadeInterface extends DaffStoreFacade<
 	 * All attributes of a configurable product.
 	 * @param id the id of the configurable product.
 	 */
-	getAllAttributes(id: string): Observable<Dictionary<string[]>>;
+	getAllAttributes(id: DaffConfigurableProduct['id']): Observable<Dictionary<string[]>>;
 
 	/**
 	 * All variants of a configurable product.
 	 * @param id the id of the configurable product.
 	 */
-	getAllVariants(id: string): Observable<DaffConfigurableProductVariant[]>;
+	getAllVariants(id: DaffConfigurableProduct['id']): Observable<DaffConfigurableProductVariant[]>;
 
 	/**
 	 * The applied attributes of a configurable product.
 	 * @param id the id of the configurable product.
 	 */
-	getAppliedAttributes(id: string): Observable<Dictionary<string>>;
+	getAppliedAttributes(id: DaffConfigurableProduct['id']): Observable<Dictionary<string>>;
 
 	/**
 	 * Get the current minimum price possible based on the applied attributes and remaining variants.
 	 * @param id the id of the configurable product.
 	 */
-	getMinimumPrice(id: string): Observable<number>;
+	getMinimumPrice(id: DaffConfigurableProduct['id']): Observable<number>;
 
 	/**
 	 * Get the current maximum price possible based on the applied attributes and remaining variants.
 	 * @param id the id of the configurable product.
 	 */
-	getMaximumPrice(id: string): Observable<number>;
+	getMaximumPrice(id: DaffConfigurableProduct['id']): Observable<number>;
 
 	/**
 	 * Get the current minimum discounted price possible based on the applied attributes and remaining variants.
 	 * @param id the id of the configurable product.
 	 */
-	getMinimumDiscountedPrice(id: string): Observable<number>;
+	getMinimumDiscountedPrice(id: DaffConfigurableProduct['id']): Observable<number>;
 
 	/**
 	 * Get the current maximum discounted price possible based on the applied attributes and remaining variants.
 	 * @param id the id of the configurable product.
 	 */
-	getMaximumDiscountedPrice(id: string): Observable<number>;
+	getMaximumDiscountedPrice(id: DaffConfigurableProduct['id']): Observable<number>;
 
 	/**
 	 * Get the current minimum percent discount possible based on the applied attributes and remaining variants.
 	 * @param id the id of the configurable product.
 	 */
-	getMinimumPercentDiscount(id: string): Observable<number>;
+	getMinimumPercentDiscount(id: DaffConfigurableProduct['id']): Observable<number>;
 
 	/**
 	 * Get the current maximum percent discount possible based on the applied attributes and remaining variants.
 	 * @param id the id of the configurable product.
 	 */
-	getMaximumPercentDiscount(id: string): Observable<number>;
+	getMaximumPercentDiscount(id: DaffConfigurableProduct['id']): Observable<number>;
 
 	/**
 	 * Returns whether the possible price for the configurable product is a range of different prices
 	 * @param id the id of the configurable product.
 	 */
-	isPriceRanged(id: string): Observable<boolean>;
+	isPriceRanged(id: DaffConfigurableProduct['id']): Observable<boolean>;
 
 	/**
 	 * Returns whether the variants of the configurable product have (a) discount(s)
 	 * @param id the id of the configurable product.
 	 */
-	hasDiscount(id: string): Observable<boolean>;
+	hasDiscount(id: DaffConfigurableProduct['id']): Observable<boolean>;
 
 	/**
 	 * Selectable configurable product attributes derived from the remaining variants and the order of currently applied attributes.
 	 * The remaining variants of the product are derived from the currently applied attributes.
 	 * @param id the id of the configurable product.
 	 */
-	getSelectableAttributes(id: string): Observable<Dictionary<string[]>>;
+	getSelectableAttributes(id: DaffConfigurableProduct['id']): Observable<Dictionary<string[]>>;
 
 	/**
 	 * The variants that match the applied attributes of a configurable product.
 	 * @param id the id of the configurable product.
 	 */
-	getMatchingVariants(id: string): Observable<DaffConfigurableProductVariant[]>;
+	getMatchingVariants(id: DaffConfigurableProduct['id']): Observable<DaffConfigurableProductVariant[]>;
 }

--- a/libs/product/src/facades/configurable-product/configurable-product.facade.ts
+++ b/libs/product/src/facades/configurable-product/configurable-product.facade.ts
@@ -8,12 +8,12 @@ import { DaffProductReducersState } from '../../reducers/product-reducers-state.
 import { DaffProduct } from '../../models/product';
 import { getDaffProductSelectors } from '../../selectors/public_api';
 import { DaffConfigurableProductFacadeInterface } from './configurable-product-facade.interface';
-import { DaffConfigurableProductVariant } from '../../models/configurable-product';
+import { DaffConfigurableProductVariant, DaffConfigurableProduct } from '../../models/configurable-product';
 
 /**
  * A facade for interacting with the configurable product state.
  * Exposes many parts of the state for easy access and allows dispatching of actions.
- * 
+ *
  * See the <a href="docs/api/product/DaffConfigurableProductFacadeInterface">DaffConfigurableProductFacadeInterface docs</a> for more details.
  */
 @Injectable({
@@ -22,58 +22,58 @@ import { DaffConfigurableProductVariant } from '../../models/configurable-produc
 export class DaffConfigurableProductFacade<T extends DaffProduct = DaffProduct> implements DaffConfigurableProductFacadeInterface {
 
 	selectors = getDaffProductSelectors<T>();
-	
+
 	constructor(private store: Store<DaffProductReducersState<T>>) {}
-	
-	getAllAttributes(id: string): Observable<Dictionary<string[]>> {
+
+	getAllAttributes(id: T['id']): Observable<Dictionary<string[]>> {
 		return this.store.pipe(select(this.selectors.selectAllConfigurableProductAttributes, { id }));
 	}
-	
-	getAllVariants(id: string): Observable<DaffConfigurableProductVariant[]> {
+
+	getAllVariants(id: T['id']): Observable<DaffConfigurableProductVariant[]> {
 		return this.store.pipe(select(this.selectors.selectAllConfigurableProductVariants, { id }));
 	}
-	
-	getAppliedAttributes(id: string): Observable<Dictionary<string>> {
+
+	getAppliedAttributes(id: T['id']): Observable<Dictionary<string>> {
 		return this.store.pipe(select(this.selectors.selectConfigurableProductAppliedAttributesAsDictionary, { id }));
 	}
 
-	getMinimumPrice(id: string): Observable<number> {
+	getMinimumPrice(id: T['id']): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectConfigurableProductMinimumPrice, { id }));
 	}
 
-	getMaximumPrice(id: string): Observable<number> {
+	getMaximumPrice(id: T['id']): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectConfigurableProductMaximumPrice, { id }));
 	}
 
-	getMinimumDiscountedPrice(id: string): Observable<number> {
+	getMinimumDiscountedPrice(id: T['id']): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectConfigurableProductMinimumDiscountedPrice, { id }));
 	}
 
-	getMaximumDiscountedPrice(id: string): Observable<number> {
+	getMaximumDiscountedPrice(id: T['id']): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectConfigurableProductMaximumDiscountedPrice, { id }));
 	}
 
-	getMinimumPercentDiscount(id: string): Observable<number> {
+	getMinimumPercentDiscount(id: T['id']): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectConfigurableProductMinimumPercentDiscount, { id }));
 	}
 
-	getMaximumPercentDiscount(id: string): Observable<number> {
+	getMaximumPercentDiscount(id: T['id']): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectConfigurableProductMaximumPercentDiscount, { id }));
 	}
 
-	isPriceRanged(id: string): Observable<boolean> {
+	isPriceRanged(id: T['id']): Observable<boolean> {
 		return this.store.pipe(select(this.selectors.isConfigurablePriceRanged, { id }));
 	}
 
-	hasDiscount(id: string): Observable<boolean> {
+	hasDiscount(id: T['id']): Observable<boolean> {
 		return this.store.pipe(select(this.selectors.selectConfigurableProductHasDiscount, { id }));
 	}
 
-	getSelectableAttributes(id: string): Observable<Dictionary<string[]>> {
+	getSelectableAttributes(id: T['id']): Observable<Dictionary<string[]>> {
 		return this.store.pipe(select(this.selectors.selectSelectableConfigurableProductAttributes, { id }));
 	}
 
-	getMatchingVariants(id: string): Observable<DaffConfigurableProductVariant[]> {
+	getMatchingVariants(id: T['id']): Observable<DaffConfigurableProductVariant[]> {
 		return this.store.pipe(select(this.selectors.selectMatchingConfigurableProductVariants, { id }));
 	}
 

--- a/libs/product/src/facades/product/product-facade.interface.ts
+++ b/libs/product/src/facades/product/product-facade.interface.ts
@@ -23,41 +23,41 @@ export interface DaffProductFacadeInterface<T extends DaffProduct = DaffProduct>
 	 * Get a product.
 	 * @param id a product id
 	 */
-	getProduct(id: string): Observable<T>;
+	getProduct(id: T['id']): Observable<T>;
 
 	/**
 	 * Get the original price for a product.
 	 * @param id a product id
 	 */
-	getPrice(id: string): Observable<number>;
+	getPrice(id: T['id']): Observable<number>;
 
 	/**
 	 * Whether a particular product has a discount.
 	 * @param id a product id
 	 */
-	hasDiscount(id: string): Observable<boolean>;
+	hasDiscount(id: T['id']): Observable<boolean>;
 
 	/**
 	 * Get the discount amount of a product.
 	 * @param id a product id
 	 */
-	getDiscountAmount(id: string): Observable<number>;
+	getDiscountAmount(id: T['id']): Observable<number>;
 
 	/**
 	 * Get the discounted price for a product.
 	 * @param id a product id
 	 */
-	getDiscountedPrice(id: string): Observable<number>;
+	getDiscountedPrice(id: T['id']): Observable<number>;
 
 	/**
 	 * Get the discount percent of a product.
 	 * @param id a product id
 	 */
-	getDiscountPercent(id: string): Observable<number>;
+	getDiscountPercent(id: T['id']): Observable<number>;
 
 	/**
 	 * Whether a product is out of stock.
 	 * @param id a product id
 	 */
-	isOutOfStock(id: string): Observable<boolean>;
+	isOutOfStock(id: T['id']): Observable<boolean>;
 }

--- a/libs/product/src/facades/product/product.facade.ts
+++ b/libs/product/src/facades/product/product.facade.ts
@@ -11,7 +11,7 @@ import { DaffProductFacadeInterface } from './product-facade.interface';
 
 /**
  * A facade for getting state about a particular product.
- * 
+ *
  * See the <a href="docs/api/product/DaffProductFacadeInterface">DaffProductFacadeInterface docs</a> for more details.
  */
 @Injectable({
@@ -28,31 +28,31 @@ export class DaffProductFacade<T extends DaffProduct = DaffProduct> implements D
 		this.product$ = this.store.pipe(select(this.selectors.selectSelectedProduct));
 	}
 
-	getProduct(id: string): Observable<T> {
+	getProduct(id: T['id']): Observable<T> {
 		return this.store.pipe(select(this.selectors.selectProduct, { id }));
 	}
 
-	getPrice(id: string): Observable<number> {
+	getPrice(id: T['id']): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectProductPrice, { id }));
 	}
 
-	hasDiscount(id: string): Observable<boolean> {
+	hasDiscount(id: T['id']): Observable<boolean> {
 		return this.store.pipe(select(this.selectors.selectProductHasDiscount, { id }));
 	}
 
-	getDiscountAmount(id: string): Observable<number> {
+	getDiscountAmount(id: T['id']): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectProductDiscountAmount, { id }));
 	}
 
-	getDiscountedPrice(id: string): Observable<number> {
+	getDiscountedPrice(id: T['id']): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectProductDiscountedPrice, { id }));
 	}
 
-	getDiscountPercent(id: string): Observable<number> {
+	getDiscountPercent(id: T['id']): Observable<number> {
 		return this.store.pipe(select(this.selectors.selectProductDiscountPercent, { id }));
 	}
 
-	isOutOfStock(id: string): Observable<boolean> {
+	isOutOfStock(id: T['id']): Observable<boolean> {
 		return this.store.pipe(select(this.selectors.selectIsProductOutOfStock, { id }));
 	}
 

--- a/libs/product/src/models/composite-configuration-item.ts
+++ b/libs/product/src/models/composite-configuration-item.ts
@@ -1,4 +1,6 @@
+import { ID } from '@daffodil/core';
+
 export interface DaffCompositeConfigurationItem {
 	qty?: number;
-	value?: string;
+	value?: ID;
 }

--- a/libs/product/src/models/composite-product-item.ts
+++ b/libs/product/src/models/composite-product-item.ts
@@ -1,3 +1,5 @@
+import { ID } from '@daffodil/core';
+
 import { DaffProduct } from './product';
 
 /**
@@ -17,7 +19,7 @@ export enum DaffCompositeProductItemInputEnum {
  * composite product, or neither if the item is optional.
  */
 export interface DaffCompositeProductItem {
-	id: number | string;
+	id: ID;
 	required: boolean;
 	title: string;
 	input_type: DaffCompositeProductItemInputEnum;
@@ -28,7 +30,7 @@ export interface DaffCompositeProductItem {
  * The composite product item option is a DaffProduct that can be added to a composite product.
  */
 export interface DaffCompositeProductItemOption extends DaffProduct {
-	id: string;
+	id: ID;
 	name: string;
 	price: number;
 	is_default: boolean;

--- a/libs/product/src/models/configurable-product.ts
+++ b/libs/product/src/models/configurable-product.ts
@@ -1,10 +1,10 @@
-import { DaffSortable } from '@daffodil/core';
+import { DaffSortable, ID } from '@daffodil/core';
 
 import { DaffProduct, DaffProductDiscount } from './product';
 import { DaffProductImage } from './product-image';
 
 /**
- * A configurable product is a product with configurable attributes. The price of a configurable product may change based on 
+ * A configurable product is a product with configurable attributes. The price of a configurable product may change based on
  * the attributes chosen, so a configurable product can have a price range. An example of a configurable product is a T-shirt.
  */
 export interface DaffConfigurableProduct extends DaffProduct {
@@ -13,7 +13,7 @@ export interface DaffConfigurableProduct extends DaffProduct {
 }
 
 /**
- * An attribute of the configurable product that the customer must choose to add the configurable product to the cart. 
+ * An attribute of the configurable product that the customer must choose to add the configurable product to the cart.
  * An example of an attribute would be size for clothing.
  */
 export interface DaffConfigurableProductAttribute extends DaffSortable {
@@ -23,16 +23,16 @@ export interface DaffConfigurableProductAttribute extends DaffSortable {
 }
 
 /**
- * A variant is one version of the configurable product with all attributes chosen. Variants exist because not all versions of every configuration of 
+ * A variant is one version of the configurable product with all attributes chosen. Variants exist because not all versions of every configuration of
  * the product might be in stock. For example, a shirt might have a medium, red shirt and a small,
- * green shirt in stock, but no small, red shirts. In this case there would be two variants (mediumRed, smallGreen) rather than the maximum 4 variants 
+ * green shirt in stock, but no small, red shirts. In this case there would be two variants (mediumRed, smallGreen) rather than the maximum 4 variants
  * (smallRed, mediumRed, smallGreen, mediumGreen). This ensures the customer can't add a configurable product to the cart that is not
- * in stock. However, variants don't usually need to be considered by the frontend dev, because daffodil abstacts away the concept of variants into 
+ * in stock. However, variants don't usually need to be considered by the frontend dev, because daffodil abstacts away the concept of variants into
  * an "available attributes" selector.
  */
 export interface DaffConfigurableProductVariant {
 	appliedAttributes: DaffProductVariantAttributesDictionary;
-	id: string;
+	id: ID;
 	price: number;
 	discount: DaffProductDiscount;
 	image?: DaffProductImage;

--- a/libs/product/src/models/product-image.ts
+++ b/libs/product/src/models/product-image.ts
@@ -1,8 +1,10 @@
+import { ID } from '@daffodil/core';
+
 /**
  * Interface for an image on a DaffProduct.
  */
 export interface DaffProductImage {
-  id: string;
+  id: ID;
   url: string;
   label: string;
 }

--- a/libs/product/src/models/product.ts
+++ b/libs/product/src/models/product.ts
@@ -1,3 +1,5 @@
+import { ID } from '@daffodil/core';
+
 import { DaffProductImage } from './product-image';
 
 export enum DaffProductTypeEnum {
@@ -10,7 +12,7 @@ export enum DaffProductTypeEnum {
  * An interface for a product usable by the @daffodil/product library.
  */
 export interface DaffProduct {
-	id: string;
+	id: ID;
 	type?: DaffProductTypeEnum;
 	url?: string;
 	price?: number;

--- a/libs/product/src/reducers/best-sellers/best-sellers-reducer-state.interface.ts
+++ b/libs/product/src/reducers/best-sellers/best-sellers-reducer-state.interface.ts
@@ -1,5 +1,7 @@
+import { DaffProduct } from '../../models/product';
+
 export interface DaffBestSellersReducerState {
-  productIds: string[],
+  productIds: DaffProduct['id'][],
   loading: boolean,
   errors: string[]
 }

--- a/libs/product/src/reducers/best-sellers/best-sellers.reducer.ts
+++ b/libs/product/src/reducers/best-sellers/best-sellers.reducer.ts
@@ -17,8 +17,8 @@ export function daffBestSellersReducer<T extends DaffProduct>(state = initialSta
     case DaffBestSellersActionTypes.BestSellersLoadSuccessAction:
       return {...state, loading: false, productIds: getIds<T>(action.payload)};
     case DaffBestSellersActionTypes.BestSellersLoadFailureAction:
-      return {...state, 
-        loading: false, 
+      return {...state,
+        loading: false,
         errors: state.errors.concat(new Array(action.payload))
       };
     case DaffBestSellersActionTypes.BestSellersResetAction:
@@ -30,8 +30,8 @@ export function daffBestSellersReducer<T extends DaffProduct>(state = initialSta
   }
 }
 
-function getIds<T extends DaffProduct>(products: T[]): string[] {
-  const ids: string[] = new Array();
+function getIds<T extends DaffProduct>(products: T[]): T['id'][] {
+  const ids: T['id'][] = new Array();
 
   products.forEach(product => {
     ids.push(product.id)

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
@@ -1,7 +1,10 @@
 import { Dictionary } from '@ngrx/entity';
+
+import { ID } from '@daffodil/core';
+
 import { DaffCompositeConfigurationItem } from '../../models/composite-configuration-item';
 
 export interface DaffCompositeProductEntity {
-	id: string;
+	id: ID;
 	items: Dictionary<DaffCompositeConfigurationItem>;
 }

--- a/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
+++ b/libs/product/src/reducers/composite-product-entities/composite-product-entity.ts
@@ -1,10 +1,9 @@
 import { Dictionary } from '@ngrx/entity';
 
-import { ID } from '@daffodil/core';
-
 import { DaffCompositeConfigurationItem } from '../../models/composite-configuration-item';
+import { DaffProduct } from '../../models/product';
 
 export interface DaffCompositeProductEntity {
-	id: ID;
+	id: DaffProduct['id'];
 	items: Dictionary<DaffCompositeConfigurationItem>;
 }

--- a/libs/product/src/reducers/configurable-product-entities/configurable-product-entity.ts
+++ b/libs/product/src/reducers/configurable-product-entities/configurable-product-entity.ts
@@ -1,7 +1,7 @@
-import { ID } from '@daffodil/core';
+import { DaffProduct } from '../../models/product';
 
 export interface DaffConfigurableProductEntity {
-	id: ID;
+	id: DaffProduct['id'];
 	attributes: DaffConfigurableProductEntityAttribute[];
 }
 

--- a/libs/product/src/reducers/configurable-product-entities/configurable-product-entity.ts
+++ b/libs/product/src/reducers/configurable-product-entities/configurable-product-entity.ts
@@ -1,5 +1,7 @@
+import { ID } from '@daffodil/core';
+
 export interface DaffConfigurableProductEntity {
-	id: string;
+	id: ID;
 	attributes: DaffConfigurableProductEntityAttribute[];
 }
 

--- a/libs/product/src/reducers/product/product-reducer-state.interface.ts
+++ b/libs/product/src/reducers/product/product-reducer-state.interface.ts
@@ -1,8 +1,10 @@
+import { DaffProduct } from '../../models/product';
+
 /**
  * Interface for product state.
  */
 export interface DaffProductReducerState {
-  selectedProductId: string,
+  selectedProductId: DaffProduct['id'],
   qty: number,
   loading: boolean,
   errors: string[]

--- a/libs/product/src/selectors/best-sellers/best-sellers.selectors.ts
+++ b/libs/product/src/selectors/best-sellers/best-sellers.selectors.ts
@@ -9,7 +9,7 @@ import { DaffProduct } from '../../models/product';
 export interface DaffBestSellersMemoizedSelectors<T extends DaffProduct = DaffProduct> {
 	selectBestSellersState: MemoizedSelector<object, DaffBestSellersReducerState>;
 	selectBestSellersLoadingState: MemoizedSelector<object, boolean>;
-	selectBestSellersIdsState: MemoizedSelector<object, string[]>;
+	selectBestSellersIdsState: MemoizedSelector<object, T['id'][]>;
 	selectBestSellersProducts: MemoizedSelector<object, T[]>;
 }
 
@@ -50,10 +50,10 @@ const createBestSellersSelectors = <T extends DaffProduct>(): DaffBestSellersMem
 	const selectBestSellersProducts = createSelector(
 		selectBestSellersIdsState,
 		selectAllProducts,
-		(ids: string[], products: T[]) => products.filter(product => ids.indexOf(product.id) > -1)
+		(ids: T['id'][], products: T[]) => products.filter(product => ids.indexOf(product.id) > -1)
 	)
 
-	return { 
+	return {
 		selectBestSellersState,
 		selectBestSellersLoadingState,
 		selectBestSellersIdsState,
@@ -63,7 +63,7 @@ const createBestSellersSelectors = <T extends DaffProduct>(): DaffBestSellersMem
 
 export const getDaffBestSellersSelectors = (() => {
 	let cache;
-	return <T extends DaffProduct>(): DaffBestSellersMemoizedSelectors<T> => cache = cache 
-		? cache 
+	return <T extends DaffProduct>(): DaffBestSellersMemoizedSelectors<T> => cache = cache
+		? cache
 		: createBestSellersSelectors<T>();
 })();

--- a/libs/product/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product/src/selectors/composite-product/composite-product.selectors.ts
@@ -15,16 +15,16 @@ export interface DaffCompositeProductMemoizedSelectors {
 	/**
 	 * Get a DaffPriceRange for a composite product based on the configuration provided excluding unselected, optional item prices.
 	 */
-	selectCompositeProductRequiredItemPricesForConfiguration: MemoizedSelectorWithProps<object, { id: string, configuration?: Dictionary<DaffCompositeConfigurationItem> }, DaffPriceRange>;
+	selectCompositeProductRequiredItemPricesForConfiguration: MemoizedSelectorWithProps<object, { id: DaffCompositeProduct['id'], configuration?: Dictionary<DaffCompositeConfigurationItem> }, DaffPriceRange>;
 	/**
 	 * Get the broadest possible DaffPriceRange for a composite product based on the configuration provided including optional item prices.
 	 */
-	selectCompositeProductOptionalItemPricesForConfiguration: MemoizedSelectorWithProps<object, { id: string, configuration?: Dictionary<DaffCompositeConfigurationItem> }, DaffPriceRange>;
+	selectCompositeProductOptionalItemPricesForConfiguration: MemoizedSelectorWithProps<object, { id: DaffCompositeProduct['id'], configuration?: Dictionary<DaffCompositeConfigurationItem> }, DaffPriceRange>;
 	/**
 	 * Get the DaffPriceRange for a composite product based on the current configuration of selected item options in redux state and
 	 * excluding unselected, optional item prices.
 	 */
-	selectCompositeProductPricesAsCurrentlyConfigured: MemoizedSelectorWithProps<object, { id: string }, DaffPriceRange>;
+	selectCompositeProductPricesAsCurrentlyConfigured: MemoizedSelectorWithProps<object, { id: DaffCompositeProduct['id'] }, DaffPriceRange>;
 }
 
 const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelectors => {
@@ -75,12 +75,12 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 		selectCompositeProductAppliedOptionsEntitiesState,
 		//todo use optional chaining when possible
 		(products, appliedOptionsEntities, props) => selectCompositeProductRequiredItemPricesForConfiguration.projector(products, {
-			id: props.id, 
+			id: props.id,
 			configuration: appliedOptionsEntities.entities[props.id] ? appliedOptionsEntities.entities[props.id].items : null
 		})
 	);
 
-	return { 
+	return {
 		selectCompositeProductRequiredItemPricesForConfiguration,
 		selectCompositeProductOptionalItemPricesForConfiguration,
 		selectCompositeProductPricesAsCurrentlyConfigured
@@ -89,8 +89,8 @@ const createCompositeProductSelectors = (): DaffCompositeProductMemoizedSelector
 
 export const getDaffCompositeProductSelectors = (() => {
 	let cache;
-	return (): DaffCompositeProductMemoizedSelectors => cache = cache 
-		? cache 
+	return (): DaffCompositeProductMemoizedSelectors => cache = cache
+		? cache
 		: createCompositeProductSelectors();
 })();
 
@@ -135,16 +135,16 @@ function getMaximumRequiredCompositeItemDiscountedPrice(item: DaffCompositeProdu
 function getMinPricesForConfiguration(product: DaffCompositeProduct, appliedOptions: Dictionary<DaffCompositeProductItemOption>): DaffProductPrices {
 	return {
 		discountedPrice: product.items.reduce((acc, item) => daffAdd(
-			acc, 
-			appliedOptionHasId(appliedOptions[item.id]) ? 
-				daffMultiply(getDiscountedPrice(appliedOptions[item.id]), appliedOptions[item.id].quantity) : 
+			acc,
+			appliedOptionHasId(appliedOptions[item.id]) ?
+				daffMultiply(getDiscountedPrice(appliedOptions[item.id]), appliedOptions[item.id].quantity) :
 				getMinimumRequiredCompositeItemDiscountedPrice(item, getOptionQty(appliedOptions[item.id]))
 		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },
 		originalPrice: product.items.reduce((acc, item) => daffAdd(
-			acc, 
-			appliedOptionHasId(appliedOptions[item.id]) ? 
-				daffMultiply(appliedOptions[item.id].price, appliedOptions[item.id].quantity) : 
+			acc,
+			appliedOptionHasId(appliedOptions[item.id]) ?
+				daffMultiply(appliedOptions[item.id].price, appliedOptions[item.id].quantity) :
 				getMinimumRequiredCompositeItemPrice(item, getOptionQty(appliedOptions[item.id]))
 		), product.price)
 	}
@@ -158,16 +158,16 @@ function getMinPricesForConfiguration(product: DaffCompositeProduct, appliedOpti
 function getMaxPricesForConfiguration(product: DaffCompositeProduct, appliedOptions: Dictionary<DaffCompositeProductItemOption>): DaffProductPrices {
 	return {
 		discountedPrice: product.items.reduce((acc, item) => daffAdd(
-			acc, 
-			appliedOptionHasId(appliedOptions[item.id]) ? 
-				daffMultiply(getDiscountedPrice(appliedOptions[item.id]), appliedOptions[item.id].quantity) : 
+			acc,
+			appliedOptionHasId(appliedOptions[item.id]) ?
+				daffMultiply(getDiscountedPrice(appliedOptions[item.id]), appliedOptions[item.id].quantity) :
 				getMaximumRequiredCompositeItemDiscountedPrice(item, getOptionQty(appliedOptions[item.id]))
 		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },
 		originalPrice: product.items.reduce((acc, item) => daffAdd(
 			acc,
-			appliedOptionHasId(appliedOptions[item.id]) ? 
-				daffMultiply(appliedOptions[item.id].price, appliedOptions[item.id].quantity) : 
+			appliedOptionHasId(appliedOptions[item.id]) ?
+				daffMultiply(appliedOptions[item.id].price, appliedOptions[item.id].quantity) :
 				getMaximumRequiredCompositeItemPrice(item, getOptionQty(appliedOptions[item.id]))
 		), product.price)
 	}
@@ -184,20 +184,20 @@ function getDiscountedPrice(product: DaffProduct): number {
 function getMaxPricesForConfigurationIncludingOptionalItems(product: DaffCompositeProduct, appliedOptions: Dictionary<DaffCompositeProductItemOption>): DaffProductPrices {
 	return {
 		discountedPrice: (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
-			acc, 
-			appliedOptionHasId(appliedOptions[item.id]) ? 
+			acc,
+			appliedOptionHasId(appliedOptions[item.id]) ?
 				daffMultiply(getDiscountedPrice(appliedOptions[item.id]), appliedOptions[item.id].quantity) :
 				appliedOptionHasQty(appliedOptions[item.id]) ?
-					daffMultiply(Math.max(...item.options.map(getDiscountedPrice)), appliedOptions[item.id].quantity) : 
+					daffMultiply(Math.max(...item.options.map(getDiscountedPrice)), appliedOptions[item.id].quantity) :
 					Math.max(...item.options.map(getDiscountedPrice))
 		), getDiscountedPrice(product)),
 		discount: { amount: null, percent: null },
 		originalPrice: (<DaffCompositeProduct>product).items.reduce((acc, item) => daffAdd(
 			acc,
-			appliedOptionHasId(appliedOptions[item.id]) ? 
-				daffMultiply(appliedOptions[item.id].price, appliedOptions[item.id].quantity) : 
+			appliedOptionHasId(appliedOptions[item.id]) ?
+				daffMultiply(appliedOptions[item.id].price, appliedOptions[item.id].quantity) :
 				appliedOptionHasQty(appliedOptions[item.id]) ?
-					daffMultiply(Math.max(...item.options.map(option => option.price)), appliedOptions[item.id].quantity) : 
+					daffMultiply(Math.max(...item.options.map(option => option.price)), appliedOptions[item.id].quantity) :
 					Math.max(...item.options.map(option => option.price))
 		), product.price)
 	}

--- a/libs/product/src/selectors/product/product.selectors.ts
+++ b/libs/product/src/selectors/product/product.selectors.ts
@@ -7,13 +7,13 @@ import { DaffProduct } from '../../models/product';
 
 export interface DaffProductPageMemoizedSelectors<T extends DaffProduct = DaffProduct> {
 	selectSelectedProductState: MemoizedSelector<object, DaffProductReducerState>;
-	selectSelectedProductId: MemoizedSelector<object, string>;
+	selectSelectedProductId: MemoizedSelector<object, T['id']>;
 	selectSelectedProductQty: MemoizedSelector<object, number>;
 	selectSelectedProductLoadingState: MemoizedSelector<object, boolean>;
 	selectSelectedProduct: MemoizedSelector<object, T>;
 }
 
-const createProductPageSelectors = <T extends DaffProduct>(): DaffProductPageMemoizedSelectors<T> => {
+const createProductPageSelectors = <T extends DaffProduct = DaffProduct>(): DaffProductPageMemoizedSelectors<T> => {
 
 	const {
 		selectProductState
@@ -60,10 +60,10 @@ const createProductPageSelectors = <T extends DaffProduct>(): DaffProductPageMem
 	const selectSelectedProduct = createSelector(
 		selectProductState,
 		selectSelectedProductId,
-		(state: DaffProductReducersState<T>, id: string) => state.products.entities[id]
+		(state: DaffProductReducersState<T>, id: T['id']) => state.products.entities[id]
 	);
 
-	return { 
+	return {
 		selectSelectedProductState,
 		selectSelectedProductId,
 		selectSelectedProductQty,
@@ -74,7 +74,7 @@ const createProductPageSelectors = <T extends DaffProduct>(): DaffProductPageMem
 
 export const getDaffProductPageSelectors = (() => {
 	let cache;
-	return <T extends DaffProduct>(): DaffProductPageMemoizedSelectors<T> => cache = cache 
-		? cache 
+	return <T extends DaffProduct>(): DaffProductPageMemoizedSelectors<T> => cache = cache
+		? cache
 		: createProductPageSelectors<T>();
 })();

--- a/libs/product/testing/src/drivers/in-memory/product.service.ts
+++ b/libs/product/testing/src/drivers/in-memory/product.service.ts
@@ -6,7 +6,7 @@ import { DaffProduct, DaffProductServiceInterface } from '@daffodil/product';
 
 /**
  * The product inmemory driver to mock the product backend service.
- * 
+ *
  * @Param HttpClient
  */
 @Injectable({
@@ -19,7 +19,7 @@ export class DaffInMemoryProductService implements DaffProductServiceInterface {
 
   /**
    * Gets all products.
-   * 
+   *
    * @returns An Observable of DaffProduct[]
    */
   getAll(): Observable<DaffProduct[]> {
@@ -28,7 +28,7 @@ export class DaffInMemoryProductService implements DaffProductServiceInterface {
 
   /**
    * Gets all best selling products.
-   * 
+   *
    * @returns An Observable of DaffProduct[]
    */
   getBestSellers(): Observable<DaffProduct[]> {
@@ -37,11 +37,11 @@ export class DaffInMemoryProductService implements DaffProductServiceInterface {
 
   /**
    * Get a product by ID.
-   * 
+   *
    * @param productId string - product ID
    * @returns An Observable of a DaffProduct
    */
-  get(productId: string): Observable<DaffProduct> {
+  get(productId: DaffProduct['id']): Observable<DaffProduct> {
     return this.http.get<DaffProduct>(this.url + productId);
   }
 }

--- a/libs/product/testing/src/drivers/testing/product.service.ts
+++ b/libs/product/testing/src/drivers/testing/product.service.ts
@@ -8,7 +8,7 @@ import { DaffProductImageFactory } from '../../factories/product-image.factory';
 
 /**
  * The product testing driver to mock the backend product service.
- * 
+ *
  * @param productFactory - A DaffProductFactory instance
  * @param productImageFactory - A DaffProductImageFactory instance
  */
@@ -16,14 +16,14 @@ import { DaffProductImageFactory } from '../../factories/product-image.factory';
   providedIn: 'root'
 })
 export class DaffTestingProductService implements DaffProductServiceInterface {
- 
+
   constructor(
     private productFactory: DaffProductFactory,
     private productImageFactory: DaffProductImageFactory) {}
 
   /**
    * Get all products as DaffProduct[].
-   * 
+   *
    * @returns An Observable of Product[]
    */
   getAll(): Observable<DaffProduct[]> {
@@ -38,7 +38,7 @@ export class DaffTestingProductService implements DaffProductServiceInterface {
 
   /**
    * Get all best selling products.
-   * 
+   *
    * @returns An Observable of Product[]
    */
   getBestSellers(): Observable<DaffProduct[]> {
@@ -52,11 +52,11 @@ export class DaffTestingProductService implements DaffProductServiceInterface {
 
   /**
    * Get product by ID
-   * 
+   *
    * @param productId product ID
    * @returns An Observable of a Product
    */
-  get(productId: string): Observable<DaffProduct> {
+  get(productId: DaffProduct['id']): Observable<DaffProduct> {
     return of(this.productFactory.create({ images: this.productImageFactory.createMany(5)}));
   }
 }

--- a/libs/product/testing/src/factories/composite-product.factory.ts
+++ b/libs/product/testing/src/factories/composite-product.factory.ts
@@ -10,7 +10,7 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 	private stubPrice = faker.random.number({min: 1, max: 1500});
 	private stubDiscount = faker.random.number({min: 0, max: this.stubPrice - 1});
 	type = DaffProductTypeEnum.Composite;
-	id = faker.random.number({min: 1, max: 10000}).toString();
+	id = faker.random.uuid();
 	url = faker.random.alphaNumeric(16);
 	price = this.stubPrice;
 	images = [];
@@ -24,13 +24,13 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 	description = 'Lorem ipsum dolor sit amet, accumsan ullamcorper ei eam. Sint appetere ocurreret no per, et cum lorem disputationi. Sit ut magna delenit, assum vidisse vocibus sed ut. In aperiri malorum accusamus sea, novum mediocritatem ius at. Duo agam probo honestatis ut. Nec regione splendide cu, unum graeco vivendum in duo.'
 	items = [
 		{
-			id: faker.random.alphaNumeric(10),
+			id: faker.random.uuid(),
 			required: faker.random.boolean(),
 			title: faker.commerce.productName(),
 			input_type: DaffCompositeProductItemInputEnum.select,
 			options: [
 				{
-					id: faker.random.alphaNumeric(10),
+					id: faker.random.uuid(),
 					name: faker.commerce.productMaterial(),
 					price: faker.random.number({min: 1, max: 100}),
 					images: [],
@@ -43,7 +43,7 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 					in_stock: true
 				},
 				{
-					id: faker.random.alphaNumeric(10),
+					id: faker.random.uuid(),
 					name: faker.commerce.productMaterial(),
 					price: faker.random.number({min: 1, max: 100}),
 					images: [],
@@ -58,13 +58,13 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 			]
 		},
 		{
-			id: faker.random.alphaNumeric(10),
+			id: faker.random.uuid(),
 			required: faker.random.boolean(),
 			title: faker.commerce.productName(),
 			input_type: DaffCompositeProductItemInputEnum.select,
 			options: [
 				{
-					id: faker.random.alphaNumeric(10),
+					id: faker.random.uuid(),
 					name: faker.commerce.productMaterial(),
 					price: faker.random.number({min: 1, max: 100}),
 					images: [],
@@ -77,7 +77,7 @@ export class MockCompositeProduct implements DaffCompositeProduct {
 					in_stock: true
 				},
 				{
-					id: faker.random.alphaNumeric(10),
+					id: faker.random.uuid(),
 					name: faker.commerce.productMaterial(),
 					price: faker.random.number({min: 1, max: 100}),
 					images: [],

--- a/libs/product/testing/src/factories/configurable-product.factory.ts
+++ b/libs/product/testing/src/factories/configurable-product.factory.ts
@@ -15,7 +15,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 	private stubDiscountVariant3 = faker.random.number({min: 0, max: this.stubPriceVariant3 - 1});
 
 	type = DaffProductTypeEnum.Configurable;
-	id = faker.random.number({min: 1, max: 10000}).toString();
+	id = faker.random.uuid();
 	url = faker.random.alphaNumeric(16);
 	price = faker.random.number({min: 1, max: 1500});
 	images = [];
@@ -112,7 +112,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 				amount: this.stubDiscountVariant1,
 				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
-			id: faker.random.alphaNumeric(16),
+			id: faker.random.uuid(),
 			in_stock: true
 		},
 		{
@@ -126,7 +126,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 				amount: this.stubDiscountVariant1,
 				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
-			id: faker.random.alphaNumeric(16),
+			id: faker.random.uuid(),
 			in_stock: true
 		},
 		{
@@ -140,7 +140,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 				amount: this.stubDiscountVariant3,
 				percent: Math.floor((this.stubDiscountVariant3/this.stubPriceVariant3) * 100)
 			},
-			id: faker.random.alphaNumeric(16),
+			id: faker.random.uuid(),
 			in_stock: true
 		},
 		{
@@ -154,7 +154,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 				amount: this.stubDiscountVariant1,
 				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
-			id: faker.random.alphaNumeric(16),
+			id: faker.random.uuid(),
 			in_stock: true
 		},
 		{
@@ -168,7 +168,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 				amount: this.stubDiscountVariant1,
 				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
-			id: faker.random.alphaNumeric(16),
+			id: faker.random.uuid(),
 			in_stock: true
 		},
 		{
@@ -182,7 +182,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 				amount: this.stubDiscountVariant3,
 				percent: Math.floor((this.stubDiscountVariant3/this.stubPriceVariant3) * 100)
 			},
-			id: faker.random.alphaNumeric(16),
+			id: faker.random.uuid(),
 			in_stock: true
 		},
 		{
@@ -196,7 +196,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 				amount: this.stubDiscountVariant1,
 				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
-			id: faker.random.alphaNumeric(16),
+			id: faker.random.uuid(),
 			in_stock: true
 		},
 		{
@@ -210,7 +210,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 				amount: this.stubDiscountVariant2,
 				percent: Math.floor((this.stubDiscountVariant2/this.stubPriceVariant2) * 100)
 			},
-			id: faker.random.alphaNumeric(16),
+			id: faker.random.uuid(),
 			in_stock: true
 		},
 		{
@@ -224,7 +224,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 				amount: this.stubDiscountVariant3,
 				percent: Math.floor((this.stubDiscountVariant3/this.stubPriceVariant3) * 100)
 			},
-			id: faker.random.alphaNumeric(16),
+			id: faker.random.uuid(),
 			in_stock: true
 		},
 		{
@@ -238,7 +238,7 @@ export class MockConfigurableProduct implements DaffConfigurableProduct {
 				amount: this.stubDiscountVariant1,
 				percent: Math.floor((this.stubDiscountVariant1/this.stubPriceVariant1) * 100)
 			},
-			id: faker.random.alphaNumeric(16),
+			id: faker.random.uuid(),
 			in_stock: true
 		}
 	]

--- a/libs/product/testing/src/factories/magento/configurable/configurable.factory.ts
+++ b/libs/product/testing/src/factories/magento/configurable/configurable.factory.ts
@@ -21,7 +21,7 @@ export class MockMagentoConfigurableProduct extends MockMagentoCoreProduct imple
 		{
 			attribute_code: 'color',
 			attribute_id: faker.random.alphaNumeric(12),
-			id: faker.random.alphaNumeric(12),
+			id: faker.random.uuid(),
 			label: 'Color',
 			position: 0,
 			product_id: faker.random.number({min: 1, max: 1000}),
@@ -52,7 +52,7 @@ export class MockMagentoConfigurableProduct extends MockMagentoCoreProduct imple
 			],
 			product: {
 				__typename: MagentoProductTypeEnum.SimpleProduct,
-				id: faker.random.number({min: 1, max: 1000}),
+				id: faker.random.uuid(),
 				url_key: faker.random.alphaNumeric(16),
 				name: faker.random.word(),
 				sku: faker.random.alphaNumeric(16),
@@ -95,7 +95,7 @@ export class MockMagentoConfigurableProduct extends MockMagentoCoreProduct imple
 			],
 			product: {
 				__typename: MagentoProductTypeEnum.SimpleProduct,
-				id: faker.random.number({min: 1, max: 1000}),
+				id: faker.random.uuid(),
 				url_key: faker.random.alphaNumeric(16),
 				name: faker.random.word(),
 				sku: faker.random.alphaNumeric(16),
@@ -137,7 +137,7 @@ export class MockMagentoConfigurableProduct extends MockMagentoCoreProduct imple
 			],
 			product: {
 				__typename: MagentoProductTypeEnum.SimpleProduct,
-				id: faker.random.number({min: 1, max: 1000}),
+				id: faker.random.uuid(),
 				url_key: faker.random.alphaNumeric(16),
 				name: faker.random.word(),
 				sku: faker.random.alphaNumeric(16),

--- a/libs/product/testing/src/factories/magento/core/product.factory.ts
+++ b/libs/product/testing/src/factories/magento/core/product.factory.ts
@@ -8,7 +8,7 @@ import { MagentoProduct, MagentoProductTypeEnum, MagentoProductStockStatusEnum }
 
 export class MockMagentoCoreProduct implements MagentoProduct {
 	__typename = MagentoProductTypeEnum.SimpleProduct;
-  id = faker.random.number({min: 1, max: 1000});
+  id = faker.random.uuid();
   url_key = faker.random.alphaNumeric(16);
   name = faker.random.word();
 	sku = faker.random.alphaNumeric(16);

--- a/libs/product/testing/src/factories/product-image.factory.ts
+++ b/libs/product/testing/src/factories/product-image.factory.ts
@@ -113,7 +113,7 @@ const productImageUrlsList: string[] = [
  * Mocked DaffProductImage object.
  */
 export class MockProductImage implements DaffProductImage {
-  id = faker.random.number({min: 1, max: 10000}).toString();
+  id = faker.random.uuid();
   url = productImageUrlsList[faker.random.number(productImageUrlsList.length-1)]
   label = faker.lorem.sentence();
 }

--- a/libs/product/testing/src/factories/product.factory.ts
+++ b/libs/product/testing/src/factories/product.factory.ts
@@ -11,7 +11,7 @@ export class MockProduct implements DaffProduct {
 	private stubDiscount = faker.random.number({min: 0, max: this.stubPrice - 1});
 
 	type = DaffProductTypeEnum.Simple;
-	id = faker.random.number({min: 1, max: 10000}).toString();
+	id = faker.random.uuid();
 	url = faker.random.alphaNumeric(16);
 	price = this.stubPrice;
 	in_stock = true;

--- a/libs/product/testing/src/helpers/mock-composite-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-composite-product-facade.ts
@@ -13,16 +13,16 @@ import {
 
 @Injectable({providedIn: 'root'})
 export class MockDaffCompositeProductFacade implements DaffCompositeProductFacadeInterface {
-	getRequiredItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): BehaviorSubject<DaffPriceRange> {
+	getRequiredItemPricesForConfiguration(id: DaffCompositeProduct['id'], configuration?: Dictionary<DaffCompositeConfigurationItem>): BehaviorSubject<DaffPriceRange> {
 		return new BehaviorSubject(null);
 	}
-	getOptionalItemPricesForConfiguration(id: string, configuration?: Dictionary<DaffCompositeConfigurationItem>): BehaviorSubject<DaffPriceRange> {
+	getOptionalItemPricesForConfiguration(id: DaffCompositeProduct['id'], configuration?: Dictionary<DaffCompositeConfigurationItem>): BehaviorSubject<DaffPriceRange> {
 		return new BehaviorSubject(null);
 	}
-	getPricesAsCurrentlyConfigured(id: string): BehaviorSubject<DaffPriceRange> {
+	getPricesAsCurrentlyConfigured(id: DaffCompositeProduct['id']): BehaviorSubject<DaffPriceRange> {
 		return new BehaviorSubject(null);
 	}
-	getAppliedOptions(id: string): BehaviorSubject<Dictionary<DaffCompositeProductItemOption>> {
+	getAppliedOptions(id: DaffCompositeProduct['id']): BehaviorSubject<Dictionary<DaffCompositeProductItemOption>> {
 		return new BehaviorSubject({});
 	}
 	isItemRequired(id: DaffCompositeProduct['id'], item_id: DaffCompositeProductItem['id']): BehaviorSubject<boolean> {

--- a/libs/product/testing/src/helpers/mock-configurable-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-configurable-product-facade.ts
@@ -2,47 +2,47 @@ import { BehaviorSubject } from 'rxjs';
 import { Dictionary } from '@ngrx/entity';
 import { Injectable } from '@angular/core';
 
-import { DaffConfigurableProductFacadeInterface, DaffConfigurableProductVariant } from '@daffodil/product';
+import { DaffConfigurableProductFacadeInterface, DaffConfigurableProductVariant, DaffConfigurableProduct } from '@daffodil/product';
 
 @Injectable({providedIn: 'root'})
 export class MockDaffConfigurableProductFacade implements DaffConfigurableProductFacadeInterface {
-	getAllAttributes(id: string): BehaviorSubject<Dictionary<string[]>> {
+	getAllAttributes(id: DaffConfigurableProduct['id']): BehaviorSubject<Dictionary<string[]>> {
 		return new BehaviorSubject({});
 	};
-	getAllVariants(id: string): BehaviorSubject<DaffConfigurableProductVariant[]> {
+	getAllVariants(id: DaffConfigurableProduct['id']): BehaviorSubject<DaffConfigurableProductVariant[]> {
 		return new BehaviorSubject([]);
 	};
-	getAppliedAttributes(id: string): BehaviorSubject<Dictionary<string>> {
+	getAppliedAttributes(id: DaffConfigurableProduct['id']): BehaviorSubject<Dictionary<string>> {
 		return new BehaviorSubject({});
 	};
-	getMinimumPrice(id: string): BehaviorSubject<number> {
+	getMinimumPrice(id: DaffConfigurableProduct['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaximumPrice(id: string): BehaviorSubject<number> {
+	getMaximumPrice(id: DaffConfigurableProduct['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMinimumDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMinimumDiscountedPrice(id: DaffConfigurableProduct['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaximumDiscountedPrice(id: string): BehaviorSubject<number> {
+	getMaximumDiscountedPrice(id: DaffConfigurableProduct['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMinimumPercentDiscount(id: string): BehaviorSubject<number> {
+	getMinimumPercentDiscount(id: DaffConfigurableProduct['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	getMaximumPercentDiscount(id: string): BehaviorSubject<number> {
+	getMaximumPercentDiscount(id: DaffConfigurableProduct['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	};
-	isPriceRanged(id: string): BehaviorSubject<boolean> {
+	isPriceRanged(id: DaffConfigurableProduct['id']): BehaviorSubject<boolean> {
 		return new BehaviorSubject(null);
 	};
-	hasDiscount(id: string): BehaviorSubject<boolean> {
+	hasDiscount(id: DaffConfigurableProduct['id']): BehaviorSubject<boolean> {
 		return new BehaviorSubject(null);
 	};
-	getSelectableAttributes(id: string): BehaviorSubject<Dictionary<string[]>> {
+	getSelectableAttributes(id: DaffConfigurableProduct['id']): BehaviorSubject<Dictionary<string[]>> {
 		return new BehaviorSubject({});
 	};
-	getMatchingVariants(id: string): BehaviorSubject<DaffConfigurableProductVariant[]> {
+	getMatchingVariants(id: DaffConfigurableProduct['id']): BehaviorSubject<DaffConfigurableProductVariant[]> {
 		return new BehaviorSubject([]);
 	};
 	dispatch(action) {};

--- a/libs/product/testing/src/helpers/mock-product-facade.ts
+++ b/libs/product/testing/src/helpers/mock-product-facade.ts
@@ -10,25 +10,25 @@ export class MockDaffProductFacade implements DaffProductFacadeInterface {
 	 * @deprecated use getProduct instead.
 	 */
 	product$: BehaviorSubject<DaffProduct> = new BehaviorSubject(null);
-	getProduct(id: string): BehaviorSubject<DaffProduct> {
+	getProduct(id: DaffProduct['id']): BehaviorSubject<DaffProduct> {
 		return new BehaviorSubject(null);
 	}
-	getPrice(id: string): BehaviorSubject<number> {
+	getPrice(id: DaffProduct['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	}
-	hasDiscount(id: string): BehaviorSubject<boolean> {
+	hasDiscount(id: DaffProduct['id']): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	}
-	getDiscountAmount(id: string): BehaviorSubject<number> {
+	getDiscountAmount(id: DaffProduct['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	}
-	getDiscountedPrice(id: string): BehaviorSubject<number> {
+	getDiscountedPrice(id: DaffProduct['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	}
-	getDiscountPercent(id: string): BehaviorSubject<number> {
+	getDiscountPercent(id: DaffProduct['id']): BehaviorSubject<number> {
 		return new BehaviorSubject(null);
 	}
-	isOutOfStock(id: string): BehaviorSubject<boolean> {
+	isOutOfStock(id: DaffProduct['id']): BehaviorSubject<boolean> {
 		return new BehaviorSubject(false);
 	}
 	dispatch(action) {};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is a lot of ambiguity in the Daffodil codebase about the actual types of ID fields. This leads to annoying coercion throughout the codebase. There is also the case where custom ngrx ID selectors force you to coerce either to `string` or `number`, which could cause some equality concerns.

Fixes: #1233, #1243 


## What is the new behavior?
All ID related fields are now the `ID` type, which is a `string`. In addition, places where the ID is referenced now pull the type from the model interface: `DaffCart['id']` rather than hardcoding the type.

All type coercion for ID fields is now contained in the transformer layer rather than scattered across the codebase.

Factories now generate ID fields with `faker.random.uuid()`, guaranteeing uniqueness (AFAIK).

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The types of all ID-related fields is now `string`. Coerce numbers to strings and back again if you must use numbers for IDs.

## Other information