### PR TITLE
fix(category): the applied_sort_option is not being set to the defaul…

### DIFF
--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
@@ -96,8 +96,8 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
       };
 
       sort_fields = {
-        default: stubCategoryPageConfigurationState.sort_options[0].value,
-        options: stubCategoryPageConfigurationState.sort_options,
+        default: stubCategoryPageConfigurationState.sort_options.options[0].value,
+        options: stubCategoryPageConfigurationState.sort_options.options,
       };
 
       products = [new MagentoProductFactory().create({ sku: stubCategoryPageConfigurationState.product_ids[0] })];

--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.ts
@@ -27,7 +27,10 @@ export class DaffMagentoCategoryPageConfigTransformerService {
       total_pages: categoryResponse.page_info.total_pages,
       total_products: categoryResponse.total_count,
       filters: categoryResponse.aggregates.map(this.transformAggregate.bind(this)),
-      sort_options: coerceDefaultSortOptionFirst(categoryResponse.sort_fields).options,
+      sort_options: {
+        default: categoryResponse.sort_fields.default,
+        options: coerceDefaultSortOptionFirst(categoryResponse.sort_fields).options,
+      },
       product_ids: categoryResponse.products.map(product => product.sku),
     };
   }

--- a/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
@@ -91,8 +91,8 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
       };
 
       const sort_fields: MagentoSortFields = {
-        default: stubCategoryPageConfigurationState.sort_options[0].value,
-        options: stubCategoryPageConfigurationState.sort_options,
+        default: stubCategoryPageConfigurationState.sort_options.options[0].value,
+        options: stubCategoryPageConfigurationState.sort_options.options,
       };
 
       const products: MagentoProduct[] = new MagentoProductFactory().createMany(1);

--- a/libs/category/src/models/category-page-configuration-state.ts
+++ b/libs/category/src/models/category-page-configuration-state.ts
@@ -1,10 +1,10 @@
 import { DaffCategoryFilter } from './category-filter';
-import { DaffCategorySortOption } from './category-sort-option';
+import { DaffCategorySortOptions } from './category-sort-options';
 import { DaffCategoryRequest } from './requests/category-request';
 
 export type DaffCategoryPageConfigurationState = DaffCategoryRequest & {
 	filters: DaffCategoryFilter[];
-  sort_options: DaffCategorySortOption[];
+  sort_options: DaffCategorySortOptions;
 	total_pages: number;
 	total_products: number;
 	product_ids: string[];

--- a/libs/category/src/models/category-sort-option.ts
+++ b/libs/category/src/models/category-sort-option.ts
@@ -1,4 +1,0 @@
-export interface DaffCategorySortOption {
-  label: string;
-  value: any;
-}

--- a/libs/category/src/models/category-sort-options.ts
+++ b/libs/category/src/models/category-sort-options.ts
@@ -1,0 +1,9 @@
+export interface DaffCategorySortOptions {
+	default: DaffCategorySortOption['value'];
+	options: DaffCategorySortOption[];
+}
+
+export interface DaffCategorySortOption {
+  label: string;
+  value: any;
+}

--- a/libs/category/src/models/public_api.ts
+++ b/libs/category/src/models/public_api.ts
@@ -9,7 +9,10 @@ export { DaffCategoryBreadcrumb } from './category-breadcrumb';
 export { DaffCategory } from './category';
 export { DaffGenericCategory } from './generic-category';
 export { DaffCategoryRequest } from './requests/category-request';
-export { DaffCategorySortOption } from './category-sort-option';
+export {
+  DaffCategorySortOption,
+  DaffCategorySortOptions,
+} from './category-sort-options';
 export * from './requests/filter-request';
 export * from './category-filter-base';
 export * from './category-applied-filter';

--- a/libs/category/state/src/facades/category.facade.spec.ts
+++ b/libs/category/state/src/facades/category.facade.spec.ts
@@ -185,7 +185,7 @@ describe('DaffCategoryFacade', () => {
     });
 
     it('should return an observable of the sort options for the selected category', () => {
-      const expected = cold('a', { a: categoryPageConfigurationState.sort_options });
+      const expected = cold('a', { a: categoryPageConfigurationState.sort_options.options });
       store.dispatch(new DaffCategoryPageLoadSuccess({ category, categoryPageConfigurationState, products: [product]}));
       expect(facade.sortOptions$).toBeObservable(expected);
     });

--- a/libs/category/state/src/reducers/category/category.reducer.spec.ts
+++ b/libs/category/state/src/reducers/category/category.reducer.spec.ts
@@ -48,7 +48,10 @@ describe('Category | Category Reducer', () => {
       page_size: null,
       total_pages: null,
       filters: [],
-      sort_options: [],
+      sort_options: {
+        default: null,
+        options: [],
+      },
       total_products: null,
       product_ids: [],
     },
@@ -578,21 +581,51 @@ describe('Category | Category Reducer', () => {
         categoryLoading: true,
         productsLoading: true,
       };
-
-      const categoryLoadSuccess = new DaffCategoryPageLoadSuccess({ category, categoryPageConfigurationState, products: null });
-      result = daffCategoryReducer(state, categoryLoadSuccess);
     });
 
     it('sets categoryLoading to false', () => {
+      categoryPageConfigurationState.applied_sort_option = null;
+      const categoryLoadSuccess = new DaffCategoryPageLoadSuccess({ category, categoryPageConfigurationState, products: null });
+      result = daffCategoryReducer(state, categoryLoadSuccess);
+
       expect(result.categoryLoading).toEqual(false);
     });
 
     it('sets productsLoading to false', () => {
+      categoryPageConfigurationState.applied_sort_option = null;
+      const categoryLoadSuccess = new DaffCategoryPageLoadSuccess({ category, categoryPageConfigurationState, products: null });
+      result = daffCategoryReducer(state, categoryLoadSuccess);
+
       expect(result.productsLoading).toEqual(false);
     });
 
-    it('sets categoryPageConfigurationState from the payload', () => {
-      expect(result.categoryPageConfigurationState).toEqual(categoryPageConfigurationState);
+    describe('when an applied_sort_option is not set in state', () => {
+
+      it('sets categoryPageConfigurationState with the default sorting option', () => {
+        state.categoryPageConfigurationState.applied_sort_option = null;
+        const categoryLoadSuccess = new DaffCategoryPageLoadSuccess({ category, categoryPageConfigurationState, products: null });
+        result = daffCategoryReducer(state, categoryLoadSuccess);
+
+        expect(result.categoryPageConfigurationState).toEqual({
+          ...categoryPageConfigurationState,
+          applied_sort_option: categoryPageConfigurationState.sort_options.default,
+        });
+      });
+    });
+
+    describe('when an applied_sort_option is set in state', () => {
+
+      it('sets the categoryPageConfigurationState with the applied_sort_option', () => {
+        const selectedOption = 'selectedOption';
+        state.categoryPageConfigurationState.applied_sort_option = selectedOption;
+        const categoryLoadSuccess = new DaffCategoryPageLoadSuccess({ category, categoryPageConfigurationState, products: null });
+        result = daffCategoryReducer(state, categoryLoadSuccess);
+
+        expect(result.categoryPageConfigurationState).toEqual({
+          ...categoryPageConfigurationState,
+          applied_sort_option: selectedOption,
+        });
+      });
     });
   });
 

--- a/libs/category/state/src/reducers/category/category.reducer.spec.ts
+++ b/libs/category/state/src/reducers/category/category.reducer.spec.ts
@@ -615,12 +615,15 @@ describe('Category | Category Reducer', () => {
 
     describe('when an applied_sort_option is set in state', () => {
 
+      afterEach(() => {
+        state.categoryPageConfigurationState.applied_sort_option = null;
+      });
+
       it('sets the categoryPageConfigurationState with the applied_sort_option', () => {
         const selectedOption = 'selectedOption';
         state.categoryPageConfigurationState.applied_sort_option = selectedOption;
         const categoryLoadSuccess = new DaffCategoryPageLoadSuccess({ category, categoryPageConfigurationState, products: null });
         result = daffCategoryReducer(state, categoryLoadSuccess);
-
         expect(result.categoryPageConfigurationState).toEqual({
           ...categoryPageConfigurationState,
           applied_sort_option: selectedOption,

--- a/libs/category/state/src/reducers/category/category.reducer.ts
+++ b/libs/category/state/src/reducers/category/category.reducer.ts
@@ -24,7 +24,10 @@ const initialState: DaffCategoryReducerState = {
     page_size: null,
     total_pages: null,
     filters: [],
-    sort_options: [],
+    sort_options: {
+      default: null,
+      options: [],
+    },
     total_products: null,
     product_ids: [],
   },
@@ -120,6 +123,7 @@ export function daffCategoryReducer<U extends DaffGenericCategory<U>, W extends 
           total_pages: action.response.categoryPageConfigurationState.total_pages,
           total_products: action.response.categoryPageConfigurationState.total_products,
           product_ids: action.response.categoryPageConfigurationState.product_ids,
+          applied_sort_option: state.categoryPageConfigurationState.applied_sort_option || action.response.categoryPageConfigurationState.sort_options.default,
         },
       };
     case DaffCategoryActionTypes.CategoryLoadFailureAction:

--- a/libs/category/state/src/selectors/category-page/category-page.selector.spec.ts
+++ b/libs/category/state/src/selectors/category-page/category-page.selector.spec.ts
@@ -196,7 +196,7 @@ describe('DaffCategoryPageSelectors', () => {
 
     it('selects the category sort options of the current category', () => {
       const selector = store.pipe(select(categorySelectors.selectCategorySortOptions));
-      const expected = cold('a', { a: stubCategoryPageConfigurationState.sort_options });
+      const expected = cold('a', { a: stubCategoryPageConfigurationState.sort_options.options });
       expect(selector).toBeObservable(expected);
     });
   });

--- a/libs/category/state/src/selectors/category-page/category-page.selector.ts
+++ b/libs/category/state/src/selectors/category-page/category-page.selector.ts
@@ -29,7 +29,7 @@ export interface DaffCategoryPageMemoizedSelectors<
 	selectCategoryTotalPages: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['total_pages']>;
 	selectCategoryPageSize: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['page_size']>;
 	selectCategoryFilters: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['filters']>;
-	selectCategorySortOptions: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['sort_options']>;
+	selectCategorySortOptions: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['sort_options']['options']>;
 	selectCategoryPageProductIds: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['product_ids']>;
 	selectIsCategoryPageEmpty: MemoizedSelector<Record<string, any>, boolean>;
 	selectCategoryPageTotalProducts: MemoizedSelector<Record<string, any>, DaffCategoryPageConfigurationState['total_products']>;
@@ -84,7 +84,7 @@ const createCategoryPageSelectors = <V extends DaffGenericCategory<V>>(): DaffCa
 
   const selectCategorySortOptions = createSelector(
     selectCategoryPageConfigurationState,
-    (state: DaffCategoryPageConfigurationState) => state.sort_options,
+    (state: DaffCategoryPageConfigurationState) => state.sort_options.options,
   );
 
   const selectCategoryPageProductIds = createSelector(

--- a/libs/category/testing/src/factories/category-page-configuration-state.factory.spec.ts
+++ b/libs/category/testing/src/factories/category-page-configuration-state.factory.spec.ts
@@ -33,8 +33,9 @@ describe('Category | Testing | Factories | DaffCategoryPageConfigurationStateFac
 
     it('should return a DaffCategoryPageConfigurationState with all required fields defined', () => {
       expect(result.id).toBeDefined();
-      expect(result.sort_options[0].label).toBeDefined();
-      expect(result.sort_options[0].value).toBeDefined();
+      expect(result.sort_options.default).toBeDefined();
+      expect(result.sort_options.options[0].label).toBeDefined();
+      expect(result.sort_options.options[0].value).toBeDefined();
       expect(result.total_pages).toBeDefined();
       expect(result.filters).toBeDefined();
       expect(result.filter_requests).toBeDefined();

--- a/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
+++ b/libs/category/testing/src/factories/category-page-configuration-state.factory.ts
@@ -29,23 +29,26 @@ export class MockCategoryPageConfigurationState implements DaffCategoryPageConfi
       },
     ],
   }];
-  sort_options = [
-    {
-      label: 'Position',
-      value: 'position',
-    },
-    {
-      label: 'Name',
-      value: 'name',
-    },
-    {
-      label: 'Price',
-      value: 'price',
-    },
-  ];
+  sort_options = {
+    default: 'position',
+    options: [
+      {
+        label: 'Position',
+        value: 'position',
+      },
+      {
+        label: 'Name',
+        value: 'name',
+      },
+      {
+        label: 'Price',
+        value: 'price',
+      },
+  	],
+  };
   total_pages = faker.random.number({ min: 1, max: 4 });
   filter_requests = [];
-  applied_sort_option = null;
+  applied_sort_option = 'position';
 	applied_sort_direction = null;
 	total_products = faker.random.number({ min: 1, max: 3 });
 	product_ids = [faker.random.number({ min: 1, max: 100 }).toString()];


### PR DESCRIPTION
…t category sort option

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The default sort option can't be set to the categoryPageConfigurationState.

## What is the new behavior?
The DaffCategoryPageConfigurationState model needs a field for the default sorting option. Without this field, the only way to set the default applied_sort_option is something like making the default sort option the first option in the list (which we already do), but this means there will always be a default option, which isn't always the case. 

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information
BREAKING CHANGE: the DaffCategoryPageConfigurationState.sort_options field has changed. A field for the default sort option has been added.