### PR TITLE
perf(cart): reduce cart item query complexity

### DIFF
--- a/libs/cart/driver/magento/src/models/responses/cart-item.ts
+++ b/libs/cart/driver/magento/src/models/responses/cart-item.ts
@@ -2,12 +2,25 @@ import {
   MagentoMoney,
   MagentoDiscount,
 } from '@daffodil/driver/magento';
-import { MagentoProduct } from '@daffodil/product/driver/magento';
+import { MagentoProductStockStatusEnum } from '@daffodil/product/driver/magento';
 
 export enum MagentoCartItemTypeEnum {
 	Simple = 'SimpleCartItem',
 	Bundle = 'BundleCartItem',
 	Configurable = 'ConfigurableCartItem'
+}
+
+export interface MagentoCartItemProduct {
+	__typename: string;
+  id: number;
+  name: string;
+  sku: string;
+  thumbnail: {
+    __typename: string;
+    label: string;
+    url: string;
+  };
+  stock_status: MagentoProductStockStatusEnum;
 }
 
 /**
@@ -19,10 +32,9 @@ export interface MagentoCartItem {
   prices: {
     price: MagentoMoney;
     row_total: MagentoMoney;
-    row_total_including_tax: MagentoMoney;
     discounts?: MagentoDiscount[];
   };
-  product: MagentoProduct;
+  product: MagentoCartItemProduct;
   quantity: number;
 }
 

--- a/libs/cart/driver/magento/src/queries/fragments/cart-item.ts
+++ b/libs/cart/driver/magento/src/queries/fragments/cart-item.ts
@@ -1,15 +1,26 @@
 import { gql } from 'apollo-angular';
 
-import { magentoProductFragment } from '@daffodil/product/driver/magento';
-
 import { moneyFragment } from './money';
+
+export const cartItemProductFragment = gql`
+  fragment cartItemProduct on ProductInterface {
+    id
+		name
+    sku
+    thumbnail {
+      label
+      url
+    }
+    stock_status
+  }
+`;
 
 export const cartItemFragment = gql`
   fragment cartItem on CartItemInterface {
 		__typename
     id
     product {
-      ...product
+      ...cartItemProduct
     }
     quantity
     prices {
@@ -17,9 +28,6 @@ export const cartItemFragment = gql`
         ...money
       }
       row_total {
-        ...money
-      }
-      row_total_including_tax {
         ...money
       }
       discounts {
@@ -49,6 +57,6 @@ export const cartItemFragment = gql`
 			}
 		}
   }
-  ${magentoProductFragment}
+  ${cartItemProductFragment}
   ${moneyFragment}
 `;

--- a/libs/cart/driver/magento/testing/src/factories/cart-item/bundle-cart-item.factory.spec.ts
+++ b/libs/cart/driver/magento/testing/src/factories/cart-item/bundle-cart-item.factory.spec.ts
@@ -30,7 +30,6 @@ describe('Cart | Testing | Factories | CartItemFactory', () => {
       expect(result.id).toBeDefined();
       expect(result.prices.price).toBeDefined();
       expect(result.prices.row_total).toBeDefined();
-      expect(result.prices.row_total_including_tax).toBeDefined();
       expect(result.product).toBeDefined();
       expect(result.quantity).toBeDefined();
       expect(result.bundle_options[0].label).toBeDefined();

--- a/libs/cart/driver/magento/testing/src/factories/cart-item/cart-item.factory.spec.ts
+++ b/libs/cart/driver/magento/testing/src/factories/cart-item/cart-item.factory.spec.ts
@@ -30,7 +30,6 @@ describe('Cart | Testing | Factories | CartItemFactory', () => {
       expect(result.id).toBeDefined();
       expect(result.prices.price).toBeDefined();
       expect(result.prices.row_total).toBeDefined();
-      expect(result.prices.row_total_including_tax).toBeDefined();
       expect(result.product).toBeDefined();
       expect(result.quantity).toBeDefined();
     });

--- a/libs/cart/driver/magento/testing/src/factories/cart-item/cart-item.factory.ts
+++ b/libs/cart/driver/magento/testing/src/factories/cart-item/cart-item.factory.ts
@@ -4,6 +4,7 @@ import * as faker from 'faker/locale/en_US';
 import {
   MagentoCartItem,
   MagentoCartItemTypeEnum,
+  MagentoCartItemProduct,
 } from '@daffodil/cart/driver/magento';
 import { DaffModelFactory } from '@daffodil/core/testing';
 import {
@@ -14,8 +15,7 @@ import {
   MagentoMoneyFactory,
   MagentoDiscountFactory,
 } from '@daffodil/driver/magento/testing';
-import { MagentoProduct } from '@daffodil/product/driver/magento';
-import { MagentoProductFactory } from '@daffodil/product/driver/magento/testing';
+import { MagentoProductStockStatusEnum } from '@daffodil/product/driver/magento';
 
 export class MockMagentoCartItem implements MagentoCartItem {
 	__typename = MagentoCartItemTypeEnum.Simple;
@@ -24,14 +24,24 @@ export class MockMagentoCartItem implements MagentoCartItem {
     __typename: 'CartItemPrices',
     price: this.money(),
     row_total: this.money(),
-    row_total_including_tax: this.money(),
     discounts: this.discounts(faker.random.number({ min: 0, max: 2 })),
   };
   product = this.createProduct();
   quantity = faker.random.number({ min: 1, max: 20 });
 
-  private createProduct(): MagentoProduct {
-    return (new MagentoProductFactory()).create();
+  private createProduct(): MagentoCartItemProduct {
+    return {
+      __typename: 'SimpleProduct',
+      id: faker.random.number({ min: 1, max: 1500 }),
+      name: faker.random.word(),
+      sku: faker.commerce.product(),
+      thumbnail: {
+        __typename: 'Thumbnail',
+        label: faker.random.word(),
+        url: faker.random.image(),
+      },
+      stock_status: MagentoProductStockStatusEnum.InStock,
+    };
   }
 
   private money(): MagentoMoney {

--- a/libs/cart/driver/magento/testing/src/factories/cart-item/configurable-cart-item.factory.spec.ts
+++ b/libs/cart/driver/magento/testing/src/factories/cart-item/configurable-cart-item.factory.spec.ts
@@ -30,7 +30,6 @@ describe('Cart | Testing | Factories | CartItemFactory', () => {
       expect(result.id).toBeDefined();
       expect(result.prices.price).toBeDefined();
       expect(result.prices.row_total).toBeDefined();
-      expect(result.prices.row_total_including_tax).toBeDefined();
       expect(result.product).toBeDefined();
       expect(result.quantity).toBeDefined();
       expect(result.configurable_options[0].option_label).toBeDefined();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: perf
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Cart item queries are toeing the Magento query complexity limit of 300.

Fixes: #1318 

## What is the new behavior?
Cart item query complexity is now greatly reduced.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information