### PR TITLE
fix(daffio): widens the api doc name and ellipsis the ref,

### DIFF
--- a/apps/daffio/src/app/docs/api-docs/components/api-docs-list/api-docs-list.component.scss
+++ b/apps/daffio/src/app/docs/api-docs/components/api-docs-list/api-docs-list.component.scss
@@ -23,6 +23,13 @@
 		display: flex;
 	}
 
+	&__name {
+		width: 100%;
+    display: block;
+    text-overflow: ellipsis;
+    overflow: hidden;
+	}
+
 	&__label {
 		@include type-label();
 		display: flex;
@@ -35,6 +42,6 @@
 
 	&__children {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 	}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, when a ref name is long in the API docs, the label gets squished and the refname overflows. This looks terrible.

## What is the new behavior?
I've widened the sections for refs a little and also ellipsised the name.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```