### PR TITLE
docs(design): rework design land import style to remove duplicate code

### DIFF
--- a/apps/design-land/src/app/accordion/accordion.module.ts
+++ b/apps/design-land/src/app/accordion/accordion.module.ts
@@ -1,12 +1,10 @@
-import { ComponentFactoryResolver, Injector, NgModule } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { AccordionComponent } from './accordion.component';
 import { DesignLandAccordionRoutingModule } from './accordion-routing.module';
 
 import { DaffAccordionModule, DaffArticleModule } from '@daffodil/design';
-import { ACCORDION_EXAMPLES } from '@daffodil/design/accordion/examples';
-import { createCustomElement } from '@angular/elements';
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 
 
@@ -22,22 +20,6 @@ import { DesignLandExampleViewerModule } from '../core/code-preview/container/ex
 		DaffArticleModule
   ],
 })
-export class AccordionModule { 
-	constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    ACCORDION_EXAMPLES
-      .map((classConstructor) => ({
-        element: createCustomElement(classConstructor, { injector }),
-        class: classConstructor,
-      }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory<unknown>(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
+export class AccordionModule {
+
 }

--- a/apps/design-land/src/app/app.component.ts
+++ b/apps/design-land/src/app/app.component.ts
@@ -1,8 +1,56 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  Injector,
+  ComponentFactoryResolver,
+} from '@angular/core';
+import { createCustomElement } from '@angular/elements';
+
+import { ACCORDION_EXAMPLES } from '@daffodil/design/accordion/examples';
+import { ARTICLE_EXAMPLES } from '@daffodil/design/article/examples';
+import { BUTTON_EXAMPLES } from '@daffodil/design/button/examples';
+import { CALLOUT_EXAMPLES } from '@daffodil/design/callout/examples';
+import { CARD_EXAMPLES } from '@daffodil/design/card/examples';
+import { CHECKBOX_EXAMPLES } from '@daffodil/design/checkbox/examples';
+import { HERO_EXAMPLES } from '@daffodil/design/hero/examples';
+import { LIST_EXAMPLES } from '@daffodil/design/list/examples';
+import { LOADING_ICON_EXAMPLES } from '@daffodil/design/loading-icon/examples';
+import { MEDIA_GALLERY_EXAMPLES } from '@daffodil/design/media-gallery/examples';
+import { QUANTITY_FIELD_EXAMPLES } from '@daffodil/design/quantity-field/examples';
+import { RADIO_EXAMPLES } from '@daffodil/design/radio/examples';
 
 @Component({
   selector: 'design-land-app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class DesignLandAppComponent {}
+export class DesignLandAppComponent {
+  constructor(
+    injector: Injector,
+    private componentFactoryResolver: ComponentFactoryResolver,
+  ) {
+    [
+      ...ARTICLE_EXAMPLES,
+      ...ACCORDION_EXAMPLES,
+      ...BUTTON_EXAMPLES,
+      ...RADIO_EXAMPLES,
+      ...CARD_EXAMPLES,
+      ...CALLOUT_EXAMPLES,
+      ...CHECKBOX_EXAMPLES,
+      ...HERO_EXAMPLES,
+      ...LOADING_ICON_EXAMPLES,
+      ...MEDIA_GALLERY_EXAMPLES,
+      ...QUANTITY_FIELD_EXAMPLES,
+      ...LIST_EXAMPLES,
+    ].map((classConstructor) => ({
+      element: createCustomElement(classConstructor, { injector }),
+      class: classConstructor,
+    }))
+      .map((customElement) => {
+        // Register the custom element with the browser.
+        customElements.define(
+          this.componentFactoryResolver.resolveComponentFactory(customElement.class).selector + '-example',
+          customElement.element,
+        );
+      });
+  }
+}

--- a/apps/design-land/src/app/article/article.module.ts
+++ b/apps/design-land/src/app/article/article.module.ts
@@ -1,20 +1,10 @@
-import {
-  NgModule,
-  Injector,
-  ComponentFactoryResolver,
-} from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { createCustomElement } from '@angular/elements';
-
 
 import { DesignLandArticleComponent } from './article.component';
 import { DesignLandArticleRoutingModule } from './article-routing.module';
 
 import { DaffArticleModule } from '@daffodil/design';
-import {
-  ArticleExamplesModule,
-  ARTICLE_EXAMPLES,
-} from '@daffodil/design/article/examples';
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 
 @NgModule({
@@ -26,24 +16,8 @@ import { DesignLandExampleViewerModule } from '../core/code-preview/container/ex
     DaffArticleModule,
     DesignLandArticleRoutingModule,
     DesignLandExampleViewerModule,
-    ArticleExamplesModule,
   ],
 })
 export class DesignLandArticleModule {
-  constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    ARTICLE_EXAMPLES.map((classConstructor) => ({
-      element: createCustomElement(classConstructor, { injector }),
-      class: classConstructor,
-    }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
+
 }

--- a/apps/design-land/src/app/button/button.module.ts
+++ b/apps/design-land/src/app/button/button.module.ts
@@ -1,18 +1,11 @@
 import { CommonModule } from '@angular/common';
-import {
-  NgModule,
-  Injector,
-  ComponentFactoryResolver,
-} from '@angular/core';
-import { createCustomElement } from '@angular/elements';
-
+import { NgModule } from '@angular/core';
 
 import {
   DaffButtonSetModule,
   DaffButtonModule,
   DaffArticleModule,
 } from '@daffodil/design';
-import { BUTTON_EXAMPLES } from '@daffodil/design/button/examples';
 
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 import { DesignLandButtonRoutingModule } from './button-routing.module';
@@ -33,21 +26,5 @@ import { ButtonComponent } from './button.component';
   ],
 })
 export class ButtonModule {
-  constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    BUTTON_EXAMPLES
-      .map((classConstructor) => ({
-        element: createCustomElement(classConstructor, { injector }),
-        class: classConstructor,
-      }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory<unknown>(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
+
 }

--- a/apps/design-land/src/app/callout/callout.module.ts
+++ b/apps/design-land/src/app/callout/callout.module.ts
@@ -1,17 +1,10 @@
 import { CommonModule } from '@angular/common';
-import {
-  NgModule,
-  Injector,
-  ComponentFactoryResolver,
-  Type,
-} from '@angular/core';
-import { createCustomElement } from '@angular/elements';
+import { NgModule } from '@angular/core';
 
 import {
   DaffCalloutModule,
   DaffArticleModule,
 } from '@daffodil/design';
-import { CALLOUT_EXAMPLES } from '@daffodil/design/callout/examples';
 
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 import { DesignLandCalloutRoutingModule } from './callout-routing.module';
@@ -32,20 +25,4 @@ import { DesignLandCalloutComponent } from './callout.component';
   ],
 })
 export class DesignLandCalloutModule {
-  constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    CALLOUT_EXAMPLES.map((classConstructor: Type<unknown>) => ({
-      element: createCustomElement(classConstructor, { injector }),
-      class: classConstructor,
-    }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
 }

--- a/apps/design-land/src/app/card/card.module.ts
+++ b/apps/design-land/src/app/card/card.module.ts
@@ -1,10 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  NgModule,
-  Injector,
-  ComponentFactoryResolver,
-} from '@angular/core';
-import { createCustomElement } from '@angular/elements';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import {
@@ -12,7 +7,6 @@ import {
   DaffCardModule,
   DaffImageModule,
 } from '@daffodil/design';
-import { CARD_EXAMPLES } from '@daffodil/design/card/examples';
 
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 import { DesignLandCardRoutingModule } from './card-routing.module';
@@ -34,21 +28,4 @@ import { CardComponent } from './card.component';
 })
 export class CardModule {
 
-  constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    CARD_EXAMPLES
-      .map((classConstructor) => ({
-        element: createCustomElement(classConstructor, { injector }),
-        class: classConstructor,
-      }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
 }

--- a/apps/design-land/src/app/checkbox/checkbox.module.ts
+++ b/apps/design-land/src/app/checkbox/checkbox.module.ts
@@ -1,36 +1,16 @@
-import {
-  NgModule,
-  ComponentFactoryResolver,
-  Injector,
-} from '@angular/core';
-import {
-  DaffCheckboxModule,
-  DaffButtonModule,
-} from '@daffodil/design';
+import { NgModule } from '@angular/core';
+import { DaffCheckboxModule } from '@daffodil/design';
 import { ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 
 import { CheckboxComponent } from './checkbox.component';
 import { DesignLandCheckboxRoutingModule } from './checkbox-routing.module';
-import { CHECKBOX_EXAMPLES } from '@daffodil/design/checkbox/examples';
-import {
-  createCustomElement,
-  NgElementConstructor,
-} from '@angular/elements';
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 
 
-
-export interface CustomClassElement<T> {
-    element: NgElementConstructor<T>;
-    class: T;
-}
-
 @NgModule({
-
   declarations: [
     CheckboxComponent,
-    ...CHECKBOX_EXAMPLES,
   ],
   imports: [
     DesignLandExampleViewerModule,
@@ -41,21 +21,5 @@ export interface CustomClassElement<T> {
   ],
 })
 export class CheckboxModule {
-  constructor(
-    injector: Injector,
-        private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    CHECKBOX_EXAMPLES
-      .map((classConstructor) => ({
-        element: createCustomElement(classConstructor, { injector }),
-        class: classConstructor,
-      }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory<unknown>(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
+
 }

--- a/apps/design-land/src/app/hero/hero.module.ts
+++ b/apps/design-land/src/app/hero/hero.module.ts
@@ -1,17 +1,10 @@
 import { CommonModule } from '@angular/common';
-import {
-  NgModule,
-  Injector,
-  ComponentFactoryResolver,
-  Type,
-} from '@angular/core';
-import { createCustomElement } from '@angular/elements';
+import { NgModule } from '@angular/core';
 
 import {
   DaffArticleModule,
   DaffHeroModule,
 } from '@daffodil/design';
-import { HERO_EXAMPLES } from '@daffodil/design/hero/examples';
 
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 import { DesignLandHeroRoutingModule } from './hero-routing.module';
@@ -32,20 +25,5 @@ import { HeroComponent } from './hero.component';
   ],
 })
 export class DesignLandHeroModule {
-  constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    HERO_EXAMPLES.map((classConstructor: Type<unknown>) => ({
-      element: createCustomElement(classConstructor, { injector }),
-      class: classConstructor,
-    }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
+
 }

--- a/apps/design-land/src/app/list/list.module.ts
+++ b/apps/design-land/src/app/list/list.module.ts
@@ -1,10 +1,5 @@
-import {
-  NgModule,
-  Injector,
-  ComponentFactoryResolver,
-} from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { createCustomElement } from '@angular/elements';
 
 import { DesignLandListRoutingModule } from './list-routing.module';
 
@@ -17,11 +12,6 @@ import {
   DaffListModule,
 } from '@daffodil/design';
 
-import {
-  ListExamplesModule,
-  LIST_EXAMPLES,
-} from '@daffodil/design/list/examples';
-
 @NgModule({
   declarations: [
     DesignLandListComponent,
@@ -33,25 +23,8 @@ import {
     DaffListModule,
 
     DesignLandExampleViewerModule,
-    ListExamplesModule,
   ],
 })
 export class DesignLandListModule {
-  constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    LIST_EXAMPLES
-      .map((classConstructor) => ({
-        element: createCustomElement(classConstructor, { injector }),
-        class: classConstructor,
-      }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
+
 }

--- a/apps/design-land/src/app/loading-icon/loading-icon.module.ts
+++ b/apps/design-land/src/app/loading-icon/loading-icon.module.ts
@@ -1,16 +1,10 @@
 import { CommonModule } from '@angular/common';
-import {
-  ComponentFactoryResolver,
-  Injector,
-  NgModule,
-} from '@angular/core';
-import { createCustomElement } from '@angular/elements';
+import { NgModule } from '@angular/core';
 
 import {
   DaffArticleModule,
   DaffLoadingIconModule,
 } from '@daffodil/design';
-import { LOADING_ICON_EXAMPLES } from '@daffodil/design/loading-icon/examples';
 
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 import { DesignLandLoadingIconRoutingModule } from './loading-icon-routing.module';
@@ -29,21 +23,5 @@ import { LoadingIconComponent } from './loading-icon.component';
   ],
 })
 export class LoadingIconModule {
-  constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    console.log(LOADING_ICON_EXAMPLES);
-    LOADING_ICON_EXAMPLES.map((classConstructor) => ({
-      element: createCustomElement(classConstructor, { injector }),
-      class: classConstructor,
-    }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
+
 }

--- a/apps/design-land/src/app/media-gallery/media-gallery.module.ts
+++ b/apps/design-land/src/app/media-gallery/media-gallery.module.ts
@@ -1,10 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  NgModule,
-  Injector,
-  ComponentFactoryResolver,
-} from '@angular/core';
-import { createCustomElement } from '@angular/elements';
+import { NgModule } from '@angular/core';
 
 
 import {
@@ -12,7 +7,6 @@ import {
   DaffMediaGalleryModule,
   DaffImageModule,
 } from '@daffodil/design';
-import { MEDIA_GALLERY_EXAMPLES } from '@daffodil/design/media-gallery/examples';
 
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 import { DesignLandMediaGalleryRoutingModule } from './media-gallery-routing-module';
@@ -34,20 +28,5 @@ import { DesignLandMediaGalleryComponent } from './media-gallery.component';
   ],
 })
 export class DesignLandMediaGalleryModule {
-  constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    MEDIA_GALLERY_EXAMPLES.map((classConstructor) => ({
-      element: createCustomElement(classConstructor, { injector }),
-      class: classConstructor,
-    }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
+
 }

--- a/apps/design-land/src/app/quantity-field/quantity-field.module.ts
+++ b/apps/design-land/src/app/quantity-field/quantity-field.module.ts
@@ -1,17 +1,11 @@
 import { CommonModule } from '@angular/common';
-import {
-  ComponentFactoryResolver,
-  Injector,
-  NgModule,
-} from '@angular/core';
-import { createCustomElement } from '@angular/elements';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import {
   DaffArticleModule,
   DaffQuantityFieldModule,
 } from '@daffodil/design';
-import { QUANTITY_FIELD_EXAMPLES } from '@daffodil/design/quantity-field/examples';
 
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 import { DesignLandQuantityFieldRoutingModule } from './quantity-field-routing.module';
@@ -20,7 +14,6 @@ import { DesignLandQuantityFieldComponent } from './quantity-field.component';
 @NgModule({
   declarations: [
     DesignLandQuantityFieldComponent,
-    ...QUANTITY_FIELD_EXAMPLES,
   ],
   imports: [
     CommonModule,
@@ -32,21 +25,5 @@ import { DesignLandQuantityFieldComponent } from './quantity-field.component';
   ],
 })
 export class DesignLandQuantityFieldModule {
-  constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    QUANTITY_FIELD_EXAMPLES
-      .map((classConstructor) => ({
-        element: createCustomElement(classConstructor, { injector }),
-        class: classConstructor,
-      }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory<unknown>(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
+
 }

--- a/apps/design-land/src/app/radio/radio.module.ts
+++ b/apps/design-land/src/app/radio/radio.module.ts
@@ -1,8 +1,4 @@
-import {
-  NgModule,
-  ComponentFactoryResolver,
-  Injector,
-} from '@angular/core';
+import { NgModule } from '@angular/core';
 import {
   DaffRadioModule,
   DaffButtonModule,
@@ -12,24 +8,11 @@ import { CommonModule } from '@angular/common';
 
 import { RadioComponent } from './radio.component';
 import { DesignLandRadioRoutingModule } from './radio-routing.module';
-import { RADIO_EXAMPLES } from '@daffodil/design/radio/examples';
-import {
-  createCustomElement,
-  NgElementConstructor,
-} from '@angular/elements';
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
-
-
-
-export interface CustomClassElement<T> {
-  element: NgElementConstructor<T>;
-  class: T;
-}
 
 @NgModule({
   declarations: [
     RadioComponent,
-    ...RADIO_EXAMPLES,
   ],
   imports: [
     DesignLandExampleViewerModule,
@@ -40,21 +23,5 @@ export interface CustomClassElement<T> {
   ],
 })
 export class RadioModule {
-  constructor(
-    injector: Injector,
-    private componentFactoryResolver: ComponentFactoryResolver,
-  ) {
-    RADIO_EXAMPLES
-      .map((classConstructor) => ({
-        element: createCustomElement(classConstructor, { injector }),
-        class: classConstructor,
-      }))
-      .map((customElement) => {
-        // Register the custom element with the browser.
-        customElements.define(
-          this.componentFactoryResolver.resolveComponentFactory<unknown>(customElement.class).selector + '-example',
-          customElement.element,
-        );
-      });
-  }
+
 }

--- a/apps/design-land/src/app/typography/typography.module.ts
+++ b/apps/design-land/src/app/typography/typography.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, Injector, ComponentFactoryResolver } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { DesignLandTypographyComponent } from './typography.component';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, when we define a new design component doc, the process involves some tedious copy-pasting of module constructors.

Fixes: N/A


## What is the new behavior?
I've updated the design-land example imports to be centralized into the root AppModule.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```