### PR TITLE
fix(product): product page actions do not initialize composite and co…

### DIFF
--- a/libs/product/state/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
+++ b/libs/product/state/src/reducers/composite-product-entities/composite-product-entities.reducer.spec.ts
@@ -7,6 +7,7 @@ import {
   DaffProductGridLoadSuccess,
   DaffBestSellersLoadSuccess,
   DaffCompositeProductApplyOption,
+  DaffProductPageLoadSuccess,
 } from '@daffodil/product/state';
 import {
   DaffProductFactory,
@@ -119,6 +120,40 @@ describe('Product | Composite Product Entities Reducer', () => {
     it('does not set a composite product entity when the given product is not composite', () => {
       const productLoadSuccess = new DaffProductLoadSuccess(product);
       result = daffCompositeProductEntitiesReducer(initialState, productLoadSuccess);
+      expect(result.entities[product.id]).toBeUndefined();
+    });
+  });
+
+  describe('when ProductPageLoadSuccessAction is triggered', () => {
+
+    let product: DaffProduct;
+    let result;
+
+    beforeEach(() => {
+      product = productFactory.create();
+    });
+
+    it('sets a composite product entity when the given product is composite', () => {
+      const productPageLoadSuccess = new DaffProductPageLoadSuccess(compositeProduct);
+      result = daffCompositeProductEntitiesReducer(initialState, productPageLoadSuccess);
+      expect(result.entities[compositeProduct.id]).toEqual({
+        id: compositeProduct.id,
+        items: {
+          [compositeProduct.items[0].id]: {
+            value: compositeProduct.items[0].options[0].id,
+            qty: compositeProduct.items[0].options[0].quantity,
+          },
+          [compositeProduct.items[1].id]: {
+            value: compositeProduct.items[1].options[0].id,
+            qty: compositeProduct.items[1].options[0].quantity,
+          },
+        },
+      });
+    });
+
+    it('does not set a composite product entity when the given product is not composite', () => {
+      const productPageLoadSuccess = new DaffProductPageLoadSuccess(product);
+      result = daffCompositeProductEntitiesReducer(initialState, productPageLoadSuccess);
       expect(result.entities[product.id]).toBeUndefined();
     });
   });

--- a/libs/product/state/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
+++ b/libs/product/state/src/reducers/composite-product-entities/composite-product-entities.reducer.ts
@@ -11,6 +11,12 @@ import {
 import {
   DaffProductGridActionTypes,
   DaffProductGridActions,
+} from '../../actions/product-grid.actions';
+import {
+  DaffProductPageActions,
+  DaffProductPageActionTypes,
+} from '../../actions/product-page.actions';
+import {
   DaffProductActionTypes,
   DaffProductActions,
   DaffBestSellersActionTypes,
@@ -30,7 +36,7 @@ import { DaffCompositeProductEntity } from './composite-product-entity';
  */
 export function daffCompositeProductEntitiesReducer<T extends DaffProduct, V extends DaffCompositeProduct>(
   state = daffCompositeProductAppliedOptionsEntitiesAdapter().getInitialState(),
-  action: DaffProductGridActions<T> | DaffBestSellersActions<T> | DaffProductActions<T> | DaffCompositeProductActions<V>): EntityState<DaffCompositeProductEntity> {
+  action: DaffProductGridActions<T> | DaffBestSellersActions<T> | DaffProductActions<T> | DaffProductPageActions<T> | DaffCompositeProductActions<V>): EntityState<DaffCompositeProductEntity> {
   const adapter = daffCompositeProductAppliedOptionsEntitiesAdapter();
   switch (action.type) {
     case DaffProductGridActionTypes.ProductGridLoadSuccessAction:
@@ -42,6 +48,7 @@ export function daffCompositeProductEntitiesReducer<T extends DaffProduct, V ext
         state,
       );
     case DaffProductActionTypes.ProductLoadSuccessAction:
+    case DaffProductPageActionTypes.ProductPageLoadSuccessAction:
       if(action.payload.type === DaffProductTypeEnum.Composite) {
         return adapter.upsertOne(
           buildCompositeProductAppliedOptionsEntity(<V><unknown>action.payload),

--- a/libs/product/state/src/reducers/configurable-product-entities/configurable-product-entities.reducer.spec.ts
+++ b/libs/product/state/src/reducers/configurable-product-entities/configurable-product-entities.reducer.spec.ts
@@ -10,6 +10,7 @@ import {
   DaffConfigurableProductApplyAttribute,
   DaffConfigurableProductRemoveAttribute,
   DaffConfigurableProductToggleAttribute,
+  DaffProductPageLoadSuccess,
 } from '@daffodil/product/state';
 import {
   DaffProductFactory,
@@ -110,6 +111,28 @@ describe('Product | Product Entities Reducer', () => {
     it('does not set a configurable product entity when the given product is not configurable', () => {
       const productLoadSuccess = new DaffProductLoadSuccess(product);
       result = daffConfigurableProductEntitiesReducer(initialState, productLoadSuccess);
+      expect(result.entities[product.id]).toBeUndefined();
+    });
+  });
+
+  describe('when ProductPageLoadSuccessAction is triggered', () => {
+
+    let product: DaffProduct;
+    let result;
+
+    beforeEach(() => {
+      product = productFactory.create();
+    });
+
+    it('sets a configurable product entity when the given product is configurable', () => {
+      const productPageLoadSuccess = new DaffProductPageLoadSuccess(configurableProduct);
+      result = daffConfigurableProductEntitiesReducer(initialState, productPageLoadSuccess);
+      expect(result.entities[configurableProduct.id]).toEqual({ id: configurableProduct.id, attributes: []});
+    });
+
+    it('does not set a configurable product entity when the given product is not configurable', () => {
+      const productPageLoadSuccess = new DaffProductPageLoadSuccess(product);
+      result = daffConfigurableProductEntitiesReducer(initialState, productPageLoadSuccess);
       expect(result.entities[product.id]).toBeUndefined();
     });
   });

--- a/libs/product/state/src/reducers/configurable-product-entities/configurable-product-entities.reducer.ts
+++ b/libs/product/state/src/reducers/configurable-product-entities/configurable-product-entities.reducer.ts
@@ -9,6 +9,12 @@ import {
 import {
   DaffProductGridActionTypes,
   DaffProductGridActions,
+} from '../../actions/product-grid.actions';
+import {
+  DaffProductPageActions,
+  DaffProductPageActionTypes,
+} from '../../actions/product-page.actions';
+import {
   DaffProductActionTypes,
   DaffProductActions,
   DaffBestSellersActionTypes,
@@ -31,7 +37,7 @@ import {
  */
 export function daffConfigurableProductEntitiesReducer<T extends DaffProduct, V extends DaffConfigurableProduct>(
   state = daffConfigurableProductAppliedAttributesEntitiesAdapter().getInitialState(),
-  action: DaffProductGridActions<T> | DaffBestSellersActions<T> | DaffProductActions<T> | DaffConfigurableProductActions<V>): EntityState<DaffConfigurableProductEntity> {
+  action: DaffProductGridActions<T> | DaffBestSellersActions<T> | DaffProductActions<T> | DaffProductPageActions<T> | DaffConfigurableProductActions<V>): EntityState<DaffConfigurableProductEntity> {
   const adapter = daffConfigurableProductAppliedAttributesEntitiesAdapter();
   switch (action.type) {
     case DaffProductGridActionTypes.ProductGridLoadSuccessAction:
@@ -43,6 +49,7 @@ export function daffConfigurableProductEntitiesReducer<T extends DaffProduct, V 
         state,
       );
     case DaffProductActionTypes.ProductLoadSuccessAction:
+    case DaffProductPageActionTypes.ProductPageLoadSuccessAction:
       if(action.payload.type === DaffProductTypeEnum.Configurable) {
         return adapter.upsertOne(
           buildConfigurableProductAppliedAttributesEntity(action.payload),


### PR DESCRIPTION
…nfigurable product state

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The recently added DaffProductPageLoadSuccess action was not added to the composite and configurable product reducers, so the state for composite and configurable products does not get initialized.

## What is the new behavior?
Composite and configurable product state gets initialized on DaffProductPageLoadSuccess actions.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```