### PR TITLE
feat(product): add a selector and facade field for composite product …

### DIFF
--- a/libs/product/state/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/state/src/facades/composite-product/composite-product-facade.interface.ts
@@ -63,7 +63,7 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	hasDiscount(priceRange: DaffPriceRange): boolean;
 
 	/**
-	 * Returns the discount percent of a composite product based on teh current configuration of the selected item options in redux
+	 * Returns the discount percent of a composite product based on the current configuration of the selected item options in redux
 	 * state and excluding unselected, optional item prices. Will return undefined if all required options are not chosen.
 	 * Note: This percent is computed client-side and should be treated as an estimate rather than an exact value.
 	 *

--- a/libs/product/state/src/facades/composite-product/composite-product-facade.interface.ts
+++ b/libs/product/state/src/facades/composite-product/composite-product-facade.interface.ts
@@ -63,6 +63,15 @@ export interface DaffCompositeProductFacadeInterface extends DaffStoreFacade<Act
 	hasDiscount(priceRange: DaffPriceRange): boolean;
 
 	/**
+	 * Returns the discount percent of a composite product based on teh current configuration of the selected item options in redux
+	 * state and excluding unselected, optional item prices. Will return undefined if all required options are not chosen.
+	 * Note: This percent is computed client-side and should be treated as an estimate rather than an exact value.
+	 *
+	 * @param id the id of the composite product.
+	 */
+	getDiscountPercent(id: DaffCompositeProduct['id']): Observable<number>;
+
+	/**
 	 * Returns whether the min and max prices of a DaffPriceRange are different.
 	 *
 	 * @param priceRange a DaffPriceRange

--- a/libs/product/state/src/facades/composite-product/composite-product.facade.spec.ts
+++ b/libs/product/state/src/facades/composite-product/composite-product.facade.spec.ts
@@ -8,6 +8,12 @@ import {
 import { cold } from 'jasmine-marbles';
 
 import {
+  daffAdd,
+  daffDivide,
+  daffMultiply,
+  daffSubtract,
+} from '@daffodil/core';
+import {
   DaffCompositeProduct,
   DaffCompositeConfigurationItem,
 } from '@daffodil/product';
@@ -193,6 +199,41 @@ describe('DaffCompositeProductFacade', () => {
       }});
 
       expect(facade.getAppliedOptions(stubCompositeProduct.id)).toBeObservable(expected);
+    });
+  });
+
+  describe('getDiscountPercent', () => {
+
+    it('should return the discount percent for a composite product', () => {
+      store.dispatch(new DaffProductLoadSuccess({
+        ...stubCompositeProduct,
+        items: [
+          {
+            ...stubCompositeProduct.items[0],
+            required: true,
+            options: [
+              {
+                ...stubCompositeProduct.items[0].options[0],
+                quantity: 1,
+                is_default: true,
+              },
+              {
+                ...stubCompositeProduct.items[0].options[1],
+                is_default: false,
+              },
+            ],
+          },
+        ],
+      }));
+
+      const totalOriginalPrice = daffAdd(stubCompositeProduct.price, stubCompositeProduct.items[0].options[0].price);
+      const primaryProductDiscountedPrice = daffSubtract(stubCompositeProduct.price, stubCompositeProduct.discount.amount);
+      const selectedOptionDiscountedPrice = daffSubtract(stubCompositeProduct.items[0].options[0].price, stubCompositeProduct.items[0].options[0].discount.amount);
+      const totalDiscountedPrice = daffAdd(primaryProductDiscountedPrice, selectedOptionDiscountedPrice);
+      const expectedDiscountPercent = daffMultiply(daffDivide(daffSubtract(totalOriginalPrice, totalDiscountedPrice), totalOriginalPrice), 100);
+      const expected = cold('a', { a: expectedDiscountPercent });
+
+      expect(facade.getDiscountPercent(stubCompositeProduct.id)).toBeObservable(expected);
     });
   });
 

--- a/libs/product/state/src/facades/composite-product/composite-product.facade.ts
+++ b/libs/product/state/src/facades/composite-product/composite-product.facade.ts
@@ -66,6 +66,10 @@ export class DaffCompositeProductFacade<T extends DaffProduct = DaffProduct> imp
 	  return this.store.pipe(select(this.selectors.selectCompositeProductAppliedOptions, { id }));
 	}
 
+	getDiscountPercent(id: T['id']): Observable<number> {
+	  return this.store.pipe(select(this.selectors.selectCompositeProductDiscountPercent, { id }));
+	}
+
 	isItemRequired(id: T['id'], item_id: DaffCompositeProductItem['id']) {
 	  return this.store.pipe(select(this.selectors.selectIsCompositeProductItemRequired, { id, item_id }));
 	}

--- a/libs/product/state/testing/src/mock-composite-product-facade.ts
+++ b/libs/product/state/testing/src/mock-composite-product-facade.ts
@@ -25,6 +25,9 @@ export class MockDaffCompositeProductFacade implements DaffCompositeProductFacad
   getAppliedOptions(id: DaffCompositeProduct['id']): BehaviorSubject<Dictionary<DaffCompositeProductItemOption>> {
     return new BehaviorSubject({});
   }
+  getDiscountPercent(id: DaffCompositeProduct['id']): BehaviorSubject<number> {
+    return new BehaviorSubject(null);
+  }
   isItemRequired(id: DaffCompositeProduct['id'], item_id: DaffCompositeProductItem['id']): BehaviorSubject<boolean> {
     return new BehaviorSubject(false);
   }


### PR DESCRIPTION
…discount percent

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
There is a selector that estimates the discount percent of the current configuration of a composite product.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```