### PR TITLE
feat(category): remove generics on PageConfiguration and Request

### DIFF
--- a/libs/category/driver/in-memory/src/backend/category.service.ts
+++ b/libs/category/driver/in-memory/src/backend/category.service.ts
@@ -24,7 +24,7 @@ import { DaffInMemoryBackendProductService } from '@daffodil/product/driver/in-m
 })
 export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
   category: DaffCategory;
-  categoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest>;
+  categoryPageConfigurationState: DaffCategoryPageConfigurationState;
 
   constructor(
     private categoryFactory: DaffCategoryFactory,

--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
@@ -32,7 +32,7 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
   });
 
   const categoryPageConfigurationStateFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
-  const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest> = categoryPageConfigurationStateFactory.create();
+  const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState = categoryPageConfigurationStateFactory.create();
   delete stubCategoryPageConfigurationState.filter_requests;
   delete stubCategoryPageConfigurationState.applied_sort_direction;
   delete stubCategoryPageConfigurationState.applied_sort_option;

--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.ts
@@ -19,7 +19,7 @@ import { coerceDefaultSortOptionFirst } from './pure/sort-default-option-first';
 })
 export class DaffMagentoCategoryPageConfigTransformerService {
 
-  transform(categoryResponse: MagentoCompleteCategoryResponse): DaffCategoryPageConfigurationState<DaffCategoryRequest> {
+  transform(categoryResponse: MagentoCompleteCategoryResponse): DaffCategoryPageConfigurationState {
     return {
       id: String(categoryResponse.category.id),
       page_size: categoryResponse.page_info.page_size,

--- a/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
@@ -36,7 +36,7 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
     id: '1',
   });
   const categoryPageConfigurationStateFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
-  const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest> = categoryPageConfigurationStateFactory.create();
+  const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState = categoryPageConfigurationStateFactory.create();
   const productFactory: DaffProductFactory = new DaffProductFactory();
   const stubProducts: DaffProduct[] = productFactory.createMany(4);
 

--- a/libs/category/driver/magento/src/transformers/custom-metadata-attributes-methods.spec.ts
+++ b/libs/category/driver/magento/src/transformers/custom-metadata-attributes-methods.spec.ts
@@ -19,7 +19,7 @@ import {
 describe('Custom Metadata Attributes Methods', () => {
 
   const categoryPageConfigurationStateFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
-  const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest> = categoryPageConfigurationStateFactory.create();
+  const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState = categoryPageConfigurationStateFactory.create();
   delete stubCategoryPageConfigurationState.filter_requests;
   delete stubCategoryPageConfigurationState.applied_sort_direction;
   delete stubCategoryPageConfigurationState.applied_sort_option;

--- a/libs/category/driver/src/interfaces/category-service.interface.ts
+++ b/libs/category/driver/src/interfaces/category-service.interface.ts
@@ -5,18 +5,15 @@ import {
   DaffCategoryRequest,
   DaffGenericCategory,
   DaffCategory,
-  DaffCategoryPageConfigurationState,
   DaffGetCategoryResponse,
 } from '@daffodil/category';
 import { DaffProduct } from '@daffodil/product';
 
 export interface DaffCategoryServiceInterface<
-	T extends DaffCategoryRequest = DaffCategoryRequest,
 	V extends DaffGenericCategory<V> = DaffCategory,
-	U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
 	W extends DaffProduct = DaffProduct
 > {
-  get(categoryRequest: T): Observable<DaffGetCategoryResponse<T, V, U, W>>;
+  get(categoryRequest: DaffCategoryRequest): Observable<DaffGetCategoryResponse<V, W>>;
 }
 
 //TODO(damienwebdev): This any generic is necessary until we ship Ivy packages, do not change it.

--- a/libs/category/src/models/category-page-configuration-state.ts
+++ b/libs/category/src/models/category-page-configuration-state.ts
@@ -2,7 +2,7 @@ import { DaffCategoryFilter } from './category-filter';
 import { DaffCategorySortOption } from './category-sort-option';
 import { DaffCategoryRequest } from './requests/category-request';
 
-export type DaffCategoryPageConfigurationState<T extends DaffCategoryRequest = DaffCategoryRequest> = T & {
+export type DaffCategoryPageConfigurationState = DaffCategoryRequest & {
 	filters: DaffCategoryFilter[];
   sort_options: DaffCategorySortOption[];
 	total_pages: number;

--- a/libs/category/src/models/get-category-response.ts
+++ b/libs/category/src/models/get-category-response.ts
@@ -3,15 +3,12 @@ import { DaffProduct } from '@daffodil/product';
 import { DaffCategory } from './category';
 import { DaffCategoryPageConfigurationState } from './category-page-configuration-state';
 import { DaffGenericCategory } from './generic-category';
-import { DaffCategoryRequest } from './requests/category-request';
 
 export interface DaffGetCategoryResponse<
-	T extends DaffCategoryRequest = DaffCategoryRequest,
 	V extends DaffGenericCategory<V> = DaffCategory,
-	U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
 	W extends DaffProduct = DaffProduct
 > {
   products: W[];
   category: V;
-  categoryPageConfigurationState: U;
+  categoryPageConfigurationState: DaffCategoryPageConfigurationState;
 }

--- a/libs/category/state/src/actions/category-page.actions.ts
+++ b/libs/category/state/src/actions/category-page.actions.ts
@@ -28,10 +28,10 @@ export enum DaffCategoryPageActionTypes {
  *
  * @param request - DaffCategoryRequest object
  */
-export class DaffCategoryPageLoad<T extends DaffCategoryRequest = DaffCategoryRequest> implements Action {
+export class DaffCategoryPageLoad implements Action {
   readonly type = DaffCategoryPageActionTypes.CategoryPageLoadAction;
 
-  constructor(public request: T) { }
+  constructor(public request: DaffCategoryRequest) { }
 }
 
 /**
@@ -40,14 +40,12 @@ export class DaffCategoryPageLoad<T extends DaffCategoryRequest = DaffCategoryRe
  * @param response - DaffGetCategoryResponse object
  */
 export class DaffCategoryPageLoadSuccess<
-  T extends DaffCategoryRequest = DaffCategoryRequest,
   V extends DaffGenericCategory<V> = DaffCategory,
-  U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
   W extends DaffProduct = DaffProduct
   > implements Action {
   readonly type = DaffCategoryPageActionTypes.CategoryPageLoadSuccessAction;
 
-  constructor(public response: DaffGetCategoryResponse<T, V, U, W>) { }
+  constructor(public response: DaffGetCategoryResponse<V, W>) { }
 }
 
 /**
@@ -122,13 +120,11 @@ export class DaffCategoryPageToggleFilter implements Action {
 }
 
 export type DaffCategoryPageActions<
-  T extends DaffCategoryRequest = DaffCategoryRequest,
   U extends DaffGenericCategory<U> = DaffCategory,
-  V extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
   W extends DaffProduct = DaffProduct
   > =
-  | DaffCategoryPageLoad<T>
-  | DaffCategoryPageLoadSuccess<T, U, V, W>
+  | DaffCategoryPageLoad
+  | DaffCategoryPageLoadSuccess<U, W>
   | DaffCategoryPageLoadFailure
   | DaffCategoryPageChangePageSize
   | DaffCategoryPageChangeCurrentPage

--- a/libs/category/state/src/actions/category.actions.ts
+++ b/libs/category/state/src/actions/category.actions.ts
@@ -32,14 +32,12 @@ export class DaffCategoryLoad<T extends DaffCategoryRequest = DaffCategoryReques
  * @param response - DaffGetCategoryResponse object
  */
 export class DaffCategoryLoadSuccess<
-  T extends DaffCategoryRequest = DaffCategoryRequest,
   V extends DaffGenericCategory<V> = DaffCategory,
-  U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
   W extends DaffProduct = DaffProduct
   > implements Action {
   readonly type = DaffCategoryActionTypes.CategoryLoadSuccessAction;
 
-  constructor(public response: DaffGetCategoryResponse<T, V, U, W>) { }
+  constructor(public response: DaffGetCategoryResponse<V, W>) { }
 }
 
 /**
@@ -54,11 +52,9 @@ export class DaffCategoryLoadFailure implements Action {
 }
 
 export type DaffCategoryActions<
-  T extends DaffCategoryRequest = DaffCategoryRequest,
   U extends DaffGenericCategory<U> = DaffCategory,
-  V extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
   W extends DaffProduct = DaffProduct
   > =
-  | DaffCategoryLoad<T>
-  | DaffCategoryLoadSuccess<T, U, V, W>
+  | DaffCategoryLoad
+  | DaffCategoryLoadSuccess<U, W>
   | DaffCategoryLoadFailure;

--- a/libs/category/state/src/actions/category.actions.ts
+++ b/libs/category/state/src/actions/category.actions.ts
@@ -20,10 +20,10 @@ export enum DaffCategoryActionTypes {
  *
  * @param request - DaffCategoryRequest object
  */
-export class DaffCategoryLoad<T extends DaffCategoryRequest = DaffCategoryRequest> implements Action {
+export class DaffCategoryLoad implements Action {
   readonly type = DaffCategoryActionTypes.CategoryLoadAction;
 
-  constructor(public request: T) { }
+  constructor(public request: DaffCategoryRequest) { }
 }
 
 /**

--- a/libs/category/state/src/effects/category-page.effects.spec.ts
+++ b/libs/category/state/src/effects/category-page.effects.spec.ts
@@ -55,9 +55,9 @@ import { DaffCategoryPageEffects } from './category-page.effects';
 
 describe('DaffCategoryPageEffects', () => {
   let actions$: Observable<any>;
-  let effects: DaffCategoryPageEffects<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState<DaffCategoryRequest>, DaffProduct>;
+  let effects: DaffCategoryPageEffects<DaffCategory, DaffProduct>;
   let stubCategory: DaffCategory;
-  let stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest>;
+  let stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState;
   let stubProducts: DaffProduct[];
   let daffCategoryDriver: DaffCategoryServiceInterface;
   let store: Store<any>;
@@ -66,7 +66,7 @@ describe('DaffCategoryPageEffects', () => {
   let categoryFactory: DaffCategoryFactory;
   let categoryPageConfigurationStateFactory: DaffCategoryPageConfigurationStateFactory;
   let productFactory: DaffProductFactory;
-  let categoryLoadSuccessAction: DaffCategoryPageLoadSuccess<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState<DaffCategoryRequest>, DaffProduct>;
+  let categoryLoadSuccessAction: DaffCategoryPageLoadSuccess<DaffCategory, DaffProduct>;
   let productGridLoadSuccessAction: DaffProductGridLoadSuccess<DaffProduct>;
 
   beforeEach(() => {

--- a/libs/category/state/src/effects/category-page.effects.ts
+++ b/libs/category/state/src/effects/category-page.effects.ts
@@ -51,24 +51,22 @@ import { getDaffCategorySelectors } from '../selectors/category.selector';
 
 @Injectable()
 export class DaffCategoryPageEffects<
-	T extends DaffCategoryRequest,
 	V extends DaffGenericCategory<V>,
-	U extends DaffCategoryPageConfigurationState<T>,
 	W extends DaffProduct
 > {
 
   constructor(
     private actions$: Actions,
-    @Inject(DaffCategoryDriver) private driver: DaffCategoryServiceInterface<T, V, U, W>,
+    @Inject(DaffCategoryDriver) private driver: DaffCategoryServiceInterface<V, W>,
     private store: Store<any>,
   ){}
 
-	private categorySelectors = getDaffCategorySelectors<T, V, U, W>();
+	private categorySelectors = getDaffCategorySelectors<V, W>();
 
   @Effect()
   loadCategoryPage$: Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryPageActionTypes.CategoryPageLoadAction),
-    switchMap((action: DaffCategoryPageLoad<T>) => {
+    switchMap((action: DaffCategoryPageLoad) => {
       daffCategoryValidateFilters(action.request.filter_requests);
       return this.processCategoryGetRequest(action.request);
     }),
@@ -82,7 +80,7 @@ export class DaffCategoryPageEffects<
     ),
     switchMap((
       [action, categoryRequest]:
-			[DaffCategoryPageChangePageSize, T],
+			[DaffCategoryPageChangePageSize, DaffCategoryRequest],
     ) => this.processCategoryGetRequest({
       ...categoryRequest,
       page_size: action.pageSize,
@@ -97,7 +95,7 @@ export class DaffCategoryPageEffects<
     ),
     switchMap((
       [action, categoryRequest]:
-			[DaffCategoryPageChangeCurrentPage, T],
+			[DaffCategoryPageChangeCurrentPage, DaffCategoryRequest],
     ) => this.processCategoryGetRequest({
       ...categoryRequest,
       current_page: action.currentPage,
@@ -112,7 +110,7 @@ export class DaffCategoryPageEffects<
     ),
     switchMap((
       [action, categoryRequest]:
-			[DaffCategoryPageChangeFilters, T],
+			[DaffCategoryPageChangeFilters, DaffCategoryRequest],
     ) => {
       daffCategoryValidateFilters(action.filters);
       return this.processCategoryGetRequest({
@@ -130,7 +128,7 @@ export class DaffCategoryPageEffects<
     ),
     switchMap((
       [action, categoryPageConfigurationState]:
-			[DaffCategoryPageToggleFilter, U],
+			[DaffCategoryPageToggleFilter, DaffCategoryPageConfigurationState],
     ) => {
       daffCategoryValidateFilters(categoryPageConfigurationState.filter_requests);
       return this.processCategoryGetRequest({
@@ -147,7 +145,7 @@ export class DaffCategoryPageEffects<
     ),
     switchMap((
       [action, categoryRequest]:
-			[DaffCategoryPageChangeSortingOption, T],
+			[DaffCategoryPageChangeSortingOption, DaffCategoryRequest],
     ) => this.processCategoryGetRequest({
       ...categoryRequest,
       applied_sort_option: action.sort.option,
@@ -155,9 +153,9 @@ export class DaffCategoryPageEffects<
     })),
   );
 
-  private processCategoryGetRequest(payload: T) {
+  private processCategoryGetRequest(payload: DaffCategoryRequest) {
     return this.driver.get(payload).pipe(
-      switchMap((resp: DaffGetCategoryResponse<T, V, U, W>) => [
+      switchMap((resp: DaffGetCategoryResponse<V, W>) => [
         new DaffProductGridLoadSuccess(resp.products),
         new DaffCategoryPageLoadSuccess(resp),
       ]),

--- a/libs/category/state/src/effects/category.effects.spec.ts
+++ b/libs/category/state/src/effects/category.effects.spec.ts
@@ -49,7 +49,7 @@ import { DaffCategoryEffects } from './category.effects';
 
 describe('DaffCategoryEffects', () => {
   let actions$: Observable<any>;
-  let effects: DaffCategoryEffects<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState<DaffCategoryRequest>, DaffProduct>;
+  let effects: DaffCategoryEffects<DaffCategory, DaffProduct>;
   let stubCategory: DaffCategory;
   let stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState;
   let stubProducts: DaffProduct[];

--- a/libs/category/state/src/effects/category.effects.ts
+++ b/libs/category/state/src/effects/category.effects.ts
@@ -40,24 +40,22 @@ import {
 
 @Injectable()
 export class DaffCategoryEffects<
-	T extends DaffCategoryRequest,
 	V extends DaffGenericCategory<V>,
-	U extends DaffCategoryPageConfigurationState<T>,
 	W extends DaffProduct
 > {
 
   constructor(
     private actions$: Actions,
-    @Inject(DaffCategoryDriver) private driver: DaffCategoryServiceInterface<T, V, U, W>,
+    @Inject(DaffCategoryDriver) private driver: DaffCategoryServiceInterface<V,W>,
   ) {}
 
   @Effect()
   loadCategory$: Observable<any> = this.actions$.pipe(
     ofType(DaffCategoryActionTypes.CategoryLoadAction),
-    mergeMap((action: DaffCategoryLoad<T>) => {
+    mergeMap((action: DaffCategoryLoad) => {
       daffCategoryValidateFilters(action.request.filter_requests);
       return this.driver.get(action.request).pipe(
-        switchMap((resp: DaffGetCategoryResponse<T, V, U, W>) => of(
+        switchMap((resp: DaffGetCategoryResponse<V,W>) => of(
           new DaffProductGridLoadSuccess(resp.products),
           new DaffCategoryLoadSuccess(resp),
         )),

--- a/libs/category/state/src/facades/category-facade.interface.ts
+++ b/libs/category/state/src/facades/category-facade.interface.ts
@@ -2,13 +2,12 @@ import { Action } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
 import {
-  DaffCategoryRequest,
   DaffGenericCategory,
   DaffCategory,
-  DaffCategoryPageConfigurationState,
   DaffCategoryFilter,
   DaffCategorySortOption,
   DaffCategoryAppliedFilter,
+  DaffCategoryPageConfigurationState,
 } from '@daffodil/category';
 import {
   DaffStoreFacade,
@@ -17,9 +16,7 @@ import {
 import { DaffProduct } from '@daffodil/product';
 
 export interface DaffCategoryFacadeInterface<
-	T extends DaffCategoryRequest = DaffCategoryRequest,
 	V extends DaffGenericCategory<V> = DaffCategory,
-	U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
 	W extends DaffProduct = DaffProduct
 > extends DaffStoreFacade<Action> {
 	/**
@@ -29,7 +26,7 @@ export interface DaffCategoryFacadeInterface<
   /**
    * The page configuration state for the selected category.
    */
-  pageConfigurationState$: Observable<U>;
+  pageConfigurationState$: Observable<DaffCategoryPageConfigurationState>;
   /**
    * The current page of products for the selected category.
    */

--- a/libs/category/state/src/facades/category.facade.spec.ts
+++ b/libs/category/state/src/facades/category.facade.spec.ts
@@ -35,12 +35,12 @@ import { DaffCategoryFacade } from './category.facade';
 
 describe('DaffCategoryFacade', () => {
   let store: Store<any>;
-  let facade: DaffCategoryFacade<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState<DaffCategoryRequest>, DaffProduct>;
+  let facade: DaffCategoryFacade<DaffCategory, DaffProduct>;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
   const categoryPageConfigurationFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
   const productFactory: DaffProductFactory = new DaffProductFactory();
   let category: DaffCategory;
-  let categoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest>;
+  let categoryPageConfigurationState: DaffCategoryPageConfigurationState;
   let product: DaffProduct;
 
   beforeEach(() => {

--- a/libs/category/state/src/facades/category.facade.ts
+++ b/libs/category/state/src/facades/category.facade.ts
@@ -29,12 +29,10 @@ import { DaffCategoryFacadeInterface } from './category-facade.interface';
   providedIn: 'root',
 })
 export class DaffCategoryFacade<
-	T extends DaffCategoryRequest = DaffCategoryRequest,
 	V extends DaffGenericCategory<V> = DaffCategory,
-	U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
 	W extends DaffProduct = DaffProduct
-> implements DaffCategoryFacadeInterface<T, V, U, W> {
-	private categorySelectors = getDaffCategorySelectors<T, V, U, W>();
+> implements DaffCategoryFacadeInterface<V,W> {
+	private categorySelectors = getDaffCategorySelectors<V,W>();
 
 	/**
 	 * The currently selected category.
@@ -43,7 +41,7 @@ export class DaffCategoryFacade<
   /**
    * The page configuration state for the selected category.
    */
-  pageConfigurationState$: Observable<U>;
+  pageConfigurationState$: Observable<DaffCategoryPageConfigurationState>;
   /**
    * The current page of products for the selected category.
    */
@@ -128,7 +126,7 @@ export class DaffCategoryFacade<
 	  return this.store.pipe(select(this.categorySelectors.selectTotalProductsByCategory, { id: categoryId }));
 	}
 
-	constructor(private store: Store<DaffCategoryReducersState<T, V, U>>) {
+	constructor(private store: Store<DaffCategoryReducersState<V>>) {
 	  this.category$ = this.store.pipe(select(this.categorySelectors.selectSelectedCategory));
 	  this.products$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageProducts));
 	  this.totalProducts$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageTotalProducts));

--- a/libs/category/state/src/reducers/category-entities/category-entities.reducer.ts
+++ b/libs/category/state/src/reducers/category-entities/category-entities.reducer.ts
@@ -19,13 +19,11 @@ import {
 import { daffCategoryEntitiesAdapter } from './category-entities-adapter';
 
 export function daffCategoryEntitiesReducer<
-  T extends DaffCategoryRequest = DaffCategoryRequest,
   V extends DaffGenericCategory<V> = DaffCategory,
-  U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
   W extends DaffProduct = DaffProduct
 >(
   state = daffCategoryEntitiesAdapter<V>().getInitialState(),
-  action: DaffCategoryActions<T, V, U, W> | DaffCategoryPageActions<T, V, U, W>,
+  action: DaffCategoryActions<V,W> | DaffCategoryPageActions<V,W>,
 ): EntityState<V> {
   switch (action.type) {
     case DaffCategoryActionTypes.CategoryLoadSuccessAction:

--- a/libs/category/state/src/reducers/category-reducers.interface.ts
+++ b/libs/category/state/src/reducers/category-reducers.interface.ts
@@ -1,19 +1,15 @@
 import { EntityState } from '@ngrx/entity';
 
 import {
-  DaffCategoryRequest,
   DaffGenericCategory,
   DaffCategory,
-  DaffCategoryPageConfigurationState,
 } from '@daffodil/category';
 
-import { DaffCategoryReducerState } from '../reducers/category/category-reducer-state.interface';
+import { DaffCategoryReducerState } from './category/category-reducer-state.interface';
 
 export interface DaffCategoryReducersState<
-	T extends DaffCategoryRequest = DaffCategoryRequest,
-	V extends DaffGenericCategory<V> = DaffCategory,
-	U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>
+	V extends DaffGenericCategory<V> = DaffCategory
 > {
-  category: DaffCategoryReducerState<T, U>;
+  category: DaffCategoryReducerState;
   categoryEntities: EntityState<V>;
 }

--- a/libs/category/state/src/reducers/category/category-reducer-state.interface.ts
+++ b/libs/category/state/src/reducers/category/category-reducer-state.interface.ts
@@ -3,11 +3,8 @@ import {
   DaffCategoryPageConfigurationState,
 } from '@daffodil/category';
 
-export interface DaffCategoryReducerState<
-	T extends DaffCategoryRequest = DaffCategoryRequest,
-	V extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>
-> {
-	categoryPageConfigurationState: V;
+export interface DaffCategoryReducerState {
+	categoryPageConfigurationState: DaffCategoryPageConfigurationState;
   categoryLoading: boolean;
   productsLoading: boolean;
   errors: string[];

--- a/libs/category/state/src/reducers/category/category.reducer.spec.ts
+++ b/libs/category/state/src/reducers/category/category.reducer.spec.ts
@@ -36,9 +36,9 @@ describe('Category | Category Reducer', () => {
   let categoryFactory: DaffCategoryFactory;
   let categoryPageConfigurationStateFactory: DaffCategoryPageConfigurationStateFactory;
   let category: DaffCategory;
-  let categoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest>;
+  let categoryPageConfigurationState: DaffCategoryPageConfigurationState;
   let categoryId: string;
-  const initialState: DaffCategoryReducerState<DaffCategoryRequest, DaffCategoryPageConfigurationState<DaffCategoryRequest>> = {
+  const initialState: DaffCategoryReducerState = {
     categoryPageConfigurationState: {
       id: null,
       filter_requests: [],
@@ -470,7 +470,7 @@ describe('Category | Category Reducer', () => {
 
     const error = 'error message';
     let result;
-    let state: DaffCategoryReducerState<DaffCategoryRequest, DaffCategoryPageConfigurationState<DaffCategoryRequest>>;
+    let state: DaffCategoryReducerState;
 
     beforeEach(() => {
       state = {
@@ -515,7 +515,7 @@ describe('Category | Category Reducer', () => {
         applied_sort_direction: categoryPageConfigurationState.applied_sort_direction,
         current_page: categoryPageConfigurationState.current_page,
       };
-      const categoryLoadAction: DaffCategoryPageLoad<DaffCategoryRequest> = new DaffCategoryPageLoad(categoryRequest);
+      const categoryLoadAction: DaffCategoryPageLoad = new DaffCategoryPageLoad(categoryRequest);
 
       result = daffCategoryReducer(initialState, categoryLoadAction);
     });
@@ -540,8 +540,8 @@ describe('Category | Category Reducer', () => {
 
   describe('when CategoryLoadSuccessAction is triggered', () => {
 
-    let result: DaffCategoryReducerState<DaffCategoryRequest, DaffCategoryPageConfigurationState<DaffCategoryRequest>>;
-    let state: DaffCategoryReducerState<DaffCategoryRequest, DaffCategoryPageConfigurationState<DaffCategoryRequest>>;
+    let result: DaffCategoryReducerState;
+    let state: DaffCategoryReducerState;
 
     beforeEach(() => {
       state = {
@@ -569,8 +569,8 @@ describe('Category | Category Reducer', () => {
 
   describe('when CategoryPageLoadSuccessAction is triggered', () => {
 
-    let result: DaffCategoryReducerState<DaffCategoryRequest, DaffCategoryPageConfigurationState<DaffCategoryRequest>>;
-    let state: DaffCategoryReducerState<DaffCategoryRequest, DaffCategoryPageConfigurationState<DaffCategoryRequest>>;
+    let result: DaffCategoryReducerState;
+    let state: DaffCategoryReducerState;
 
     beforeEach(() => {
       state = {
@@ -600,7 +600,7 @@ describe('Category | Category Reducer', () => {
 
     const error = 'error message';
     let result;
-    let state: DaffCategoryReducerState<DaffCategoryRequest, DaffCategoryPageConfigurationState<DaffCategoryRequest>>;
+    let state: DaffCategoryReducerState;
 
     beforeEach(() => {
       state = {

--- a/libs/category/state/src/reducers/category/category.reducer.ts
+++ b/libs/category/state/src/reducers/category/category.reducer.ts
@@ -14,7 +14,7 @@ import {
 import { DaffCategoryReducerState } from './category-reducer-state.interface';
 import { toggleCategoryFilter } from './toggle-filter/core';
 
-const initialState: DaffCategoryReducerState<any, any> = {
+const initialState: DaffCategoryReducerState = {
   categoryPageConfigurationState: {
     id: null,
     filter_requests: [],
@@ -33,7 +33,7 @@ const initialState: DaffCategoryReducerState<any, any> = {
   errors: [],
 };
 
-export function daffCategoryReducer<T extends DaffCategoryRequest, U extends DaffGenericCategory<U>, V extends DaffCategoryPageConfigurationState<T>, W extends DaffProduct>(state = initialState, action: DaffCategoryActions<T, U, V, W> | DaffCategoryPageActions<T, U, V, W>): DaffCategoryReducerState<T, V> {
+export function daffCategoryReducer<U extends DaffGenericCategory<U>, W extends DaffProduct>(state = initialState, action: DaffCategoryActions<U, W> | DaffCategoryPageActions<U, W>): DaffCategoryReducerState {
   switch (action.type) {
     case DaffCategoryActionTypes.CategoryLoadAction:
       return {

--- a/libs/category/state/src/selectors/category-entities/category-entities.selector.spec.ts
+++ b/libs/category/state/src/selectors/category-entities/category-entities.selector.spec.ts
@@ -27,12 +27,12 @@ import { getDaffCategoryEntitiesSelectors } from './category-entities.selector';
 
 describe('DaffCategoryEntitiesSelectors', () => {
 
-  let store: Store<DaffCategoryReducersState<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState<DaffCategoryRequest>>>;
+  let store: Store<DaffCategoryReducersState<DaffCategory>>;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
   const categoryPageConfigurationFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
   let stubCategory: DaffCategory;
-  const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest> = categoryPageConfigurationFactory.create();
-  const categorySelectors = getDaffCategoryEntitiesSelectors<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState<DaffCategoryRequest>>();
+  const stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState = categoryPageConfigurationFactory.create();
+  const categorySelectors = getDaffCategoryEntitiesSelectors<DaffCategory>();
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/libs/category/state/src/selectors/category-entities/category-entities.selector.ts
+++ b/libs/category/state/src/selectors/category-entities/category-entities.selector.ts
@@ -26,16 +26,16 @@ export interface DaffCategoryEntitiesMemoizedSelectors<V extends DaffGenericCate
 	selectCategoryTotal: MemoizedSelector<Record<string, any>, number>;
 }
 
-const createCategoryFeatureSelectors = <T extends DaffCategoryRequest, V extends DaffGenericCategory<V>, U extends DaffCategoryPageConfigurationState<T>>(): DaffCategoryEntitiesMemoizedSelectors<V> => {
+const createCategoryFeatureSelectors = <V extends DaffGenericCategory<V>>(): DaffCategoryEntitiesMemoizedSelectors<V> => {
 
   const entitiesSelectors = daffCategoryEntitiesAdapter<V>().getSelectors();
-  const categoryFeatureState = getDaffCategoryFeatureSelector<T, V, U>().selectCategoryFeatureState;
+  const categoryFeatureState = getDaffCategoryFeatureSelector<V>().selectCategoryFeatureState;
   /**
    * Category Entities State
    */
   const selectCategoryEntitiesState = createSelector(
     categoryFeatureState,
-    (state: DaffCategoryReducersState<T, V, U>) => state.categoryEntities,
+    (state: DaffCategoryReducersState<V>) => state.categoryEntities,
   );
 
   const selectCategoryIds = createSelector(
@@ -69,7 +69,7 @@ const createCategoryFeatureSelectors = <T extends DaffCategoryRequest, V extends
 
 export const getDaffCategoryEntitiesSelectors = (() => {
   let cache;
-  return <T extends DaffCategoryRequest, V extends DaffGenericCategory<V>, U extends DaffCategoryPageConfigurationState<T>>(): DaffCategoryEntitiesMemoizedSelectors<V> => cache = cache
+  return <V extends DaffGenericCategory<V>>(): DaffCategoryEntitiesMemoizedSelectors<V> => cache = cache
     ? cache
-    : createCategoryFeatureSelectors<T, V, U>();
+    : createCategoryFeatureSelectors<V>();
 })();

--- a/libs/category/state/src/selectors/category-feature.selector.ts
+++ b/libs/category/state/src/selectors/category-feature.selector.ts
@@ -17,16 +17,14 @@ import {
 
 
 export interface DaffCategoryFeatureMemoizedSelectors<
-	T extends DaffCategoryRequest = DaffCategoryRequest,
 	V extends DaffGenericCategory<V> = DaffCategory,
-	U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>
 > {
-	selectCategoryFeatureState: MemoizedSelector<Record<string, any>, DaffCategoryReducersState<T, V, U>>;
+	selectCategoryFeatureState: MemoizedSelector<Record<string, any>, DaffCategoryReducersState<V>>;
 }
 
 export const getDaffCategoryFeatureSelector = (() => {
   let cache;
-  return <T extends DaffCategoryRequest, V extends DaffGenericCategory<V>, U extends DaffCategoryPageConfigurationState<T>>(): DaffCategoryFeatureMemoizedSelectors<T, V, U> => cache = cache
+  return <V extends DaffGenericCategory<V>>(): DaffCategoryFeatureMemoizedSelectors<V> => cache = cache
     ? cache
-    : { selectCategoryFeatureState: createFeatureSelector<DaffCategoryReducersState<T, V, U>>(DAFF_CATEGORY_STORE_FEATURE_KEY) };
+    : { selectCategoryFeatureState: createFeatureSelector<DaffCategoryReducersState<V>>(DAFF_CATEGORY_STORE_FEATURE_KEY) };
 })();

--- a/libs/category/state/src/selectors/category-page/category-page.selector.spec.ts
+++ b/libs/category/state/src/selectors/category-page/category-page.selector.spec.ts
@@ -31,12 +31,12 @@ import { getDaffCategoryPageSelectors } from './category-page.selector';
 
 describe('DaffCategoryPageSelectors', () => {
 
-  let store: Store<DaffCategoryReducersState<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState<DaffCategoryRequest>>>;
+  let store: Store<DaffCategoryReducersState<DaffCategory>>;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
   const categoryPageConfigurationFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
   let stubCategory: DaffCategory;
-  let stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest>;
-  const categorySelectors = getDaffCategoryPageSelectors<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState<DaffCategoryRequest>>();
+  let stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState;
+  const categorySelectors = getDaffCategoryPageSelectors<DaffCategory>();
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/libs/category/state/src/selectors/category-page/category-page.selector.ts
+++ b/libs/category/state/src/selectors/category-page/category-page.selector.ts
@@ -21,39 +21,37 @@ import { buildAppliedFilter } from '../applied-filter/applied-filter-methods';
 import { getDaffCategoryFeatureSelector } from '../category-feature.selector';
 
 export interface DaffCategoryPageMemoizedSelectors<
-	T extends DaffCategoryRequest = DaffCategoryRequest,
-	V extends DaffGenericCategory<V> = DaffCategory,
-	U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>
+	V extends DaffGenericCategory<V> = DaffCategory
 > {
-	selectCategoryState: MemoizedSelector<Record<string, any>, DaffCategoryReducerState<T, U>>;
-	selectCategoryPageConfigurationState: MemoizedSelector<Record<string, any>, U>;
-	selectCategoryCurrentPage: MemoizedSelector<Record<string, any>, U['current_page']>;
-	selectCategoryTotalPages: MemoizedSelector<Record<string, any>, U['total_pages']>;
-	selectCategoryPageSize: MemoizedSelector<Record<string, any>, U['page_size']>;
-	selectCategoryFilters: MemoizedSelector<Record<string, any>, U['filters']>;
-	selectCategorySortOptions: MemoizedSelector<Record<string, any>, U['sort_options']>;
-	selectCategoryPageProductIds: MemoizedSelector<Record<string, any>, U['product_ids']>;
+	selectCategoryState: MemoizedSelector<Record<string, any>, DaffCategoryReducerState>;
+	selectCategoryPageConfigurationState: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState>;
+	selectCategoryCurrentPage: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['current_page']>;
+	selectCategoryTotalPages: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['total_pages']>;
+	selectCategoryPageSize: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['page_size']>;
+	selectCategoryFilters: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['filters']>;
+	selectCategorySortOptions: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['sort_options']>;
+	selectCategoryPageProductIds: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['product_ids']>;
 	selectIsCategoryPageEmpty: MemoizedSelector<Record<string, any>, boolean>;
-	selectCategoryPageTotalProducts: MemoizedSelector<Record<string, any>, U['total_products']>;
-	selectCategoryPageFilterRequests: MemoizedSelector<Record<string, any>, U['filter_requests']>;
+	selectCategoryPageTotalProducts: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['total_products']>;
+	selectCategoryPageFilterRequests: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['filter_requests']>;
 	selectCategoryPageAppliedFilters: MemoizedSelector<Record<string, any>, DaffCategoryAppliedFilter[]>;
-	selectCategoryPageAppliedSortOption: MemoizedSelector<Record<string, any>, U['applied_sort_option']>;
-	selectCategoryPageAppliedSortDirection: MemoizedSelector<Record<string, any>, U['applied_sort_direction']>;
-	selectSelectedCategoryId: MemoizedSelector<Record<string, any>, U['id']>;
+	selectCategoryPageAppliedSortOption: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['applied_sort_option']>;
+	selectCategoryPageAppliedSortDirection: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['applied_sort_direction']>;
+	selectSelectedCategoryId: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['id']>;
 	selectCategoryLoading: MemoizedSelector<Record<string, any>, boolean>;
 	selectCategoryProductsLoading: MemoizedSelector<Record<string, any>, boolean>;
 	selectCategoryErrors: MemoizedSelector<Record<string, any>, string[]>;
 }
 
-const createCategoryPageSelectors = <T extends DaffCategoryRequest, V extends DaffGenericCategory<V>, U extends DaffCategoryPageConfigurationState<T>>(): DaffCategoryPageMemoizedSelectors<T, V, U> => {
-  const selectCategoryFeatureState = getDaffCategoryFeatureSelector<T, V, U>().selectCategoryFeatureState;
+const createCategoryPageSelectors = <V extends DaffGenericCategory<V>>(): DaffCategoryPageMemoizedSelectors<V> => {
+  const selectCategoryFeatureState = getDaffCategoryFeatureSelector<V>().selectCategoryFeatureState;
 
   /**
    * Category State
    */
   const selectCategoryState = createSelector(
     selectCategoryFeatureState,
-    (state: DaffCategoryReducersState<T, V, U>) => state.category,
+    (state: DaffCategoryReducersState<V>) => state.category,
   );
 
   /**
@@ -61,37 +59,37 @@ const createCategoryPageSelectors = <T extends DaffCategoryRequest, V extends Da
    */
   const selectCategoryPageConfigurationState = createSelector(
     selectCategoryState,
-    (state: DaffCategoryReducerState<T, U>) => state.categoryPageConfigurationState,
+    (state: DaffCategoryReducerState) => state.categoryPageConfigurationState,
   );
 
   const selectCategoryCurrentPage = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.current_page,
+    (state: DaffCategoryPageConfigurationState) => state.current_page,
   );
 
   const selectCategoryTotalPages = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.total_pages,
+    (state: DaffCategoryPageConfigurationState) => state.total_pages,
   );
 
   const selectCategoryPageSize = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.page_size,
+    (state: DaffCategoryPageConfigurationState) => state.page_size,
   );
 
   const selectCategoryFilters = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.filters,
+    (state: DaffCategoryPageConfigurationState) => state.filters,
   );
 
   const selectCategorySortOptions = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.sort_options,
+    (state: DaffCategoryPageConfigurationState) => state.sort_options,
   );
 
   const selectCategoryPageProductIds = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.product_ids,
+    (state: DaffCategoryPageConfigurationState) => state.product_ids,
   );
 
   const selectIsCategoryPageEmpty = createSelector(
@@ -101,12 +99,12 @@ const createCategoryPageSelectors = <T extends DaffCategoryRequest, V extends Da
 
   const selectCategoryPageTotalProducts = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.total_products,
+    (state: DaffCategoryPageConfigurationState) => state.total_products,
   );
 
   const selectCategoryPageFilterRequests = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.filter_requests,
+    (state: DaffCategoryPageConfigurationState) => state.filter_requests,
   );
 
   const selectCategoryPageAppliedFilters = createSelector(
@@ -126,12 +124,12 @@ const createCategoryPageSelectors = <T extends DaffCategoryRequest, V extends Da
 
   const selectCategoryPageAppliedSortOption = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.applied_sort_option,
+    (state: DaffCategoryPageConfigurationState) => state.applied_sort_option,
   );
 
   const selectCategoryPageAppliedSortDirection = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.applied_sort_direction,
+    (state: DaffCategoryPageConfigurationState) => state.applied_sort_direction,
   );
 
   /**
@@ -139,7 +137,7 @@ const createCategoryPageSelectors = <T extends DaffCategoryRequest, V extends Da
    */
   const selectSelectedCategoryId = createSelector(
     selectCategoryPageConfigurationState,
-    (state: U) => state.id,
+    (state: DaffCategoryPageConfigurationState) => state.id,
   );
 
   /**
@@ -147,7 +145,7 @@ const createCategoryPageSelectors = <T extends DaffCategoryRequest, V extends Da
    */
   const selectCategoryLoading = createSelector(
     selectCategoryState,
-    (state: DaffCategoryReducerState<T, U>) => state.categoryLoading,
+    (state: DaffCategoryReducerState) => state.categoryLoading,
   );
 
   /**
@@ -155,7 +153,7 @@ const createCategoryPageSelectors = <T extends DaffCategoryRequest, V extends Da
    */
   const selectCategoryProductsLoading = createSelector(
     selectCategoryState,
-    (state: DaffCategoryReducerState<T, U>) => state.productsLoading,
+    (state: DaffCategoryReducerState) => state.productsLoading,
   );
 
   /**
@@ -163,7 +161,7 @@ const createCategoryPageSelectors = <T extends DaffCategoryRequest, V extends Da
    */
   const selectCategoryErrors = createSelector(
     selectCategoryState,
-    (state: DaffCategoryReducerState<T, U>) => state.errors,
+    (state: DaffCategoryReducerState) => state.errors,
   );
 
   return {
@@ -190,7 +188,7 @@ const createCategoryPageSelectors = <T extends DaffCategoryRequest, V extends Da
 
 export const getDaffCategoryPageSelectors = (() => {
   let cache;
-  return <T extends DaffCategoryRequest, V extends DaffGenericCategory<V>, U extends DaffCategoryPageConfigurationState<T>>(): DaffCategoryPageMemoizedSelectors<T, V, U> => cache = cache
+  return <V extends DaffGenericCategory<V>>(): DaffCategoryPageMemoizedSelectors<V> => cache = cache
     ? cache
-    : createCategoryPageSelectors<T, V, U>();
+    : createCategoryPageSelectors<V>();
 })();

--- a/libs/category/state/src/selectors/category.selector.spec.ts
+++ b/libs/category/state/src/selectors/category.selector.spec.ts
@@ -35,12 +35,12 @@ import { getDaffCategorySelectors } from './category.selector';
 
 describe('DaffCategorySelectors', () => {
 
-  let store: Store<DaffCategoryReducersState<DaffCategoryRequest, DaffCategory, DaffCategoryPageConfigurationState<DaffCategoryRequest>>>;
+  let store: Store<DaffCategoryReducersState<DaffCategory>>;
   const categoryFactory: DaffCategoryFactory = new DaffCategoryFactory();
   const categoryPageConfigurationFactory: DaffCategoryPageConfigurationStateFactory = new DaffCategoryPageConfigurationStateFactory();
   const productFactory: DaffProductFactory = new DaffProductFactory();
   let stubCategory: DaffCategory;
-  let stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState<DaffCategoryRequest>;
+  let stubCategoryPageConfigurationState: DaffCategoryPageConfigurationState;
   let product: DaffProduct;
   const categorySelectors = getDaffCategorySelectors();
 

--- a/libs/category/state/src/selectors/category.selector.ts
+++ b/libs/category/state/src/selectors/category.selector.ts
@@ -26,13 +26,11 @@ import {
 } from './category-page/category-page.selector';
 
 export interface DaffCategoryMemoizedSelectors<
-	T extends DaffCategoryRequest = DaffCategoryRequest,
 	V extends DaffGenericCategory<V> = DaffCategory,
-	U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
 	W extends DaffProduct = DaffProduct
 > extends
-	DaffCategoryFeatureMemoizedSelectors<T, V, U>,
-	DaffCategoryPageMemoizedSelectors<T, V, U>,
+	DaffCategoryFeatureMemoizedSelectors<V>,
+	DaffCategoryPageMemoizedSelectors<V>,
 	DaffCategoryEntitiesMemoizedSelectors<V> {
 	selectSelectedCategory: MemoizedSelector<Record<string, any>, V>;
 	selectCategoryPageProducts: MemoizedSelector<Record<string, any>, W[]>;
@@ -41,16 +39,16 @@ export interface DaffCategoryMemoizedSelectors<
 	selectTotalProductsByCategory: MemoizedSelectorWithProps<Record<string, any>, Record<string, any>, number>;
 }
 
-const createCategorySelectors = <T extends DaffCategoryRequest, V extends DaffGenericCategory<V>, U extends DaffCategoryPageConfigurationState<T>, W extends DaffProduct>(): DaffCategoryMemoizedSelectors<T, V, U, W> => {
+const createCategorySelectors = <V extends DaffGenericCategory<V>, W extends DaffProduct>(): DaffCategoryMemoizedSelectors<V, W> => {
   const { selectProductEntities, selectAllProducts } = getDaffProductSelectors<W>();
 
   const {
     selectCategoryEntities,
-  } = getDaffCategoryEntitiesSelectors<T, V, U>();
+  } = getDaffCategoryEntitiesSelectors<V>();
   const {
     selectSelectedCategoryId,
     selectCategoryPageProductIds,
-  } = getDaffCategoryPageSelectors<T, V, U>();
+  } = getDaffCategoryPageSelectors<V>();
   /**
    * Combinatoric Category Selectors
    */
@@ -88,9 +86,9 @@ const createCategorySelectors = <T extends DaffCategoryRequest, V extends DaffGe
   );
 
   return {
-    ...getDaffCategoryFeatureSelector<T, V, U>(),
-    ...getDaffCategoryEntitiesSelectors<T, V, U>(),
-    ...getDaffCategoryPageSelectors<T, V, U>(),
+    ...getDaffCategoryFeatureSelector<V>(),
+    ...getDaffCategoryEntitiesSelectors<V>(),
+    ...getDaffCategoryPageSelectors<V>(),
     selectSelectedCategory,
     selectCategoryPageProducts,
     selectCategory,
@@ -102,11 +100,9 @@ const createCategorySelectors = <T extends DaffCategoryRequest, V extends DaffGe
 export const getDaffCategorySelectors = (() => {
   let cache;
   return <
-		T extends DaffCategoryRequest = DaffCategoryRequest,
 		V extends DaffGenericCategory<V> = DaffCategory,
-		U extends DaffCategoryPageConfigurationState<T> = DaffCategoryPageConfigurationState<T>,
 		W extends DaffProduct = DaffProduct
-	>(): DaffCategoryMemoizedSelectors<T, V, U, W> => cache = cache
+	>(): DaffCategoryMemoizedSelectors<V, W> => cache = cache
     ? cache
-    : createCategorySelectors<T, V, U, W>();
+    : createCategorySelectors<V,W>();
 })();

--- a/libs/category/testing/src/factories/category-page-configuration-state.factory.spec.ts
+++ b/libs/category/testing/src/factories/category-page-configuration-state.factory.spec.ts
@@ -25,7 +25,7 @@ describe('Category | Testing | Factories | DaffCategoryPageConfigurationStateFac
 
   describe('create', () => {
 
-    let result: DaffCategoryPageConfigurationState<DaffCategoryRequest>;
+    let result: DaffCategoryPageConfigurationState;
 
     beforeEach(() => {
       result = categoryPageConfigurationStateFactory.create();
@@ -44,7 +44,7 @@ describe('Category | Testing | Factories | DaffCategoryPageConfigurationStateFac
   });
 
   describe('createMany', () => {
-    let result: DaffCategoryPageConfigurationState<DaffCategoryRequest>[];
+    let result: DaffCategoryPageConfigurationState[];
 
     it('should create as many categories as desired', () => {
       result = categoryPageConfigurationStateFactory.createMany(2);

--- a/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
+++ b/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
@@ -8,7 +8,7 @@ import {
 } from '@daffodil/category';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
-export class MockCategoryPageConfigurationState implements DaffCategoryPageConfigurationState<DaffCategoryRequest> {
+export class MockCategoryPageConfigurationState implements DaffCategoryPageConfigurationState {
   id = faker.random.uuid();
   page_size = 20;
   current_page = 1;
@@ -54,7 +54,7 @@ export class MockCategoryPageConfigurationState implements DaffCategoryPageConfi
 @Injectable({
   providedIn: 'root',
 })
-export class DaffCategoryPageConfigurationStateFactory extends DaffModelFactory<DaffCategoryPageConfigurationState<DaffCategoryRequest>>{
+export class DaffCategoryPageConfigurationStateFactory extends DaffModelFactory<DaffCategoryPageConfigurationState>{
   constructor(){
     super(MockCategoryPageConfigurationState);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, `@daffodil/category` exposes some generics on making category requests (along with the subsequent responses about category pages) that are extremely verbose and over-complicate things.

Fixes: N/A


## What is the new behavior?
I've pulled these generics back, as there's no real use-case for them.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information