### PR TITLE
ci: reference main branches by branch name instead of ref

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -71,7 +71,7 @@ stages:
                 branch: origin/$(System.PullRequest.TargetBranch)
               # for non PR builds, we want to create the cache for the current commit
               ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-                branch: $(Build.SourceBranch)
+                branch: origin/$(Build.SourceBranchName)
 
           # This cache step will only hit if the specified files have not changed
           # If a cache miss occurs, we know that a full build must happen


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On non-PR CI builds, the branch is referenced by the `Build.SourceBranch`, which apparently cannot satisfy `git rev-parse`: [`fatal: ambiguous argument 'refs/heads/develop': unknown revision or path not in the working tree.`](https://dev.azure.com/graycore/Daffodil/_build/results?buildId=5483&view=logs&j=1f97645b-94f8-5e6d-a639-942c49422e38&t=ccbeeddb-a51b-5a75-c616-1d4a66457f08&l=12).

This causes the build cache to not be saved for the commit SHA.


## What is the new behavior?
The branch is referenced by branch name instead, which hopefully will work.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information