### PR TITLE
@griest024 feat(category): add filter type field query to replacement driver

### DIFF
--- a/libs/category/driver/magento-replacement/ng-package.json
+++ b/libs/category/driver/magento-replacement/ng-package.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/category/driver/magento-replacement",
+  "deleteDestPath": false,
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/category/driver/magento-replacement/package.json
+++ b/libs/category/driver/magento-replacement/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@daffodil/category/driver/magento-replacement"
+}

--- a/libs/category/driver/magento-replacement/src/category-driver.module.ts
+++ b/libs/category/driver/magento-replacement/src/category-driver.module.ts
@@ -1,0 +1,57 @@
+import { CommonModule } from '@angular/common';
+import {
+  ModuleWithProviders,
+  NgModule,
+} from '@angular/core';
+
+import { DaffCategoryDriver } from '@daffodil/category/driver';
+import { DAFF_MAGENTO_CACHEABLE_OPERATIONS } from '@daffodil/driver/magento';
+
+import { DaffMagentoCategoryService } from './category.service';
+import { DAFF_MAGENTO_GET_CATEGORY_QUERY_NAME } from './queries/get-category';
+import { DAFF_MAGENTO_GET_PRODUCTS_QUERY_NAME } from './queries/get-products';
+import { DAFF_MAGENTO_GET_FILTER_TYPES_QUERY_NAME } from './queries/public_api';
+import { DaffMagentoAppliedFiltersTransformService } from './transformers/applied-filter-transformer.service';
+import { DaffMagentoAppliedSortOptionTransformService } from './transformers/applied-sort-option-transformer.service';
+import { DaffMagentoCategoryPageConfigTransformerService } from './transformers/category-page-config-transformer.service';
+import { DaffMagentoCategoryResponseTransformService } from './transformers/category-response-transform.service';
+import { DaffMagentoCategoryTransformerService } from './transformers/category-transformer.service';
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+})
+export class DaffCategoryMagentoDriverModule {
+  static forRoot(): ModuleWithProviders<DaffCategoryMagentoDriverModule> {
+    return {
+      ngModule: DaffCategoryMagentoDriverModule,
+      providers: [
+        {
+          provide: DaffCategoryDriver,
+          useExisting: DaffMagentoCategoryService,
+        },
+        DaffMagentoCategoryPageConfigTransformerService,
+        DaffMagentoCategoryResponseTransformService,
+        DaffMagentoCategoryTransformerService,
+        DaffMagentoAppliedFiltersTransformService,
+        DaffMagentoAppliedSortOptionTransformService,
+        {
+          provide: DAFF_MAGENTO_CACHEABLE_OPERATIONS,
+          useValue: DAFF_MAGENTO_GET_CATEGORY_QUERY_NAME,
+          multi: true,
+        },
+        {
+          provide: DAFF_MAGENTO_CACHEABLE_OPERATIONS,
+          useValue: DAFF_MAGENTO_GET_FILTER_TYPES_QUERY_NAME,
+          multi: true,
+        },
+        {
+          provide: DAFF_MAGENTO_CACHEABLE_OPERATIONS,
+          useValue: DAFF_MAGENTO_GET_PRODUCTS_QUERY_NAME,
+          multi: true,
+        },
+      ],
+    };
+  }
+}

--- a/libs/category/driver/magento-replacement/src/category.service.spec.ts
+++ b/libs/category/driver/magento-replacement/src/category.service.spec.ts
@@ -1,0 +1,260 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ApolloTestingModule,
+  ApolloTestingController,
+} from 'apollo-angular/testing';
+import { Observable } from 'rxjs';
+
+import {
+  DaffCategoryRequestReplacement,
+  DaffCategory,
+  DaffCategoryFilterEqualRequestReplacement,
+  DaffCategoryFilterRangeRequestOption,
+  daffCategoryComputeFilterRangePairLabel,
+  DaffGetCategoryResponseReplacement,
+  DaffCategoryPageMetadata,
+  DaffCategoryFilterRangeNumericRequest,
+} from '@daffodil/category';
+import {
+  DaffMagentoCategoryTransformerService,
+  MagentoGetACategoryResponse,
+  MagentoGetCategoryFilterTypesResponse,
+  MagentoCategory,
+  MagentoSortFields,
+  MagentoAggregation,
+  MagentoCategoryFilterTypeField,
+  MagentoPageInfo,
+  MagentoGetCategoryQuery,
+  MagentoGetCategoryFilterTypes,
+  MagentoGetProductsResponse,
+  MagentoGetProductsQuery,
+} from '@daffodil/category/driver/magento-replacement';
+import {
+  DaffCategoryDriverMagentoCategoryFactory,
+  DaffCategoryDriverMagentoSortFieldsFactory,
+  DaffCategoryDriverMagentoAggregationFactory,
+  DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory,
+  DaffCategoryDriverMagentoPageInfoFactory,
+  DaffCategoryDriverMagentoAggregationPriceFactory,
+  DaffCategoryDriverMagentoAggregationSelectFactory,
+} from '@daffodil/category/driver/magento-replacement/testing';
+import {
+  DaffCategoryFactory,
+  DaffCategoryPageMetadataFactory,
+  DaffCategoryFilterRequestEqualFactory,
+  DaffCategoryFilterRequestRangeNumericFactory,
+  DaffCategoryFilterRangeNumericRequestOptionFactory,
+} from '@daffodil/category/testing';
+import { DaffProduct } from '@daffodil/product';
+import {
+  MagentoProduct,
+  MagentoSimpleProduct,
+} from '@daffodil/product/driver/magento';
+import { MagentoSimpleProductFactory } from '@daffodil/product/driver/magento/testing';
+import { DaffProductFactory } from '@daffodil/product/testing';
+
+import { DaffMagentoCategoryService } from './category.service';
+
+describe('Driver | Magento | Category | CategoryService', () => {
+  let categoryService: DaffMagentoCategoryService;
+  let categoryFactory: DaffCategoryFactory;
+  let categoryPageMetadataFactory: DaffCategoryPageMetadataFactory;
+  let controller: ApolloTestingController;
+  let productFactory: DaffProductFactory;
+  let equalFilterRequestFactory: DaffCategoryFilterRequestEqualFactory;
+  let rangeFilterRequestFactory: DaffCategoryFilterRequestRangeNumericFactory;
+  let rangeFilterRequestOptionFactory: DaffCategoryFilterRangeNumericRequestOptionFactory;
+  let magentoCategoryFactory: DaffCategoryDriverMagentoCategoryFactory;
+  let magentoSortFieldsFactory: DaffCategoryDriverMagentoSortFieldsFactory;
+  let priceAggregateFactory: DaffCategoryDriverMagentoAggregationPriceFactory;
+  let selectAggregateFactory: DaffCategoryDriverMagentoAggregationSelectFactory;
+  let magentoFilterTypeFieldFactory: DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory;
+  let magentoProductFactory: MagentoSimpleProductFactory;
+  let magentoPageInfoFactory: DaffCategoryDriverMagentoPageInfoFactory;
+
+  let mockCategoryRequest: DaffCategoryRequestReplacement;
+  let mockCategory: DaffCategory;
+  let equalFilterRequest: DaffCategoryFilterEqualRequestReplacement;
+  let rangeFilterRequest: DaffCategoryFilterRangeNumericRequest;
+  let rangeFilterRequestOption: DaffCategoryFilterRangeRequestOption<number>;
+  let rangeFilterRequestOptionLabel: string;
+  let mockMagentoCategory: MagentoCategory;
+  let mockMagentoSortFields: MagentoSortFields;
+  let mockMagentoSelectAggregation: MagentoAggregation;
+  let mockMagentoPriceAggregation: MagentoAggregation;
+  let mockMagentoSelectFilterTypeField: MagentoCategoryFilterTypeField;
+  let mockMagentoPriceFilterTypeField: MagentoCategoryFilterTypeField;
+  let mockMagentoProduct: MagentoProduct;
+  let mockMagentoPageInfo: MagentoPageInfo;
+  let mockGetCategoryResponse: MagentoGetACategoryResponse;
+  let mockGetFilterTypesResponse: MagentoGetCategoryFilterTypesResponse;
+  let mockGetProductsResponse: MagentoGetProductsResponse;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ApolloTestingModule,
+      ],
+      providers: [
+        DaffMagentoCategoryService,
+        // { provide: DaffMagentoCategoryTransformerService, useValue: magentoCategoryResponseTransformerService },
+      ],
+    });
+
+    categoryService = TestBed.inject(DaffMagentoCategoryService);
+    controller = TestBed.inject(ApolloTestingController);
+
+    categoryFactory = TestBed.inject(DaffCategoryFactory);
+    categoryPageMetadataFactory = TestBed.inject(DaffCategoryPageMetadataFactory);
+    productFactory = TestBed.inject(DaffProductFactory);
+    equalFilterRequestFactory = TestBed.inject(DaffCategoryFilterRequestEqualFactory);
+    rangeFilterRequestFactory = TestBed.inject(DaffCategoryFilterRequestRangeNumericFactory);
+    rangeFilterRequestOptionFactory = TestBed.inject(DaffCategoryFilterRangeNumericRequestOptionFactory);
+    magentoCategoryFactory = TestBed.inject(DaffCategoryDriverMagentoCategoryFactory);
+    magentoSortFieldsFactory = TestBed.inject(DaffCategoryDriverMagentoSortFieldsFactory);
+    selectAggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationSelectFactory);
+    priceAggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationPriceFactory);
+    rangeFilterRequestOptionFactory = TestBed.inject(DaffCategoryFilterRangeNumericRequestOptionFactory);
+    magentoProductFactory = TestBed.inject(MagentoSimpleProductFactory);
+    magentoPageInfoFactory = TestBed.inject(DaffCategoryDriverMagentoPageInfoFactory);
+    magentoFilterTypeFieldFactory = TestBed.inject(DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory);
+
+    mockCategory = categoryFactory.create();
+    mockCategoryRequest = {
+      id: mockCategory.id,
+    };
+    mockMagentoProduct = magentoProductFactory.create();
+    mockMagentoCategory = magentoCategoryFactory.create({
+      id: mockCategory.id,
+      products: {
+        items: [
+          mockMagentoProduct,
+        ],
+      },
+    });
+    mockMagentoSortFields = magentoSortFieldsFactory.create();
+    mockMagentoPriceAggregation = priceAggregateFactory.create();
+    mockMagentoSelectAggregation = selectAggregateFactory.create();
+    mockMagentoSelectFilterTypeField = magentoFilterTypeFieldFactory.create({
+      name: mockMagentoSelectAggregation.attribute_code,
+      type: {
+        name: mockMagentoSelectAggregation.type,
+      },
+    });
+    mockMagentoPriceFilterTypeField = magentoFilterTypeFieldFactory.create({
+      name: mockMagentoPriceAggregation.attribute_code,
+      type: {
+        name: mockMagentoPriceAggregation.type,
+      },
+    });
+    mockMagentoPageInfo = magentoPageInfoFactory.create();
+
+    // transformedCategory = categoryFactory.create();
+    // transformedCategoryPageMetadata =  categoryPageMetadataFactory.create();
+    // transformedProducts =  productFactory.createMany(3);
+
+    mockGetCategoryResponse = {
+      categoryList: [
+        mockMagentoCategory,
+      ],
+    };
+    mockGetFilterTypesResponse = {
+      __type: {
+        inputFields: [
+          mockMagentoPriceFilterTypeField,
+          mockMagentoSelectFilterTypeField,
+        ],
+      },
+    };
+    mockGetProductsResponse = {
+      products: {
+        // items: [
+        //   mockMagentoProduct,
+        // ],
+        // TODO: fixme
+        items: [],
+        total_count: 1,
+        page_info: mockMagentoPageInfo,
+        aggregations: [
+          mockMagentoPriceAggregation,
+          mockMagentoSelectAggregation,
+        ],
+        sort_fields: mockMagentoSortFields,
+      },
+    };
+  });
+
+  it('should be created', () => {
+    expect(categoryService).toBeTruthy();
+  });
+
+  describe('get | getting a category', () => {
+    let result: Observable<DaffGetCategoryResponseReplacement>;
+
+    beforeEach(() => {
+      result = categoryService.get(mockCategoryRequest);
+    });
+
+    it('should return a category with the correct info', done => {
+      result.subscribe(res => {
+        expect(res.category.id).toEqual(String(mockMagentoCategory.id));
+        expect(res.category.name).toEqual(String(mockMagentoCategory.name));
+        done();
+      });
+
+      const categoryOp = controller.expectOne(MagentoGetCategoryQuery);
+      const filterTypesOp = controller.expectOne(MagentoGetCategoryFilterTypes);
+      const productsOp = controller.expectOne(MagentoGetProductsQuery);
+
+      categoryOp.flushData(mockGetCategoryResponse);
+      filterTypesOp.flushData(mockGetFilterTypesResponse);
+      productsOp.flushData(mockGetProductsResponse);
+    });
+
+    describe('when filters are requested', () => {
+      beforeEach(() => {
+        equalFilterRequest = equalFilterRequestFactory.create({
+          name: mockMagentoSelectFilterTypeField.name,
+          value: mockMagentoSelectAggregation.options.map(agg => agg.value),
+        });
+        rangeFilterRequestOption = rangeFilterRequestOptionFactory.create();
+        rangeFilterRequest = rangeFilterRequestFactory.create({
+          name: mockMagentoPriceFilterTypeField.name,
+          value: rangeFilterRequestOption,
+        });
+        rangeFilterRequestOptionLabel = daffCategoryComputeFilterRangePairLabel(rangeFilterRequestOption.min, rangeFilterRequestOption.max);
+        mockCategoryRequest = {
+          ...mockCategoryRequest,
+          filter_requests: [
+            equalFilterRequest,
+            rangeFilterRequest,
+          ],
+        };
+
+        result = categoryService.get(mockCategoryRequest);
+      });
+
+      it('should apply those filters', done => {
+        result.subscribe(res => {
+          equalFilterRequest.value.forEach(option => {
+            expect(res.categoryPageMetadata.filters[equalFilterRequest.name].options[option].applied).toBeTrue();
+          });
+          expect(res.categoryPageMetadata.filters[rangeFilterRequest.name].options[rangeFilterRequestOptionLabel].applied).toBeTrue();
+          done();
+        });
+
+        const categoryOp = controller.expectOne(MagentoGetCategoryQuery);
+        const filterTypesOp = controller.expectOne(MagentoGetCategoryFilterTypes);
+        const productsOp = controller.expectOne(MagentoGetProductsQuery);
+
+        categoryOp.flushData(mockGetCategoryResponse);
+        filterTypesOp.flushData(mockGetFilterTypesResponse);
+        productsOp.flushData(mockGetProductsResponse);
+      });
+    });
+  });
+
+  afterEach(() => {
+    controller.verify();
+  });
+});

--- a/libs/category/driver/magento-replacement/src/category.service.ts
+++ b/libs/category/driver/magento-replacement/src/category.service.ts
@@ -1,0 +1,128 @@
+import { Injectable } from '@angular/core';
+import { Apollo } from 'apollo-angular';
+import {
+  Observable,
+  combineLatest,
+  of,
+} from 'rxjs';
+import {
+  map,
+  switchMap,
+} from 'rxjs/operators';
+
+import {
+  DaffGetCategoryResponseReplacement,
+  daffApplyRequestsToFilters,
+  DaffCategoryPageMetadata,
+  DaffCategoryRequestReplacement,
+  DaffCategoryFilterRequestReplacement,
+} from '@daffodil/category';
+import { DaffCategoryServiceInterface } from '@daffodil/category/driver';
+
+import { MagentoGetCategoryFilterTypesResponse } from './models/get-filter-types-response.interface';
+import {
+  MagentoGetACategoryResponse,
+  MagentoGetProductsResponse,
+  MagentoCompleteCategoryResponse,
+  MagentoGetProductsByCategoriesRequest,
+} from './models/public_api';
+import { MagentoGetCategoryFilterTypes } from './queries/get-filter-types';
+import {
+  MagentoGetProductsQuery,
+  MagentoGetCategoryQuery,
+} from './queries/public_api';
+import {
+  DaffMagentoCategoryResponseTransformService,
+  DaffMagentoAppliedFiltersTransformService,
+  DaffMagentoAppliedSortOptionTransformService,
+} from './transformers/public_api';
+import { addMetadataTypesToAggregates } from './transformers/pure/aggregate/add-metadata-types-to-aggregates';
+
+const applyFiltersOnResponse = (requests: DaffCategoryFilterRequestReplacement[], response: DaffGetCategoryResponseReplacement): DaffGetCategoryResponseReplacement => ({
+  ...response,
+  categoryPageMetadata: {
+    ...response.categoryPageMetadata,
+    filters: daffApplyRequestsToFilters(requests, response.categoryPageMetadata.filters),
+  },
+});
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffMagentoCategoryService implements DaffCategoryServiceInterface {
+
+  constructor(
+    private apollo: Apollo,
+		private magentoCategoryResponseTransformer: DaffMagentoCategoryResponseTransformService,
+		private magentoAppliedFiltersTransformer: DaffMagentoAppliedFiltersTransformService,
+		private magentoAppliedSortTransformer: DaffMagentoAppliedSortOptionTransformService,
+  ) {}
+
+  //todo the MagentoGetCategoryQuery needs to get its own product ids.
+  // TODO(griest024): fix return type
+  /**
+   * Gets a category based on parameters. Default current_page is 1, and default page_size is 20.
+   *
+   * @param categoryRequest A DaffCategoryRequestReplacement object.
+   */
+  get(categoryRequest: any): Observable<any> {
+    return combineLatest([
+      this.apollo.query<MagentoGetACategoryResponse>({
+        query: MagentoGetCategoryQuery,
+        variables: { filters: { category_uid: { eq: categoryRequest.id }}},
+      }),
+      this.apollo.query<MagentoGetCategoryFilterTypesResponse>({
+        query: MagentoGetCategoryFilterTypes,
+      }),
+      this.apollo.query<MagentoGetProductsResponse>({
+        query: MagentoGetProductsQuery,
+        variables: this.getProductsQueryVariables(categoryRequest),
+      }),
+    ]).pipe(
+      map(([
+        category,
+        filterTypes,
+        products,
+      ]) => this.transformCategory(category.data, filterTypes.data, products.data)),
+      map(result => categoryRequest.filter_requests
+        ? applyFiltersOnResponse(categoryRequest.filter_requests, result)
+        : result,
+      ),
+    );
+  }
+
+  private getProductsQueryVariables(request: DaffCategoryRequestReplacement): MagentoGetProductsByCategoriesRequest {
+    const queryVariables = {
+      filter: this.magentoAppliedFiltersTransformer.transform(request.id, request.filter_requests),
+    };
+    if(request.page_size) {
+      queryVariables['pageSize'] = request.page_size;
+    }
+    if(request.current_page) {
+      queryVariables['currentPage'] = request.current_page;
+    }
+    if(request.applied_sort_option && request.applied_sort_direction) {
+      queryVariables['sort'] = this.magentoAppliedSortTransformer.transform(request.applied_sort_option, request.applied_sort_direction);
+    }
+
+    return queryVariables;
+  }
+
+  private transformCategory(
+    categoryResponse: MagentoGetACategoryResponse,
+    filterTypesResponse: MagentoGetCategoryFilterTypesResponse,
+    productsResponse: MagentoGetProductsResponse,
+  ): DaffGetCategoryResponseReplacement {
+    const aggregations = addMetadataTypesToAggregates(filterTypesResponse, productsResponse);
+    const completeCategory = {
+      category: categoryResponse.categoryList[0],
+      products: productsResponse.products.items,
+      aggregates: aggregations.products.aggregations,
+      sort_fields: aggregations.products.sort_fields,
+      total_count: productsResponse.products.total_count,
+      page_info: productsResponse.products.page_info,
+    };
+
+    return this.magentoCategoryResponseTransformer.transform(completeCategory);
+  }
+}

--- a/libs/category/driver/magento-replacement/src/index.ts
+++ b/libs/category/driver/magento-replacement/src/index.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/libs/category/driver/magento-replacement/src/models/aggregation.ts
+++ b/libs/category/driver/magento-replacement/src/models/aggregation.ts
@@ -1,0 +1,18 @@
+import { MagentoCategoryFilterType } from './filter-type.enum';
+
+/**
+ * Filterable options for products.
+ */
+export interface MagentoAggregation {
+	attribute_code: string;
+	type?: MagentoCategoryFilterType;
+	count?: number;
+	label?: string;
+	options?: MagentoAggregationOption[];
+}
+
+export interface MagentoAggregationOption {
+	value: string;
+	count?: number;
+	label?: string;
+}

--- a/libs/category/driver/magento-replacement/src/models/category.ts
+++ b/libs/category/driver/magento-replacement/src/models/category.ts
@@ -1,0 +1,21 @@
+import { MagentoProduct } from '@daffodil/product/driver/magento';
+
+export interface MagentoCategory {
+  id: number;
+	name?: string;
+	description?: string;
+  breadcrumbs?: MagentoBreadcrumb[];
+  level?: number;
+	children_count?: number;
+	products?: {
+		items?: MagentoProduct[];
+	};
+  children?: MagentoCategory[];
+}
+
+export interface MagentoBreadcrumb {
+  category_id: number;
+  category_name: string;
+  category_level: number;
+  category_url_key: string;
+}

--- a/libs/category/driver/magento-replacement/src/models/complete-category-response.ts
+++ b/libs/category/driver/magento-replacement/src/models/complete-category-response.ts
@@ -1,0 +1,15 @@
+import { MagentoProduct } from '@daffodil/product/driver/magento';
+
+import { MagentoAggregation } from './aggregation';
+import { MagentoCategory } from './category';
+import { MagentoPageInfo } from './page-info';
+import { MagentoSortFields } from './sort-fields';
+
+export interface MagentoCompleteCategoryResponse {
+  category: MagentoCategory;
+	aggregates: MagentoAggregation[];
+	products: MagentoProduct[];
+	sort_fields: MagentoSortFields;
+	page_info: MagentoPageInfo;
+	total_count: number;
+}

--- a/libs/category/driver/magento-replacement/src/models/filter-type-field.interface.ts
+++ b/libs/category/driver/magento-replacement/src/models/filter-type-field.interface.ts
@@ -1,0 +1,8 @@
+import { MagentoCategoryFilterType } from './filter-type.enum';
+
+export interface MagentoCategoryFilterTypeField {
+  name: string;
+  type: {
+    name: MagentoCategoryFilterType;
+  };
+}

--- a/libs/category/driver/magento-replacement/src/models/filter-type.enum.ts
+++ b/libs/category/driver/magento-replacement/src/models/filter-type.enum.ts
@@ -1,0 +1,6 @@
+// maybe this shoould be in @daffodil/product/driver/magento?
+export enum MagentoCategoryFilterType {
+  Equal = 'FilterEqualTypeInput',
+  Match = 'FilterEqualTypeInput',
+  Range = 'FilterRangeTypeInput'
+}

--- a/libs/category/driver/magento-replacement/src/models/get-category-response.ts
+++ b/libs/category/driver/magento-replacement/src/models/get-category-response.ts
@@ -1,0 +1,5 @@
+import { MagentoCategory } from './category';
+
+export interface MagentoGetACategoryResponse {
+  categoryList: MagentoCategory[];
+}

--- a/libs/category/driver/magento-replacement/src/models/get-filter-types-response.interface.ts
+++ b/libs/category/driver/magento-replacement/src/models/get-filter-types-response.interface.ts
@@ -1,0 +1,7 @@
+import { MagentoCategoryFilterTypeField } from './filter-type-field.interface';
+
+export interface MagentoGetCategoryFilterTypesResponse {
+  __type: {
+    inputFields: MagentoCategoryFilterTypeField[];
+  };
+}

--- a/libs/category/driver/magento-replacement/src/models/get-products-response.ts
+++ b/libs/category/driver/magento-replacement/src/models/get-products-response.ts
@@ -1,0 +1,17 @@
+import { MagentoProduct } from '@daffodil/product/driver/magento';
+
+import {
+  MagentoAggregation,
+  MagentoSortFields,
+} from '../models/public_api';
+import { MagentoPageInfo } from './page-info';
+
+export interface MagentoGetProductsResponse {
+	products: {
+		items: MagentoProduct[];
+		page_info: MagentoPageInfo;
+		total_count: number;
+    aggregations: MagentoAggregation[];
+    sort_fields: MagentoSortFields;
+	};
+}

--- a/libs/category/driver/magento-replacement/src/models/page-info.ts
+++ b/libs/category/driver/magento-replacement/src/models/page-info.ts
@@ -1,0 +1,5 @@
+export interface MagentoPageInfo {
+  current_page: number;
+  page_size: number;
+  total_pages: number;
+}

--- a/libs/category/driver/magento-replacement/src/models/public_api.ts
+++ b/libs/category/driver/magento-replacement/src/models/public_api.ts
@@ -1,0 +1,28 @@
+export { MagentoCompleteCategoryResponse } from './complete-category-response';
+export {
+  MagentoCategory,
+  MagentoBreadcrumb,
+} from './category';
+export { MagentoGetACategoryResponse } from './get-category-response';
+export {
+  MagentoSortFields,
+  MagentoSortOption,
+} from './sort-fields';
+export { MagentoPageInfo } from './page-info';
+export { MagentoGetProductsResponse } from './get-products-response';
+export {
+  MagentoAggregation,
+  MagentoAggregationOption,
+} from './aggregation';
+export { MagentoGetProductsByCategoriesRequest } from './requests/get-products-by-categories-request';
+export {
+  MagentoCategoryFilters,
+  MagentoFilterAction,
+} from './requests/filters';
+export { MagentoSortFieldAction } from './requests/sort';
+export { MagentoCategoryFilterActionEnum } from './requests/filters';
+export { MagentoSortDirectionEnum } from './requests/sort';
+export { MagentoCustomMetadataAttribute } from './requests/custom-metadata-attribute';
+export { MagentoCategoryFilterTypeField } from './filter-type-field.interface';
+export { MagentoCategoryFilterType } from './filter-type.enum';
+export { MagentoGetCategoryFilterTypesResponse } from './get-filter-types-response.interface';

--- a/libs/category/driver/magento-replacement/src/models/requests/custom-metadata-attribute.ts
+++ b/libs/category/driver/magento-replacement/src/models/requests/custom-metadata-attribute.ts
@@ -1,0 +1,4 @@
+export interface MagentoCustomMetadataAttribute {
+	attribute_code: string;
+	entity_type: string;
+}

--- a/libs/category/driver/magento-replacement/src/models/requests/filters.ts
+++ b/libs/category/driver/magento-replacement/src/models/requests/filters.ts
@@ -1,0 +1,15 @@
+export enum MagentoCategoryFilterActionEnum {
+	Equal = 'eq',
+	To = 'to',
+	From = 'from',
+	In = 'in',
+	Match = 'match'
+}
+
+export interface MagentoCategoryFilters {
+	[x: string]: MagentoFilterAction;
+}
+
+export type MagentoFilterAction = {
+	[key in MagentoCategoryFilterActionEnum]?: string | string[];
+};

--- a/libs/category/driver/magento-replacement/src/models/requests/get-products-by-categories-request.ts
+++ b/libs/category/driver/magento-replacement/src/models/requests/get-products-by-categories-request.ts
@@ -1,0 +1,10 @@
+import { MagentoCategoryFilters } from './filters';
+import { MagentoSortFieldAction } from './sort';
+
+export interface MagentoGetProductsByCategoriesRequest {
+	filter: MagentoCategoryFilters;
+	search?: string;
+	pageSize?: number;
+	currentPage?: number;
+	sort?: MagentoSortFieldAction;
+}

--- a/libs/category/driver/magento-replacement/src/models/requests/sort.ts
+++ b/libs/category/driver/magento-replacement/src/models/requests/sort.ts
@@ -1,0 +1,8 @@
+export enum MagentoSortDirectionEnum {
+	Ascending = 'ASC',
+	Decending = 'DESC'
+}
+
+export interface MagentoSortFieldAction {
+	[x: string]: MagentoSortDirectionEnum;
+}

--- a/libs/category/driver/magento-replacement/src/models/sort-fields.ts
+++ b/libs/category/driver/magento-replacement/src/models/sort-fields.ts
@@ -1,0 +1,9 @@
+export interface MagentoSortFields {
+  default: string;
+  options: MagentoSortOption[];
+}
+
+export interface MagentoSortOption {
+  label: string;
+  value: string;
+}

--- a/libs/category/driver/magento-replacement/src/public_api.ts
+++ b/libs/category/driver/magento-replacement/src/public_api.ts
@@ -1,0 +1,6 @@
+export { DaffMagentoCategoryService } from './category.service';
+export { DaffCategoryMagentoDriverModule } from './category-driver.module';
+
+export * from './models/public_api';
+export * from './queries/public_api';
+export * from './transformers/public_api';

--- a/libs/category/driver/magento-replacement/src/queries/get-category.ts
+++ b/libs/category/driver/magento-replacement/src/queries/get-category.ts
@@ -1,0 +1,25 @@
+import { gql } from 'apollo-angular';
+
+export const DAFF_MAGENTO_GET_CATEGORY_QUERY_NAME = 'MagentoGetCategoryQuery';
+
+export const MagentoGetCategoryQuery = gql`
+query ${DAFF_MAGENTO_GET_CATEGORY_QUERY_NAME}($filters: CategoryFilterInput){
+	categoryList(filters: $filters) {
+		id
+		name
+		level
+		description
+		breadcrumbs {
+			category_id
+			category_name
+			category_level
+			category_url_key
+		}
+		products {
+			items {
+				sku
+			}
+		}
+		children_count
+	}
+}`;

--- a/libs/category/driver/magento-replacement/src/queries/get-filter-types.ts
+++ b/libs/category/driver/magento-replacement/src/queries/get-filter-types.ts
@@ -1,0 +1,16 @@
+import { gql } from 'apollo-angular';
+
+export const DAFF_MAGENTO_GET_FILTER_TYPES_QUERY_NAME = 'MagentoGetFilterFieldTypesForCategory';
+
+export const MagentoGetCategoryFilterTypes = gql`
+query ${DAFF_MAGENTO_GET_FILTER_TYPES_QUERY_NAME} {
+  __type (name: "ProductAttributeFilterInput") {
+    inputFields {
+      name
+      type {
+        name
+      }
+    }
+  }
+}
+`;

--- a/libs/category/driver/magento-replacement/src/queries/get-products.ts
+++ b/libs/category/driver/magento-replacement/src/queries/get-products.ts
@@ -1,0 +1,44 @@
+import { gql } from 'apollo-angular';
+
+import { magentoProductFragment } from '@daffodil/product/driver/magento';
+
+export const DAFF_MAGENTO_GET_PRODUCTS_QUERY_NAME = 'MagentoGetProducts';
+/**
+ * This query only exists because products and their associated aggregations/filter cannot
+ * be retrieved through a category call.
+ */
+export const MagentoGetProductsQuery = gql`
+query ${DAFF_MAGENTO_GET_PRODUCTS_QUERY_NAME}($filter: ProductAttributeFilterInput!, $search: String, $pageSize: Int, $currentPage: Int, $sort: ProductAttributeSortInput)
+{
+	products(filter: $filter, search: $search, pageSize: $pageSize, currentPage: $currentPage, sort: $sort)
+	{
+		total_count
+		items {
+			...product
+		}
+		page_info {
+			page_size
+			current_page
+			total_pages
+		}
+		aggregations {
+			label
+			count
+			attribute_code
+			options {
+					count
+					label
+					value
+			}
+		}
+		sort_fields {
+			default
+			options {
+				label
+				value
+			}
+		}
+	}
+}
+${magentoProductFragment}
+`;

--- a/libs/category/driver/magento-replacement/src/queries/public_api.ts
+++ b/libs/category/driver/magento-replacement/src/queries/public_api.ts
@@ -1,0 +1,3 @@
+export * from './get-filter-types';
+export * from './get-category';
+export * from './get-products';

--- a/libs/category/driver/magento-replacement/src/transformers/applied-filter-transformer.service.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/applied-filter-transformer.service.spec.ts
@@ -1,0 +1,101 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  DaffCategoryFilterRequestReplacement,
+  DaffCategoryFilterTypeReplacement,
+  DaffCategoryFilterRangeNumeric,
+  DaffCategoryFilterRangeNumericRequest,
+  DaffCategoryFilterEqualRequestReplacement,
+} from '@daffodil/category';
+import {
+  MagentoCategoryFilters,
+  MagentoCategoryFilterActionEnum,
+} from '@daffodil/category/driver/magento-replacement';
+import {
+  DaffCategoryFilterRequestRangeNumericFactory,
+  DaffCategoryFilterRequestEqualFactory,
+} from '@daffodil/category/testing';
+
+import { DaffMagentoAppliedFiltersTransformService } from './applied-filter-transformer.service';
+
+describe('DaffMagentoAppliedFiltersTransformService', () => {
+  let rangeFilterRequestFactory: DaffCategoryFilterRequestRangeNumericFactory;
+  let equalFilterRequestFactory: DaffCategoryFilterRequestEqualFactory;
+  let service: DaffMagentoAppliedFiltersTransformService;
+  const categoryId = 'id';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DaffMagentoAppliedFiltersTransformService,
+      ],
+    });
+    service = TestBed.inject(DaffMagentoAppliedFiltersTransformService);
+    rangeFilterRequestFactory = TestBed.inject(DaffCategoryFilterRequestRangeNumericFactory);
+    equalFilterRequestFactory = TestBed.inject(DaffCategoryFilterRequestEqualFactory);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('transform', () => {
+
+    it('should return only a category filter when there are no additional filters', () => {
+      const expectedReturn: MagentoCategoryFilters = {
+        category_id: {
+          eq: 'id',
+        },
+      };
+
+      expect(service.transform(categoryId, null)).toEqual(expectedReturn);
+    });
+
+    describe('when the filter type is Range', () => {
+      let rangeFilterRequest: DaffCategoryFilterRangeNumericRequest;
+
+      beforeEach(() => {
+        rangeFilterRequest = rangeFilterRequestFactory.create({
+          value: {
+            min: 30,
+            max: 40,
+          },
+        });
+      });
+
+      it('should transform a range filter request into a valid magento FromTo filter', () => {
+        const expectedReturn: MagentoCategoryFilters = {
+          category_id: {
+            eq: 'id',
+          },
+          [rangeFilterRequest.name]: {
+            [MagentoCategoryFilterActionEnum.From]: '30',
+            [MagentoCategoryFilterActionEnum.To]: '40',
+          },
+        };
+
+        expect(service.transform(categoryId, [rangeFilterRequest])).toEqual(expectedReturn);
+      });
+    });
+
+    describe('when the filter type is not Range', () => {
+      let equalFilterRequest: DaffCategoryFilterEqualRequestReplacement;
+
+      beforeEach(() => {
+        equalFilterRequest = equalFilterRequestFactory.create();
+      });
+
+      it('should transform an array of DaffCategoryFilterRequestReplacement into a MagentoCategoryFilters', () => {
+        const expectedReturn: MagentoCategoryFilters = {
+          category_id: {
+            eq: 'id',
+          },
+          [equalFilterRequest.name]: {
+            [MagentoCategoryFilterActionEnum.In]: equalFilterRequest.value,
+          },
+        };
+        expect(service.transform(categoryId, [equalFilterRequest])).toEqual(expectedReturn);
+      });
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/applied-filter-transformer.service.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/applied-filter-transformer.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@angular/core';
+
+import {
+  DaffCategory,
+  DaffCategoryFilterRequestReplacement,
+  DaffCategoryFilterTypeReplacement,
+} from '@daffodil/category';
+
+import {
+  MagentoCategoryFilters,
+  MagentoCategoryFilterActionEnum,
+} from '../models/public_api';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffMagentoAppliedFiltersTransformService {
+
+  transform(categoryId: DaffCategory['id'], daffFilters: DaffCategoryFilterRequestReplacement[]): MagentoCategoryFilters {
+    const magentoFilters: MagentoCategoryFilters = {
+      category_id: {
+        [MagentoCategoryFilterActionEnum.Equal]: String(categoryId),
+      },
+    };
+
+    if(!daffFilters) {
+      return magentoFilters;
+    }
+
+    daffFilters.forEach(filter => {
+      // The FromTo filter needs special treatment, because Magento accepts the "from" and "to" filters
+      // separately (it also outputs FromTo filter pairs together)
+      if(filter.type === DaffCategoryFilterTypeReplacement.RangeNumeric) {
+        magentoFilters[filter.name] = {
+          ...magentoFilters[filter.name],
+          ...this.getRangeFromValue(filter.value.min.toString()),
+          ...this.getRangeToValue(filter.value.max.toString()),
+        };
+      } else {
+        magentoFilters[filter.name] = {
+          ...magentoFilters[filter.name],
+          [this.getFilterAction(filter.type)]: this.getFilterValue(filter.type, filter.value),
+        };
+      }
+    });
+
+    return magentoFilters;
+  }
+
+  /**
+   * Returns an In action for Equal type and a Match action for Match type.
+   */
+  private getFilterAction(type: DaffCategoryFilterTypeReplacement): MagentoCategoryFilterActionEnum {
+    return type === DaffCategoryFilterTypeReplacement.Equal
+      ? MagentoCategoryFilterActionEnum.In
+      : MagentoCategoryFilterActionEnum.Match;
+  }
+
+  /**
+   * Returns an array for Equal type and a string for Match type.
+   */
+  private getFilterValue(type: DaffCategoryFilterTypeReplacement, value: DaffCategoryFilterRequestReplacement['value']): string | string[] {
+    return type === DaffCategoryFilterTypeReplacement.Equal ? value : value[0];
+  }
+
+  private getRangeFromValue(fromValue: string) {
+    return fromValue !== '*' ? { [MagentoCategoryFilterActionEnum.From]: fromValue } : null;
+  }
+
+  private getRangeToValue(toValue: string) {
+    return toValue !== '*' ? { [MagentoCategoryFilterActionEnum.To]: toValue } : null;
+  }
+}

--- a/libs/category/driver/magento-replacement/src/transformers/applied-sort-option-transformer.service.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/applied-sort-option-transformer.service.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  MagentoSortFieldAction,
+  MagentoSortDirectionEnum,
+} from '@daffodil/category/driver/magento-replacement';
+import { DaffSortDirectionEnum } from '@daffodil/core/state';
+
+
+import { DaffMagentoAppliedSortOptionTransformService } from './applied-sort-option-transformer.service';
+
+describe('DaffMagentoAppliedSortOptionTransformService', () => {
+
+  let service: DaffMagentoAppliedSortOptionTransformService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DaffMagentoAppliedSortOptionTransformService,
+      ],
+    });
+    service = TestBed.inject(DaffMagentoAppliedSortOptionTransformService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('transform', () => {
+
+    it('should return a MagentoSortOptionAction', () => {
+      const expectedReturn: MagentoSortFieldAction = {
+        sortOption: MagentoSortDirectionEnum.Ascending,
+      };
+      expect(service.transform('sortOption', DaffSortDirectionEnum.Ascending)).toEqual(expectedReturn);
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/applied-sort-option-transformer.service.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/applied-sort-option-transformer.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+
+import { DaffSortDirectionEnum } from '@daffodil/core/state';
+
+import {
+  MagentoSortFieldAction,
+  MagentoSortDirectionEnum,
+} from '../models/public_api';
+
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffMagentoAppliedSortOptionTransformService {
+
+  transform(appliedOption: string, appliedDirection: DaffSortDirectionEnum): MagentoSortFieldAction {
+    return {
+      [appliedOption]: this.transformDirection(appliedDirection),
+    };
+  }
+
+  private transformDirection(direction: DaffSortDirectionEnum): MagentoSortDirectionEnum {
+    if(direction === DaffSortDirectionEnum.Ascending) {
+      return MagentoSortDirectionEnum.Ascending;
+    } else if(direction === DaffSortDirectionEnum.Descending) {
+      return MagentoSortDirectionEnum.Decending;
+    }
+  }
+}

--- a/libs/category/driver/magento-replacement/src/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/category-page-config-transformer.service.spec.ts
@@ -1,0 +1,153 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  DaffCategory,
+  DaffCategoryPageMetadata,
+  DaffCategoryFilterTypeReplacement,
+  DaffCategoryFromToFilterSeparator,
+} from '@daffodil/category';
+import {
+  MagentoCompleteCategoryResponse,
+  MagentoCategory,
+  MagentoAggregation,
+  MagentoPageInfo,
+  MagentoSortFields,
+} from '@daffodil/category/driver/magento-replacement';
+import {
+  DaffCategoryDriverMagentoAggregationSelectFactory,
+  DaffCategoryDriverMagentoAggregationPriceFactory,
+} from '@daffodil/category/driver/magento-replacement/testing';
+import {
+  DaffCategoryFactory,
+  DaffCategoryPageMetadataFactory,
+} from '@daffodil/category/testing';
+import { MagentoProduct } from '@daffodil/product/driver/magento';
+import { MagentoProductFactory } from '@daffodil/product/driver/magento/testing';
+
+import { DaffMagentoCategoryPageConfigTransformerService } from './category-page-config-transformer.service';
+
+describe('DaffMagentoCategoryPageConfigTransformerService', () => {
+
+  let service: DaffMagentoCategoryPageConfigTransformerService;
+
+  let stubCategory: DaffCategory;
+  let stubCategoryPageMetadata: DaffCategoryPageMetadata;
+  let aggregation: MagentoAggregation;
+
+  let priceAggregateFactory: DaffCategoryDriverMagentoAggregationPriceFactory;
+  let selectAggregateFactory: DaffCategoryDriverMagentoAggregationSelectFactory;
+  let categoryFactory: DaffCategoryFactory;
+  let categoryPageMetadataFactory: DaffCategoryPageMetadataFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DaffMagentoCategoryPageConfigTransformerService,
+      ],
+    });
+
+    service = TestBed.inject(DaffMagentoCategoryPageConfigTransformerService);
+    categoryPageMetadataFactory = TestBed.inject(DaffCategoryPageMetadataFactory);
+    categoryFactory = TestBed.inject(DaffCategoryFactory);
+    selectAggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationSelectFactory);
+    priceAggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationPriceFactory);
+
+    stubCategory = categoryFactory.create({
+      id: '1',
+    });
+    stubCategoryPageMetadata = categoryPageMetadataFactory.create();
+
+    delete stubCategoryPageMetadata.filters;
+    delete stubCategoryPageMetadata.applied_sort_direction;
+    delete stubCategoryPageMetadata.applied_sort_option;
+    stubCategoryPageMetadata.id = stubCategory.id;
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('transform', () => {
+    let completeCategoryResponse: MagentoCompleteCategoryResponse;
+    let category: MagentoCategory;
+    let aggregates: MagentoAggregation[];
+    let page_info: MagentoPageInfo;
+    let sort_fields: MagentoSortFields;
+    let products: MagentoProduct[];
+    let result: DaffCategoryPageMetadata;
+
+    beforeEach(() => {
+      category = {
+        id: Number(stubCategory.id),
+        name: stubCategory.name,
+        breadcrumbs: [{
+          category_id: Number(stubCategory.breadcrumbs[0].categoryId),
+          category_name: stubCategory.breadcrumbs[0].categoryName,
+          category_level: stubCategory.breadcrumbs[0].categoryLevel,
+          category_url_key: stubCategory.breadcrumbs[0].categoryUrlKey,
+        }],
+        children_count: stubCategory.children_count,
+      };
+
+      page_info = {
+        page_size: stubCategoryPageMetadata.page_size,
+        current_page: stubCategoryPageMetadata.current_page,
+        total_pages: stubCategoryPageMetadata.total_pages,
+      };
+
+      sort_fields = {
+        default: stubCategoryPageMetadata.sort_options.options[0].value,
+        options: stubCategoryPageMetadata.sort_options.options,
+      };
+
+      products = [new MagentoProductFactory().create({ sku: stubCategoryPageMetadata.product_ids[0] })];
+
+      completeCategoryResponse = {
+        category,
+        aggregates: [],
+        page_info,
+        sort_fields,
+        products,
+        total_count: stubCategoryPageMetadata.total_products,
+      };
+    });
+
+    describe('when the sort options are immutable', () => {
+      beforeEach(() => {
+        Object.freeze(sort_fields.options);
+      });
+
+      it('should complete successfully', () => {
+        expect(service.transform(completeCategoryResponse)).toBeTruthy();
+      });
+    });
+
+    describe('when the aggregate is a select', () => {
+      beforeEach(() => {
+        aggregation = selectAggregateFactory.create();
+        result = service.transform({
+          ...completeCategoryResponse,
+          aggregates: [aggregation],
+        });
+      });
+
+      it('should return a DaffCategoryPageMetadata with an equal filter type', () => {
+        expect(result.filters[aggregation.attribute_code].type).toEqual(DaffCategoryFilterTypeReplacement.Equal);
+      });
+    });
+
+    describe('when the aggregate is a price', () => {
+      beforeEach(() => {
+        aggregation = priceAggregateFactory.create();
+        result = service.transform({
+          ...completeCategoryResponse,
+          aggregates: [aggregation],
+        });
+      });
+
+      it('should return a DaffCategoryPageMetadata with a range filter type', () => {
+        expect(result.filters[aggregation.attribute_code].type).toEqual(DaffCategoryFilterTypeReplacement.RangeNumeric);
+      });
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/category-page-config-transformer.service.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/category-page-config-transformer.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+
+import {
+  DaffCategoryPageMetadata,
+  daffCategoryFilterArrayToDict,
+} from '@daffodil/category';
+
+import { MagentoCompleteCategoryResponse } from '../models/public_api';
+import { transformAggregate } from './pure/aggregate/transform';
+import { coerceDefaultSortOptionFirst } from './pure/sort-default-option-first';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffMagentoCategoryPageConfigTransformerService {
+
+  transform(categoryResponse: MagentoCompleteCategoryResponse): DaffCategoryPageMetadata {
+    return {
+      id: String(categoryResponse.category.id),
+      page_size: categoryResponse.page_info.page_size,
+      current_page: categoryResponse.page_info.current_page,
+      total_pages: categoryResponse.page_info.total_pages,
+      total_products: categoryResponse.total_count,
+      filters: daffCategoryFilterArrayToDict(categoryResponse.aggregates.map(transformAggregate)),
+      sort_options: {
+        default: categoryResponse.sort_fields.default,
+        options: coerceDefaultSortOptionFirst(categoryResponse.sort_fields).options,
+      },
+      product_ids: categoryResponse.products.map(product => product.sku),
+      // TODO: implement?
+      applied_sort_direction: null,
+      applied_sort_option: null,
+    };
+  }
+}

--- a/libs/category/driver/magento-replacement/src/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/category-response-transform.service.spec.ts
@@ -1,0 +1,147 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  DaffCategory,
+  DaffCategoryPageMetadata,
+} from '@daffodil/category';
+import {
+  DaffMagentoCategoryTransformerService,
+  DaffMagentoCategoryPageConfigTransformerService,
+  MagentoCompleteCategoryResponse,
+  MagentoCategory,
+  MagentoAggregation,
+  MagentoPageInfo,
+  MagentoSortFields,
+} from '@daffodil/category/driver/magento-replacement';
+import { DaffCategoryDriverMagentoAggregationFactory } from '@daffodil/category/driver/magento-replacement/testing';
+import {
+  DaffCategoryFactory,
+  DaffCategoryPageMetadataFactory,
+} from '@daffodil/category/testing';
+import { transformManyMagentoProducts } from '@daffodil/product/driver/magento';
+import { MagentoProductFactory } from '@daffodil/product/driver/magento/testing';
+import { DaffProductFactory } from '@daffodil/product/testing';
+
+import { DaffMagentoCategoryResponseTransformService } from './category-response-transform.service';
+
+describe('DaffMagentoCategoryResponseTransformService', () => {
+
+  let service: DaffMagentoCategoryResponseTransformService;
+
+  let stubCategory: DaffCategory;
+  let stubCategoryPageMetadata: DaffCategoryPageMetadata;
+
+  let productFactory: DaffProductFactory;
+  let magentoProductFactory: MagentoProductFactory;
+  let categoryFactory: DaffCategoryFactory;
+  let categoryPageMetadataFactory: DaffCategoryPageMetadataFactory;
+  let aggregateFactory: DaffCategoryDriverMagentoAggregationFactory;
+
+  let magentoCategoryTransformerServiceSpy: jasmine.SpyObj<DaffMagentoCategoryTransformerService>;
+  let magentoCategoryPageConfigurationTransformerServiceSpy: jasmine.SpyObj<DaffMagentoCategoryPageConfigTransformerService>;
+
+  beforeEach(() => {
+    magentoCategoryTransformerServiceSpy = jasmine.createSpyObj('DaffMagentoCategoryTransformerService', ['transform']);
+    magentoCategoryPageConfigurationTransformerServiceSpy = jasmine.createSpyObj('DaffMagentoCategoryPageConfigTransformerService', ['transform']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        DaffMagentoCategoryResponseTransformService,
+        { provide: DaffMagentoCategoryTransformerService, useValue: magentoCategoryTransformerServiceSpy },
+        { provide: DaffMagentoCategoryPageConfigTransformerService, useValue: magentoCategoryPageConfigurationTransformerServiceSpy },
+      ],
+    });
+
+    service = TestBed.inject(DaffMagentoCategoryResponseTransformService);
+    categoryPageMetadataFactory = TestBed.inject(DaffCategoryPageMetadataFactory);
+    categoryFactory = TestBed.inject(DaffCategoryFactory);
+    productFactory = TestBed.inject(DaffProductFactory);
+    magentoProductFactory = TestBed.inject(MagentoProductFactory);
+    aggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationFactory);
+
+    stubCategory = categoryFactory.create({
+      id: '1',
+    });
+    stubCategoryPageMetadata = categoryPageMetadataFactory.create();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('transform', () => {
+
+    let completeCategory: MagentoCompleteCategoryResponse;
+
+    beforeEach(() => {
+      magentoCategoryTransformerServiceSpy.transform.and.returnValue(stubCategory);
+      magentoCategoryPageConfigurationTransformerServiceSpy.transform.and.returnValue(stubCategoryPageMetadata);
+
+      const category: MagentoCategory = {
+        id: Number(stubCategory.id),
+        name: stubCategory.name,
+        breadcrumbs: [{
+          category_id: Number(stubCategory.breadcrumbs[0].categoryId),
+          category_name: stubCategory.breadcrumbs[0].categoryName,
+          category_level: stubCategory.breadcrumbs[0].categoryLevel,
+          category_url_key: stubCategory.breadcrumbs[0].categoryUrlKey,
+        }],
+        children_count: stubCategory.children_count,
+      };
+      const aggregates: MagentoAggregation[] = aggregateFactory.createMany(1);
+
+      const page_info: MagentoPageInfo = {
+        page_size: stubCategoryPageMetadata.page_size,
+        current_page: stubCategoryPageMetadata.current_page,
+        total_pages: stubCategoryPageMetadata.total_pages,
+      };
+
+      const sort_fields: MagentoSortFields = {
+        default: stubCategoryPageMetadata.sort_options.options[0].value,
+        options: stubCategoryPageMetadata.sort_options.options,
+      };
+
+      const products = magentoProductFactory.createMany(1);
+
+      completeCategory = {
+        category,
+        aggregates,
+        page_info,
+        sort_fields,
+        products,
+        total_count: products.length,
+      };
+    });
+
+    it('should call transform on the magentoCategoryTransformerService', () => {
+      service.transform(completeCategory);
+
+      expect(magentoCategoryTransformerServiceSpy.transform).toHaveBeenCalledWith(completeCategory.category);
+    });
+
+    it('should call transform on the magentoCategoryPageConfigurationService', () => {
+      service.transform(completeCategory);
+
+      expect(magentoCategoryPageConfigurationTransformerServiceSpy.transform).toHaveBeenCalledWith(completeCategory);
+    });
+
+    it('should return the same number of products it receives', () => {
+      expect(service.transform(completeCategory).products.length).toEqual(completeCategory.products.length);
+    });
+
+    it('should return a DaffGetCategoryResponseReplacement', () => {
+      expect(service.transform(completeCategory)).toEqual(
+        {
+          ...{ magentoCompleteCategoryResponse: completeCategory },
+          category: stubCategory,
+          products: transformManyMagentoProducts(completeCategory.products),
+          categoryPageMetadata: stubCategoryPageMetadata,
+        },
+      );
+    });
+
+    it('should return the magento MagentoCompleteCategoryResponse on the daffodil response', () => {
+      expect((<any>service.transform(completeCategory)).magentoCompleteCategoryResponse).toEqual(completeCategory);
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/category-response-transform.service.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/category-response-transform.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+
+import { DaffGetCategoryResponseReplacement } from '@daffodil/category';
+import { transformManyMagentoProducts } from '@daffodil/product/driver/magento';
+
+import { MagentoCompleteCategoryResponse } from '../models/public_api';
+import { DaffMagentoCategoryPageConfigTransformerService } from './category-page-config-transformer.service';
+import { DaffMagentoCategoryTransformerService } from './category-transformer.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffMagentoCategoryResponseTransformService {
+
+  constructor(
+    private magentoCategoryTransformerService: DaffMagentoCategoryTransformerService,
+    private magentoCategoryPageConfigurationTransformerService: DaffMagentoCategoryPageConfigTransformerService,
+  ) {}
+
+  transform(completeCategory: MagentoCompleteCategoryResponse): DaffGetCategoryResponseReplacement {
+    return {
+      ...{ magentoCompleteCategoryResponse: completeCategory },
+      category: this.magentoCategoryTransformerService.transform(completeCategory.category),
+      categoryPageMetadata: this.magentoCategoryPageConfigurationTransformerService.transform(completeCategory),
+      products: transformManyMagentoProducts(completeCategory.products),
+    };
+  }
+}

--- a/libs/category/driver/magento-replacement/src/transformers/category-transformer.service.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/category-transformer.service.spec.ts
@@ -1,0 +1,116 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  DaffCategory,
+  DaffCategoryBreadcrumb,
+} from '@daffodil/category';
+import { MagentoCategory } from '@daffodil/category/driver/magento-replacement';
+import { DaffCategoryFactory } from '@daffodil/category/testing';
+
+import { DaffMagentoCategoryTransformerService } from './category-transformer.service';
+
+describe('DaffMagentoCategoryTransformerService', () => {
+
+  let service: DaffMagentoCategoryTransformerService;
+  let categoryFactory: DaffCategoryFactory;
+  let stubCategory: DaffCategory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DaffMagentoCategoryTransformerService,
+      ],
+    });
+
+    service = TestBed.inject(DaffMagentoCategoryTransformerService);
+    categoryFactory = TestBed.inject(DaffCategoryFactory);
+
+    stubCategory = categoryFactory.create({
+      id: '1',
+    });
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('transform', () => {
+
+    let magentoCategory: MagentoCategory;
+
+    beforeEach(() => {
+      magentoCategory = {
+        id: Number(stubCategory.id),
+        name: stubCategory.name,
+        breadcrumbs: [{
+          category_id: Number(stubCategory.breadcrumbs[0].categoryId),
+          category_name: stubCategory.breadcrumbs[0].categoryName,
+          category_level: stubCategory.breadcrumbs[0].categoryLevel,
+          category_url_key: stubCategory.breadcrumbs[0].categoryUrlKey,
+        }],
+        description: stubCategory.description,
+        products: {
+          items: [{
+            __typename: 'simple',
+            id: 1,
+            name: 'name',
+            sku: stubCategory.product_ids[0],
+            url_key: 'url_key',
+            image: null,
+            price_range: null,
+            thumbnail: {
+              url: 'url',
+              label: 'label',
+            },
+          }],
+        },
+        children_count: stubCategory.children_count,
+      };
+    });
+
+    it('should return a DaffCategory', () => {
+      expect(service.transform(magentoCategory)).toEqual(stubCategory);
+    });
+
+    it('should return breadcrumbs in order of category_level', () => {
+      magentoCategory.breadcrumbs = [{
+        category_id: 3,
+        category_name: 'category3',
+        category_level: 3,
+        category_url_key: 'urlKey3',
+      },
+      {
+        category_id: 1,
+        category_name: 'category1',
+        category_level: 1,
+        category_url_key: 'urlKey1',
+      },
+      {
+        category_id: 2,
+        category_name: 'category2',
+        category_level: 2,
+        category_url_key: 'urlKey2',
+      }];
+      const expectedBreadcrumbs: DaffCategoryBreadcrumb[] = [{
+        categoryId: '1',
+        categoryName: 'category1',
+        categoryLevel: 1,
+        categoryUrlKey: 'urlKey1',
+      },
+      {
+        categoryId: '2',
+        categoryName: 'category2',
+        categoryLevel: 2,
+        categoryUrlKey: 'urlKey2',
+      },
+      {
+        categoryId: '3',
+        categoryName: 'category3',
+        categoryLevel: 3,
+        categoryUrlKey: 'urlKey3',
+      }];
+
+      expect(service.transform(magentoCategory).breadcrumbs).toEqual(expectedBreadcrumbs);
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/category-transformer.service.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/category-transformer.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+
+import {
+  DaffCategory,
+  DaffCategoryBreadcrumb,
+} from '@daffodil/category';
+
+import {
+  MagentoBreadcrumb,
+  MagentoCategory,
+} from '../models/public_api';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffMagentoCategoryTransformerService {
+
+  transform(category: MagentoCategory): DaffCategory {
+    return {
+      id: String(category.id),
+      name: category.name,
+      description: category.description,
+      children_count: category.children_count,
+      breadcrumbs: category.breadcrumbs
+        ?.map(breadcrumb => this.transformBreadcrumb(breadcrumb))
+        .sort((a, b) => a.categoryLevel - b.categoryLevel) || null,
+      product_ids: category.products.items.map(product => product.sku),
+      total_products: category.products.items.length,
+    };
+  }
+
+  private transformBreadcrumb(breadcrumb: MagentoBreadcrumb): DaffCategoryBreadcrumb {
+    return {
+      categoryId: String(breadcrumb.category_id),
+      categoryName: breadcrumb.category_name,
+      categoryLevel: breadcrumb.category_level,
+      categoryUrlKey: breadcrumb.category_url_key,
+    };
+  }
+}

--- a/libs/category/driver/magento-replacement/src/transformers/public_api.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/public_api.ts
@@ -1,0 +1,5 @@
+export { DaffMagentoAppliedFiltersTransformService } from './applied-filter-transformer.service';
+export { DaffMagentoAppliedSortOptionTransformService } from './applied-sort-option-transformer.service';
+export { DaffMagentoCategoryPageConfigTransformerService } from './category-page-config-transformer.service';
+export { DaffMagentoCategoryResponseTransformService } from './category-response-transform.service';
+export { DaffMagentoCategoryTransformerService } from './category-transformer.service';

--- a/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/add-metadata-types-to-aggregates.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/add-metadata-types-to-aggregates.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  MagentoGetCategoryFilterTypesResponse,
+  MagentoGetProductsResponse,
+} from '@daffodil/category/driver/magento-replacement';
+
+import { addMetadataTypesToAggregates } from './add-metadata-types-to-aggregates';
+
+describe('Custom Metadata Attributes Methods', () => {
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  describe('addMetadataTypesToAggregates', () => {
+    let initialCategoryResponse: MagentoGetProductsResponse;
+    let outputCategoryResponse: MagentoGetProductsResponse;
+    let attributeResponse: MagentoGetCategoryFilterTypesResponse;
+
+    it('should add the attribute types to the aggregates', () => {
+      initialCategoryResponse = {
+        products: {
+          aggregations: [],
+          sort_fields: null,
+          items: [],
+          page_info: null,
+          total_count: 0,
+        },
+      };
+      attributeResponse = {
+        __type: {
+          inputFields: [],
+        },
+      };;
+
+      outputCategoryResponse = {
+        products: {
+          aggregations: [],
+          sort_fields: null,
+          items: [],
+          page_info: null,
+          total_count: 0,
+        },
+      };
+
+      expect(addMetadataTypesToAggregates(attributeResponse, initialCategoryResponse)).toEqual(outputCategoryResponse);
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/add-metadata-types-to-aggregates.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/add-metadata-types-to-aggregates.ts
@@ -1,0 +1,24 @@
+import {
+  MagentoGetCategoryFilterTypesResponse,
+  MagentoGetProductsResponse,
+} from '../../../models/public_api';
+import { getMatchedAttributeType } from './get-matched-attribute-type';
+
+export function addMetadataTypesToAggregates(
+  attributeResponse: MagentoGetCategoryFilterTypesResponse,
+  aggregationResponse: MagentoGetProductsResponse,
+): MagentoGetProductsResponse {
+
+  return {
+    ...aggregationResponse,
+    products: {
+      ...aggregationResponse.products,
+      aggregations: [
+        ...aggregationResponse.products.aggregations.map((aggregate) => ({
+          ...aggregate,
+          type: getMatchedAttributeType(aggregate, attributeResponse),
+        })),
+      ],
+    },
+  };
+}

--- a/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/get-matched-attribute-type.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/get-matched-attribute-type.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  MagentoCategoryFilterTypeField,
+  MagentoAggregation,
+  MagentoGetCategoryFilterTypesResponse,
+  MagentoCategoryFilterType,
+} from '@daffodil/category/driver/magento-replacement';
+import {
+  DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory,
+  DaffCategoryDriverMagentoAggregationFactory,
+} from '@daffodil/category/driver/magento-replacement/testing';
+
+import { getMatchedAttributeType } from './get-matched-attribute-type';
+
+describe('@daffodil/category/driver/magento-replacement | getMatchedAttributeType', () => {
+  let filterFieldFactory: DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory;
+  let aggregateFactory: DaffCategoryDriverMagentoAggregationFactory;
+
+  let filterField: MagentoCategoryFilterTypeField;
+  let aggregation: MagentoAggregation;
+  let filterTypesResponse: MagentoGetCategoryFilterTypesResponse;
+
+  let result: MagentoCategoryFilterType;
+
+  beforeEach(() => {
+    filterFieldFactory = TestBed.inject(DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory);
+    aggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationFactory);
+
+    aggregation = aggregateFactory.create();
+    filterField = filterFieldFactory.create({
+      name: aggregation.attribute_code,
+      type: {
+        name: aggregation.type,
+      },
+    });
+    filterTypesResponse = {
+      __type: {
+        inputFields: [
+          ...filterFieldFactory.createMany(3),
+          filterField,
+        ],
+      },
+    };
+
+    result = getMatchedAttributeType(aggregation, filterTypesResponse);
+  });
+
+  it('should return the specified aggregate\'s type from the filter field response', () => {
+    expect(result).toEqual(filterField.type.name);
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/get-matched-attribute-type.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/get-matched-attribute-type.ts
@@ -1,0 +1,8 @@
+import { MagentoGetCategoryFilterTypesResponse } from '../../../models/get-filter-types-response.interface';
+import {
+  MagentoAggregation,
+  MagentoCategoryFilterType,
+} from '../../../models/public_api';
+
+export const getMatchedAttributeType = (aggregate: MagentoAggregation, attributes: MagentoGetCategoryFilterTypesResponse): MagentoCategoryFilterType =>
+  attributes.__type.inputFields.filter(item => item.name === aggregate.attribute_code)[0].type.name;

--- a/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/transform.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/transform.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  DaffCategoryFilterReplacement,
+  DaffCategoryFilterTypeReplacement,
+} from '@daffodil/category';
+import { MagentoAggregation } from '@daffodil/category/driver/magento-replacement';
+import {
+  DaffCategoryDriverMagentoAggregationPriceFactory,
+  DaffCategoryDriverMagentoAggregationSelectFactory,
+} from '@daffodil/category/driver/magento-replacement/testing';
+
+import { transformAggregate } from './transform';
+
+describe('@daffodil/category/driver/magento-replacement | transformAggregate', () => {
+  let priceAggregateFactory: DaffCategoryDriverMagentoAggregationPriceFactory;
+  let selectAggregateFactory: DaffCategoryDriverMagentoAggregationSelectFactory;
+  let aggregation: MagentoAggregation;
+
+  let result: DaffCategoryFilterReplacement;
+
+  beforeEach(() => {
+    selectAggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationSelectFactory);
+    priceAggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationPriceFactory);
+
+    aggregation = selectAggregateFactory.create();
+
+    result = transformAggregate(aggregation);
+  });
+
+  describe('for a price aggregate', () => {
+    beforeEach(() => {
+      aggregation = priceAggregateFactory.create();
+      result = transformAggregate(aggregation);
+    });
+
+    it('should return a range filter', () => {
+      expect(result.type).toEqual(DaffCategoryFilterTypeReplacement.RangeNumeric);
+    });
+  });
+
+  describe('for a select aggregate', () => {
+    beforeEach(() => {
+      aggregation = selectAggregateFactory.create();
+      result = transformAggregate(aggregation);
+    });
+
+    it('should return an equal filter', () => {
+      expect(result.type).toEqual(DaffCategoryFilterTypeReplacement.Equal);
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/transform.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/transform.ts
@@ -1,0 +1,19 @@
+import { DaffCategoryFilterReplacement } from '@daffodil/category';
+
+import {
+  MagentoAggregation,
+  MagentoCategoryFilterType,
+} from '../../../models/public_api';
+import { transformAggregateEqual } from './type/equal';
+import { transformAggregateRange } from './type/range';
+
+export const transformAggregate = (aggregate: MagentoAggregation): DaffCategoryFilterReplacement => {
+  switch (aggregate.type) {
+    case MagentoCategoryFilterType.Range:
+      return transformAggregateRange(aggregate);
+    case MagentoCategoryFilterType.Equal:
+    case MagentoCategoryFilterType.Match:
+    default:
+      return transformAggregateEqual(aggregate);
+  }
+};

--- a/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/type/equal.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/type/equal.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  DaffCategoryFilterEqual,
+  DaffCategoryFilterTypeReplacement,
+} from '@daffodil/category';
+import { MagentoAggregation } from '@daffodil/category/driver/magento-replacement';
+import { DaffCategoryDriverMagentoAggregationSelectFactory } from '@daffodil/category/driver/magento-replacement/testing';
+
+import { transformAggregateEqual } from './equal';
+
+describe('@daffodil/category/driver/magento-replacement | transformers | transformAggregateEqual', () => {
+  let selectAggregateFactory: DaffCategoryDriverMagentoAggregationSelectFactory;
+  let aggregation: MagentoAggregation;
+
+  let result: DaffCategoryFilterEqual;
+
+  beforeEach(() => {
+    selectAggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationSelectFactory);
+
+    aggregation = selectAggregateFactory.create();
+
+    result = transformAggregateEqual(aggregation);
+  });
+
+  it('should return a DaffCategoryFilterEqual with the transformed fields', () => {
+    expect(result.type).toEqual(DaffCategoryFilterTypeReplacement.Equal);
+    expect(result.name).toEqual(aggregation.attribute_code);
+    expect(result.label).toEqual(aggregation.label);
+    aggregation.options.forEach(option => {
+      const resOpt = result.options[option.value];
+      expect(resOpt.applied).toBeFalse();
+      expect(resOpt.label).toEqual(option.label);
+      expect(resOpt.count).toEqual(option.count);
+      expect(resOpt.value).toEqual(option.value);
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/type/equal.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/type/equal.ts
@@ -1,0 +1,23 @@
+import { DaffCategoryFilterEqualOption } from '@daffodil/category';
+import {
+  DaffCategoryFilterEqual,
+  DaffCategoryFilterTypeReplacement,
+} from '@daffodil/category';
+import { Dict } from '@daffodil/core';
+
+import { MagentoAggregation } from '../../../../models/public_api';
+
+export const transformAggregateEqual = (aggregate: MagentoAggregation): DaffCategoryFilterEqual => ({
+  label: aggregate.label,
+  type: DaffCategoryFilterTypeReplacement.Equal,
+  name: aggregate.attribute_code,
+  options: aggregate.options.reduce((acc, option) => {
+    acc[option.value] = {
+      applied: false,
+      label: option.label,
+      count: option.count,
+      value: option.value,
+    };
+    return acc;
+  }, <Dict<DaffCategoryFilterEqualOption>>{}),
+});

--- a/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/type/range.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/type/range.spec.ts
@@ -1,0 +1,55 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  DaffCategoryFilterRangeBase,
+  DaffCategoryFilterTypeReplacement,
+} from '@daffodil/category';
+import { MagentoAggregation } from '@daffodil/category/driver/magento-replacement';
+import { DaffCategoryDriverMagentoAggregationPriceFactory } from '@daffodil/category/driver/magento-replacement/testing';
+
+import { transformAggregateRange } from './range';
+
+describe('@daffodil/category/driver/magento-replacement | transformers | transformAggregateRange', () => {
+  let priceAggregateFactory: DaffCategoryDriverMagentoAggregationPriceFactory;
+  let aggregation: MagentoAggregation;
+  let min: number;
+  let max: number;
+
+  let result: DaffCategoryFilterRangeBase<number>;
+
+  beforeEach(() => {
+    priceAggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationPriceFactory);
+
+    min = 0;
+    max = 100;
+    aggregation = priceAggregateFactory.create({
+      options: [
+        {
+          value: `${min}-10`,
+          count: 1,
+          label: `${min}-10`,
+        },
+        {
+          value: '10-90',
+          count: 1,
+          label: '10-90',
+        },
+        {
+          value: `90-${max}`,
+          count: 1,
+          label: `90-${max}`,
+        },
+      ],
+    });
+
+    result = transformAggregateRange(aggregation);
+  });
+
+  it('should return a DaffCategoryFilterRangeBase<number> with the transformed fields', () => {
+    expect(result.type).toEqual(DaffCategoryFilterTypeReplacement.RangeNumeric);
+    expect(result.name).toEqual(aggregation.attribute_code);
+    expect(result.label).toEqual(aggregation.label);
+    expect(result.min).toEqual(min);
+    expect(result.max).toEqual(max);
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/type/range.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/aggregate/type/range.ts
@@ -1,0 +1,21 @@
+import {
+  DaffCategoryFilterTypeReplacement,
+  DaffCategoryFilterRangeNumeric,
+} from '@daffodil/category';
+
+import { MagentoAggregation } from '../../../../models/public_api';
+
+/**
+ * The char that Magento uses to separate individual elements of the buckets
+ * they return for range elements
+ */
+export const magentoBucketSeparator = '-';
+
+export const transformAggregateRange = (aggregate: MagentoAggregation): DaffCategoryFilterRangeNumeric => ({
+  label: aggregate.label,
+  type: DaffCategoryFilterTypeReplacement.RangeNumeric,
+  name: aggregate.attribute_code,
+  min: parseInt(aggregate.options[0].value.split('-')[0], 10),
+  max: parseInt(aggregate.options[aggregate.options.length - 1].value.split(magentoBucketSeparator)[1], 10),
+  options: {},
+});

--- a/libs/category/driver/magento-replacement/src/transformers/pure/sort-default-option-first.spec.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/sort-default-option-first.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoSortFields } from '@daffodil/category/driver/magento-replacement';
+import { DaffCategoryDriverMagentoSortFieldsFactory } from '@daffodil/category/driver/magento-replacement/testing';
+
+import { coerceDefaultSortOptionFirst } from './sort-default-option-first';
+
+describe('@daffodil/category/driver/magento-replacement | transformers | coerceDefaultSortOptionFirst', () => {
+  let sortFieldsFactory: DaffCategoryDriverMagentoSortFieldsFactory;
+  let sortFields: MagentoSortFields;
+  let defaultOption: string;
+  let result: MagentoSortFields;
+
+  beforeEach(() => {
+    sortFieldsFactory = TestBed.inject(DaffCategoryDriverMagentoSortFieldsFactory);
+
+    defaultOption = 'defaultOption';
+    sortFields = sortFieldsFactory.create({
+      default: defaultOption,
+      options: [
+        {
+          label: '1',
+          value: '1',
+        },
+        {
+          label: defaultOption,
+          value: defaultOption,
+        },
+      ],
+    });
+
+    result = coerceDefaultSortOptionFirst(sortFields);
+  });
+
+  it('should move the default option to the front of the options list', () => {
+    expect(result.options[0].value).toEqual(defaultOption);
+  });
+});

--- a/libs/category/driver/magento-replacement/src/transformers/pure/sort-default-option-first.ts
+++ b/libs/category/driver/magento-replacement/src/transformers/pure/sort-default-option-first.ts
@@ -1,0 +1,14 @@
+import { MagentoSortFields } from '../../models/sort-fields';
+
+export function coerceDefaultSortOptionFirst(sort_fields: MagentoSortFields): MagentoSortFields {
+  const index = sort_fields.options.findIndex(option => sort_fields.default === option.value);
+
+  return {
+    ...sort_fields,
+    options: [
+      sort_fields.options[index],
+      ...sort_fields.options.slice(0, index),
+      ...sort_fields.options.slice(index + 1),
+    ],
+  };
+}

--- a/libs/category/driver/magento-replacement/testing/ng-package.json
+++ b/libs/category/driver/magento-replacement/testing/ng-package.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/category/driver/magento-replacement/testing",
+  "deleteDestPath": false,
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/category/driver/magento-replacement/testing/package.json
+++ b/libs/category/driver/magento-replacement/testing/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@daffodil/category/driver/magento-replacement/testing"
+}

--- a/libs/category/driver/magento-replacement/testing/src/factories/aggregation/aggregation.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/aggregation/aggregation.factory.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoAggregation } from '@daffodil/category/driver/magento-replacement';
+
+import { DaffCategoryDriverMagentoAggregationFactory } from './aggregation.factory';
+
+describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriverMagentoAggregationFactory', () => {
+
+  let factory: DaffCategoryDriverMagentoAggregationFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffCategoryDriverMagentoAggregationFactory],
+    });
+
+    factory = TestBed.inject(DaffCategoryDriverMagentoAggregationFactory);
+  });
+
+  it('should be created', () => {
+    expect(factory).toBeTruthy();
+  });
+
+  describe('create', () => {
+
+    let result: MagentoAggregation;
+
+    beforeEach(() => {
+      result = factory.create();
+    });
+
+    it('should return', () => {
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/testing/src/factories/aggregation/aggregation.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/aggregation/aggregation.factory.spec.ts
@@ -28,7 +28,12 @@ describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriver
       result = factory.create();
     });
 
-    it('should return', () => {
+    it('should return an aggregation', () => {
+      expect(result.attribute_code).toBeDefined();
+      expect(result.type).toBeDefined();
+      expect(result.count).toBeDefined();
+      expect(result.label).toBeDefined();
+      expect(result.options).toBeDefined();
     });
   });
 });

--- a/libs/category/driver/magento-replacement/testing/src/factories/aggregation/aggregation.factory.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/aggregation/aggregation.factory.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { MagentoAggregation } from '@daffodil/category/driver/magento-replacement';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+import { DaffCategoryDriverMagentoAggregationPriceFactory } from './type/price.factory';
+import { DaffCategoryDriverMagentoAggregationSelectFactory } from './type/select.factory';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffCategoryDriverMagentoAggregationFactory extends DaffModelFactory<MagentoAggregation> {
+  constructor(private selectFactory: DaffCategoryDriverMagentoAggregationSelectFactory, private priceFactory: DaffCategoryDriverMagentoAggregationPriceFactory){
+    super(faker.random.number({ min: 1, max: 2 }) === 2 ? selectFactory.type : priceFactory.type);
+  }
+}

--- a/libs/category/driver/magento-replacement/testing/src/factories/aggregation/public_api.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/aggregation/public_api.ts
@@ -1,0 +1,3 @@
+export { DaffCategoryDriverMagentoAggregationFactory } from './aggregation.factory';
+export { DaffCategoryDriverMagentoAggregationPriceFactory } from './type/price.factory';
+export { DaffCategoryDriverMagentoAggregationSelectFactory } from './type/select.factory';

--- a/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/price.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/price.factory.spec.ts
@@ -1,7 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 
 import { DaffCategoryFilterReplacement } from '@daffodil/category';
-import { MagentoAggregation } from '@daffodil/category/driver/magento-replacement';
+import {
+  MagentoAggregation,
+  MagentoCategoryFilterType,
+} from '@daffodil/category/driver/magento-replacement';
 
 import { DaffCategoryDriverMagentoAggregationPriceFactory } from './price.factory';
 
@@ -29,7 +32,12 @@ describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriver
       result = factory.create();
     });
 
-    it('should return', () => {
+    it('should return a price aggregation', () => {
+      expect(result.attribute_code).toEqual('price');
+      expect(result.type).toEqual(MagentoCategoryFilterType.Range);
+      expect(result.count).toBeDefined();
+      expect(result.label).toBeDefined();
+      expect(result.options).toBeDefined();
     });
   });
 });

--- a/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/price.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/price.factory.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DaffCategoryFilterReplacement } from '@daffodil/category';
+import { MagentoAggregation } from '@daffodil/category/driver/magento-replacement';
+
+import { DaffCategoryDriverMagentoAggregationPriceFactory } from './price.factory';
+
+describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriverMagentoAggregationPriceFactory', () => {
+
+  let factory: DaffCategoryDriverMagentoAggregationPriceFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffCategoryDriverMagentoAggregationPriceFactory],
+    });
+
+    factory = TestBed.inject(DaffCategoryDriverMagentoAggregationPriceFactory);
+  });
+
+  it('should be created', () => {
+    expect(factory).toBeTruthy();
+  });
+
+  describe('create', () => {
+
+    let result: MagentoAggregation;
+
+    beforeEach(() => {
+      result = factory.create();
+    });
+
+    it('should return', () => {
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/price.factory.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/price.factory.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import {
+  MagentoAggregation,
+  MagentoCategoryFilterType,
+} from '@daffodil/category/driver/magento-replacement';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+class MockMagentoAggregationPrice implements MagentoAggregation {
+  attribute_code = 'price';
+	type = MagentoCategoryFilterType.Range;
+	count = faker.random.number();
+	label = 'Price';
+	options = [
+	  {
+	    value: '0-10',
+	    count: faker.random.number(),
+	    label: '0-10',
+	  },
+	  {
+	    value: '10-20',
+	    count: faker.random.number(),
+	    label: '10-20',
+	  },
+	  {
+	    value: '20-30',
+	    count: faker.random.number(),
+	    label: '20-30',
+	  },
+	  {
+	    value: '30-40',
+	    count: faker.random.number(),
+	    label: '30-40',
+	  },
+	];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffCategoryDriverMagentoAggregationPriceFactory extends DaffModelFactory<MagentoAggregation> {
+  constructor(){
+    super(MockMagentoAggregationPrice);
+  }
+}

--- a/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/select.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/select.factory.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoAggregation } from '@daffodil/category/driver/magento-replacement';
+
+import { DaffCategoryDriverMagentoAggregationSelectFactory } from './select.factory';
+
+describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriverMagentoAggregationSelectFactory', () => {
+
+  let factory: DaffCategoryDriverMagentoAggregationSelectFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffCategoryDriverMagentoAggregationSelectFactory],
+    });
+
+    factory = TestBed.inject(DaffCategoryDriverMagentoAggregationSelectFactory);
+  });
+
+  it('should be created', () => {
+    expect(factory).toBeTruthy();
+  });
+
+  describe('create', () => {
+
+    let result: MagentoAggregation;
+
+    beforeEach(() => {
+      result = factory.create();
+    });
+
+    it('should return', () => {
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/select.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/select.factory.spec.ts
@@ -1,6 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 
-import { MagentoAggregation } from '@daffodil/category/driver/magento-replacement';
+import {
+  MagentoAggregation,
+  MagentoCategoryFilterType,
+} from '@daffodil/category/driver/magento-replacement';
 
 import { DaffCategoryDriverMagentoAggregationSelectFactory } from './select.factory';
 
@@ -28,7 +31,12 @@ describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriver
       result = factory.create();
     });
 
-    it('should return', () => {
+    it('should return a select aggregation', () => {
+      expect(result.attribute_code).toEqual('select');
+      expect(result.type).toEqual(MagentoCategoryFilterType.Equal);
+      expect(result.count).toBeDefined();
+      expect(result.label).toBeDefined();
+      expect(result.options).toBeDefined();
     });
   });
 });

--- a/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/select.factory.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/aggregation/type/select.factory.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import {
+  MagentoAggregation,
+  MagentoCategoryFilterType,
+} from '@daffodil/category/driver/magento-replacement';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+class MockMagentoAggregationSelect implements MagentoAggregation {
+  attribute_code = 'select';
+	type = MagentoCategoryFilterType.Equal;
+	count = faker.random.number();
+	label = faker.random.word();
+	options =  [
+	  {
+	    count: faker.random.number(),
+	    label: faker.random.word(),
+	    value: faker.random.uuid(),
+	  },
+	  {
+	    count: faker.random.number(),
+	    label: faker.random.word(),
+	    value: faker.random.uuid(),
+	  },
+	  {
+	    count: faker.random.number(),
+	    label: faker.random.word(),
+	    value: faker.random.uuid(),
+	  },
+	];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffCategoryDriverMagentoAggregationSelectFactory extends DaffModelFactory<MagentoAggregation> {
+  constructor(){
+    super(MockMagentoAggregationSelect);
+  }
+}

--- a/libs/category/driver/magento-replacement/testing/src/factories/category.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/category.factory.spec.ts
@@ -31,7 +31,15 @@ describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriver
       result = factory.create();
     });
 
-    it('should return', () => {
+    it('should return a category', () => {
+      expect(result.id).toBeDefined();
+      expect(result.name).toBeDefined();
+      expect(result.description).toBeDefined();
+      expect(result.breadcrumbs).toBeDefined();
+      expect(result.level).toBeDefined();
+      expect(result.children_count).toBeDefined();
+      expect(result.children).toBeDefined();
+      expect(result.products).toBeDefined();
     });
   });
 });

--- a/libs/category/driver/magento-replacement/testing/src/factories/category.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/category.factory.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  MagentoAggregation,
+  MagentoCategory,
+} from '@daffodil/category/driver/magento-replacement';
+
+import { DaffCategoryDriverMagentoCategoryFactory } from './category.factory';
+
+describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriverMagentoCategoryFactory', () => {
+
+  let factory: DaffCategoryDriverMagentoCategoryFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffCategoryDriverMagentoCategoryFactory],
+    });
+
+    factory = TestBed.inject(DaffCategoryDriverMagentoCategoryFactory);
+  });
+
+  it('should be created', () => {
+    expect(factory).toBeTruthy();
+  });
+
+  describe('create', () => {
+
+    let result: MagentoCategory;
+
+    beforeEach(() => {
+      result = factory.create();
+    });
+
+    it('should return', () => {
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/testing/src/factories/category.factory.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/category.factory.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { MagentoCategory } from '@daffodil/category/driver/magento-replacement';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+class MockMagentoCategory implements MagentoCategory {
+  id = faker.random.number();
+  name? = faker.random.word();
+  description? = faker.random.words(40);
+  breadcrumbs? =  [];
+  level? =  faker.random.number(15);
+  children_count? = faker.random.number(15);
+  products? =  { items: []};
+  children?: MagentoCategory[] = [];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffCategoryDriverMagentoCategoryFactory extends DaffModelFactory<MagentoCategory> {
+  constructor(){
+    super(MockMagentoCategory);
+  }
+}

--- a/libs/category/driver/magento-replacement/testing/src/factories/filter-type-field.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/filter-type-field.factory.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoCategoryFilterTypeField } from '@daffodil/category/driver/magento-replacement';
+
+import { DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory } from './filter-type-field.factory';
+
+describe('@daffodil/category/driver/magento-replacement/testing | Factories | DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory', () => {
+  let factory: DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory],
+    });
+
+    factory = TestBed.inject(DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory);
+  });
+
+  it('should be created', () => {
+    expect(factory).toBeTruthy();
+  });
+
+  describe('create', () => {
+
+    let result: MagentoCategoryFilterTypeField;
+
+    beforeEach(() => {
+      result = factory.create();
+    });
+
+    it('should return with all fields defined', () => {
+      expect(result.name).toBeDefined();
+      expect(result.type.name).toBeDefined();
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/testing/src/factories/filter-type-field.factory.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/filter-type-field.factory.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import {
+  MagentoCategoryFilterTypeField,
+  MagentoCategoryFilterType,
+} from '@daffodil/category/driver/magento-replacement';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+const TYPES = [
+  MagentoCategoryFilterType.Equal,
+  MagentoCategoryFilterType.Range,
+  MagentoCategoryFilterType.Match,
+];
+
+class MockMagentoCategoryFilterTypeField implements MagentoCategoryFilterTypeField {
+  name = faker.random.word();
+  type = {
+    name: TYPES[faker.random.number({ min: 0, max: TYPES.length - 1 })],
+  };
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory extends DaffModelFactory<MagentoCategoryFilterTypeField> {
+  constructor(){
+    super(MockMagentoCategoryFilterTypeField);
+  }
+}

--- a/libs/category/driver/magento-replacement/testing/src/factories/page-info.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/page-info.factory.spec.ts
@@ -29,6 +29,9 @@ describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriver
     });
 
     it('should return', () => {
+      expect(result.current_page).toBeDefined();
+      expect(result.page_size).toBeDefined();
+      expect(result.total_pages).toBeDefined();
     });
   });
 });

--- a/libs/category/driver/magento-replacement/testing/src/factories/page-info.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/page-info.factory.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoPageInfo } from '@daffodil/category/driver/magento-replacement';
+
+import { DaffCategoryDriverMagentoPageInfoFactory } from './page-info.factory';
+
+describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriverMagentoPageInfoFactory', () => {
+
+  let factory: DaffCategoryDriverMagentoPageInfoFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffCategoryDriverMagentoPageInfoFactory],
+    });
+
+    factory = TestBed.inject(DaffCategoryDriverMagentoPageInfoFactory);
+  });
+
+  it('should be created', () => {
+    expect(factory).toBeTruthy();
+  });
+
+  describe('create', () => {
+
+    let result: MagentoPageInfo;
+
+    beforeEach(() => {
+      result = factory.create();
+    });
+
+    it('should return', () => {
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/testing/src/factories/page-info.factory.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/page-info.factory.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import {
+  MagentoCategory,
+  MagentoPageInfo,
+} from '@daffodil/category/driver/magento-replacement';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+class MockMagentoPageInfo implements MagentoPageInfo {
+  current_page =  1;
+  page_size = faker.random.number(100);
+  total_pages = faker.random.number(100);
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffCategoryDriverMagentoPageInfoFactory extends DaffModelFactory<MagentoPageInfo> {
+  constructor(){
+    super(MockMagentoPageInfo);
+  }
+}

--- a/libs/category/driver/magento-replacement/testing/src/factories/public_api.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/public_api.ts
@@ -1,0 +1,6 @@
+export * from './aggregation/public_api';
+
+export { DaffCategoryDriverMagentoCategoryFactory } from './category.factory';
+export { DaffCategoryDriverMagentoCategoryFilterTypeFieldFactory } from './filter-type-field.factory';
+export { DaffCategoryDriverMagentoPageInfoFactory } from './page-info.factory';
+export { DaffCategoryDriverMagentoSortFieldsFactory } from './sort-fields.factory';

--- a/libs/category/driver/magento-replacement/testing/src/factories/sort-fields.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/sort-fields.factory.spec.ts
@@ -29,6 +29,8 @@ describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriver
     });
 
     it('should return', () => {
+      expect(result.default).toBeDefined();
+      expect(result.options).toBeDefined();
     });
   });
 });

--- a/libs/category/driver/magento-replacement/testing/src/factories/sort-fields.factory.spec.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/sort-fields.factory.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MagentoSortFields } from '@daffodil/category/driver/magento-replacement';
+
+import { DaffCategoryDriverMagentoSortFieldsFactory } from './sort-fields.factory';
+
+describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriverMagentoSortFieldsFactory', () => {
+
+  let factory: DaffCategoryDriverMagentoSortFieldsFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffCategoryDriverMagentoSortFieldsFactory],
+    });
+
+    factory = TestBed.inject(DaffCategoryDriverMagentoSortFieldsFactory);
+  });
+
+  it('should be created', () => {
+    expect(factory).toBeTruthy();
+  });
+
+  describe('create', () => {
+
+    let result: MagentoSortFields;
+
+    beforeEach(() => {
+      result = factory.create();
+    });
+
+    it('should return', () => {
+    });
+  });
+});

--- a/libs/category/driver/magento-replacement/testing/src/factories/sort-fields.factory.ts
+++ b/libs/category/driver/magento-replacement/testing/src/factories/sort-fields.factory.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
+
+import { MagentoSortFields } from '@daffodil/category/driver/magento-replacement';
+import { DaffModelFactory } from '@daffodil/core/testing';
+
+class MockMagentoSortFields implements MagentoSortFields {
+  default = 'position';
+  options = [
+    {
+      label: 'string',
+      value: 'position',
+    },
+  ];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffCategoryDriverMagentoSortFieldsFactory extends DaffModelFactory<MagentoSortFields> {
+  constructor(){
+    super(MockMagentoSortFields);
+  }
+}

--- a/libs/category/driver/magento-replacement/testing/src/index.ts
+++ b/libs/category/driver/magento-replacement/testing/src/index.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/libs/category/driver/magento-replacement/testing/src/public_api.ts
+++ b/libs/category/driver/magento-replacement/testing/src/public_api.ts
@@ -1,0 +1,1 @@
+export * from './factories/public_api';

--- a/libs/category/tsconfig.json
+++ b/libs/category/tsconfig.json
@@ -27,6 +27,12 @@
       "@daffodil/category/driver/magento": [
         "libs/category/driver/magento/src"
       ],
+      "@daffodil/category/driver/magento-replacement": [
+        "libs/category/driver/magento-replacement/src"
+      ],
+      "@daffodil/category/driver/magento-replacement/testing": [
+        "libs/category/driver/magento-replacement/testing/src"
+      ],
       "@daffodil/category/testing": [
         "libs/category/testing/src"
       ],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Category driver makes an uncachable aggregations query to get filter types.


## What is the new behavior?
Category driver makes cachable filter type fields query.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
supersedes #1452  and #1450 