### PR TITLE
fix(cart): in-memory api does not update collection of carts as expected

### DIFF
--- a/apps/demo/src/app/cart/components/cart-item/cart-item.component.html
+++ b/apps/demo/src/app/cart/components/cart-item/cart-item.component.html
@@ -13,12 +13,12 @@
       <span class="demo-cart-item__mobile-qty">Qty: </span>
       <span class="demo-cart-item__mobile-qty">{{item.qty}}</span>
       <span class="demo-cart-item__desktop-qty">
-        <daff-qty-dropdown [qty]="item.qty" [id]="item.item_id"></daff-qty-dropdown>
+        <daff-qty-dropdown [qty]="item.qty" [id]="item.item_id" (qtyChanged)="onQtyChanged($event)"></daff-qty-dropdown>
       </span>
     </div>
     <div class="demo-cart-item__change">
       <a>Edit</a>
-      <a>Remove</a>
+      <a class="demo-cart-item__remove" (click)="removeItem()">Remove</a>
     </div>
   </div>
 </div>

--- a/apps/demo/src/app/cart/components/cart-item/cart-item.component.ts
+++ b/apps/demo/src/app/cart/components/cart-item/cart-item.component.ts
@@ -2,24 +2,31 @@ import { Component, OnInit, Input } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { DaffCartItem } from '@daffodil/cart';
+import { DaffCartFacade, DaffCartItemDelete, DaffCartItemUpdate } from '@daffodil/cart/state';
 
 @Component({
   selector: 'demo-cart-item',
   templateUrl: './cart-item.component.html',
   styleUrls: ['./cart-item.component.scss']
 })
-export class CartItemComponent implements OnInit {
+export class CartItemComponent {
 
   @Input() item: DaffCartItem;
 
   constructor(
-    private router: Router
+		private router: Router,
+		private facade: DaffCartFacade
   ) { }
-
-  ngOnInit() {
-  }
 
   redirectToProduct() {
     this.router.navigateByUrl('/product/' + this.item.product_id);
-  }
+	}
+	
+	onQtyChanged(qty) {
+		this.facade.dispatch(new DaffCartItemUpdate(this.item.item_id, { qty }))
+	}
+
+	removeItem() {
+		this.facade.dispatch(new DaffCartItemDelete(this.item.item_id));
+	}
 }

--- a/apps/demo/src/app/drivers/in-memory/backend/backend.service.spec.ts
+++ b/apps/demo/src/app/drivers/in-memory/backend/backend.service.spec.ts
@@ -32,7 +32,7 @@ describe('Driver | In Memory | InMemoryService', () => {
   });
 
   describe('post', () => {
-    describe('when collectionName includes "cart"', () => {
+    describe('when collectionName is a DaffInMemoryBackendCartRootService collection name', () => {
       let reqInfo;
       let result;
       let returnedValue;
@@ -43,7 +43,7 @@ describe('Driver | In Memory | InMemoryService', () => {
           returnedValue
         );
         reqInfo = {
-          collectionName: 'cart-item'
+          collectionName: DaffInMemoryBackendCartRootService.COLLECTION_NAMES[0]
         };
 
         result = service.post(reqInfo);
@@ -119,7 +119,7 @@ describe('Driver | In Memory | InMemoryService', () => {
       });
     });
 
-    describe('when collectionName is cart', () => {
+    describe('when collectionName is a DaffInMemoryBackendCartRootService collection name', () => {
 
       let reqInfo;
       let result;
@@ -129,7 +129,7 @@ describe('Driver | In Memory | InMemoryService', () => {
         returnedValue = 'returnedValue';
         spyOn(service.cartTestingService, 'get').and.returnValue(returnedValue);
         reqInfo = {
-          collectionName: 'cart'
+          collectionName: DaffInMemoryBackendCartRootService.COLLECTION_NAMES[0]
         }
 
         result = service.get(reqInfo);
@@ -153,7 +153,7 @@ describe('Driver | In Memory | InMemoryService', () => {
   });
 
   describe('put', () => {
-    describe('when collectionName is cart-items', () => {
+    describe('when collectionName is a DaffInMemoryBackendCartRootService collection name', () => {
       let reqInfo;
       let result;
       let returnedValue;
@@ -164,7 +164,7 @@ describe('Driver | In Memory | InMemoryService', () => {
           returnedValue
         );
         reqInfo = {
-          collectionName: 'cart-items'
+          collectionName: DaffInMemoryBackendCartRootService.COLLECTION_NAMES[0]
         };
 
         result = service.put(reqInfo);
@@ -189,7 +189,7 @@ describe('Driver | In Memory | InMemoryService', () => {
   });
 
   describe('delete', () => {
-    describe('when collectionName is cart-items', () => {
+    describe('when collectionName is a DaffInMemoryBackendCartRootService collection name', () => {
       let reqInfo;
       let result;
       let returnedValue;
@@ -200,7 +200,7 @@ describe('Driver | In Memory | InMemoryService', () => {
           returnedValue
         );
         reqInfo = {
-          collectionName: 'cart-items'
+          collectionName: DaffInMemoryBackendCartRootService.COLLECTION_NAMES[0]
         };
 
         result = service.delete(reqInfo);

--- a/apps/demo/src/app/drivers/in-memory/backend/backend.service.spec.ts
+++ b/apps/demo/src/app/drivers/in-memory/backend/backend.service.spec.ts
@@ -32,7 +32,7 @@ describe('Driver | In Memory | InMemoryService', () => {
   });
 
   describe('post', () => {
-    describe('when collectionName is cart', () => {
+    describe('when collectionName includes "cart"', () => {
       let reqInfo;
       let result;
       let returnedValue;
@@ -43,7 +43,7 @@ describe('Driver | In Memory | InMemoryService', () => {
           returnedValue
         );
         reqInfo = {
-          collectionName: 'cart'
+          collectionName: 'cart-item'
         };
 
         result = service.post(reqInfo);
@@ -119,10 +119,107 @@ describe('Driver | In Memory | InMemoryService', () => {
       });
     });
 
+    describe('when collectionName is cart', () => {
+
+      let reqInfo;
+      let result;
+      let returnedValue;
+
+      beforeEach(() => {
+        returnedValue = 'returnedValue';
+        spyOn(service.cartTestingService, 'get').and.returnValue(returnedValue);
+        reqInfo = {
+          collectionName: 'cart'
+        }
+
+        result = service.get(reqInfo);
+      });
+
+      it('should call cartTestingService.get', () => {
+        expect(service.cartTestingService.get).toHaveBeenCalledWith(reqInfo);
+      });
+
+      it('should return the returned value of cartTestingService.get', () => {
+        expect(result).toEqual(returnedValue);
+      });
+    });
+
     describe('when collectionName is none of the above', () => {
 
       it('should return undefined', () => {
         expect(service.get({collectionName: 'noneOfTheAbove'})).toEqual(undefined);
+      });
+    });
+  });
+
+  describe('put', () => {
+    describe('when collectionName is cart-items', () => {
+      let reqInfo;
+      let result;
+      let returnedValue;
+
+      beforeEach(() => {
+        returnedValue = 'returnedValue';
+        spyOn(service.cartTestingService, 'put').and.returnValue(
+          returnedValue
+        );
+        reqInfo = {
+          collectionName: 'cart-items'
+        };
+
+        result = service.put(reqInfo);
+      });
+
+      it('should call cartTestingService.put', () => {
+        expect(service.cartTestingService.put).toHaveBeenCalledWith(reqInfo);
+      });
+
+      it('should return the returned value of cartTestingService.put', () => {
+        expect(result).toEqual(returnedValue);
+      });
+    });
+
+    describe('when collectionName is none of the above', () => {
+      it('should return undefined', () => {
+        expect(service.put({ collectionName: 'noneOfTheAbove' })).toEqual(
+          undefined
+        );
+      });
+    });
+  });
+
+  describe('delete', () => {
+    describe('when collectionName is cart-items', () => {
+      let reqInfo;
+      let result;
+      let returnedValue;
+
+      beforeEach(() => {
+        returnedValue = 'returnedValue';
+        spyOn(service.cartTestingService, 'delete').and.returnValue(
+          returnedValue
+        );
+        reqInfo = {
+          collectionName: 'cart-items'
+        };
+
+        result = service.delete(reqInfo);
+      });
+
+      it('should call cartTestingService.delete', () => {
+        expect(service.cartTestingService.delete).toHaveBeenCalledWith(reqInfo);
+      });
+
+      it('should return the returned value of cartTestingService.delete', () => {
+        expect(result).toEqual(returnedValue);
+      });
+    });
+
+    describe('when collectionName is none of the above', () => {
+      it('should return undefined', () => {
+        expect(service.delete({ collectionName: 'noneOfTheAbove' })).toEqual(
+          undefined
+        );
       });
     });
   });

--- a/apps/demo/src/app/drivers/in-memory/backend/backend.service.ts
+++ b/apps/demo/src/app/drivers/in-memory/backend/backend.service.ts
@@ -33,8 +33,8 @@ export class DemoInMemoryBackendService implements InMemoryDbService {
   }
 
   post(reqInfo: any) {
-    const collectionName = reqInfo.collectionName;
-    if (collectionName === 'cart') {
+		const collectionName = reqInfo.collectionName;
+    if (collectionName.includes('cart')) {
       return this.cartTestingService.post(reqInfo);
     } else if (collectionName === 'checkout') {
       return this.checkoutTestingService.post(reqInfo);
@@ -51,8 +51,24 @@ export class DemoInMemoryBackendService implements InMemoryDbService {
       return this.productTestingService.get(reqInfo);
     } else if (collectionName === 'navigation') {
       return this.navigationTestingService.get(reqInfo);
-    }
-  }
+    } else if (collectionName === 'cart') {
+			return this.cartTestingService.get(reqInfo);
+		}
+	}
+	
+	put(reqInfo: any) {
+		const collectionName = reqInfo.collectionName;
+		if(collectionName === 'cart-items') {
+			return this.cartTestingService.put(reqInfo);
+		}
+	}
+	
+	delete(reqInfo: any) {
+		const collectionName = reqInfo.collectionName;
+		if(collectionName === 'cart-items') {
+			return this.cartTestingService.delete(reqInfo);
+		}
+	}
 
   createDb(reqInfo: RequestInfo): MockDaffDatabase {
     return {

--- a/apps/demo/src/app/drivers/in-memory/backend/backend.service.ts
+++ b/apps/demo/src/app/drivers/in-memory/backend/backend.service.ts
@@ -34,7 +34,7 @@ export class DemoInMemoryBackendService implements InMemoryDbService {
 
   post(reqInfo: any) {
 		const collectionName = reqInfo.collectionName;
-    if (collectionName.includes('cart')) {
+    if (DaffInMemoryBackendCartRootService.COLLECTION_NAMES.indexOf(collectionName) > -1) {
       return this.cartTestingService.post(reqInfo);
     } else if (collectionName === 'checkout') {
       return this.checkoutTestingService.post(reqInfo);
@@ -51,21 +51,21 @@ export class DemoInMemoryBackendService implements InMemoryDbService {
       return this.productTestingService.get(reqInfo);
     } else if (collectionName === 'navigation') {
       return this.navigationTestingService.get(reqInfo);
-    } else if (collectionName === 'cart') {
+    } else if (DaffInMemoryBackendCartRootService.COLLECTION_NAMES.indexOf(collectionName) > -1) {
 			return this.cartTestingService.get(reqInfo);
 		}
 	}
 	
 	put(reqInfo: any) {
 		const collectionName = reqInfo.collectionName;
-		if(collectionName === 'cart-items') {
+		if(DaffInMemoryBackendCartRootService.COLLECTION_NAMES.indexOf(collectionName) > -1) {
 			return this.cartTestingService.put(reqInfo);
 		}
 	}
 	
 	delete(reqInfo: any) {
 		const collectionName = reqInfo.collectionName;
-		if(collectionName === 'cart-items') {
+		if(DaffInMemoryBackendCartRootService.COLLECTION_NAMES.indexOf(collectionName) > -1) {
 			return this.cartTestingService.delete(reqInfo);
 		}
 	}

--- a/apps/demo/src/app/product/components/add-to-cart/add-to-cart.component.spec.ts
+++ b/apps/demo/src/app/product/components/add-to-cart/add-to-cart.component.spec.ts
@@ -2,6 +2,7 @@ import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
+import { DaffCartItemInputType } from '@daffodil/cart';
 
 import { AddToCartComponent } from './add-to-cart.component';
 
@@ -72,7 +73,11 @@ describe('AddToCartComponent', () => {
 
       addToCartComponent.emitAddToCart();
 
-      expect(addToCartComponent.addToCart.emit).toHaveBeenCalledWith({productId: addToCartComponent.additive.id, qty: addToCartComponent.qty});
+      expect(addToCartComponent.addToCart.emit).toHaveBeenCalledWith({
+				productId: addToCartComponent.additive.id, 
+				qty: addToCartComponent.qty, 
+				type: DaffCartItemInputType.Simple
+			});
     });
   });
 });

--- a/apps/demo/src/app/product/components/add-to-cart/add-to-cart.component.ts
+++ b/apps/demo/src/app/product/components/add-to-cart/add-to-cart.component.ts
@@ -1,4 +1,5 @@
 import { Component, Output, EventEmitter, Input, ViewEncapsulation } from '@angular/core';
+import { DaffCartItemInput, DaffCartItemInputType } from '@daffodil/cart';
 
 @Component({
   selector: 'demo-add-to-cart',
@@ -12,13 +13,13 @@ import { Component, Output, EventEmitter, Input, ViewEncapsulation } from '@angu
 export class AddToCartComponent {
   @Input() additive: any;
   @Input() qty: number;
-  @Output() addToCart: EventEmitter<any> = new EventEmitter();
+  @Output() addToCart: EventEmitter<DaffCartItemInput> = new EventEmitter();
 
   onAddToCart() {
     this.emitAddToCart();
   }
 
   emitAddToCart() {
-    this.addToCart.emit({productId: this.additive.id, qty: this.qty});
+    this.addToCart.emit({productId: this.additive.id, qty: this.qty, type: DaffCartItemInputType.Simple});
   }
 }

--- a/apps/demo/src/app/product/pages/product-view/product-view.component.spec.ts
+++ b/apps/demo/src/app/product/pages/product-view/product-view.component.spec.ts
@@ -4,11 +4,12 @@ import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffAddToCart } from '@daffodil/cart/state';
+import { DaffCartItemAdd } from '@daffodil/cart/state';
 import { DaffCartTestingModule, MockDaffCartFacade } from '@daffodil/cart/state/testing';
 import { DaffProduct, DaffProductLoad } from '@daffodil/product';
 import { DaffProductFactory, DaffProductTestingModule, MockDaffProductFacade } from '@daffodil/product/testing';
 import { DaffLoadingIconModule } from '@daffodil/design';
+import { DaffCartItemInputType } from '@daffodil/cart';
 
 import { ProductViewComponent } from './product-view.component';
 import { ActivatedRouteStub } from '../../../testing/ActivatedRouteStub';
@@ -131,12 +132,13 @@ describe('ProductViewComponent', () => {
       spyOn(cartFacade, 'dispatch');
       const payload = {
 				productId: 'id',
-				qty: 1
+				qty: 1,
+				type: DaffCartItemInputType.Simple
 			};
 
       addToCartComponent.addToCart.emit(payload);
 
-      expect(cartFacade.dispatch).toHaveBeenCalledWith(new DaffAddToCart(payload));
+      expect(cartFacade.dispatch).toHaveBeenCalledWith(new DaffCartItemAdd(payload));
     });
   });
 

--- a/apps/demo/src/app/product/pages/product-view/product-view.component.ts
+++ b/apps/demo/src/app/product/pages/product-view/product-view.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, ParamMap } from '@angular/router';
-import { tap, take, filter, map, } from 'rxjs/operators';
+import { take, filter, map, } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
 import { DaffProductFacade, DaffProductLoad, DaffProduct } from '@daffodil/product';
-import { DaffAddToCart, DaffCartFacade } from '@daffodil/cart/state';
+import { DaffCartFacade, DaffCartItemAdd } from '@daffodil/cart/state';
+import { DaffCartItemInput } from '@daffodil/cart';
 
 @Component({
   selector: 'demo-product-view',
@@ -42,7 +43,7 @@ export class ProductViewComponent implements OnInit {
     this.loading$ = this.productViewFacade.loading$;
 	}
 
-	onAddToCart(cartItem) {
-		this.cartFacade.dispatch(new DaffAddToCart(cartItem));
+	onAddToCart(cartItem: DaffCartItemInput) {
+		this.cartFacade.dispatch(new DaffCartItemAdd(cartItem));
 	}
 }

--- a/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
@@ -85,40 +85,61 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
   }
 
   private updateItem(reqInfo: RequestInfo, itemId: DaffCartItem['item_id']): DaffCart {
-    const cart = this.getCart(reqInfo);
-    const item = reqInfo.utils.getJsonBody(reqInfo.req);
-    const itemIndex = cart.items.findIndex(({item_id}) => itemId === item_id)
+		const cart = this.getCart(reqInfo);
+		const cartIndex = reqInfo.collection.findIndex(c => c.id === reqInfo.id);
+		const itemChanges = reqInfo.utils.getJsonBody(reqInfo.req);
+		const itemIndex = cart.items.findIndex((item) => itemId === item.item_id);
+		reqInfo.collection[cartIndex] = {
+			...cart,
+			items: cart.items.map(
+				(item, index) => index === itemIndex ? {
+					...cart.items[itemIndex],
+					...itemChanges
+				} : item
+			)
+		}
 
-    cart.items[itemIndex] = {
-      ...cart.items[itemIndex],
-      ...item
-    };
-		cart.items = Object.assign([], cart.items);
-
-    return cart
+    return reqInfo.collection[cartIndex]
   }
 
   private addItem(reqInfo: RequestInfo): DaffCart {
-    const cart = this.getCart(reqInfo);
+		const cart = this.getCart(reqInfo);
+		const cartIndex = reqInfo.collection.findIndex(c => c.id === reqInfo.id);
 		const itemInput = reqInfo.utils.getJsonBody(reqInfo.req);
 		const existingCartItemIndex = cart.items.findIndex(item => item.product_id === itemInput.productId);
 		if(existingCartItemIndex > -1) {
-			cart.items[existingCartItemIndex].qty = cart.items[existingCartItemIndex].qty + itemInput.qty;
+			const updatedCartItem = {
+				...cart.items[existingCartItemIndex],
+				qty: cart.items[existingCartItemIndex].qty + itemInput.qty
+			}
+			reqInfo.collection[cartIndex] = {
+				...cart,
+				items: cart.items.map(
+					(item, index) => index === existingCartItemIndex ? updatedCartItem : item
+				)
+			}
 		} else {
-			cart.items.push(this.transformItemInput(itemInput));
+			reqInfo.collection[cartIndex] = {
+				...cart,
+				items: [
+					...cart.items,
+					this.transformItemInput(itemInput)
+				]
+			}
 		}
-		cart.items = Object.assign([], cart.items);
 
-    return cart;
+    return reqInfo.collection[0];
   }
 
   private deleteItem(reqInfo: RequestInfo, itemId: DaffCartItem['item_id']): DaffCart {
-    const cart = this.getCart(reqInfo);
+		const cart = this.getCart(reqInfo);
     const itemIndex = cart.items.findIndex(({item_id}) => itemId === item_id);
+		const cartIndex = reqInfo.collection.findIndex(c => c.id === reqInfo.id);
+		reqInfo.collection[cartIndex] = {
+			...cart,
+			items: cart.items.filter((item, index) => index !== itemIndex)
+		};
 
-		cart.items.splice(itemIndex, 1);
-		cart.items = Object.assign([], cart.items);
-
-    return cart;
+    return reqInfo.collection[cartIndex];
   }
 }

--- a/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
@@ -128,7 +128,7 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
 			}
 		}
 
-    return reqInfo.collection[0];
+    return reqInfo.collection[cartIndex];
   }
 
   private deleteItem(reqInfo: RequestInfo, itemId: DaffCartItem['item_id']): DaffCart {

--- a/libs/cart/driver/in-memory/src/backend/cart-root.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-root.service.ts
@@ -59,10 +59,10 @@ export class DaffInMemoryBackendCartRootService implements InMemoryDbService, Da
   ) {}
 
   createDb(reqInfo: RequestInfo) {
-    if (reqInfo) {
-      const seedData = reqInfo.utils.getJsonBody(reqInfo.req).carts;
+		if (reqInfo) {
+			const seedData = reqInfo.utils.getJsonBody(reqInfo.req).carts;
       if (seedData) {
-        this.carts = seedData;
+				this.carts = seedData;
       }
     }
 
@@ -76,7 +76,7 @@ export class DaffInMemoryBackendCartRootService implements InMemoryDbService, Da
   }
 
   post(reqInfo: RequestInfo) {
-    return this.delegateRequest(reqInfo)
+		return this.delegateRequest(reqInfo)
   }
 
   put(reqInfo: RequestInfo) {
@@ -88,7 +88,7 @@ export class DaffInMemoryBackendCartRootService implements InMemoryDbService, Da
   }
 
   private delegateRequest(reqInfo: RequestInfo) {
-    reqInfo.collection = this.carts;
+		reqInfo.collection = this.carts;
 
     switch (reqInfo.collectionName) {
       case 'cart':

--- a/libs/cart/driver/in-memory/src/drivers/cart/cart.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/drivers/cart/cart.service.spec.ts
@@ -59,7 +59,7 @@ describe('Driver | In Memory | Cart | CartService', () => {
     it('should throw a daffodil error when it receives an error', (done) => {
 			cartService.get(cartId).pipe(
 				catchError((error) => {
-					expect(error).toEqual(DaffCartNotFoundError);
+					expect(error).toEqual(new DaffCartNotFoundError(error.message));
 					done();
 					return of(null);
 				})

--- a/libs/cart/driver/in-memory/src/drivers/cart/cart.service.ts
+++ b/libs/cart/driver/in-memory/src/drivers/cart/cart.service.ts
@@ -16,7 +16,7 @@ export class DaffInMemoryCartService implements DaffCartServiceInterface<DaffCar
 
   get(cartId: DaffCart['id']): Observable<DaffCart> {
     return this.http.get<DaffCart>(`${this.url}/${cartId}`).pipe(
-			catchError((error: Error) => throwError(DaffCartNotFoundError)),
+			catchError((error: Error) => throwError(new DaffCartNotFoundError(error.message))),
 			map(result => result)
 		);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The cart in memory implementation for the demo app does not accept "cart-item" requests. Additionally, the way we currently update the in-memory database doesn't work. It just silently fails.

## What is the new behavior?
The cart feature in the demo app works as expected, and the cart in-memory services work now.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```