### PR TITLE
perf(demo): don't negate async pipes

### DIFF
--- a/apps/demo/src/app/cart/components/add-to-cart-notification/components/add-to-cart-notification/add-to-cart-notification.component.html
+++ b/apps/demo/src/app/cart/components/add-to-cart-notification/components/add-to-cart-notification/add-to-cart-notification.component.html
@@ -1,5 +1,5 @@
 <div class="demo-add-to-cart-notification">
-  <div class="demo-add-to-cart-notification__header"  *ngIf="!(loading$ | async)">
+  <div class="demo-add-to-cart-notification__header"  *ngIf="(loading$ | async) === false">
     <span class="demo-add-to-cart-notification__check-icon">
       <fa-icon [icon]="faCheck" aria-hidden="true"></fa-icon>
     </span>
@@ -8,9 +8,9 @@
       <fa-icon [icon]="faTimes" aria-hidden="true"></fa-icon>
     </button>
   </div>
-  <demo-product-added *ngIf="!(loading$ | async)" class="demo-add-to-cart-notification__product-added"
+  <demo-product-added *ngIf="(loading$ | async) === false" class="demo-add-to-cart-notification__product-added"
     [product]="product$ | async" [qty]="productQty$ | async"></demo-product-added>
-  <div *ngIf="!(loading$ | async)" daff-button-set class="demo-add-to-cart-notification__button-set">
+  <div *ngIf="(loading$ | async) === false" daff-button-set class="demo-add-to-cart-notification__button-set">
     <button type="button" daff-stroked-button demoViewCart>
       View Cart ({{(cartItemCount$ | async)}})
     </button>

--- a/apps/demo/src/app/cart/pages/cart-view/cart-view.component.html
+++ b/apps/demo/src/app/cart/pages/cart-view/cart-view.component.html
@@ -1,4 +1,4 @@
 <daff-container size="md">
-	<demo-cart *ngIf="!(loading$ | async)" [cart]="cart$ | async" class="demo-cart-view__cart"></demo-cart>
+	<demo-cart *ngIf="(loading$ | async) === false" [cart]="cart$ | async" class="demo-cart-view__cart"></demo-cart>
 	<daff-loading-icon *ngIf="loading$ | async"></daff-loading-icon>
 </daff-container>

--- a/apps/demo/src/app/checkout/components/payment/payment/payment.component.html
+++ b/apps/demo/src/app/checkout/components/payment/payment/payment.component.html
@@ -1,7 +1,7 @@
 <div class="payment">
   <demo-payment-form 
-    [hidden]="!(showPaymentForm$ | async)"
-    [paymentInfo]="paymentInfo" 
+    [hidden]="(showPaymentForm$ | async) === false"
+    [paymentInfo]="paymentInfo"
     [billingAddress]="billingAddress"
     [billingAddressIsShippingAddress]="billingAddressIsShippingAddress"
     (updatePaymentInfo)="onUpdatePaymentInfo($event)"

--- a/apps/demo/src/app/checkout/components/place-order/place-order.component.html
+++ b/apps/demo/src/app/checkout/components/place-order/place-order.component.html
@@ -1,1 +1,1 @@
-<button type="button" daff-button color="black" class="demo-place-order__button" [disabled]="!(enablePlaceOrderButton$ | async)" (click)="placeOrder()">Place Order</button>
+<button type="button" daff-button color="black" class="demo-place-order__button" [disabled]="(enablePlaceOrderButton$ | async) === false" (click)="placeOrder()">Place Order</button>

--- a/apps/demo/src/app/checkout/components/shipping/shipping/shipping.component.html
+++ b/apps/demo/src/app/checkout/components/shipping/shipping/shipping.component.html
@@ -1,6 +1,6 @@
 <div class="shipping">
   <demo-shipping-form 
-    [hidden]="!(showShippingForm$ | async)"
+    [hidden]="(showShippingForm$ | async) === false"
     [shippingAddress]="shippingAddress"
     [editMode]="showPaymentView"
     (submitted)="onUpdateShippingInfo($event)">

--- a/apps/demo/src/app/checkout/pages/checkout-view/checkout-view.component.html
+++ b/apps/demo/src/app/checkout/pages/checkout-view/checkout-view.component.html
@@ -1,5 +1,5 @@
 <daff-container size="md">
-	<div class="demo-checkout" *ngIf="!(loading$ | async)">
+	<div class="demo-checkout" *ngIf="(loading$ | async) === false">
 		<daff-accordion class="demo-checkout__mobile-cart">
 			<daff-accordion-item [initiallyActive]="false">
 				<h3 daffAccordionItemTitle>Cart Summary ({{(cart$ | async) ? (cart$ | async).items.length : 0}})</h3>

--- a/apps/demo/src/app/core/sidebar/containers/sidebar/sidebar.component.html
+++ b/apps/demo/src/app/core/sidebar/containers/sidebar/sidebar.component.html
@@ -1,6 +1,6 @@
 <daff-sidebar class="demo-sidebar" (escapePressed)="onClose()">
   <span class="demo-sidebar__close" (click)="onClose()"><fa-icon [icon]="faTimes"></fa-icon></span>
-  <demo-sidebar-list [tree]="tree$ | async" *ngIf="!(treeLoading$ | async)"></demo-sidebar-list>
+  <demo-sidebar-list [tree]="tree$ | async" *ngIf="(treeLoading$ | async) === false"></demo-sidebar-list>
   <div class="demo-sidebar__error" *ngFor="let error of (treeErrors$ | async)"> {{ error }}</div>
   <daff-loading-icon *ngIf="treeLoading$ | async"></daff-loading-icon>
 </daff-sidebar>

--- a/apps/demo/src/app/newsletter/newsletter.component.html
+++ b/apps/demo/src/app/newsletter/newsletter.component.html
@@ -9,14 +9,14 @@
       </div>
     </div>
     <div>
-      <div class="demo-newsletter__right" *ngIf="!(success$ | async) && !(error$ | async) && !(loading$ | async)">
+      <div class="demo-newsletter__right" *ngIf="(success$ | async) === false && (hasError$ | async) === false && (loading$ | async) === false">
         <ng-container *ngIf="email.invalid && email.dirty">Please enter a valid email</ng-container>
         <input daff-input type="text" class="demo-newsletter__input" placeholder="Email" name="email" [formControl]="email"
           required email />
         <button type="submit" daff-button color="secondary" class="demo-newsletter__button"
           (click)='onNewsletterSubmit()'>Sign Up</button>
       </div>
-      <div class="demo-newsletter__retry" *ngIf="(error$ | async) && !(loading$| async) && !(success$ | async)">
+      <div class="demo-newsletter__retry" *ngIf="(hasError$ | async) && (loading$| async) === false && (success$ | async) === false">
         Error
         <button type="submit" daff-button color="secondary" class="demo-newsletter__button"
           (click)='onNewsletterRetry()'>Retry</button>

--- a/apps/demo/src/app/newsletter/newsletter.component.ts
+++ b/apps/demo/src/app/newsletter/newsletter.component.ts
@@ -1,38 +1,58 @@
-import { Component } from '@angular/core';
-import { DaffNewsletterFacade, DaffNewsletterActionTypes, DaffNewsletterSubmission, DaffNewsletterCancel, DaffNewsletterRetry } from '@daffodil/newsletter';
-import { DaffNewsletterSubscribe } from '@daffodil/newsletter';
-import { FormControl, Validators } from '@angular/forms';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
+import {
+  FormControl,
+  Validators,
+} from '@angular/forms';
+import { map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
-
+import {
+  DaffNewsletterFacade,
+  DaffNewsletterSubscribe,
+  DaffNewsletterSubmission,
+  DaffNewsletterCancel,
+  DaffNewsletterRetry,
+} from '@daffodil/newsletter';
 
 @Component({
   selector: 'demo-newsletter',
   templateUrl: './newsletter.component.html',
-  styleUrls: ['./newsletter.component.scss']
+  styleUrls: ['./newsletter.component.scss'],
 })
-export class NewsletterComponent {
+export class NewsletterComponent implements OnInit {
 
   success$ = this.newsletterFacade.success$;
   error$ = this.newsletterFacade.error$;
   loading$ = this.newsletterFacade.loading$;
+  hasError$: Observable<boolean>;
 
   email: FormControl = new FormControl('', Validators.email);
 
   constructor(public newsletterFacade: DaffNewsletterFacade) {
   }
+
+  ngOnInit() {
+    this.hasError$ = this.error$.pipe(
+      map(error => !!error),
+    );
+  }
+
   onNewsletterSubmit() {
     if (this.email.valid) {
       this.newsletterFacade.dispatch(new DaffNewsletterSubscribe<DaffNewsletterSubmission>(this._makeSubmission(this.email.value)));
     }
   }
   onNewsletterCancel() {
-    this.newsletterFacade.dispatch(new DaffNewsletterCancel);
+    this.newsletterFacade.dispatch(new DaffNewsletterCancel());
   }
   onNewsletterRetry() {
     this.newsletterFacade.dispatch(new DaffNewsletterRetry<DaffNewsletterSubmission>(this._makeSubmission(this.email.value)));
   }
 
   private _makeSubmission(email: string): DaffNewsletterSubmission {
-    return { email: email };
+    return { email };
   }
 }

--- a/apps/demo/src/app/product/containers/best-sellers/best-sellers.component.html
+++ b/apps/demo/src/app/product/containers/best-sellers/best-sellers.component.html
@@ -1,4 +1,4 @@
-<div class="demo-best-sellers" *ngIf="!(loading$ | async)">
+<div class="demo-best-sellers" *ngIf="(loading$ | async) === false">
 	<div class="demo-best-sellers__title">best sellers</div>
 	<demo-product-grid [products]="bestSellers$ | async"></demo-product-grid>
 </div>

--- a/apps/demo/src/app/product/pages/product-grid-view/product-grid-view.component.html
+++ b/apps/demo/src/app/product/pages/product-grid-view/product-grid-view.component.html
@@ -1,4 +1,4 @@
 <daff-container size="lg">
-  <demo-product-grid *ngIf="!(loading$ | async)" [products]="products$ | async"></demo-product-grid>
+  <demo-product-grid *ngIf="(loading$ | async) === false" [products]="products$ | async"></demo-product-grid>
   <daff-loading-icon *ngIf="loading$ | async"></daff-loading-icon>
 <daff-container>

--- a/apps/demo/src/app/product/pages/product-view/product-view.component.html
+++ b/apps/demo/src/app/product/pages/product-view/product-view.component.html
@@ -1,4 +1,4 @@
-<demo-product [product]="product$ | async" [qty]="1" (updateQty)="updateQty($event)" *ngIf="!(loading$ | async)">
+<demo-product [product]="product$ | async" [qty]="1" (updateQty)="updateQty($event)" *ngIf="(loading$ | async) === false">
 	<demo-add-to-cart (addToCart)="onAddToCart($event)" [additive]="product$ | async" [qty]="1"></demo-add-to-cart>
 </demo-product>
 <daff-loading-icon *ngIf="(loading$ | async)"></daff-loading-icon>

--- a/apps/demo/src/app/thank-you/pages/thank-you-view.component.html
+++ b/apps/demo/src/app/thank-you/pages/thank-you-view.component.html
@@ -1,6 +1,6 @@
 <daff-container size="md">
   <div order-container #OrderContainer="OrderContainer">
-    <div class="demo-thank-you-view" *ngIf="!(OrderContainer.loading$ | async)">
+    <div class="demo-thank-you-view" *ngIf="(OrderContainer.loading$ | async) === false">
       <daff-accordion class="demo-thank-you-view__mobile-cart">
         <daff-accordion-item [initiallyActive]="false">
           <h3 daffAccordionItemTitle>Cart Summary ({{(OrderContainer.order$ | async).items.length}})</h3>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Perf
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Some async pipes are negated. Since async pipes initially emit `null`, this will cause the negation to always be true even when it really shouldn't be. When the component is initialized and the pipes emit their correct values, many of these negations will switch from being `true` to `false`. This can cause many elements to be added or removed, thrashing the layout and causing perf issues.

See http://codelyzer.com/rules/template-no-negated-async/ for more info.

## What is the new behavior?
Async pipes are now explicitly compared to `false` when the negation is desired.

In the case of the newsletter component, a new `hasError$` field had to be added to ensure that the emitted value was a boolean.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is preparation for the eslint migration, where this style will be enforced by a linter rule (its a recommended angular eslint rule).