### PR TITLE
style(design): allow image to inherit parent border-radius

### DIFF
--- a/libs/design/src/atoms/image/image.component.scss
+++ b/libs/design/src/atoms/image/image.component.scss
@@ -2,6 +2,7 @@
 
 :host {
 	display: inline-block;
+	border-radius: inherit;
 	position: relative;
 	width: 100%;
 
@@ -19,6 +20,7 @@
 
 .daff-image {
 	&__wrapper {
+		border-radius: inherit;
 		height: 0;
 	}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Images placed inside card can't inherit the border-radius because of the wrapper div.

Fixes: N/A


## What is the new behavior?
Allow border-radius on wrapper to be inherited.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information