### PR TITLE
feat(design): remove default theme and template file on hero component

### DIFF
--- a/apps/design-land/src/app/hero/hero.component.html
+++ b/apps/design-land/src/app/hero/hero.component.html
@@ -1,33 +1,24 @@
 <daff-article>
   <h1>Hero</h1>
-  <p><code>DaffHeroComponent</code> is a top level container that is large and captivating. It should only be used once as the first container on any given page. It supports transcluding any content and optionally including a predefined <code>title</code> and <code>subtitle</code>.</p>
+  <p><code>DaffHeroComponent</code> is a top level container that is large and captivating. It should only be used once as the first container on any given page. It supports transclusion of any content and includes predefined <code>tagline</code>, <code>title</code> and <code>subtitle</code> styles.</p>
 
   <h2>Supported Content Types</h2>
-  A <code>&lt;daff-hero&gt;</code> transcludes:
+  A <code>&lt;daff-hero&gt;</code> can transclude:
   <ul>
-    <li><code>[daffHeroTagline]</code></li>
-    <li><code>[daffHeroTitle]</code></li>
-    <li><code>[daffHeroSubtitle]</code></li>
+    <li><code>[daffHeroTagline]</code> - Hero tagline</li>
+    <li><code>[daffHeroTitle]</code> - Hero title, used with the <code>&lt;h1&gt;</code> tag</li>
+    <li><code>[daffHeroSubtitle]</code> - Hero subtitle, used with the <code>&lt;h2&gt;</code> tag</li>
     <li>Any additional components</li>
   </ul>
 
-  <h3>Tagline</h3>
-  <p>Hero tagline is used by adding <code>daffHeroTagline</code> to a <code>&lt;p&gt;</code> or <code>&lt;div&gt;</code> tag.</p>
-
-  <h3>Title</h3>
-  <p>Hero title is used by adding <code>daffHeroTitle</code> to a <code>&lt;h1&gt;</code> tag.</p>
-
-  <h3>Subtitle</h3>
-  <p>Hero subtitle is used by adding <code>daffHeroSubtitle</code> to a <code>&lt;h2&gt;</code> tag.</p>
-
   <h3>Theming</h3>
-  <p>The hero's background color is defined by using the <code>color</code> property. By default, the color is set to <code>theme-contrast</code>. This can be changed to one of the supported colors.</p>
+  <p>The default background color of a hero is light gray, but it can be updated to one of the supported colors by using the <code>color</code> property.</p>
   <p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
 
   <design-land-example-viewer-container example="hero-theming"></design-land-example-viewer-container>
 
   <h2>Size</h2>
-  <p>The <code>size</code> property will be deprecated in v1.0.0. The <code>compact</code> value will be replaced by the <code>DaffCompactable</code> interface.</p>
+  <p>The <code>size</code> property will be deprecated in v1.0.0. <code>compact</code> will be replaced by the <code>DaffCompactable</code> interface.</p>
 
   <h2>Layout</h2>
   <p>The <code>layout</code> property will be deprecated in v1.0.0</p>

--- a/libs/design/hero/examples/src/hero-theming/hero-theming.component.html
+++ b/libs/design/hero/examples/src/hero-theming/hero-theming.component.html
@@ -1,14 +1,12 @@
 <daff-hero [color]="colorControl.value">
-	<div>
-		<div daffHeroTagline>Hero Tagline</div>
-		<h1 daffHeroTitle>Hero Title</h1>
-		<h2 daffHeroSubtitle>Hero subtitle</h2>
-		<div>Additional Content (i.e. buttons, images)</div>
-	</div>
+	<div daffHeroTagline>Hero Tagline</div>
+	<h1 daffHeroTitle>Hero Title</h1>
+	<h2 daffHeroSubtitle>Hero subtitle</h2>
+	<div>Additional Content (i.e. buttons, images)</div>
 </daff-hero>
 
 <select [formControl]="colorControl">
-	<option value="theme">Default</option>
+	<option value="">Default</option>
 	<option value="primary">Primary</option>
 	<option value="secondary">Secondary</option>
 	<option value="tertiary">Tertiary</option>

--- a/libs/design/hero/examples/src/hero-theming/hero-theming.component.ts
+++ b/libs/design/hero/examples/src/hero-theming/hero-theming.component.ts
@@ -9,7 +9,7 @@ import { DaffPalette } from '@daffodil/design';
   templateUrl: './hero-theming.component.html',
 })
 export class HeroThemingComponent {
-  color: DaffPalette = 'theme';
+  color: DaffPalette = 'primary';
 
-  colorControl: FormControl = new FormControl('theme');
+  colorControl: FormControl = new FormControl('');
 }

--- a/libs/design/src/molecules/hero/README.md
+++ b/libs/design/src/molecules/hero/README.md
@@ -1,38 +1,22 @@
 # Hero
-`DaffHeroComponent` is a top level container that is large and captivating. It should only be used once as the first container on any given page. It supports transcluding any content and optionally including a predefined `tagline`, `title` and `subtitle`.
+`DaffHeroComponent` is a top level container that is large and captivating. It should only be used once as the first container on any given page. It supports transclusion of any content and includes predefined `tagline`, `title` and `subtitle` styles.
 
 ## Supported Content Types
-A `daff-hero` transcludes:
-- `[daffHeroTitle]`
-- `[daffHeroSubtitle]`
+A `daff-hero` can transclude:
+- `[daffHeroTagline]` - Hero tagline
+- `[daffHeroTitle]` - Hero title, used with the `<h1>` tag
+- `[daffHeroSubtitle]` - Hero subtitle, used with the `<h2>` tag
 - Any additional components
 
-### Title
-- Hero title is used by adding `<daffHeroTitle>` to a `<h1>` tag.
-
-### Subtitle
-Hero subtitle is used by adding `daffHeroSubtitle` to a `<h2>` tag.
-
 ## Theming
-The hero's background color is defined by using the `color` property. By default, the color is set to `theme`. This can be changed to one of the supported colors.
+The default background color of a hero is light gray, but it can be updated to one of the supported colors by using the `color` property.
 
-Supported colors: `primary, secondary, tertiary, black, white, theme, and theme-contrast`
+Supported colors: `primary | secondary | tertiary | black | white | theme | theme-contrast`
 
-## Colors
-- To define a hero background color, add `color="[value]"` to the hero tag.
-- Values: `primary`, `secondary`, `tertiary`, and `black`, and `white`
+<design-land-example-viewer-container example="hero-theming"></design-land-example-viewer-container>
 
 ## Size
-- The `size` property will be deprecated in v1.0.0
+- The `size` property will be deprecated in v1.0.0. `compact` will be replaced by the `DaffCompactable` interface.
 
 ## Layout
-- The `size` property will be deprecated in v1.0.0
-
-
-## Usage
-```
-<daff-hero color="primary">
-  <h1 daffHeroTitle>Hero Title</h1>
-  <h2 daffHeroSubtitle>Hero subtitle</h2>
-</daff-hero>
-```
+- The `layout` property will be deprecated in v1.0.0

--- a/libs/design/src/molecules/hero/hero/hero.component.html
+++ b/libs/design/src/molecules/hero/hero/hero.component.html
@@ -1,4 +1,0 @@
-<ng-content select="[daffHeroTagline]"></ng-content>
-<ng-content select="[daffHeroTitle]"></ng-content>
-<ng-content select="[daffHeroSubtitle]"></ng-content>
-<ng-content></ng-content>

--- a/libs/design/src/molecules/hero/hero/hero.component.spec.ts
+++ b/libs/design/src/molecules/hero/hero/hero.component.spec.ts
@@ -106,12 +106,8 @@ describe('DaffHeroComponent', () => {
       expect(de.nativeElement.classList.contains('daff-primary')).toEqual(true);
     });
 
-    it('should set the default color to `theme`', () => {
-      wrapper.color = 'theme';
-      fixture.detectChanges();
-
-      expect(wrapper.color).toEqual('theme');
-      expect(de.nativeElement.classList.contains('daff-theme')).toEqual(true);
+    it('should not set a default color', () => {
+      expect(component.color).toBeFalsy();
     });
   });
 });

--- a/libs/design/src/molecules/hero/hero/hero.component.ts
+++ b/libs/design/src/molecules/hero/hero/hero.component.ts
@@ -34,11 +34,11 @@ class DaffHeroBase {
   constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
 }
 
-const _daffHeroBase = daffColorMixin(DaffHeroBase, 'theme');
+const _daffHeroBase = daffColorMixin(DaffHeroBase);
 
 @Component({
   selector: 'daff-hero',
-  templateUrl: './hero.component.html',
+  template: '<ng-content></ng-content>',
   styleUrls: ['./hero.component.scss'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Base and theme colors are the same. Hero template doesn't actually work if `<daff-container>` needs to be used to contain a hero's inner elements.

Fixes: N/A


## What is the new behavior?
Update default/base color to white and theme color to gray, similar to what was done in card. Remove template constraint.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information