### PR TITLE
feat(cart): reset cart item daffState on failure

### DIFF
--- a/libs/cart/state/src/actions/cart-item.actions.ts
+++ b/libs/cart/state/src/actions/cart-item.actions.ts
@@ -55,10 +55,10 @@ export class DaffCartItemLoadSuccess<T extends DaffStatefulCartItem = DaffStatef
   constructor(public payload: T) {}
 }
 
-export class DaffCartItemLoadFailure implements Action {
+export class DaffCartItemLoadFailure<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemLoadFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError, public itemId: T['item_id']) {}
 }
 
 export class DaffCartItemUpdate<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
@@ -76,10 +76,10 @@ export class DaffCartItemUpdateSuccess<
   constructor(public payload: Partial<T>, public itemId: V['item_id']) {}
 }
 
-export class DaffCartItemUpdateFailure implements Action {
+export class DaffCartItemUpdateFailure<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemUpdateFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError, public itemId: T['item_id']) {}
 }
 
 export class DaffCartItemAdd<T extends DaffCartItemInput = DaffCartItemInput> implements Action {
@@ -112,10 +112,10 @@ export class DaffCartItemDeleteSuccess<T extends DaffCart = DaffCart> implements
   constructor(public payload: Partial<T>) {}
 }
 
-export class DaffCartItemDeleteFailure implements Action {
+export class DaffCartItemDeleteFailure<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemDeleteFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError, public itemId: T['item_id']) {}
 }
 
 export class DaffCartItemStateReset implements Action {
@@ -132,14 +132,14 @@ export type DaffCartItemActions<
   | DaffCartItemListFailure
   | DaffCartItemLoad<T>
   | DaffCartItemLoadSuccess<T>
-  | DaffCartItemLoadFailure
+  | DaffCartItemLoadFailure<T>
   | DaffCartItemUpdate<T>
   | DaffCartItemUpdateSuccess<V, T>
-  | DaffCartItemUpdateFailure
+  | DaffCartItemUpdateFailure<T>
   | DaffCartItemAdd<U>
   | DaffCartItemAddSuccess<V>
   | DaffCartItemAddFailure
   | DaffCartItemDelete<T>
   | DaffCartItemDeleteSuccess<V>
-  | DaffCartItemDeleteFailure
+  | DaffCartItemDeleteFailure<T>
   | DaffCartItemStateReset;

--- a/libs/cart/state/src/effects/cart-item.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-item.effects.spec.ts
@@ -182,7 +182,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
         const error: DaffStateError = { code: 'code', message: 'Failed to load cart item' };
         const response = cold('#', {}, error);
         driverGetSpy.and.returnValue(response);
-        const cartItemLoadFailureAction = new DaffCartItemLoadFailure(error);
+        const cartItemLoadFailureAction = new DaffCartItemLoadFailure(error, mockCartItem.item_id);
         actions$ = hot('--a', { a: cartItemLoadAction });
         expected = cold('--b', { b: cartItemLoadFailureAction });
       });
@@ -276,7 +276,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
         const error: DaffStateError = { code: 'code', message: 'Failed to update cart item' };
         const response = cold('#', {}, error);
         driverUpdateSpy.and.returnValue(response);
-        const cartItemUpdateFailureAction = new DaffCartItemUpdateFailure(error);
+        const cartItemUpdateFailureAction = new DaffCartItemUpdateFailure(error, mockCartItem.item_id);
         actions$ = hot('--a', { a: cartItemUpdateAction });
         expected = cold('--b', { b: cartItemUpdateFailureAction });
       });
@@ -367,7 +367,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
         const error: DaffStateError = { code: 'code', message: 'Failed to remove the cart item' };
         const response = cold('#', {}, error);
         driverDeleteSpy.and.returnValue(response);
-        const cartItemRemoveCartFailureAction = new DaffCartItemDeleteFailure(error);
+        const cartItemRemoveCartFailureAction = new DaffCartItemDeleteFailure(error, mockCartItem.item_id);
         actions$ = hot('--a', { a: cartItemDeleteAction });
         expected = cold('--b', { b: cartItemRemoveCartFailureAction });
       });

--- a/libs/cart/state/src/effects/cart-item.effects.ts
+++ b/libs/cart/state/src/effects/cart-item.effects.ts
@@ -81,7 +81,7 @@ export class DaffCartItemEffects<
     switchMap((action: DaffCartItemLoad<T>) =>
       this.driver.get(this.storage.getCartId(), action.itemId).pipe(
         map((resp: T) => new DaffCartItemLoadSuccess(resp)),
-        catchError(error => of(new DaffCartItemLoadFailure(this.errorMatcher(error)))),
+        catchError(error => of(new DaffCartItemLoadFailure(this.errorMatcher(error), action.itemId))),
       ),
     ),
   );
@@ -110,7 +110,7 @@ export class DaffCartItemEffects<
         action.changes,
       ).pipe(
         map((resp: V) => new DaffCartItemUpdateSuccess(resp, action.itemId)),
-        catchError(error => of(new DaffCartItemUpdateFailure(this.errorMatcher(error)))),
+        catchError(error => of(new DaffCartItemUpdateFailure(this.errorMatcher(error), action.itemId))),
       ),
     ),
   );
@@ -128,7 +128,7 @@ export class DaffCartItemEffects<
     mergeMap((action: DaffCartItemDelete<T>) =>
       this.driver.delete(this.storage.getCartId(), action.itemId).pipe(
         map((resp: V) => new DaffCartItemDeleteSuccess(resp)),
-        catchError(error => of(new DaffCartItemDeleteFailure(this.errorMatcher(error)))),
+        catchError(error => of(new DaffCartItemDeleteFailure(this.errorMatcher(error), action.itemId))),
       ),
     ),
   );

--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -832,7 +832,7 @@ describe('DaffCartFacade', () => {
     it('should contain an error upon a failed item load', () => {
       const error: DaffStateError = { code: 'error code', message: 'error message' };
       const expected = cold('a', { a: [error]});
-      facade.dispatch(new DaffCartItemLoadFailure(error));
+      facade.dispatch(new DaffCartItemLoadFailure(error, 'itemId'));
       expect(facade.itemErrors$).toBeObservable(expected);
     });
   });

--- a/libs/cart/state/src/models/stateful-cart-item.ts
+++ b/libs/cart/state/src/models/stateful-cart-item.ts
@@ -14,5 +14,6 @@ export enum DaffCartItemStateEnum {
 	New = 'new',
 	Updated = 'updated',
 	Mutating = 'mutating',
+	Error = 'error',
 	Default = 'default'
 }

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -443,7 +443,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('should reset daffState on the cart item', () => {
-      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Default);
+      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Error);
     });
   });
 
@@ -465,7 +465,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('should reset daffState on the cart item', () => {
-      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Default);
+      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Error);
     });
   });
 
@@ -487,7 +487,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('should reset daffState on the cart item', () => {
-      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Default);
+      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Error);
     });
   });
 });

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -13,12 +13,16 @@ import {
   DaffCartItemUpdate,
   DaffResolveCartSuccess,
   DaffStatefulCartItem,
+  DaffCartItemLoadFailure,
+  DaffCartItemDeleteFailure,
+  DaffCartItemUpdateFailure,
 } from '@daffodil/cart/state';
 import { DaffStatefulCartItemFactory } from '@daffodil/cart/state/testing';
 import {
   DaffCartFactory,
   DaffCartItemFactory,
 } from '@daffodil/cart/testing';
+import { DaffStateError } from '@daffodil/core/state';
 
 import { daffCartItemEntitiesAdapter } from './cart-item-entities-reducer-adapter';
 import { daffCartItemEntitiesReducer } from './cart-item-entities.reducer';
@@ -418,6 +422,72 @@ describe('Cart | Cart Item Entities Reducer', () => {
 
     it('sets the cart item state to mutating', () => {
       expect(result.entities[stubCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Mutating);
+    });
+  });
+
+  describe('when CartItemLoadFailureAction is triggered', () => {
+    let error: DaffStateError;
+    let statefulCartItem: DaffStatefulCartItem;
+    let result;
+
+    beforeEach(() => {
+      error = {
+        code: 'code',
+        message: 'message',
+      };
+      statefulCartItem = statefulCartItemFactory.create();
+      const cartItemLoadSuccess = new DaffCartItemLoadSuccess(statefulCartItem);
+      const cartItemLoadFailure = new DaffCartItemLoadFailure(error, statefulCartItem.item_id);
+
+      result = daffCartItemEntitiesReducer(daffCartItemEntitiesReducer(initialState, cartItemLoadSuccess), cartItemLoadFailure);
+    });
+
+    it('should reset daffState on the cart item', () => {
+      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Default);
+    });
+  });
+
+  describe('when CartItemDeleteFailureAction is triggered', () => {
+    let error: DaffStateError;
+    let statefulCartItem: DaffStatefulCartItem;
+    let result;
+
+    beforeEach(() => {
+      error = {
+        code: 'code',
+        message: 'message',
+      };
+      statefulCartItem = statefulCartItemFactory.create();
+      const cartItemLoadSuccess = new DaffCartItemLoadSuccess(statefulCartItem);
+      const cartItemDeleteFailure = new DaffCartItemDeleteFailure(error, statefulCartItem.item_id);
+
+      result = daffCartItemEntitiesReducer(daffCartItemEntitiesReducer(initialState, cartItemLoadSuccess), cartItemDeleteFailure);
+    });
+
+    it('should reset daffState on the cart item', () => {
+      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Default);
+    });
+  });
+
+  describe('when CartItemUpdateFailureAction is triggered', () => {
+    let error: DaffStateError;
+    let statefulCartItem: DaffStatefulCartItem;
+    let result;
+
+    beforeEach(() => {
+      error = {
+        code: 'code',
+        message: 'message',
+      };
+      statefulCartItem = statefulCartItemFactory.create();
+      const cartItemLoadSuccess = new DaffCartItemLoadSuccess(statefulCartItem);
+      const cartItemUpdateFailure = new DaffCartItemUpdateFailure(error, statefulCartItem.item_id);
+
+      result = daffCartItemEntitiesReducer(daffCartItemEntitiesReducer(initialState, cartItemLoadSuccess), cartItemUpdateFailure);
+    });
+
+    it('should reset daffState on the cart item', () => {
+      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Default);
     });
   });
 });

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -56,6 +56,13 @@ export function daffCartItemEntitiesReducer<
         updateMutatedCartItemState<T>(<T[]>action.payload.items, state.entities, action.itemId),
         state,
       );
+    case DaffCartItemActionTypes.CartItemDeleteFailureAction:
+    case DaffCartItemActionTypes.CartItemLoadFailureAction:
+    case DaffCartItemActionTypes.CartItemUpdateFailureAction:
+      return adapter.upsertOne({
+        ...state.entities[action.itemId],
+        daffState: DaffCartItemStateEnum.Default,
+      }, state);
     case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
     case DaffCartActionTypes.CartLoadSuccessAction:
     case DaffCartActionTypes.ResolveCartSuccessAction:

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -61,7 +61,7 @@ export function daffCartItemEntitiesReducer<
     case DaffCartItemActionTypes.CartItemUpdateFailureAction:
       return adapter.upsertOne({
         ...state.entities[action.itemId],
-        daffState: DaffCartItemStateEnum.Default,
+        daffState: DaffCartItemStateEnum.Error,
       }, state);
     case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
     case DaffCartActionTypes.CartLoadSuccessAction:

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
@@ -104,7 +104,7 @@ describe('Cart | Reducer | Cart Item', () => {
         },
       };
 
-      const cartItemUpdateFailure = new DaffCartItemUpdateFailure(error);
+      const cartItemUpdateFailure = new DaffCartItemUpdateFailure(error, cartItem.item_id);
 
       result = cartItemReducer(state, cartItemUpdateFailure);
     });
@@ -167,7 +167,7 @@ describe('Cart | Reducer | Cart Item', () => {
         },
       };
 
-      const cartItemRemoveFailure = new DaffCartItemDeleteFailure(error);
+      const cartItemRemoveFailure = new DaffCartItemDeleteFailure(error, cartItem.item_id);
 
       result = cartItemReducer(state, cartItemRemoveFailure);
     });
@@ -331,7 +331,7 @@ describe('Cart | Reducer | Cart Item', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartItemLoadFailure = new DaffCartItemLoadFailure(error);
+      const cartItemLoadFailure = new DaffCartItemLoadFailure(error, cartItem.item_id);
 
       result = cartItemReducer(state, cartItemLoadFailure);
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Cart item operation failures leave `daffState` unchanged.


## What is the new behavior?
Cart item operation failures reset `daffState` to default.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information