### PR TITLE
ci(all): cache node_modules and use npm install instead of ci

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -10,9 +10,6 @@ pr:
     include:
       - master
       - develop
-variables:
-  npm_config_cache: $(Pipeline.Workspace)/.npm
-  node_version: 10.x
 
 stages:
   - stage: Daffodil_CI
@@ -24,8 +21,8 @@ stages:
           vmImage: 'Ubuntu 16.04'
         strategy:
           matrix:
-            node_10_x:
-              node_version: 10.x
+            node_12_x:
+              node_version: 12.x
         steps:
           - template: ./templates/setup-node.yml
 
@@ -38,8 +35,8 @@ stages:
           vmImage: 'Ubuntu 16.04'
         strategy:
           matrix:
-            node_10_x:
-              node_version: 10.x
+            node_12_x:
+              node_version: 12.x
         steps:
           - template: ./templates/setup-node.yml
 

--- a/.azure/templates/setup-node.yml
+++ b/.azure/templates/setup-node.yml
@@ -7,8 +7,8 @@ steps:
   - task: Cache@2
     inputs:
       key: $(Build.SourcesDirectory)/package-lock.json
-      path: $(npm_config_cache)
-    displayName: Cache npm
+      path: $(Build.SourcesDirectory)/node_modules
+    displayName: Cache Node Modules
 
-  - script: npx npm ci
+  - script: npx npm install
     displayName: Install Dependencies


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- The `.npm` folder is cached
- Deps are installed with `npm ci`, which deletes `node_modules`

## What is the new behavior?
- The `node_modules` folder is cached
- Deps are installed with `npm install`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information