### PR TITLE
build(design): add a script to build docs and design-land together

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -784,8 +784,8 @@
               "apps/design-land/src/assets",
               {
                 "glob": "**/*",
-                "input": "dist/docs/design-examples",
-                "output": "/assets/design-examples"
+                "input": "dist/docs/",
+                "output": "/assets/"
               }
             ],
             "styles": [

--- a/apps/design-land/README.md
+++ b/apps/design-land/README.md
@@ -1,0 +1,7 @@
+# Design Land
+
+## Writing Documentation
+
+```bash
+npx lerna run serve --scope="@daffodil/design-land"
+```

--- a/apps/design-land/package.json
+++ b/apps/design-land/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@daffodil/design-land",
+  "version": "0.0.0-PLACEHOLDER",
+  "private": true,
+  "author": "Graycore LLC",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/graycoreio/daffodil/issues"
+  },
+  "scripts": {
+    "serve": "ng s design-land & lerna run watch --scope='@daffodil/tools-dgeni'"
+  },
+  "homepage": "https://github.com/graycoreio/daffodil",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/graycoreio/daffodil"
+  },
+  "devDependencies": {
+    "@daffodil/design": "0.0.0-PLACEHOLDER",
+    "@daffodil/tools-dgeni": "0.0.0-PLACEHOLDER"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20231,15 +20231,6 @@
       "dev": true,
       "optional": true
     },
-    "filewatcher": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/filewatcher/-/filewatcher-3.0.1.tgz",
-      "integrity": "sha1-9KGVc1Xdr0Q8zXiolfPVXiPIoDQ=",
-      "dev": true,
-      "requires": {
-        "debounce": "^1.0.0"
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -22245,12 +22236,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.1.0.tgz",
       "integrity": "sha512-DxJP1y2YzCqVLy7DrQN0iuR2l48vMOBWukX2d/J9aN2o5x9un5psIIq/2UFRh91UGARmfvPH86y1p4qbC1dITg==",
-      "dev": true
-    },
-    "growly": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
     "guess-parser": {
@@ -28650,27 +28635,6 @@
         }
       }
     },
-    "node-notifier": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
-      "dev": true,
-      "requires": {
-        "growly": "^1.3.0",
-        "is-wsl": "^1.1.0",
-        "semver": "^5.5.0",
-        "shellwords": "^0.1.1",
-        "which": "^1.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
     "node-releases": {
       "version": "1.1.35",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
@@ -34384,12 +34348,6 @@
         "rechoir": "^0.6.2"
       }
     },
-    "shellwords": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -37297,22 +37255,21 @@
       }
     },
     "ts-node-dev": {
-      "version": "1.0.0-pre.43",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.0.0-pre.43.tgz",
-      "integrity": "sha512-vtFeqKNMcRdE0R00RZRMM2v7V6HadJSllJ7o1PPUc797cTyKLW2k4UsdbNaxoDEQ9PU2HIc2M+SawgM6ONh4ig==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.6.tgz",
+      "integrity": "sha512-RTUi7mHMNQospArGz07KiraQcdgUVNXKsgO2HAi7FoiyPMdTDqdniB6K1dqyaIxT7c9v/VpSbfBZPS6uVpaFLQ==",
       "dev": true,
       "requires": {
+        "chokidar": "^3.5.1",
         "dateformat": "~1.0.4-1.2.3",
         "dynamic-dedupe": "^0.3.0",
-        "filewatcher": "~3.0.0",
-        "minimist": "^1.1.3",
-        "mkdirp": "^0.5.1",
-        "node-notifier": "^5.4.0",
+        "minimist": "^1.2.5",
+        "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
-        "tree-kill": "^1.2.1",
-        "ts-node": "*",
+        "tree-kill": "^1.2.2",
+        "ts-node": "^9.0.0",
         "tsconfig": "^7.0.0"
       },
       "dependencies": {
@@ -37341,6 +37298,12 @@
             "get-stdin": "^4.0.1",
             "meow": "^3.3.0"
           }
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
         },
         "find-up": {
           "version": "1.1.2",
@@ -37397,6 +37360,18 @@
             "redent": "^1.0.0",
             "trim-newlines": "^1.0.0"
           }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
@@ -37473,6 +37448,12 @@
             "glob": "^7.1.3"
           }
         },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -37491,10 +37472,48 @@
             "get-stdin": "^4.0.1"
           }
         },
+        "tree-kill": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+          "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+          "dev": true
+        },
         "trim-newlines": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
           "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+          "dev": true
+        },
+        "ts-node": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
+          },
+          "dependencies": {
+            "source-map-support": {
+              "version": "0.5.19",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+              "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+              "dev": true,
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            }
+          }
+        },
+        "yn": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+          "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "stylelint-selector-bem-pattern": "^2.1.0",
     "ts-loader": "^5.2.0",
     "ts-node": "~7.0.1",
-    "ts-node-dev": "^1.0.0-pre.42",
+    "ts-node-dev": "^1.1.6",
     "tsconfig-paths": "^3.8.0",
     "tsickle": "^0.39.1",
     "tslib": "^2.0.3",

--- a/tools/dgeni/build.ts
+++ b/tools/dgeni/build.ts
@@ -1,12 +1,13 @@
 import { Dgeni } from 'dgeni';
-import { apiDocs } from './src/transforms/daffodil-api-package';
-import { guideDocPackage } from './src/transforms/daffodil-guides-package';
-import { designExamplePackage } from './src/transforms/daffodil-design-examples-package';
-
 import rimraf from 'rimraf';
 
-rimraf('../../dist/docs/**/*', function() {
-	new Dgeni([guideDocPackage]).generate().catch(() => process.exit(1));
-	new Dgeni([apiDocs]).generate().catch(() => process.exit(1));
-	new Dgeni([designExamplePackage]).generate().catch(() => process.exit(1));
+import { apiDocs } from './src/transforms/daffodil-api-package';
+import { designExamplePackage } from './src/transforms/daffodil-design-examples-package';
+import { guideDocPackage } from './src/transforms/daffodil-guides-package';
+
+
+rimraf('../../dist/docs/**/*', () => {
+  new Dgeni([guideDocPackage]).generate().catch(() => process.exit(1));
+  new Dgeni([apiDocs]).generate().catch(() => process.exit(1));
+  new Dgeni([designExamplePackage]).generate().catch(() => process.exit(1));
 });

--- a/tools/dgeni/package.json
+++ b/tools/dgeni/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0-PLACEHOLDER",
   "scripts": {
     "build": "ts-node -r tsconfig-paths/register build",
-    "watch": "ts-node-dev --respawn --debounce 100 -r tsconfig-paths/register build",
+    "watch": "ts-node-dev --watch='../../libs/**/*' --respawn --debounce 100 -r tsconfig-paths/register build",
     "test": "ts-node -r tsconfig-paths/register ../../node_modules/jasmine/bin/jasmine.js --config=jasmine.json",
     "test:watch": "ts-node-dev --respawn --debounce 100 -r tsconfig-paths/register ../../node_modules/.bin/jasmine --config=jasmine.json"
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, running design-land (and daff.io) while building docs is pretty painful. There's no clean way to write docs (and importantly generate them) while simultaneously running the design-land app.

Fixes: N/A


## What is the new behavior?
I've added a new script that replaces "ng s design-land". This will build docs and serve the app simultaneously, making doc-writing significantly more pleasant. 

```bash
npx lerna run serve --scope="@daffodil/design-land"
```

## Does this PR introduce a breaking change?
```
[x] Yes (internally only).
[ ] No
```

Run the new command.


## Other information
cc: @xelaint 