### PR TITLE
feat(design): update daffodil's brand palette to turqoise and create green palette to use for success UI

### DIFF
--- a/apps/daffio/src/scss/theme.scss
+++ b/apps/daffio/src/scss/theme.scss
@@ -2,7 +2,7 @@
 
 $primary: daff-configure-palette($daff-blue, 60);
 $secondary: daff-configure-palette($daff-purple, 60);
-$tertiary: daff-configure-palette($daff-green, 60);
+$tertiary: daff-configure-palette($daff-turquoise, 60);
 
 $theme: daff-configure-theme($primary, $secondary, $tertiary, "light");
 

--- a/apps/demo/src/scss/theme.scss
+++ b/apps/demo/src/scss/theme.scss
@@ -2,7 +2,7 @@
 
 $primary: daff-configure-palette($daff-blue, 60);
 $secondary: daff-configure-palette($daff-purple, 60);
-$tertiary: daff-configure-palette($daff-green, 60);
+$tertiary: daff-configure-palette($daff-turquoise, 60);
 
 $theme: daff-configure-theme($primary, $secondary, $tertiary, 'light');
 

--- a/apps/design-land/src/app/foundations/color/color.component.html
+++ b/apps/design-land/src/app/foundations/color/color.component.html
@@ -81,7 +81,7 @@
 			<div style="background-color: #51e1ae;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#51e1ae</span></div>
 			<div style="background-color: #37c193;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#37c193</span></div>
 			<div style="background-color: #1fa67c;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#1fa67c</span></div>
-			<div class="dl-color__default" style="background-color: #00835f;"><span class="dl-color__hex">60 Green</span><span class="dl-color__hue">#00835f</span></div>
+			<div class="dl-color__default" style="background-color: #00835f;"><span class="dl-color__hex">60 Turquoise</span><span class="dl-color__hue">#00835f</span></div>
 			<div style="background-color: #0f654a;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#0f654a</span></div>
 			<div style="background-color: #104b37;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#104b37</span></div>
 			<div style="background-color: #0d3426;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#0d3426</span></div>
@@ -90,7 +90,7 @@
 	</div>
 
 	<h3>Decorative palettes</h3>
-	<p>The decorative palettes consists of colors that should be reserved for indicators, avatars, an data visualization. These colors should be used sparingly. The yellow palette is important to the Daffodil brand and should not be used for warning indicators.</p>
+	<p>The decorative palettes consists of colors that should be reserved for indicators, avatars, and data visualization. These colors should be used sparingly. The yellow palette is important to the Daffodil brand and should not be used for warning indicators.</p>
 	<div class="dl-color__decorative-grid">
 		<div class="dl-color__palette brand-yellow">
 			<div style="background-color: #fffaeb;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#fffaeb</span></div>
@@ -105,6 +105,19 @@
 			<div style="background-color: #7a5e00;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#7a5e00</span></div>
 		</div>
 
+		<div class="dl-color__palette bronze">
+			<div style="background-color: #fbf2ec;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#fbf2ec</span></div>
+			<div style="background-color: #f7e1d3;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#f7e1d3</span></div>
+			<div style="background-color: #f2c093;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#f2c093</span></div>
+			<div style="background-color: #e49d40;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#e49d40</span></div>
+			<div style="background-color: #d2801a;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#d2801a</span></div>
+			<div class="dl-color__default" style="background-color: #b36200;"><span class="dl-color__hex">60 Bronze</span><span class="dl-color__hue">#b36200</span></div>
+			<div style="background-color: #955400;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#955400</span></div>
+			<div style="background-color: #704000;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#704000</span></div>
+			<div style="background-color: #462900;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#462900</span></div>
+			<div style="background-color: #1a0f00;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#1a0f00</span></div>
+		</div>
+
 		<div class="dl-color__palette red-palette">
 			<div style="background-color: #fcf1f1;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#fcf1f1</span></div>
 			<div style="background-color: #fae0e0;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#fae0e0</span></div>
@@ -117,18 +130,18 @@
 			<div style="background-color: #5e0c10;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#5e0c10</span></div>
 			<div style="background-color: #3f0809;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#400808</span></div>
 		</div>
-	
-		<div class="dl-color__palette bronze">
-			<div style="background-color: #fbf2ec;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#fbf2ec</span></div>
-			<div style="background-color: #f7e1d3;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#f7e1d3</span></div>
-			<div style="background-color: #f2c093;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#f2c093</span></div>
-			<div style="background-color: #e49d40;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#e49d40</span></div>
-			<div style="background-color: #d2801a;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#d2801a</span></div>
-			<div class="dl-color__default" style="background-color: #b36200;"><span class="dl-color__hex">60 Bronze</span><span class="dl-color__hue">#b36200</span></div>
-			<div style="background-color: #955400;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#955400</span></div>
-			<div style="background-color: #704000;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#704000</span></div>
-			<div style="background-color: #462900;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#462900</span></div>
-			<div style="background-color: #1a0f00;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#1a0f00</span></div>
+
+		<div class="dl-color__palette green">
+			<div style="background-color: #dafcde;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#dafcde</span></div>
+			<div style="background-color: #a9fbb5;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#a9fbb5</span></div>
+			<div style="background-color: #4ee56e;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#4ee56e</span></div>
+			<div style="background-color: #35c457;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#35c457</span></div>
+			<div style="background-color: #1da943;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#1da943</span></div>
+			<div class="dl-color__default" style="background-color: #00872f;"><span class="dl-color__hex">60 Green</span><span class="dl-color__hue">#00872f</span></div>
+			<div style="background-color: #0e6726;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#0e6726</span></div>
+			<div style="background-color: #0f4c1e;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#0f4c1e</span></div>
+			<div style="background-color: #0c3515;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#0c3515</span></div>
+			<div style="background-color: #07230d;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#07230d</span></div>
 		</div>
 	</div>
 </daff-article>

--- a/apps/design-land/src/app/foundations/color/color.component.scss
+++ b/apps/design-land/src/app/foundations/color/color.component.scss
@@ -24,13 +24,14 @@
 		grid-template-columns: 1fr;
 		grid-template-areas:
 			'brand-yellow'
+			'bronze'
 			'red-palette'
-			'bronze';
+			'green-palette';
 
 		@include breakpoint(tablet) {
-			grid-template-columns: repeat(3, 1fr);
+			grid-template-columns: repeat(4, 1fr);
 			grid-template-areas:
-				'brand-yellow red-palette bronze';
+				'brand-yellow bronze red-palette green-palette';
 		}
 	}
 
@@ -93,6 +94,10 @@
 
 		&.bronze {
 			grid-area: bronze;
+		}
+
+		&.green {
+			grid-area: green-palette;
 		}
 	}
 

--- a/apps/design-land/src/scss/theme.scss
+++ b/apps/design-land/src/scss/theme.scss
@@ -2,7 +2,7 @@
 
 $primary: daff-configure-palette($daff-blue, 60);
 $secondary: daff-configure-palette($daff-purple, 60);
-$tertiary: daff-configure-palette($daff-green, 60);
+$tertiary: daff-configure-palette($daff-turquoise, 60);
 
 $theme: daff-configure-theme($primary, $secondary, $tertiary, 'light');
 

--- a/libs/design/src/scss/theming/_variables.scss
+++ b/libs/design/src/scss/theming/_variables.scss
@@ -35,7 +35,7 @@ $daff-purple: (
 
 $daff-accent: $daff-purple;
 
-$daff-green: (
+$daff-turquoise: (
 	10: #d6fcea,
 	20: #9dfbd3,
 	30: #51e1ae,
@@ -85,6 +85,19 @@ $daff-bronze: (
 	80: #704000,
 	90: #462900,
 	100: #1a0f00,
+);
+
+$daff-green: (
+	10: #dafcde,
+	20: #a9fbb5,
+	30: #4ee56e,
+	40: #35c457,
+	50: #1da943,
+	60: #00852e,
+	70: #0e6726,
+	80: #0f4c1e,
+	90: #0c3515,
+	100: #07230d,
 );
 
 $daff-gray: (

--- a/libs/design/src/scss/theming/prebuilt/internal-theme.scss
+++ b/libs/design/src/scss/theming/prebuilt/internal-theme.scss
@@ -6,7 +6,7 @@
 
 $primary: daff-configure-palette($daff-blue, 60);
 $secondary: daff-configure-palette($daff-purple, 60);
-$tertiary: daff-configure-palette($daff-green, 60);
+$tertiary: daff-configure-palette($daff-turquoise, 60);
 
 $theme: daff-configure-theme($primary, $secondary, $tertiary);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Missing a palette for 'success' state usage.

Fixes: N/A


## What is the new behavior?
Update Daffodil's tertiary color palette name to `daff-turquoise` and create a `daff-green` palette that can be used to style states relevant to success / completion.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information