### PR TITLE
feat(cart): add in-memory extra_attributes hook token

### DIFF
--- a/libs/cart/driver/in-memory/src/backend/cart-address/cart-address.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-address/cart-address.service.spec.ts
@@ -4,6 +4,7 @@ import {
   DaffCart,
   DaffCartAddress,
 } from '@daffodil/cart';
+import { DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK } from '@daffodil/cart/driver/in-memory';
 import {
   DaffCartFactory,
   DaffCartAddressFactory,
@@ -23,11 +24,16 @@ describe('DaffInMemoryBackendCartAddressService', () => {
   let baseUrl;
   let cartUrl;
   let collection: DaffCart[];
+  let extraAttributes;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         DaffInMemoryBackendCartAddressService,
+        {
+          provide: DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+          useValue: () => extraAttributes,
+        },
       ],
     });
     service = TestBed.inject(DaffInMemoryBackendCartAddressService);
@@ -37,6 +43,9 @@ describe('DaffInMemoryBackendCartAddressService', () => {
 
     mockCart = cartFactory.create();
     mockCartAddress = cartAddressFactory.create();
+    extraAttributes = {
+      extraField: 'extraField',
+    };
     mockCart.billing_address = mockCartAddress;
     collection = [mockCart];
     cartId = mockCart.id;
@@ -77,6 +86,10 @@ describe('DaffInMemoryBackendCartAddressService', () => {
     it('should return a cart with the updated street', () => {
       expect(result.body.billing_address.street).toEqual(updatedStreet);
       expect(result.body.shipping_address.street).toEqual(updatedStreet);
+    });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
     });
   });
 });

--- a/libs/cart/driver/in-memory/src/backend/cart-address/cart-address.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-address/cart-address.service.ts
@@ -1,4 +1,7 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+  Inject,
+} from '@angular/core';
 import {
   STATUS,
   RequestInfo,
@@ -7,10 +10,19 @@ import {
 import { DaffCart } from '@daffodil/cart';
 import { DaffInMemoryDataServiceInterface } from '@daffodil/core/testing';
 
+import {
+  DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+  DaffCartInMemoryExtraAttributesHook,
+} from '../../injection-tokens/public_api';
+
 @Injectable({
   providedIn: 'root',
 })
 export class DaffInMemoryBackendCartAddressService implements DaffInMemoryDataServiceInterface {
+  constructor(
+    @Inject(DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK) private extraFieldsHook: DaffCartInMemoryExtraAttributesHook,
+  ) {}
+
   put(reqInfo: RequestInfo) {
     return reqInfo.utils.createResponse$(() => ({
       body: this.updateAddress(reqInfo),
@@ -29,6 +41,9 @@ export class DaffInMemoryBackendCartAddressService implements DaffInMemoryDataSe
     cart.billing_address = address;
     cart.shipping_address = address;
 
-    return cart;
+    return {
+      ...cart,
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
+    };
   }
 }

--- a/libs/cart/driver/in-memory/src/backend/cart-billing-address/cart-billing-address.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-billing-address/cart-billing-address.service.spec.ts
@@ -4,6 +4,7 @@ import {
   DaffCart,
   DaffCartAddress,
 } from '@daffodil/cart';
+import { DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK } from '@daffodil/cart/driver/in-memory';
 import {
   DaffCartFactory,
   DaffCartAddressFactory,
@@ -23,11 +24,16 @@ describe('DaffInMemoryBackendCartBillingAddressService', () => {
   let baseUrl;
   let cartUrl;
   let collection: DaffCart[];
+  let extraAttributes;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         DaffInMemoryBackendCartBillingAddressService,
+        {
+          provide: DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+          useValue: () => extraAttributes,
+        },
       ],
     });
     service = TestBed.inject(DaffInMemoryBackendCartBillingAddressService);
@@ -37,6 +43,9 @@ describe('DaffInMemoryBackendCartBillingAddressService', () => {
 
     mockCart = cartFactory.create();
     mockCartAddress = cartAddressFactory.create();
+    extraAttributes = {
+      extraField: 'extraField',
+    };
     mockCart.billing_address = mockCartAddress;
     collection = [mockCart];
     cartId = mockCart.id;
@@ -90,6 +99,10 @@ describe('DaffInMemoryBackendCartBillingAddressService', () => {
 
     it('should return a cart with the updated street', () => {
       expect(result.body.billing_address.street).toEqual(updatedStreet);
+    });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
     });
   });
 });

--- a/libs/cart/driver/in-memory/src/backend/cart-billing-address/cart-billing-address.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-billing-address/cart-billing-address.service.ts
@@ -1,4 +1,7 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+  Inject,
+} from '@angular/core';
 import {
   STATUS,
   RequestInfo,
@@ -10,10 +13,19 @@ import {
 } from '@daffodil/cart';
 import { DaffInMemoryDataServiceInterface } from '@daffodil/core/testing';
 
+import {
+  DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+  DaffCartInMemoryExtraAttributesHook,
+} from '../../injection-tokens/public_api';
+
 @Injectable({
   providedIn: 'root',
 })
 export class DaffInMemoryBackendCartBillingAddressService implements DaffInMemoryDataServiceInterface {
+  constructor(
+    @Inject(DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK) private extraFieldsHook: DaffCartInMemoryExtraAttributesHook,
+  ) {}
+
   get(reqInfo: RequestInfo) {
     return reqInfo.utils.createResponse$(() => ({
       body: this.getBillingAddress(reqInfo),
@@ -42,6 +54,9 @@ export class DaffInMemoryBackendCartBillingAddressService implements DaffInMemor
 
     cart.billing_address = address;
 
-    return cart;
+    return {
+      ...cart,
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
+    };
   }
 }

--- a/libs/cart/driver/in-memory/src/backend/cart-coupon/cart-coupon.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-coupon/cart-coupon.service.spec.ts
@@ -4,6 +4,7 @@ import {
   DaffCart,
   DaffCartCoupon,
 } from '@daffodil/cart';
+import { DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK } from '@daffodil/cart/driver/in-memory';
 import {
   DaffCartFactory,
   DaffCartCouponFactory,
@@ -23,11 +24,16 @@ describe('DaffInMemoryBackendCartCouponService', () => {
   let baseUrl;
   let cartUrl;
   let collection: DaffCart[];
+  let extraAttributes;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         DaffInMemoryBackendCartCouponService,
+        {
+          provide: DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+          useValue: () => extraAttributes,
+        },
       ],
     });
     service = TestBed.inject(DaffInMemoryBackendCartCouponService);
@@ -37,6 +43,9 @@ describe('DaffInMemoryBackendCartCouponService', () => {
 
     mockCart = cartFactory.create();
     mockCartCoupon = cartCouponFactory.create();
+    extraAttributes = {
+      extraField: 'extraField',
+    };
     mockCart.coupons = [mockCartCoupon];
     collection = [mockCart];
     cartId = mockCart.id;
@@ -82,11 +91,15 @@ describe('DaffInMemoryBackendCartCouponService', () => {
       mockCart.coupons = [];
       reqInfoStub.url = cartUrl;
       reqInfoStub.req.body = mockCartCoupon;
+      result = service.post(reqInfoStub);
     });
 
     it('should return a cart with the added item', () => {
-      result = service.post(reqInfoStub);
       expect(result.body.coupons).toContain(mockCartCoupon);
+    });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
     });
   });
 
@@ -104,6 +117,10 @@ describe('DaffInMemoryBackendCartCouponService', () => {
     it('should remove the coupon from the cart', () => {
       expect(result.body.coupons.find(({ code }) => couponCode === code)).toBeFalsy();
     });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
+    });
   });
 
   describe('processing a remove all coupons request', () => {
@@ -117,6 +134,10 @@ describe('DaffInMemoryBackendCartCouponService', () => {
 
     it('should return a cart with no coupons', () => {
       expect(result.body.coupons).toEqual([]);
+    });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
     });
   });
 });

--- a/libs/cart/driver/in-memory/src/backend/cart-coupon/cart-coupon.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-coupon/cart-coupon.service.ts
@@ -1,4 +1,7 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+  Inject,
+} from '@angular/core';
 import {
   STATUS,
   RequestInfo,
@@ -10,10 +13,19 @@ import {
 } from '@daffodil/cart';
 import { DaffInMemoryDataServiceInterface } from '@daffodil/core/testing';
 
+import {
+  DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+  DaffCartInMemoryExtraAttributesHook,
+} from '../../injection-tokens/public_api';
+
 @Injectable({
   providedIn: 'root',
 })
 export class DaffInMemoryBackendCartCouponService implements DaffInMemoryDataServiceInterface {
+  constructor(
+    @Inject(DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK) private extraFieldsHook: DaffCartInMemoryExtraAttributesHook,
+  ) {}
+
   get(reqInfo: RequestInfo) {
     return reqInfo.utils.createResponse$(() => ({
       body: this.listCoupons(reqInfo),
@@ -67,7 +79,10 @@ export class DaffInMemoryBackendCartCouponService implements DaffInMemoryDataSer
 
     cart.coupons.push(coupon);
 
-    return cart;
+    return {
+      ...cart,
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
+    };
   }
 
   private removeCoupon(reqInfo: RequestInfo, couponCode: DaffCartCoupon['code']): DaffCart {
@@ -75,7 +90,10 @@ export class DaffInMemoryBackendCartCouponService implements DaffInMemoryDataSer
 
     cart.coupons = cart.coupons.filter(({ code }) => code !== couponCode);
 
-    return cart;
+    return {
+      ...cart,
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
+    };
   }
 
   private removeAllCoupons(reqInfo: RequestInfo): DaffCart {
@@ -83,6 +101,9 @@ export class DaffInMemoryBackendCartCouponService implements DaffInMemoryDataSer
 
     cart.coupons = [];
 
-    return cart;
+    return {
+      ...cart,
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
+    };
   }
 }

--- a/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.spec.ts
@@ -6,6 +6,7 @@ import {
   DaffCartItem,
   DaffCartItemInputType,
 } from '@daffodil/cart';
+import { DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK } from '@daffodil/cart/driver/in-memory';
 import {
   DaffCartFactory,
   DaffCartItemFactory,
@@ -26,11 +27,16 @@ describe('DaffInMemoryBackendCartItemsService', () => {
   let baseUrl;
   let cartUrl;
   let collection: DaffCart[];
+  let extraAttributes;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         DaffInMemoryBackendCartItemsService,
+        {
+          provide: DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+          useValue: () => extraAttributes,
+        },
       ],
     });
     service = TestBed.inject(DaffInMemoryBackendCartItemsService);
@@ -40,6 +46,9 @@ describe('DaffInMemoryBackendCartItemsService', () => {
 
     mockCart = cartFactory.create();
     mockCartItems = cartItemFactory.createMany(3);
+    extraAttributes = {
+      extraField: 'extraField',
+    };
     mockCart.items = mockCartItems;
     collection = [mockCart];
     mockCartItemInput = {
@@ -107,10 +116,10 @@ describe('DaffInMemoryBackendCartItemsService', () => {
       reqInfoStub.url = cartUrl;
       reqInfoStub.req.body = mockCartItemInput;
       productId = mockCartItemInput.productId;
+      result = service.post(reqInfoStub);
     });
 
     it('should return a cart with the added item', () => {
-      result = service.post(reqInfoStub);
       expect(result.body.items).toContain(jasmine.objectContaining({ product_id: productId }));
     });
 
@@ -121,6 +130,10 @@ describe('DaffInMemoryBackendCartItemsService', () => {
       result = service.post(reqInfoStub);
 
       expect(result.body.items[0].qty).toEqual(cart_item_qty + 2);
+    });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
     });
   });
 
@@ -141,6 +154,10 @@ describe('DaffInMemoryBackendCartItemsService', () => {
     it('should update the cart item', () => {
       expect(result.body.items[0].qty).toEqual(qty);
     });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
+    });
   });
 
   describe('processing an delete request', () => {
@@ -156,6 +173,10 @@ describe('DaffInMemoryBackendCartItemsService', () => {
 
     it('should remove the cart item from the cart', () => {
       expect(result.body.items.find(({ item_id }) => itemId === item_id)).toBeFalsy();
+    });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
     });
   });
 });

--- a/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
@@ -1,4 +1,7 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+  Inject,
+} from '@angular/core';
 import {
   STATUS,
   RequestInfo,
@@ -12,11 +15,19 @@ import {
 import { DaffCartItemFactory } from '@daffodil/cart/testing';
 import { DaffInMemoryDataServiceInterface } from '@daffodil/core/testing';
 
+import {
+  DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+  DaffCartInMemoryExtraAttributesHook,
+} from '../../injection-tokens/public_api';
+
 @Injectable({
   providedIn: 'root',
 })
 export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServiceInterface {
-  constructor(private cartItemFactory: DaffCartItemFactory) {}
+  constructor(
+    private cartItemFactory: DaffCartItemFactory,
+    @Inject(DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK) private extraFieldsHook: DaffCartInMemoryExtraAttributesHook,
+  ) {}
 
   get(reqInfo: RequestInfo) {
     return reqInfo.utils.createResponse$(() => {
@@ -99,6 +110,7 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
           ...itemChanges,
         } : item,
       ),
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
     };
 
     return reqInfo.collection[cartIndex];
@@ -119,6 +131,7 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
         items: cart.items.map(
           (item, index) => index === existingCartItemIndex ? updatedCartItem : item,
         ),
+        extra_attributes: this.extraFieldsHook(reqInfo, cart),
       };
     } else {
       reqInfo.collection[cartIndex] = {
@@ -127,6 +140,7 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
           ...cart.items,
           this.transformItemInput(itemInput),
         ],
+        extra_attributes: this.extraFieldsHook(reqInfo, cart),
       };
     }
 
@@ -140,6 +154,7 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
     reqInfo.collection[cartIndex] = {
       ...cart,
       items: cart.items.filter((item, index) => index !== itemIndex),
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
     };
 
     return reqInfo.collection[cartIndex];

--- a/libs/cart/driver/in-memory/src/backend/cart-payment/cart-payment.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-payment/cart-payment.service.spec.ts
@@ -5,6 +5,7 @@ import {
   DaffCartPaymentMethod,
   DaffCartAddress,
 } from '@daffodil/cart';
+import { DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK } from '@daffodil/cart/driver/in-memory';
 import {
   DaffCartFactory,
   DaffCartPaymentFactory,
@@ -27,11 +28,16 @@ describe('DaffInMemoryBackendCartPaymentService', () => {
   let baseUrl;
   let cartUrl;
   let collection: DaffCart[];
+  let extraAttributes;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         DaffInMemoryBackendCartPaymentService,
+        {
+          provide: DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+          useValue: () => extraAttributes,
+        },
       ],
     });
     service = TestBed.inject(DaffInMemoryBackendCartPaymentService);
@@ -43,6 +49,9 @@ describe('DaffInMemoryBackendCartPaymentService', () => {
     mockCart = cartFactory.create();
     mockCartPayment = cartPaymentFactory.create();
     mockCartAddress = cartAddressFactory.create();
+    extraAttributes = {
+      extraField: 'extraField',
+    };
     mockCart.billing_address = mockCartAddress;
     mockCart.payment = mockCartPayment;
     collection = [mockCart];
@@ -96,6 +105,10 @@ describe('DaffInMemoryBackendCartPaymentService', () => {
     it('should return a cart with the updated payment', () => {
       expect(result.body.payment).toEqual(newPayment);
     });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
+    });
   });
 
   describe('processing an update payment with billing request', () => {
@@ -116,6 +129,10 @@ describe('DaffInMemoryBackendCartPaymentService', () => {
       expect(result.body.payment).toEqual(newPayment);
       expect(result.body.billing_address).toEqual(mockCartAddress);
     });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
+    });
   });
 
   describe('processing a remove payment request', () => {
@@ -129,6 +146,10 @@ describe('DaffInMemoryBackendCartPaymentService', () => {
 
     it('should return a cart with no payment', () => {
       expect(result.body.payment).toBeFalsy();
+    });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
     });
   });
 });

--- a/libs/cart/driver/in-memory/src/backend/cart-payment/cart-payment.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-payment/cart-payment.service.ts
@@ -1,4 +1,7 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+  Inject,
+} from '@angular/core';
 import {
   STATUS,
   RequestInfo,
@@ -10,10 +13,19 @@ import {
 } from '@daffodil/cart';
 import { DaffInMemoryDataServiceInterface } from '@daffodil/core/testing';
 
+import {
+  DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+  DaffCartInMemoryExtraAttributesHook,
+} from '../../injection-tokens/public_api';
+
 @Injectable({
   providedIn: 'root',
 })
 export class DaffInMemoryBackendCartPaymentService implements DaffInMemoryDataServiceInterface {
+  constructor(
+    @Inject(DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK) private extraFieldsHook: DaffCartInMemoryExtraAttributesHook,
+  ) {}
+
   get(reqInfo: RequestInfo) {
     return reqInfo.utils.createResponse$(() => ({
       body: this.getPayment(reqInfo),
@@ -53,7 +65,10 @@ export class DaffInMemoryBackendCartPaymentService implements DaffInMemoryDataSe
       cart.billing_address = address;
     }
 
-    return cart;
+    return {
+      ...cart,
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
+    };
   }
 
   private removePayment(reqInfo: RequestInfo): DaffCart {
@@ -61,6 +76,9 @@ export class DaffInMemoryBackendCartPaymentService implements DaffInMemoryDataSe
 
     cart.payment = null;
 
-    return cart;
+    return {
+      ...cart,
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
+    };
   }
 }

--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-address/cart-shipping-address.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-address/cart-shipping-address.service.spec.ts
@@ -4,6 +4,7 @@ import {
   DaffCart,
   DaffCartAddress,
 } from '@daffodil/cart';
+import { DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK } from '@daffodil/cart/driver/in-memory';
 import {
   DaffCartFactory,
   DaffCartAddressFactory,
@@ -23,11 +24,16 @@ describe('DaffInMemoryBackendCartShippingAddressService', () => {
   let baseUrl;
   let cartUrl;
   let collection: DaffCart[];
+  let extraAttributes;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         DaffInMemoryBackendCartShippingAddressService,
+        {
+          provide: DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+          useValue: () => extraAttributes,
+        },
       ],
     });
     service = TestBed.inject(DaffInMemoryBackendCartShippingAddressService);
@@ -37,6 +43,9 @@ describe('DaffInMemoryBackendCartShippingAddressService', () => {
 
     mockCart = cartFactory.create();
     mockCartAddress = cartAddressFactory.create();
+    extraAttributes = {
+      extraField: 'extraField',
+    };
     mockCart.shipping_address = mockCartAddress;
     collection = [mockCart];
     cartId = mockCart.id;
@@ -90,6 +99,10 @@ describe('DaffInMemoryBackendCartShippingAddressService', () => {
 
     it('should return a cart with the updated street', () => {
       expect(result.body.shipping_address.street).toEqual(updatedStreet);
+    });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
     });
   });
 });

--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-address/cart-shipping-address.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-address/cart-shipping-address.service.ts
@@ -1,4 +1,7 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+  Inject,
+} from '@angular/core';
 import {
   STATUS,
   RequestInfo,
@@ -10,10 +13,19 @@ import {
 } from '@daffodil/cart';
 import { DaffInMemoryDataServiceInterface } from '@daffodil/core/testing';
 
+import {
+  DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+  DaffCartInMemoryExtraAttributesHook,
+} from '../../injection-tokens/public_api';
+
 @Injectable({
   providedIn: 'root',
 })
 export class DaffInMemoryBackendCartShippingAddressService implements DaffInMemoryDataServiceInterface {
+  constructor(
+    @Inject(DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK) private extraFieldsHook: DaffCartInMemoryExtraAttributesHook,
+  ) {}
+
   get(reqInfo: RequestInfo) {
     return reqInfo.utils.createResponse$(() => ({
       body: this.getShippingAddress(reqInfo),
@@ -42,6 +54,9 @@ export class DaffInMemoryBackendCartShippingAddressService implements DaffInMemo
 
     cart.shipping_address = address;
 
-    return cart;
+    return {
+      ...cart,
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
+    };
   }
 }

--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-information/cart-shipping-information.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-information/cart-shipping-information.service.spec.ts
@@ -4,6 +4,7 @@ import {
   DaffCart,
   DaffCartShippingInformation,
 } from '@daffodil/cart';
+import { DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK } from '@daffodil/cart/driver/in-memory';
 import {
   DaffCartFactory,
   DaffCartShippingRateFactory,
@@ -23,11 +24,16 @@ describe('DaffInMemoryBackendCartShippingInformationService', () => {
   let baseUrl;
   let cartUrl;
   let collection: DaffCart[];
+  let extraAttributes;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         DaffInMemoryBackendCartShippingInformationService,
+        {
+          provide: DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+          useValue: () => extraAttributes,
+        },
       ],
     });
     service = TestBed.inject(DaffInMemoryBackendCartShippingInformationService);
@@ -39,6 +45,9 @@ describe('DaffInMemoryBackendCartShippingInformationService', () => {
     mockCartShippingInformation = {
       ...cartShippingInformationFactory.create(),
       address_id: null,
+    };
+    extraAttributes = {
+      extraField: 'extraField',
     };
     mockCart.shipping_information = mockCartShippingInformation;
     collection = [mockCart];
@@ -95,6 +104,10 @@ describe('DaffInMemoryBackendCartShippingInformationService', () => {
     it('should return a cart with the updated shipping information', () => {
       expect(result.body.shipping_information).toEqual(newShippingInformation);
     });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
+    });
   });
 
   describe('processing a remove shipping information request', () => {
@@ -108,6 +121,10 @@ describe('DaffInMemoryBackendCartShippingInformationService', () => {
 
     it('should return a cart with no shipping information', () => {
       expect(result.body.shipping_information).toBeFalsy();
+    });
+
+    it('should set extra_attributes to the value returned by the provided hook function', () => {
+      expect(result.body.extra_attributes).toEqual(extraAttributes);
     });
   });
 });

--- a/libs/cart/driver/in-memory/src/backend/cart-shipping-information/cart-shipping-information.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-shipping-information/cart-shipping-information.service.ts
@@ -1,4 +1,7 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+  Inject,
+} from '@angular/core';
 import {
   STATUS,
   RequestInfo,
@@ -10,10 +13,19 @@ import {
 } from '@daffodil/cart';
 import { DaffInMemoryDataServiceInterface } from '@daffodil/core/testing';
 
+import {
+  DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+  DaffCartInMemoryExtraAttributesHook,
+} from '../../injection-tokens/public_api';
+
 @Injectable({
   providedIn: 'root',
 })
 export class DaffInMemoryBackendCartShippingInformationService implements DaffInMemoryDataServiceInterface {
+  constructor(
+    @Inject(DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK) private extraFieldsHook: DaffCartInMemoryExtraAttributesHook,
+  ) {}
+
   get(reqInfo: RequestInfo) {
     return reqInfo.utils.createResponse$(() => ({
       body: this.getShippingInformation(reqInfo),
@@ -49,7 +61,10 @@ export class DaffInMemoryBackendCartShippingInformationService implements DaffIn
 
     cart.shipping_information = shippingInformation;
 
-    return cart;
+    return {
+      ...cart,
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
+    };
   }
 
   private removeShippingInformation(reqInfo: RequestInfo): DaffCart {
@@ -57,6 +72,9 @@ export class DaffInMemoryBackendCartShippingInformationService implements DaffIn
 
     cart.shipping_information = null;
 
-    return cart;
+    return {
+      ...cart,
+      extra_attributes: this.extraFieldsHook(reqInfo, cart),
+    };
   }
 }

--- a/libs/cart/driver/in-memory/src/injection-tokens/extra-attributes-hook.token.ts
+++ b/libs/cart/driver/in-memory/src/injection-tokens/extra-attributes-hook.token.ts
@@ -1,0 +1,29 @@
+import { InjectionToken } from '@angular/core';
+import { RequestInfo } from 'angular-in-memory-web-api';
+
+import { DaffCart } from '@daffodil/cart';
+
+export type DaffCartInMemoryExtraAttributesHook = (reqInfo: RequestInfo, cart: DaffCart) => Record<string, any>;
+
+/**
+ * Allows an app dev to generate extra fields in the in-memory backend.
+ * This enables the in-memory drivers to return responses similar to what the
+ * frontend would expect from the production platform.
+ *
+ * The value returned by the hook function will be set to the returned cart's `extra_attributes` field
+ * for driver calls that return a cart.
+ *
+ * The following example demonstrates adding the `numberOfCartItems` field to `extra_attributes`:
+ * ```ts
+ * (reqInfo: RequestInfo, cart: DaffCart) => ({
+ *   numberOfCartItems: cart.items.length
+ * })
+ * ```
+ *
+ * Note that this and any `extra_attributes` features are for advanced users
+ * and should be used with care.
+ */
+export const DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK =
+  new InjectionToken<DaffCartInMemoryExtraAttributesHook>('DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK', {
+    factory: () => (reqInfo, cart) => ({}),
+  });

--- a/libs/cart/driver/in-memory/src/injection-tokens/public_api.ts
+++ b/libs/cart/driver/in-memory/src/injection-tokens/public_api.ts
@@ -1,0 +1,4 @@
+export {
+  DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK,
+  DaffCartInMemoryExtraAttributesHook,
+} from './extra-attributes-hook.token';

--- a/libs/cart/driver/in-memory/src/public_api.ts
+++ b/libs/cart/driver/in-memory/src/public_api.ts
@@ -1,2 +1,3 @@
 export * from './drivers/public_api';
 export * from './backend/public_api';
+export * from './injection-tokens/public_api';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no way for app devs to provide extra fields to the in memory backend.


## What is the new behavior?
Aoo devs can now use the `DAFF_CART_IN_MEMORY_EXTRA_ATTRIBUTES_HOOK` to provide extra fields to the in memory backend.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information