### PR TITLE
feat(demo): init state booleans to false

### DIFF
--- a/apps/demo/src/app/checkout/reducers/index.spec.ts
+++ b/apps/demo/src/app/checkout/reducers/index.spec.ts
@@ -22,7 +22,7 @@ describe('selectDemoCheckoutState', () => {
 
     stubShowShippingForm = true;
     expectedShowPaymentView = false;
-    expectedShowPaymentForm = null;
+    expectedShowPaymentForm = false;
     store = TestBed.inject(Store);
     store.dispatch(new SetShowShippingForm(stubShowShippingForm));
   }));

--- a/apps/demo/src/app/checkout/reducers/payment.reducer.spec.ts
+++ b/apps/demo/src/app/checkout/reducers/payment.reducer.spec.ts
@@ -6,11 +6,11 @@ describe('Checkout | Payment Reducer', () => {
   describe('initialState', () => {
     
     it('should set showPaymentView to false', () => {
-      expect(initialState.showPaymentView).toBeFalsy();
+      expect(initialState.showPaymentView).toBeFalse();
     });
 
-    it('should set showPaymentForm to null', () => {
-      expect(initialState.showPaymentForm).toBeNull();
+    it('should set showPaymentForm to false', () => {
+      expect(initialState.showPaymentForm).toBeFalse();
     });
   });
 

--- a/apps/demo/src/app/checkout/reducers/payment.reducer.ts
+++ b/apps/demo/src/app/checkout/reducers/payment.reducer.ts
@@ -7,7 +7,7 @@ export interface State {
 
 export const initialState: State = {
   showPaymentView: false,
-  showPaymentForm: null
+  showPaymentForm: false,
 };
 
 export function reducer(state = initialState, action: PaymentActions): State {

--- a/apps/demo/src/app/checkout/reducers/shipping.reducer.ts
+++ b/apps/demo/src/app/checkout/reducers/shipping.reducer.ts
@@ -5,7 +5,7 @@ export interface State {
 }
 
 export const initialState: State = {
-  showShippingForm: null
+  showShippingForm: false,
 };
 
 export function reducer(state = initialState, action: ShippingActions): State {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Some state booleans were initialized to `null`, which would make it difficult to check equality on async pipes in the template. Currently we simply negate the pipe, but that is not recommended and will be invalid in the upcoming lint PR.


## What is the new behavior?
Relevant state booleans are initialized to `false`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
See http://codelyzer.com/rules/template-no-negated-async/ for motivation for not using async pipe negations.