### PR TITLE
feat(core,cart): extend and clarify DaffStates and DaffStateable

### DIFF
--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -60,7 +60,6 @@ import {
   DaffCartPlaceOrder,
   DaffCartPlaceOrderFailure,
   DaffCartPlaceOrderSuccess,
-  DaffCartItemLoadingState,
   DaffCartItemAdd,
   DaffCartResolveState,
 } from '@daffodil/cart/state';
@@ -73,6 +72,7 @@ import {
   DaffConfigurableCartItemFactory,
   DaffCompositeCartItemFactory,
 } from '@daffodil/cart/testing';
+import { DaffState } from '@daffodil/core/state';
 import {
   DaffLoadingState,
   DaffStateError,
@@ -126,15 +126,15 @@ describe('DaffCartFacade', () => {
     shippingMethodFactory = TestBed.inject(DaffCartShippingRateFactory);
 
     loading = {
-      [DaffCartOperationType.Cart]: DaffLoadingState.Complete,
-      [DaffCartOperationType.Item]: DaffCartItemLoadingState.Complete,
-      [DaffCartOperationType.ShippingAddress]: DaffLoadingState.Complete,
-      [DaffCartOperationType.BillingAddress]: DaffLoadingState.Complete,
-      [DaffCartOperationType.ShippingInformation]: DaffLoadingState.Complete,
-      [DaffCartOperationType.ShippingMethods]: DaffLoadingState.Complete,
-      [DaffCartOperationType.Payment]: DaffLoadingState.Complete,
-      [DaffCartOperationType.PaymentMethods]: DaffLoadingState.Complete,
-      [DaffCartOperationType.Coupon]: DaffLoadingState.Complete,
+      [DaffCartOperationType.Cart]: DaffState.Complete,
+      [DaffCartOperationType.Item]: DaffState.Complete,
+      [DaffCartOperationType.ShippingAddress]: DaffState.Complete,
+      [DaffCartOperationType.BillingAddress]: DaffState.Complete,
+      [DaffCartOperationType.ShippingInformation]: DaffState.Complete,
+      [DaffCartOperationType.ShippingMethods]: DaffState.Complete,
+      [DaffCartOperationType.Payment]: DaffState.Complete,
+      [DaffCartOperationType.PaymentMethods]: DaffState.Complete,
+      [DaffCartOperationType.Coupon]: DaffState.Complete,
     };
     errors = {
       [DaffCartOperationType.Cart]: [],
@@ -1109,10 +1109,10 @@ describe('DaffCartFacade', () => {
       const statefulCartItems = statefulCartItemFactory.createMany(2);
       const expected = cold('a', {
         a:
-					statefulCartItems.reduce((acc, item) => ({
-					  ...acc,
-					  [item.item_id]: item,
-					}), {}),
+          statefulCartItems.reduce((acc, item) => ({
+            ...acc,
+            [item.item_id]: item,
+          }), {}),
       });
       facade.dispatch(new DaffCartItemListSuccess(statefulCartItems));
       expect(facade.itemDictionary$).toBeObservable(expected);

--- a/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.spec.ts
@@ -15,7 +15,7 @@ import {
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import {
-  DaffLoadingState,
+  DaffState,
   DaffStateError,
 } from '@daffodil/core/state';
 
@@ -47,7 +47,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
 
       const result = cartBillingAddressReducer(initialState, cartListLoadAction);
 
-      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffLoadingState.Resolving);
+      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Resolving);
     });
   });
 
@@ -60,7 +60,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.BillingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
       };
 
@@ -70,7 +70,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should set billing_address from action.payload', () => {
@@ -92,7 +92,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.BillingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -106,7 +106,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the billing address section of state.errors', () => {
@@ -120,7 +120,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
 
       const result = cartBillingAddressReducer(initialState, cartBillingAddressUpdateAction);
 
-      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -134,7 +134,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.BillingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
       };
 
@@ -146,7 +146,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the billing address section of state.errors to an empty array', () => {
@@ -164,7 +164,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.BillingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -180,7 +180,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the billing address section of state.errors', () => {
@@ -194,7 +194,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
 
       const result = cartBillingAddressReducer(initialState, cartAddressUpdateAction);
 
-      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -208,7 +208,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.BillingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
       };
 
@@ -220,7 +220,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the billing address section of state.errors to an empty array', () => {
@@ -238,7 +238,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.BillingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -254,7 +254,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the billing address section of state.errors', () => {

--- a/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.ts
@@ -1,5 +1,5 @@
 import { DaffCart } from '@daffodil/cart';
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffState } from '@daffodil/core/state';
 
 import {
   DaffCartBillingAddressActionTypes,
@@ -27,14 +27,14 @@ export function cartBillingAddressReducer<T extends DaffCart>(
     case DaffCartBillingAddressActionTypes.CartBillingAddressLoadAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Resolving),
+        ...setLoading(state.loading, DaffState.Resolving),
       };
 
     case DaffCartBillingAddressActionTypes.CartBillingAddressUpdateAction:
     case DaffCartAddressActionTypes.CartAddressUpdateAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Mutating),
+        ...setLoading(state.loading, DaffState.Mutating),
       };
 
     case DaffCartBillingAddressActionTypes.CartBillingAddressLoadSuccessAction:
@@ -45,7 +45,7 @@ export function cartBillingAddressReducer<T extends DaffCart>(
           ...state.cart,
           billing_address: action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartBillingAddressActionTypes.CartBillingAddressUpdateSuccessAction:
@@ -57,7 +57,7 @@ export function cartBillingAddressReducer<T extends DaffCart>(
           ...state.cart,
           ...action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartBillingAddressActionTypes.CartBillingAddressLoadFailureAction:
@@ -66,7 +66,7 @@ export function cartBillingAddressReducer<T extends DaffCart>(
       return {
         ...state,
         ...addError(state.errors, action.payload),
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     default:

--- a/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
+
 import {
   DaffCart,
   DaffCartCoupon,
@@ -25,8 +26,8 @@ import {
   DaffCartFactory,
   DaffCartCouponFactory,
 } from '@daffodil/cart/testing';
+import { DaffState } from '@daffodil/core/state';
 import {
-  DaffLoadingState,
   DaffStateError,
 } from '@daffodil/core/state';
 
@@ -66,7 +67,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
       const result = reducer(initialState, cartCouponApplyAction);
 
-      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -79,7 +80,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Coupon]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
       };
 
@@ -93,7 +94,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the coupon section of state.errors to an empty array', () => {
@@ -111,7 +112,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Coupon]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -125,7 +126,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the coupon section of state.errors', () => {
@@ -139,7 +140,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
       const result = reducer(initialState, cartCouponListAction);
 
-      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffLoadingState.Resolving);
+      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Resolving);
     });
   });
 
@@ -152,7 +153,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Coupon]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
       };
 
@@ -166,7 +167,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the coupon section of state.errors to an empty array', () => {
@@ -184,7 +185,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Coupon]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -198,7 +199,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the coupon section of state.errors', () => {
@@ -212,7 +213,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
       const result = reducer(initialState, cartCouponRemoveAction);
 
-      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -226,7 +227,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Coupon]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
       };
 
@@ -238,7 +239,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the coupon section of state.errors to an empty array', () => {
@@ -256,7 +257,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Coupon]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -272,7 +273,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the coupon section of state.errors', () => {
@@ -282,11 +283,11 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
   describe('when CartCouponRemoveAllAction is triggered', () => {
     it('should indicate that the cart coupon is being mutated', () => {
-      const expectedState = {
+      const expectedState: DaffCartReducerState<DaffCart> = {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Coupon]: DaffLoadingState.Mutating,
+          [DaffCartOperationType.Coupon]: DaffState.Mutating,
         },
       };
       const cartClear = new DaffCartCouponRemoveAll();
@@ -314,7 +315,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         },
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Coupon]: DaffLoadingState.Complete,
+          [DaffCartOperationType.Coupon]: DaffState.Complete,
         },
       };
 
@@ -336,7 +337,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Coupon]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -352,7 +353,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the coupon section of state.errors', () => {

--- a/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.spec.ts
@@ -27,9 +27,7 @@ import {
   DaffCartCouponFactory,
 } from '@daffodil/cart/testing';
 import { DaffState } from '@daffodil/core/state';
-import {
-  DaffStateError,
-} from '@daffodil/core/state';
+import { DaffStateError } from '@daffodil/core/state';
 
 import { cartCouponReducer as reducer } from './cart-coupon.reducer';
 

--- a/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.ts
@@ -1,4 +1,5 @@
 import { DaffCart } from '@daffodil/cart';
+import { DaffState } from '@daffodil/core/state';
 import { DaffLoadingState } from '@daffodil/core/state';
 
 import { DaffCartCouponActionTypes } from '../../actions/public_api';
@@ -24,7 +25,7 @@ export function cartCouponReducer<T extends DaffCart>(
     case DaffCartCouponActionTypes.CartCouponListAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Resolving),
+        ...setLoading(state.loading, DaffState.Resolving),
       };
 
     case DaffCartCouponActionTypes.CartCouponApplyAction:
@@ -32,7 +33,7 @@ export function cartCouponReducer<T extends DaffCart>(
     case DaffCartCouponActionTypes.CartCouponRemoveAllAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Mutating),
+        ...setLoading(state.loading, DaffState.Mutating),
       };
 
     case DaffCartCouponActionTypes.CartCouponApplySuccessAction:
@@ -45,7 +46,7 @@ export function cartCouponReducer<T extends DaffCart>(
           ...state.cart,
           ...action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartCouponActionTypes.CartCouponListSuccessAction:
@@ -56,7 +57,7 @@ export function cartCouponReducer<T extends DaffCart>(
           ...state.cart,
           coupons: action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartCouponActionTypes.CartCouponApplyFailureAction:
@@ -66,7 +67,7 @@ export function cartCouponReducer<T extends DaffCart>(
       return {
         ...state,
         ...addError(state.errors, action.payload),
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     default:

--- a/libs/cart/state/src/reducers/cart-initial-state.ts
+++ b/libs/cart/state/src/reducers/cart-initial-state.ts
@@ -1,9 +1,8 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartOperationType } from './cart-operation-type.enum';
 import { DaffCartResolveState } from './cart-resolve/cart-resolve-state.enum';
 import { DaffCartReducerState } from './cart-state.interface';
-import { DaffCartItemLoadingState } from './loading/cart-loading.type';
 
 export const initialState: DaffCartReducerState<any> = Object.freeze({
   cart: {
@@ -21,15 +20,15 @@ export const initialState: DaffCartReducerState<any> = Object.freeze({
     available_payment_methods: [],
   },
   loading: {
-    [DaffCartOperationType.Cart]: DaffLoadingState.Complete,
-    [DaffCartOperationType.Item]: DaffCartItemLoadingState.Complete,
-    [DaffCartOperationType.ShippingAddress]: DaffLoadingState.Complete,
-    [DaffCartOperationType.BillingAddress]: DaffLoadingState.Complete,
-    [DaffCartOperationType.ShippingInformation]: DaffLoadingState.Complete,
-    [DaffCartOperationType.ShippingMethods]: DaffLoadingState.Complete,
-    [DaffCartOperationType.Payment]: DaffLoadingState.Complete,
-    [DaffCartOperationType.PaymentMethods]: DaffLoadingState.Complete,
-    [DaffCartOperationType.Coupon]: DaffLoadingState.Complete,
+    [DaffCartOperationType.Cart]: DaffState.Complete,
+    [DaffCartOperationType.Item]: DaffState.Complete,
+    [DaffCartOperationType.ShippingAddress]: DaffState.Complete,
+    [DaffCartOperationType.BillingAddress]: DaffState.Complete,
+    [DaffCartOperationType.ShippingInformation]: DaffState.Complete,
+    [DaffCartOperationType.ShippingMethods]: DaffState.Complete,
+    [DaffCartOperationType.Payment]: DaffState.Complete,
+    [DaffCartOperationType.PaymentMethods]: DaffState.Complete,
+    [DaffCartOperationType.Coupon]: DaffState.Complete,
   },
   errors: {
     [DaffCartOperationType.Cart]: [],

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
@@ -19,12 +19,14 @@ import {
   DaffCartItemListSuccess,
   DaffCartItemListFailure,
   initialState,
-  DaffCartItemLoadingState,
   DaffStatefulCartItem,
 } from '@daffodil/cart/state';
 import { DaffStatefulCartItemFactory } from '@daffodil/cart/state/testing';
 import { DaffCartFactory } from '@daffodil/cart/testing';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffStateError,
+  DaffState,
+} from '@daffodil/core/state';
 
 import { cartItemReducer } from './cart-item.reducer';
 
@@ -64,7 +66,7 @@ describe('Cart | Reducer | Cart Item', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
 
@@ -78,7 +80,7 @@ describe('Cart | Reducer | Cart Item', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the item section of state.errors to an empty array', () => {
@@ -96,7 +98,7 @@ describe('Cart | Reducer | Cart Item', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -110,7 +112,7 @@ describe('Cart | Reducer | Cart Item', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the item section of state.errors', () => {
@@ -127,7 +129,7 @@ describe('Cart | Reducer | Cart Item', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
 
@@ -141,7 +143,7 @@ describe('Cart | Reducer | Cart Item', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the item section of state.errors to an empty array', () => {
@@ -159,7 +161,7 @@ describe('Cart | Reducer | Cart Item', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -173,7 +175,7 @@ describe('Cart | Reducer | Cart Item', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the item section of state.errors', () => {
@@ -191,7 +193,7 @@ describe('Cart | Reducer | Cart Item', () => {
 
       const result = cartItemReducer(initialState, cartItemAddAction);
 
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Adding);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Adding);
     });
   });
 
@@ -205,7 +207,7 @@ describe('Cart | Reducer | Cart Item', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
 
@@ -217,7 +219,7 @@ describe('Cart | Reducer | Cart Item', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the item section of state.errors to an empty array', () => {
@@ -235,7 +237,7 @@ describe('Cart | Reducer | Cart Item', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -251,7 +253,7 @@ describe('Cart | Reducer | Cart Item', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the item section of state.errors', () => {
@@ -261,11 +263,11 @@ describe('Cart | Reducer | Cart Item', () => {
 
   describe('when CartItemLoadAction is triggered', () => {
     it('should indicate that the cart is loading', () => {
-      const expectedState = {
+      const expectedState: DaffCartReducerState<DaffCart> = {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
       const cartItemLoad = new DaffCartItemLoad('itemId');
@@ -291,7 +293,7 @@ describe('Cart | Reducer | Cart Item', () => {
         cart,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
 
@@ -299,7 +301,7 @@ describe('Cart | Reducer | Cart Item', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
 
     it('should set item from action.payload', () => {
@@ -321,7 +323,7 @@ describe('Cart | Reducer | Cart Item', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -337,7 +339,7 @@ describe('Cart | Reducer | Cart Item', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the item section of state.errors', () => {
@@ -347,11 +349,11 @@ describe('Cart | Reducer | Cart Item', () => {
 
   describe('when CartItemListAction is triggered', () => {
     it('should indicate that the cart is loading', () => {
-      const expectedState = {
+      const expectedState: DaffCartReducerState<any> = {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
       const cartItemList = new DaffCartItemList();
@@ -371,7 +373,7 @@ describe('Cart | Reducer | Cart Item', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
 
@@ -379,7 +381,7 @@ describe('Cart | Reducer | Cart Item', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
 
     it('should set items from action.payload', () => {
@@ -401,7 +403,7 @@ describe('Cart | Reducer | Cart Item', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Item]: DaffCartItemLoadingState.Resolving,
+          [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -417,7 +419,7 @@ describe('Cart | Reducer | Cart Item', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffCartItemLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the item section of state.errors', () => {

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
@@ -1,4 +1,5 @@
 import { DaffCart } from '@daffodil/cart';
+import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartItemActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
@@ -9,10 +10,7 @@ import {
   initializeErrorAdder,
   initializeErrorResetter,
 } from '../errors/error-state-helpers';
-import {
-  DaffCartItemLoadingState,
-  initializeLoadingSetter,
-} from '../loading/cart-loading.type';
+import { initializeLoadingSetter } from '../loading/cart-loading.type';
 
 const addError = initializeErrorAdder(DaffCartOperationType.Item);
 const resetErrors = initializeErrorResetter(DaffCartOperationType.Item);
@@ -27,13 +25,13 @@ export function cartItemReducer<T extends DaffCart>(
     case DaffCartItemActionTypes.CartItemLoadAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffCartItemLoadingState.Resolving),
+        ...setLoading(state.loading, DaffState.Resolving),
       };
 
     case DaffCartItemActionTypes.CartItemAddAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffCartItemLoadingState.Adding),
+        ...setLoading(state.loading, DaffState.Adding),
       };
 
     case DaffCartItemActionTypes.CartItemListSuccessAction:
@@ -44,7 +42,7 @@ export function cartItemReducer<T extends DaffCart>(
           ...state.cart,
           items: action.payload,
         },
-        ...setLoading(state.loading, DaffCartItemLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartItemActionTypes.CartItemLoadSuccessAction:
@@ -59,7 +57,7 @@ export function cartItemReducer<T extends DaffCart>(
               : item,
           ),
         },
-        ...setLoading(state.loading, DaffCartItemLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartItemActionTypes.CartItemUpdateSuccessAction:
@@ -72,7 +70,7 @@ export function cartItemReducer<T extends DaffCart>(
           ...state.cart,
           ...action.payload,
         },
-        ...setLoading(state.loading, DaffCartItemLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartItemActionTypes.CartItemListFailureAction:
@@ -83,7 +81,7 @@ export function cartItemReducer<T extends DaffCart>(
       return {
         ...state,
         ...addError(state.errors, action.payload),
-        ...setLoading(state.loading, DaffCartItemLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     default:

--- a/libs/cart/state/src/reducers/cart-order/cart-order-initial-state.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order-initial-state.ts
@@ -1,4 +1,4 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartOrderReducerState } from './cart-order-state.interface';
 
@@ -8,6 +8,6 @@ export const daffCartOrderInitialState: DaffCartOrderReducerState<any> = {
     orderId: null,
     cartId: null,
   },
-  loading: DaffLoadingState.Complete,
+  loading: DaffState.Complete,
   errors: [],
 };

--- a/libs/cart/state/src/reducers/cart-order/cart-order-state.interface.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order-state.interface.ts
@@ -1,11 +1,12 @@
 import { DaffCartOrderResult } from '@daffodil/cart';
 import {
-  DaffLoadingState,
   DaffStateError,
+  DaffMutableLoadingState,
 } from '@daffodil/core/state';
+
 
 export interface DaffCartOrderReducerState<T extends DaffCartOrderResult = DaffCartOrderResult> {
   cartOrderResult: T;
-  loading: DaffLoadingState;
+  loading: DaffMutableLoadingState;
   errors: DaffStateError[];
 }

--- a/libs/cart/state/src/reducers/cart-order/cart-order.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order.reducer.spec.ts
@@ -6,7 +6,7 @@ import {
   daffCartOrderInitialState as initialState,
 } from '@daffodil/cart/state';
 import {
-  DaffLoadingState,
+  DaffState,
   DaffStateError,
 } from '@daffodil/core/state';
 
@@ -28,7 +28,7 @@ describe('Cart | Reducer | CartOrder', () => {
 
       const result = reducer(initialState, cartPlaceOrderAction);
 
-      expect(result.loading).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading).toEqual(DaffState.Mutating);
     });
   });
 
@@ -43,7 +43,7 @@ describe('Cart | Reducer | CartOrder', () => {
       cartId = 'cartId';
       state = {
         ...initialState,
-        loading: DaffLoadingState.Resolving,
+        loading: DaffState.Resolving,
       };
 
       const cartPlaceOrderSuccess = new DaffCartPlaceOrderSuccess({
@@ -60,7 +60,7 @@ describe('Cart | Reducer | CartOrder', () => {
     });
 
     it('should indicate that the place order operation is not in progress', () => {
-      expect(result.loading).toEqual(DaffLoadingState.Complete);
+      expect(result.loading).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in state', () => {
@@ -76,7 +76,7 @@ describe('Cart | Reducer | CartOrder', () => {
     beforeEach(() => {
       state = {
         ...initialState,
-        loading: DaffLoadingState.Resolving,
+        loading: DaffState.Resolving,
         errors: [
           ...initialState.errors,
           error,
@@ -89,7 +89,7 @@ describe('Cart | Reducer | CartOrder', () => {
     });
 
     it('should indicate that the place order operation is not in progress', () => {
-      expect(result.loading).toEqual(DaffLoadingState.Complete);
+      expect(result.loading).toEqual(DaffState.Complete);
     });
 
     it('should add an error to state', () => {

--- a/libs/cart/state/src/reducers/cart-order/cart-order.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order.reducer.ts
@@ -1,4 +1,5 @@
 import { DaffCartOrderResult } from '@daffodil/cart';
+import { DaffState } from '@daffodil/core/state';
 import { DaffLoadingState } from '@daffodil/core/state';
 
 import {
@@ -16,21 +17,21 @@ export function daffCartOrderReducer<T extends DaffCartOrderResult = DaffCartOrd
     case DaffCartOrderActionTypes.CartPlaceOrderAction:
       return {
         ...state,
-        loading: DaffLoadingState.Mutating,
+        loading: DaffState.Mutating,
       };
 
     case DaffCartOrderActionTypes.CartPlaceOrderSuccessAction:
       return {
         ...state,
         errors: [],
-        loading: DaffLoadingState.Complete,
+        loading: DaffState.Complete,
         cartOrderResult: action.payload,
       };
 
     case DaffCartOrderActionTypes.CartPlaceOrderFailureAction:
       return {
         ...state,
-        loading: DaffLoadingState.Complete,
+        loading: DaffState.Complete,
         errors: [
           ...state.errors,
           action.payload,

--- a/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import {
-  DaffLoadingState,
+  DaffState,
   DaffStateError,
 } from '@daffodil/core/state';
 
@@ -42,7 +42,7 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
       const cartPaymentMethodsLoadAction = new DaffCartPaymentMethodsLoad();
       const result = cartPaymentMethodsReducer(initialState, cartPaymentMethodsLoadAction);
 
-      expect(result.loading[DaffCartOperationType.PaymentMethods]).toEqual(DaffLoadingState.Resolving);
+      expect(result.loading[DaffCartOperationType.PaymentMethods]).toEqual(DaffState.Resolving);
     });
   });
 
@@ -55,7 +55,7 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.PaymentMethods]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.PaymentMethods]: DaffState.Resolving,
         },
       };
 
@@ -65,7 +65,7 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.PaymentMethods]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.PaymentMethods]).toEqual(DaffState.Complete);
     });
 
     it('should set available_payment_methods from action.payload', () => {
@@ -87,7 +87,7 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.PaymentMethods]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.PaymentMethods]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -101,7 +101,7 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.PaymentMethods]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.PaymentMethods]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the payment methods section of state.errors', () => {

--- a/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.ts
@@ -1,5 +1,5 @@
 import { DaffCart } from '@daffodil/cart';
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartPaymentMethodsActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
@@ -24,7 +24,7 @@ export function cartPaymentMethodsReducer<T extends DaffCart>(
     case DaffCartPaymentMethodsActionTypes.CartPaymentMethodsLoadAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Resolving),
+        ...setLoading(state.loading, DaffState.Resolving),
       };
 
     case DaffCartPaymentMethodsActionTypes.CartPaymentMethodsLoadSuccessAction:
@@ -35,14 +35,14 @@ export function cartPaymentMethodsReducer<T extends DaffCart>(
           ...state.cart,
           available_payment_methods: action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartPaymentMethodsActionTypes.CartPaymentMethodsLoadFailureAction:
       return {
         ...state,
         ...addError(state.errors, action.payload),
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     default:

--- a/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.spec.ts
@@ -19,7 +19,7 @@ import {
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import {
-  DaffLoadingState,
+  DaffState,
   DaffStateError,
 } from '@daffodil/core/state';
 
@@ -51,7 +51,7 @@ describe('Cart | Reducer | Cart Payment', () => {
 
       const result = cartPaymentReducer(initialState, cartListLoadAction);
 
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Resolving);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Resolving);
     });
   });
 
@@ -64,7 +64,7 @@ describe('Cart | Reducer | Cart Payment', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Payment]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
       };
 
@@ -74,7 +74,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Complete);
     });
 
     it('should set payment from action.payload', () => {
@@ -96,7 +96,7 @@ describe('Cart | Reducer | Cart Payment', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Payment]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -110,7 +110,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the payment section of state.errors', () => {
@@ -124,7 +124,7 @@ describe('Cart | Reducer | Cart Payment', () => {
 
       const result = cartPaymentReducer(initialState, cartPaymentUpdateAction);
 
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -138,7 +138,7 @@ describe('Cart | Reducer | Cart Payment', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Payment]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
       };
 
@@ -150,7 +150,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the payment section of state.errors to an empty array', () => {
@@ -168,7 +168,7 @@ describe('Cart | Reducer | Cart Payment', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Payment]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -184,7 +184,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the payment section of state.errors', () => {
@@ -198,7 +198,7 @@ describe('Cart | Reducer | Cart Payment', () => {
 
       const result = cartPaymentReducer(initialState, cartPaymentUpdateWithBillingAction);
 
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -212,7 +212,7 @@ describe('Cart | Reducer | Cart Payment', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Payment]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
       };
 
@@ -224,7 +224,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the payment section of state.errors to an empty array', () => {
@@ -242,7 +242,7 @@ describe('Cart | Reducer | Cart Payment', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Payment]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -258,7 +258,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the payment section of state.errors', () => {
@@ -268,11 +268,11 @@ describe('Cart | Reducer | Cart Payment', () => {
 
   describe('when CartPaymentRemoveAction is triggered', () => {
     it('should indicate that the cart payment is being mutated', () => {
-      const expectedState = {
+      const expectedState: DaffCartReducerState<DaffCart> = {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Payment]: DaffLoadingState.Mutating,
+          [DaffCartOperationType.Payment]: DaffState.Mutating,
         },
       };
       const cartPaymentRemove = new DaffCartPaymentRemove();
@@ -297,7 +297,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the payment section of state.errors to an empty array', () => {
@@ -315,7 +315,7 @@ describe('Cart | Reducer | Cart Payment', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Payment]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -331,7 +331,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the payment section of state.errors', () => {

--- a/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.ts
@@ -1,4 +1,5 @@
 import { DaffCart } from '@daffodil/cart';
+import { DaffState } from '@daffodil/core/state';
 import { DaffLoadingState } from '@daffodil/core/state';
 
 import { DaffCartPaymentActionTypes } from '../../actions/public_api';
@@ -24,7 +25,7 @@ export function cartPaymentReducer<T extends DaffCart>(
     case DaffCartPaymentActionTypes.CartPaymentLoadAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Resolving),
+        ...setLoading(state.loading, DaffState.Resolving),
       };
 
     case DaffCartPaymentActionTypes.CartPaymentUpdateAction:
@@ -32,7 +33,7 @@ export function cartPaymentReducer<T extends DaffCart>(
     case DaffCartPaymentActionTypes.CartPaymentRemoveAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Mutating),
+        ...setLoading(state.loading, DaffState.Mutating),
       };
 
     case DaffCartPaymentActionTypes.CartPaymentLoadSuccessAction:
@@ -43,7 +44,7 @@ export function cartPaymentReducer<T extends DaffCart>(
           ...state.cart,
           payment: action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartPaymentActionTypes.CartPaymentRemoveSuccessAction:
@@ -54,7 +55,7 @@ export function cartPaymentReducer<T extends DaffCart>(
           ...state.cart,
           payment: null,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartPaymentActionTypes.CartPaymentUpdateSuccessAction:
@@ -66,7 +67,7 @@ export function cartPaymentReducer<T extends DaffCart>(
           ...state.cart,
           ...action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartPaymentActionTypes.CartPaymentLoadFailureAction:
@@ -76,7 +77,7 @@ export function cartPaymentReducer<T extends DaffCart>(
       return {
         ...state,
         ...addError(state.errors, action.payload),
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
 

--- a/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.spec.ts
@@ -15,7 +15,7 @@ import {
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import {
-  DaffLoadingState,
+  DaffState,
   DaffStateError,
 } from '@daffodil/core/state';
 
@@ -47,7 +47,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
 
       const result = cartShippingAddressReducer(initialState, cartListLoadAction);
 
-      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffLoadingState.Resolving);
+      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Resolving);
     });
   });
 
@@ -60,7 +60,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
       };
 
@@ -70,7 +70,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should set shipping_address from action.payload', () => {
@@ -92,7 +92,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -106,7 +106,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the shipping address section of state.errors', () => {
@@ -120,7 +120,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
 
       const result = cartShippingAddressReducer(initialState, cartShippingAddressUpdateAction);
 
-      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -134,7 +134,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
       };
 
@@ -146,7 +146,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the shipping address section of state.errors to an empty array', () => {
@@ -164,7 +164,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -180,7 +180,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the shipping address section of state.errors', () => {
@@ -194,7 +194,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
 
       const result = cartShippingAddressReducer(initialState, cartAddressUpdateAction);
 
-      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -208,7 +208,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
       };
 
@@ -220,7 +220,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the shipping address section of state.errors to an empty array', () => {
@@ -238,7 +238,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingAddress]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -254,7 +254,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the shipping address section of state.errors', () => {

--- a/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.ts
@@ -1,4 +1,5 @@
 import { DaffCart } from '@daffodil/cart';
+import { DaffState } from '@daffodil/core/state';
 import { DaffLoadingState } from '@daffodil/core/state';
 
 import {
@@ -27,14 +28,14 @@ export function cartShippingAddressReducer<T extends DaffCart>(
     case DaffCartShippingAddressActionTypes.CartShippingAddressLoadAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Resolving),
+        ...setLoading(state.loading, DaffState.Resolving),
       };
 
     case DaffCartShippingAddressActionTypes.CartShippingAddressUpdateAction:
     case DaffCartAddressActionTypes.CartAddressUpdateAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Mutating),
+        ...setLoading(state.loading, DaffState.Mutating),
       };
 
     case DaffCartShippingAddressActionTypes.CartShippingAddressLoadSuccessAction:
@@ -45,7 +46,7 @@ export function cartShippingAddressReducer<T extends DaffCart>(
           ...state.cart,
           shipping_address: action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartShippingAddressActionTypes.CartShippingAddressUpdateSuccessAction:
@@ -57,7 +58,7 @@ export function cartShippingAddressReducer<T extends DaffCart>(
           ...state.cart,
           ...action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartShippingAddressActionTypes.CartShippingAddressLoadFailureAction:
@@ -66,7 +67,7 @@ export function cartShippingAddressReducer<T extends DaffCart>(
       return {
         ...state,
         ...addError(state.errors, action.payload),
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     default:

--- a/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.spec.ts
@@ -21,7 +21,7 @@ import {
   DaffCartShippingRateFactory,
 } from '@daffodil/cart/testing';
 import {
-  DaffLoadingState,
+  DaffState,
   DaffStateError,
 } from '@daffodil/core/state';
 
@@ -60,7 +60,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
 
       const result = cartShippingInformationReducer(initialState, cartShippingInformationLoadAction);
 
-      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffLoadingState.Resolving);
+      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffState.Resolving);
     });
   });
 
@@ -74,7 +74,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
         cart,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingInformation]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingInformation]: DaffState.Resolving,
         },
       };
 
@@ -84,7 +84,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffState.Complete);
     });
 
     it('should set shipping_information from action.payload', () => {
@@ -106,7 +106,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingInformation]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingInformation]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -120,7 +120,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the shipping information section of state.errors', () => {
@@ -134,7 +134,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
 
       const result = cartShippingInformationReducer(initialState, cartShippingInformationUpdateAction);
 
-      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -148,7 +148,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingInformation]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingInformation]: DaffState.Resolving,
         },
       };
 
@@ -160,7 +160,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the shipping information section of state.errors to an empty array', () => {
@@ -178,7 +178,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingInformation]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingInformation]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -194,7 +194,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the shipping information section of state.errors', () => {
@@ -204,11 +204,11 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
 
   describe('when CartShippingInformationDeleteAction is triggered', () => {
     it('should indicate that the cart shipping information is being mutated', () => {
-      const expectedState = {
+      const expectedState: DaffCartReducerState<DaffCart> = {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingInformation]: DaffLoadingState.Mutating,
+          [DaffCartOperationType.ShippingInformation]: DaffState.Mutating,
         },
       };
       const cartShippingInformationRemove = new DaffCartShippingInformationDelete();
@@ -237,7 +237,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
         },
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingInformation]: DaffLoadingState.Complete,
+          [DaffCartOperationType.ShippingInformation]: DaffState.Complete,
         },
       };
 
@@ -259,7 +259,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingInformation]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingInformation]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -275,7 +275,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the shipping information section of state.errors', () => {

--- a/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.ts
@@ -1,5 +1,5 @@
 import { DaffCart } from '@daffodil/cart';
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartShippingInformationActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
@@ -24,14 +24,14 @@ export function cartShippingInformationReducer<T extends DaffCart>(
     case DaffCartShippingInformationActionTypes.CartShippingInformationLoadAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Resolving),
+        ...setLoading(state.loading, DaffState.Resolving),
       };
 
     case DaffCartShippingInformationActionTypes.CartShippingInformationUpdateAction:
     case DaffCartShippingInformationActionTypes.CartShippingInformationDeleteAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Mutating),
+        ...setLoading(state.loading, DaffState.Mutating),
       };
 
     case DaffCartShippingInformationActionTypes.CartShippingInformationLoadSuccessAction:
@@ -43,7 +43,7 @@ export function cartShippingInformationReducer<T extends DaffCart>(
           // TODO: remove workaround
           shipping_information: { ...action.payload, address_id: null },
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartShippingInformationActionTypes.CartShippingInformationUpdateSuccessAction:
@@ -57,7 +57,7 @@ export function cartShippingInformationReducer<T extends DaffCart>(
           shipping_information: null,
           ...action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartShippingInformationActionTypes.CartShippingInformationLoadFailureAction:
@@ -66,7 +66,7 @@ export function cartShippingInformationReducer<T extends DaffCart>(
       return {
         ...state,
         ...addError(state.errors, action.payload),
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     default:

--- a/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.spec.ts
@@ -17,9 +17,10 @@ import {
   DaffCartShippingRateFactory,
 } from '@daffodil/cart/testing';
 import {
-  DaffLoadingState,
+  DaffState,
   DaffStateError,
 } from '@daffodil/core/state';
+
 
 import { cartShippingMethodsReducer } from './cart-shipping-methods.reducer';
 
@@ -56,7 +57,7 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
       const cartShippingMethodsLoadAction = new DaffCartShippingMethodsLoad();
       const result = cartShippingMethodsReducer(initialState, cartShippingMethodsLoadAction);
 
-      expect(result.loading[DaffCartOperationType.ShippingMethods]).toEqual(DaffLoadingState.Resolving);
+      expect(result.loading[DaffCartOperationType.ShippingMethods]).toEqual(DaffState.Resolving);
     });
   });
 
@@ -69,7 +70,7 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingMethods]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingMethods]: DaffState.Resolving,
         },
       };
 
@@ -79,7 +80,7 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingMethods]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingMethods]).toEqual(DaffState.Complete);
     });
 
     it('should set available_shipping_methods from action.payload', () => {
@@ -101,7 +102,7 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.ShippingMethods]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.ShippingMethods]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -115,7 +116,7 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.ShippingMethods]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.ShippingMethods]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the shipping methods section of state.errors', () => {

--- a/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.ts
@@ -1,5 +1,5 @@
 import { DaffCart } from '@daffodil/cart';
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartShippingMethodsActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
@@ -24,7 +24,7 @@ export function cartShippingMethodsReducer<T extends DaffCart>(
     case DaffCartShippingMethodsActionTypes.CartShippingMethodsLoadAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Resolving),
+        ...setLoading(state.loading, DaffState.Resolving),
       };
 
     case DaffCartShippingMethodsActionTypes.CartShippingMethodsLoadSuccessAction:
@@ -35,14 +35,14 @@ export function cartShippingMethodsReducer<T extends DaffCart>(
           ...state.cart,
           available_shipping_methods: action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartShippingMethodsActionTypes.CartShippingMethodsLoadFailureAction:
       return {
         ...state,
         ...addError(state.errors, action.payload),
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     default:

--- a/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
@@ -1,3 +1,4 @@
+
 import { DaffCart } from '@daffodil/cart';
 import {
   DaffCartLoad,
@@ -23,8 +24,8 @@ import {
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import { DaffStorageServiceError } from '@daffodil/core';
+import { DaffState } from '@daffodil/core/state';
 import {
-  DaffLoadingState,
   DaffStateError,
   daffTransformErrorToStateError,
 } from '@daffodil/core/state';
@@ -62,7 +63,7 @@ describe('Cart | Reducer | Cart', () => {
 
       const result = cartReducer(initialState, cartListLoadAction);
 
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Resolving);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Resolving);
     });
   });
 
@@ -72,7 +73,7 @@ describe('Cart | Reducer | Cart', () => {
 
       const result = cartReducer(initialState, cartResolveAction);
 
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Resolving);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Resolving);
     });
   });
 
@@ -85,7 +86,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
       };
 
@@ -99,7 +100,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the cart section of state.errors to an empty array', () => {
@@ -116,7 +117,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
       };
 
@@ -130,7 +131,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the cart section of state.errors to an empty array', () => {
@@ -147,7 +148,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -161,7 +162,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the cart section of state.errors', () => {
@@ -178,7 +179,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -192,7 +193,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the cart section of state.errors', () => {
@@ -209,7 +210,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -223,7 +224,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the cart section of state.errors', () => {
@@ -240,7 +241,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -254,7 +255,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the cart section of state.errors', () => {
@@ -268,7 +269,7 @@ describe('Cart | Reducer | Cart', () => {
 
       const result = cartReducer(initialState, cartCreateAction);
 
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -281,7 +282,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
       };
 
@@ -298,7 +299,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the cart section of state.errors to an empty array', () => {
@@ -315,7 +316,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -329,7 +330,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the cart section of state.errors', () => {
@@ -346,7 +347,7 @@ describe('Cart | Reducer | Cart', () => {
 
       const result = cartReducer(initialState, addToCartAction);
 
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Mutating);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Mutating);
     });
   });
 
@@ -360,7 +361,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
       };
 
@@ -372,7 +373,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should reset the errors in the cart section of state.errors to an empty array', () => {
@@ -389,7 +390,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -403,7 +404,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the cart section of state.errors', () => {
@@ -413,11 +414,11 @@ describe('Cart | Reducer | Cart', () => {
 
   describe('when CartClearAction is triggered', () => {
     it('should indicate that the cart is being mutated', () => {
-      const expectedState = {
+      const expectedState: DaffCartReducerState<DaffCart> = {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Mutating,
+          [DaffCartOperationType.Cart]: DaffState.Mutating,
         },
       };
       const cartClear = new DaffCartClear();
@@ -445,7 +446,7 @@ describe('Cart | Reducer | Cart', () => {
         },
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Complete,
+          [DaffCartOperationType.Cart]: DaffState.Complete,
         },
       };
 
@@ -466,7 +467,7 @@ describe('Cart | Reducer | Cart', () => {
         ...initialState,
         loading: {
           ...initialState.loading,
-          [DaffCartOperationType.Cart]: DaffLoadingState.Resolving,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
           ...initialState.errors,
@@ -480,7 +481,7 @@ describe('Cart | Reducer | Cart', () => {
     });
 
     it('should indicate that the cart is not loading', () => {
-      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffLoadingState.Complete);
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
     });
 
     it('should add an error to the cart section of state.errors', () => {

--- a/libs/cart/state/src/reducers/cart/cart.reducer.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.ts
@@ -1,5 +1,5 @@
 import { DaffCart } from '@daffodil/cart';
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
@@ -25,7 +25,7 @@ export function cartReducer<T extends DaffCart>(
     case DaffCartActionTypes.CartLoadAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Resolving),
+        ...setLoading(state.loading, DaffState.Resolving),
       };
 
     case DaffCartActionTypes.CartClearAction:
@@ -33,7 +33,7 @@ export function cartReducer<T extends DaffCart>(
     case DaffCartActionTypes.CartCreateAction:
       return {
         ...state,
-        ...setLoading(state.loading, DaffLoadingState.Mutating),
+        ...setLoading(state.loading, DaffState.Mutating),
       };
 
     case DaffCartActionTypes.CartLoadSuccessAction:
@@ -48,7 +48,7 @@ export function cartReducer<T extends DaffCart>(
           ...state.cart,
           ...action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     case DaffCartActionTypes.CartCreateSuccessAction:
@@ -59,7 +59,7 @@ export function cartReducer<T extends DaffCart>(
           ...initialState.cart,
           ...action.payload,
         },
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
     case DaffCartActionTypes.CartLoadFailureAction:
     case DaffCartActionTypes.CartClearFailureAction:
@@ -71,7 +71,7 @@ export function cartReducer<T extends DaffCart>(
       return {
         ...state,
         ...addError(state.errors, action.payload),
-        ...setLoading(state.loading, DaffLoadingState.Complete),
+        ...setLoading(state.loading, DaffState.Complete),
       };
 
     default:

--- a/libs/cart/state/src/reducers/loading/cart-loading.type.ts
+++ b/libs/cart/state/src/reducers/loading/cart-loading.type.ts
@@ -1,27 +1,27 @@
-import { DaffLoadingState } from '@daffodil/core/state';
+import {
+  DaffLoadingState,
+  DaffMutableLoadingState,
+  DaffState,
+} from '@daffodil/core/state';
 
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 
 export interface DaffCartLoading {
-	[DaffCartOperationType.Cart]: DaffLoadingState;
+	[DaffCartOperationType.Cart]: DaffMutableLoadingState;
 	[DaffCartOperationType.Item]: DaffCartItemLoadingState;
-	[DaffCartOperationType.BillingAddress]: DaffLoadingState;
-	[DaffCartOperationType.ShippingAddress]: DaffLoadingState;
-	[DaffCartOperationType.Payment]: DaffLoadingState;
+	[DaffCartOperationType.BillingAddress]: DaffMutableLoadingState;
+	[DaffCartOperationType.ShippingAddress]: DaffMutableLoadingState;
+	[DaffCartOperationType.Payment]: DaffMutableLoadingState;
 	[DaffCartOperationType.PaymentMethods]: DaffLoadingState;
-	[DaffCartOperationType.ShippingInformation]: DaffLoadingState;
+	[DaffCartOperationType.ShippingInformation]: DaffMutableLoadingState;
 	[DaffCartOperationType.ShippingMethods]: DaffLoadingState;
-	[DaffCartOperationType.Coupon]: DaffLoadingState;
+	[DaffCartOperationType.Coupon]: DaffMutableLoadingState;
 }
 
-export enum DaffCartItemLoadingState {
-  Resolving = 'Resolving',
-	Adding = 'Adding',
-  Complete = 'Complete',
-}
+export type DaffCartItemLoadingState = DaffMutableLoadingState | DaffState.Adding;
 
 export const initializeLoadingSetter = (loadingSpace: DaffCartOperationType) =>
-  (loadingObj: DaffCartLoading, loading: DaffLoadingState | DaffCartItemLoadingState) => ({
+  (loadingObj: DaffCartLoading, loading: DaffLoadingState | DaffMutableLoadingState | DaffCartItemLoadingState) => ({
     loading: {
       ...loadingObj,
       [loadingSpace]: loading,

--- a/libs/cart/state/src/selectors/cart-order/cart-order.selector.spec.ts
+++ b/libs/cart/state/src/selectors/cart-order/cart-order.selector.spec.ts
@@ -17,6 +17,7 @@ import {
   DaffCartPlaceOrder,
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
+import { DaffState } from '@daffodil/core/state';
 import { DaffLoadingState } from '@daffodil/core/state';
 
 import { getCartOrderSelectors } from './cart-order.selector';
@@ -71,7 +72,7 @@ describe('Cart | Selector | CartOrder', () => {
           orderId,
           cartId: cart.id,
         },
-        loading: DaffLoadingState.Complete,
+        loading: DaffState.Complete,
         errors: [],
       };
       const selector = store.pipe(select(selectCartOrderState));

--- a/libs/cart/state/src/selectors/cart-order/cart-order.selector.ts
+++ b/libs/cart/state/src/selectors/cart-order/cart-order.selector.ts
@@ -7,7 +7,7 @@ import {
   DaffCartOrderResult,
   DaffCart,
 } from '@daffodil/cart';
-import { DaffLoadingState } from '@daffodil/core/state';
+import { DaffState } from '@daffodil/core/state';
 
 import { DaffStatefulCartItem } from '../../models/stateful-cart-item';
 import {
@@ -60,11 +60,11 @@ const createCartOrderSelectors = <
   );
   const selectCartOrderLoading = createSelector(
     selectCartOrderState,
-    (state: DaffCartOrderReducerState<V>) => state.loading !== DaffLoadingState.Complete,
+    (state: DaffCartOrderReducerState<V>) => state.loading !== DaffState.Complete,
   );
   const selectCartOrderMutating = createSelector(
     selectCartOrderState,
-    (state: DaffCartOrderReducerState<V>) => state.loading === DaffLoadingState.Mutating,
+    (state: DaffCartOrderReducerState<V>) => state.loading === DaffState.Mutating,
   );
   const selectCartOrderErrors = createSelector(
     selectCartOrderState,

--- a/libs/cart/state/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/state/src/selectors/cart/cart.selector.spec.ts
@@ -51,7 +51,7 @@ import {
   DaffCartShippingRateFactory,
 } from '@daffodil/cart/testing';
 import {
-  DaffLoadingState,
+  DaffState,
   DaffStateError,
 } from '@daffodil/core/state';
 
@@ -178,15 +178,15 @@ describe('Cart | Selector | Cart', () => {
       shipping_information: shippingMethodFactory.create(),
     });
     loading = {
-      [DaffCartOperationType.Cart]: DaffLoadingState.Complete,
-      [DaffCartOperationType.Item]: DaffCartItemLoadingState.Complete,
-      [DaffCartOperationType.ShippingAddress]: DaffLoadingState.Complete,
-      [DaffCartOperationType.BillingAddress]: DaffLoadingState.Complete,
-      [DaffCartOperationType.ShippingInformation]: DaffLoadingState.Complete,
-      [DaffCartOperationType.ShippingMethods]: DaffLoadingState.Complete,
-      [DaffCartOperationType.Payment]: DaffLoadingState.Complete,
-      [DaffCartOperationType.PaymentMethods]: DaffLoadingState.Complete,
-      [DaffCartOperationType.Coupon]: DaffLoadingState.Complete,
+      [DaffCartOperationType.Cart]: DaffState.Complete,
+      [DaffCartOperationType.Item]: DaffState.Complete,
+      [DaffCartOperationType.ShippingAddress]: DaffState.Complete,
+      [DaffCartOperationType.BillingAddress]: DaffState.Complete,
+      [DaffCartOperationType.ShippingInformation]: DaffState.Complete,
+      [DaffCartOperationType.ShippingMethods]: DaffState.Complete,
+      [DaffCartOperationType.Payment]: DaffState.Complete,
+      [DaffCartOperationType.PaymentMethods]: DaffState.Complete,
+      [DaffCartOperationType.Coupon]: DaffState.Complete,
     };
     errors = {
       [DaffCartOperationType.Cart]: [],

--- a/libs/cart/state/src/selectors/cart/cart.selector.ts
+++ b/libs/cart/state/src/selectors/cart/cart.selector.ts
@@ -1,7 +1,6 @@
 import {
   createSelector,
   MemoizedSelector,
-  MemoizedSelectorWithProps,
   DefaultProjectorFn,
 } from '@ngrx/store';
 
@@ -11,9 +10,8 @@ import {
   DaffCartOrderResult,
   DaffCartTotalTypeEnum,
 } from '@daffodil/cart';
-import { daffSubtract } from '@daffodil/core';
 import {
-  DaffLoadingState,
+  DaffState,
   DaffStateError,
 } from '@daffodil/core/state';
 import { daffComparePersonalAddresses } from '@daffodil/geography';
@@ -256,103 +254,103 @@ const createCartSelectors = <
   );
   const selectCartLoading = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Cart] !== DaffLoadingState.Complete,
+    loadingObject => loadingObject[DaffCartOperationType.Cart] !== DaffState.Complete,
   );
   const selectCartResolving = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Cart] === DaffLoadingState.Resolving,
+    loadingObject => loadingObject[DaffCartOperationType.Cart] === DaffState.Resolving,
   );
   const selectCartMutating = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Cart] === DaffLoadingState.Mutating,
+    loadingObject => loadingObject[DaffCartOperationType.Cart] === DaffState.Mutating,
   );
   const selectBillingAddressLoading = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.BillingAddress] !== DaffLoadingState.Complete,
+    loadingObject => loadingObject[DaffCartOperationType.BillingAddress] !== DaffState.Complete,
   );
   const selectBillingAddressResolving = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.BillingAddress] === DaffLoadingState.Resolving,
+    loadingObject => loadingObject[DaffCartOperationType.BillingAddress] === DaffState.Resolving,
   );
   const selectBillingAddressMutating = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.BillingAddress] === DaffLoadingState.Mutating,
+    loadingObject => loadingObject[DaffCartOperationType.BillingAddress] === DaffState.Mutating,
   );
   const selectShippingAddressLoading = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.ShippingAddress] !== DaffLoadingState.Complete,
+    loadingObject => loadingObject[DaffCartOperationType.ShippingAddress] !== DaffState.Complete,
   );
   const selectShippingAddressResolving = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.ShippingAddress] === DaffLoadingState.Resolving,
+    loadingObject => loadingObject[DaffCartOperationType.ShippingAddress] === DaffState.Resolving,
   );
   const selectShippingAddressMutating = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.ShippingAddress] === DaffLoadingState.Mutating,
+    loadingObject => loadingObject[DaffCartOperationType.ShippingAddress] === DaffState.Mutating,
   );
   const selectShippingInformationLoading = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.ShippingInformation] !== DaffLoadingState.Complete,
+    loadingObject => loadingObject[DaffCartOperationType.ShippingInformation] !== DaffState.Complete,
   );
   const selectShippingInformationResolving = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.ShippingInformation] === DaffLoadingState.Resolving,
+    loadingObject => loadingObject[DaffCartOperationType.ShippingInformation] === DaffState.Resolving,
   );
   const selectShippingInformationMutating = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.ShippingInformation] === DaffLoadingState.Mutating,
+    loadingObject => loadingObject[DaffCartOperationType.ShippingInformation] === DaffState.Mutating,
   );
   const selectShippingMethodsLoading = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.ShippingMethods] !== DaffLoadingState.Complete,
+    loadingObject => loadingObject[DaffCartOperationType.ShippingMethods] !== DaffState.Complete,
   );
   const selectShippingMethodsResolving = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.ShippingMethods] === DaffLoadingState.Resolving,
+    loadingObject => loadingObject[DaffCartOperationType.ShippingMethods] === DaffState.Resolving,
   );
   const selectPaymentLoading = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Payment] !== DaffLoadingState.Complete,
+    loadingObject => loadingObject[DaffCartOperationType.Payment] !== DaffState.Complete,
   );
   const selectPaymentResolving = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Payment] === DaffLoadingState.Resolving,
+    loadingObject => loadingObject[DaffCartOperationType.Payment] === DaffState.Resolving,
   );
   const selectPaymentMutating = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Payment] === DaffLoadingState.Mutating,
+    loadingObject => loadingObject[DaffCartOperationType.Payment] === DaffState.Mutating,
   );
   const selectPaymentMethodsLoading = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.PaymentMethods] !== DaffLoadingState.Complete,
+    loadingObject => loadingObject[DaffCartOperationType.PaymentMethods] !== DaffState.Complete,
   );
   const selectPaymentMethodsResolving = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.PaymentMethods] === DaffLoadingState.Resolving,
+    loadingObject => loadingObject[DaffCartOperationType.PaymentMethods] === DaffState.Resolving,
   );
   const selectItemLoading = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Item] !== DaffCartItemLoadingState.Complete,
+    loadingObject => loadingObject[DaffCartOperationType.Item] !== DaffState.Complete,
   );
   const selectItemAdding = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Item] === DaffCartItemLoadingState.Adding,
+    loadingObject => loadingObject[DaffCartOperationType.Item] === DaffState.Adding,
   );
   const selectItemResolving = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Item] === DaffCartItemLoadingState.Resolving,
+    loadingObject => loadingObject[DaffCartOperationType.Item] === DaffState.Resolving,
   );
   const selectCouponLoading = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Coupon] !== DaffLoadingState.Complete,
+    loadingObject => loadingObject[DaffCartOperationType.Coupon] !== DaffState.Complete,
   );
   const selectCouponResolving = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Coupon] === DaffLoadingState.Resolving,
+    loadingObject => loadingObject[DaffCartOperationType.Coupon] === DaffState.Resolving,
   );
   const selectCouponMutating = createSelector(
     selectCartLoadingObject,
-    loadingObject => loadingObject[DaffCartOperationType.Coupon] === DaffLoadingState.Mutating,
+    loadingObject => loadingObject[DaffCartOperationType.Coupon] === DaffState.Mutating,
   );
   const selectCartFeatureLoading = createSelector(
     selectCartLoadingObject,

--- a/libs/core/state/src/index.ts
+++ b/libs/core/state/src/index.ts
@@ -1,5 +1,5 @@
 export * from './operators/public_api';
-export * from './loading/public_api';
+export * from './states/public_api';
 export * from './errors/public_api';
 export * from './collection/public_api';
 

--- a/libs/core/state/src/loading/loading-state.enum.ts
+++ b/libs/core/state/src/loading/loading-state.enum.ts
@@ -1,5 +1,0 @@
-export enum DaffLoadingState {
-  Resolving = 'Resolving',
-	Mutating = 'Mutating',
-  Complete = 'Complete',
-}

--- a/libs/core/state/src/loading/public_api.ts
+++ b/libs/core/state/src/loading/public_api.ts
@@ -1,1 +1,0 @@
-export { DaffLoadingState } from './loading-state.enum';

--- a/libs/core/state/src/states/loading.ts
+++ b/libs/core/state/src/states/loading.ts
@@ -1,0 +1,6 @@
+import { DaffState } from './state.enum';
+
+/**
+ * A state description for an object that is read-only.
+ */
+export type DaffLoadingState = DaffState.Resolving | DaffState.Stable;

--- a/libs/core/state/src/states/mutable-loading.ts
+++ b/libs/core/state/src/states/mutable-loading.ts
@@ -1,0 +1,7 @@
+import { DaffLoadingState } from './loading';
+import { DaffState } from './state.enum';
+
+/**
+ * A description for an object that is both readable and writable.
+ */
+export type DaffMutableLoadingState = DaffLoadingState | DaffState.Mutating;

--- a/libs/core/state/src/states/public_api.ts
+++ b/libs/core/state/src/states/public_api.ts
@@ -1,0 +1,4 @@
+export { DaffState } from './state.enum';
+export { DaffMutableLoadingState } from './mutable-loading';
+export { DaffLoadingState } from './loading';
+export { DaffStateable } from './stateable.interface';

--- a/libs/core/state/src/states/state.enum.ts
+++ b/libs/core/state/src/states/state.enum.ts
@@ -16,8 +16,8 @@ export const enum DaffState {
   Resolving = 'Resolving',
 
   /**
-   * The 'Adding' state represents a temporary period while an item is currently
-   * in the process of being added to state.
+   * The 'Adding' state represents a temporary period while an item is being
+   * added to state.
    */
   Adding = 'Adding',
 
@@ -43,7 +43,7 @@ export const enum DaffState {
   Mutated = 'Mutated',
 
   /**
-   * The 'Deleting' state occurs when an object is in the process of being
+   * The "Deleting" state occurs when an object is in the process of being
    * removed from state.
    */
   Deleting = 'Deleting',

--- a/libs/core/state/src/states/state.enum.ts
+++ b/libs/core/state/src/states/state.enum.ts
@@ -1,0 +1,58 @@
+/**
+ * The DaffState enumerates the vast majority of state modifications that can exist
+ * in UI applications.
+ */
+export const enum DaffState {
+  /**
+   * The 'Stable' state represents when no action is being taken upon an object.
+   */
+  Stable = 'Stable',
+
+  /**
+   * The 'Resolving' state represents when there's uncertainty in the current status
+   * of a state, e.g. when we're loading something that hasn't been loaded into
+   * state before.
+   */
+  Resolving = 'Resolving',
+
+  /**
+   * The 'Adding' state represents a temporary period while an item is currently
+   * in the process of being added to state.
+   */
+  Adding = 'Adding',
+
+  /**
+   * The 'Added' state represents when an object was recently added to state.
+   * This typically is associated with a subsequent decay to a 'Stable' state.
+   */
+  Added = 'Added',
+
+  /**
+   * The 'Mutating' state describes when an object that currently exists in state
+   * is being changed in some way.
+   *
+   * Disambiguation: This has nothing to do with immutability.
+   */
+	Mutating = 'Mutating',
+
+  /**
+   * The 'Mutated' state describes when an object has recently been modified in
+   * state. This state is typically associated with a subsequent decay into a
+   * 'Stable' state.
+   */
+	Mutated = 'Mutated',
+
+  /**
+   * The 'Deleting' state occurs when an object is in the process of being
+   * removed from state.
+   */
+  Deleting = 'Deleting',
+
+  /**
+   * An alias for 'Stable'.
+   *
+   * @deprecated
+   * Use DaffState.Stable instead.
+   */
+  Complete = 'Stable'
+}

--- a/libs/core/state/src/states/state.enum.ts
+++ b/libs/core/state/src/states/state.enum.ts
@@ -33,14 +33,14 @@ export const enum DaffState {
    *
    * Disambiguation: This has nothing to do with immutability.
    */
-	Mutating = 'Mutating',
+  Mutating = 'Mutating',
 
   /**
    * The 'Mutated' state describes when an object has recently been modified in
    * state. This state is typically associated with a subsequent decay into a
    * 'Stable' state.
    */
-	Mutated = 'Mutated',
+  Mutated = 'Mutated',
 
   /**
    * The 'Deleting' state occurs when an object is in the process of being

--- a/libs/core/state/src/states/stateable.interface.ts
+++ b/libs/core/state/src/states/stateable.interface.ts
@@ -1,0 +1,9 @@
+import { DaffState } from './state.enum';
+
+/**
+ * The interface an object must implement to consistently describe its current
+ * state.
+ */
+export interface DaffStateable<T extends DaffState> {
+  daffState: T;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, DaffState has details shared across several packages.

Fixes: N/A

## What is the new behavior?
This moves most of that burden to core for organizational purposes. I've also outlined a new interface called DaffStateable which would be implemented to enforce consistency across the codebase.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Users who depend on the old `DaffLoadingState` enum should use the new `DaffStates` enum.

## Other information