### PR TITLE
feat(cart): init available shipping methods in in-memory driver

### DIFF
--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-methods/cart-shipping-methods.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-methods/cart-shipping-methods.service.spec.ts
@@ -76,7 +76,7 @@ describe('DaffInMemoryBackendCartShippingMethodsService', () => {
         mockCart.shipping_address = cartAddressFactory.create();
       });
 
-      describe('and when the cart already has available shipping methods', () => {
+      describe('and the cart already has available shipping methods', () => {
         beforeEach(() => {
           mockCart.available_shipping_methods = [mockCartShippingMethod];
 
@@ -88,7 +88,7 @@ describe('DaffInMemoryBackendCartShippingMethodsService', () => {
         });
       });
 
-      describe('and when the cart has no available shipping methods', () => {
+      describe('and the cart has no available shipping methods', () => {
         beforeEach(() => {
           mockCart.available_shipping_methods = [];
 

--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-methods/cart-shipping-methods.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-methods/cart-shipping-methods.service.spec.ts
@@ -7,6 +7,7 @@ import {
 import {
   DaffCartFactory,
   DaffCartShippingRateFactory,
+  DaffCartAddressFactory,
 } from '@daffodil/cart/testing';
 
 import { DaffInMemoryBackendCartShippingMethodsService } from './cart-shipping-methods.service';
@@ -15,6 +16,7 @@ describe('DaffInMemoryBackendCartShippingMethodsService', () => {
   let service: DaffInMemoryBackendCartShippingMethodsService;
   let cartFactory: DaffCartFactory;
   let cartShippingFactory: DaffCartShippingRateFactory;
+  let cartAddressFactory: DaffCartAddressFactory;
 
   let mockCart: DaffCart;
   let mockCartShippingMethod: DaffCartShippingRate;
@@ -34,6 +36,7 @@ describe('DaffInMemoryBackendCartShippingMethodsService', () => {
 
     cartFactory = TestBed.inject(DaffCartFactory);
     cartShippingFactory = TestBed.inject(DaffCartShippingRateFactory);
+    cartAddressFactory = TestBed.inject(DaffCartAddressFactory);
 
     mockCart = cartFactory.create();
     mockCartShippingMethod = cartShippingFactory.create();
@@ -66,12 +69,49 @@ describe('DaffInMemoryBackendCartShippingMethodsService', () => {
 
     beforeEach(() => {
       reqInfoStub.url = cartUrl;
-
-      result = service.get(reqInfoStub);
     });
 
-    it('should return the cart\'s available shipping methods', () => {
-      expect(result.body).toEqual([mockCartShippingMethod]);
+    describe('when the cart has a shipping address', () => {
+      beforeEach(() => {
+        mockCart.shipping_address = cartAddressFactory.create();
+      });
+
+      describe('and when the cart already has available shipping methods', () => {
+        beforeEach(() => {
+          mockCart.available_shipping_methods = [mockCartShippingMethod];
+
+          result = service.get(reqInfoStub);
+        });
+
+        it('should return the cart\'s available shipping methods', () => {
+          expect(result.body).toEqual([mockCartShippingMethod]);
+        });
+      });
+
+      describe('and when the cart has no available shipping methods', () => {
+        beforeEach(() => {
+          mockCart.available_shipping_methods = [];
+
+          result = service.get(reqInfoStub);
+        });
+
+        it('should initialize and return the cart\'s available shipping methods', () => {
+          expect(result.body.length).toBeGreaterThan(0);
+          expect(mockCart.available_shipping_methods.length).toBeGreaterThan(0);
+        });
+      });
+    });
+
+    describe('when the cart does not have a shipping address', () => {
+      beforeEach(() => {
+        mockCart.shipping_address = null;
+
+        result = service.get(reqInfoStub);
+      });
+
+      it('should return an empty array', () => {
+        expect(result.body).toEqual([]);
+      });
     });
   });
 });

--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-methods/cart-shipping-methods.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-methods/cart-shipping-methods.service.ts
@@ -8,12 +8,17 @@ import {
   DaffCart,
   DaffCartShippingRate,
 } from '@daffodil/cart';
+import { DaffCartShippingRateFactory } from '@daffodil/cart/testing';
 import { DaffInMemoryDataServiceInterface } from '@daffodil/core/testing';
 
 @Injectable({
   providedIn: 'root',
 })
 export class DaffInMemoryBackendCartShippingMethodsService implements DaffInMemoryDataServiceInterface {
+  constructor(
+    private shippingMethodFactory: DaffCartShippingRateFactory,
+  ) {}
+
   get(reqInfo: RequestInfo) {
     return reqInfo.utils.createResponse$(() => ({
       body: this.listShippingMethods(reqInfo),
@@ -26,6 +31,16 @@ export class DaffInMemoryBackendCartShippingMethodsService implements DaffInMemo
   }
 
   private listShippingMethods(reqInfo): DaffCartShippingRate[] {
-    return this.getCart(reqInfo).available_shipping_methods;
+    const cart  = this.getCart(reqInfo);
+
+    if (cart.shipping_address) {
+      if (cart.available_shipping_methods?.length === 0) {
+        cart.available_shipping_methods = this.shippingMethodFactory.createMany(3);
+      }
+    } else {
+      cart.available_shipping_methods = [];
+    }
+
+    return cart.available_shipping_methods;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In-memory driver returns no available shipping methods


## What is the new behavior?
In-memory driver will init available shipping methods, or remove them if there is no shipping address

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information