### PR TITLE
fix(navigation): magento sometimes returns null in place of arrays

### DIFF
--- a/libs/navigation/driver/magento/src/transformers/navigation-transformer.spec.ts
+++ b/libs/navigation/driver/magento/src/transformers/navigation-transformer.spec.ts
@@ -138,4 +138,11 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
     const breadcrumbsResult = service.transform(categoryNode).children[1].breadcrumbs;
     expect(breadcrumbsResult[0].categoryLevel).toBeLessThan(breadcrumbsResult[1].categoryLevel);
   });
+
+  it('should set children to an empty array when magento returns a null children array', () => {
+    categoryNode.children = null;
+    const categoryResult = service.transform(categoryNode);
+
+    expect(categoryResult.children).toEqual([]);
+  });
 });

--- a/libs/navigation/driver/magento/src/transformers/navigation-transformer.ts
+++ b/libs/navigation/driver/magento/src/transformers/navigation-transformer.ts
@@ -30,7 +30,7 @@ export class DaffMagentoNavigationTransformerService implements DaffNavigationTr
       [],
       children: node.children?.filter(child => child.include_in_menu)
         .sort((a, b) => a.position - b.position)
-        .map(child => this.transform(child)),
+        .map(child => this.transform(child)) || [],
     };
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Magento sometimes returns the category.children array as null, which breaks the magento transformer.

## What is the new behavior?
The daff magento transformer sets the children to an empty array in that case.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```