### PR TITLE
feat(category): append url_suffix to category uri

### DIFF
--- a/libs/category/driver/magento/src/models/category.ts
+++ b/libs/category/driver/magento/src/models/category.ts
@@ -3,6 +3,7 @@ import { MagentoProduct } from '@daffodil/product/driver/magento';
 export interface MagentoCategory {
   id: number;
   url_path: string;
+  url_suffix: string;
 	name?: string;
 	description?: string;
   breadcrumbs?: MagentoBreadcrumb[];

--- a/libs/category/driver/magento/src/queries/get-category.ts
+++ b/libs/category/driver/magento/src/queries/get-category.ts
@@ -7,6 +7,7 @@ query ${DAFF_MAGENTO_GET_CATEGORY_QUERY_NAME}($filters: CategoryFilterInput){
 	categoryList(filters: $filters) {
 		id
     url_path
+    url_suffix
 		name
 		level
 		description

--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
@@ -29,6 +29,7 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 
   let service: DaffMagentoCategoryPageConfigTransformerService;
 
+  let uri: DaffCategory['uri'];
   let stubCategory: DaffCategory;
   let stubCategoryPageMetadata: DaffCategoryPageMetadata;
   let aggregation: MagentoAggregation;
@@ -51,8 +52,10 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
     selectAggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationSelectFactory);
     priceAggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationPriceFactory);
 
+    uri = 'uri';
     stubCategory = categoryFactory.create({
       id: '1',
+      uri: `${uri}.html`,
     });
     stubCategoryPageMetadata = categoryPageMetadataFactory.create();
 
@@ -79,6 +82,7 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
       category = {
         id: Number(stubCategory.id),
         url_path: stubCategory.uri,
+        url_suffix: '.html',
         name: stubCategory.name,
         breadcrumbs: [{
           category_id: Number(stubCategory.breadcrumbs[0].categoryId),

--- a/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
@@ -28,6 +28,7 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
 
   let service: DaffMagentoCategoryResponseTransformService;
 
+  let uri: DaffCategory['uri'];
   let stubCategory: DaffCategory;
   let stubCategoryPageMetadata: DaffCategoryPageMetadata;
 
@@ -59,8 +60,10 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
     magentoProductFactory = TestBed.inject(MagentoProductFactory);
     aggregateFactory = TestBed.inject(DaffCategoryDriverMagentoAggregationFactory);
 
+    uri = 'uri';
     stubCategory = categoryFactory.create({
       id: '1',
+      uri: `${uri}.html`,
     });
     stubCategoryPageMetadata = categoryPageMetadataFactory.create();
   });
@@ -79,7 +82,8 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
 
       const category: MagentoCategory = {
         id: Number(stubCategory.id),
-        url_path: stubCategory.uri,
+        url_path: uri,
+        url_suffix: '.html',
         name: stubCategory.name,
         breadcrumbs: [{
           category_id: Number(stubCategory.breadcrumbs[0].categoryId),

--- a/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
@@ -15,6 +15,8 @@ describe('DaffMagentoCategoryTransformerService', () => {
   let categoryFactory: DaffCategoryFactory;
   let stubCategory: DaffCategory;
 
+  let uri: DaffCategory['uri'];
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -25,8 +27,10 @@ describe('DaffMagentoCategoryTransformerService', () => {
     service = TestBed.inject(DaffMagentoCategoryTransformerService);
     categoryFactory = TestBed.inject(DaffCategoryFactory);
 
+    uri = 'uri';
     stubCategory = categoryFactory.create({
       id: '1',
+      uri: `${uri}.html`,
     });
   });
 
@@ -41,7 +45,8 @@ describe('DaffMagentoCategoryTransformerService', () => {
     beforeEach(() => {
       magentoCategory = {
         id: Number(stubCategory.id),
-        url_path: stubCategory.uri,
+        url_path: uri,
+        url_suffix: '.html',
         name: stubCategory.name,
         breadcrumbs: [{
           category_id: Number(stubCategory.breadcrumbs[0].categoryId),

--- a/libs/category/driver/magento/src/transformers/category-transformer.service.ts
+++ b/libs/category/driver/magento/src/transformers/category-transformer.service.ts
@@ -18,7 +18,7 @@ export class DaffMagentoCategoryTransformerService {
   transform(category: MagentoCategory): DaffCategory {
     return {
       id: String(category.id),
-      uri: category.url_path,
+      uri: `${category.url_path}${category.url_suffix}`,
       name: category.name,
       description: category.description,
       children_count: category.children_count,

--- a/libs/category/driver/magento/testing/src/factories/category.factory.spec.ts
+++ b/libs/category/driver/magento/testing/src/factories/category.factory.spec.ts
@@ -34,6 +34,7 @@ describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriver
     it('should return a category', () => {
       expect(result.id).toBeDefined();
       expect(result.url_path).toBeDefined();
+      expect(result.url_suffix).toBeDefined();
       expect(result.name).toBeDefined();
       expect(result.description).toBeDefined();
       expect(result.breadcrumbs).toBeDefined();

--- a/libs/category/driver/magento/testing/src/factories/category.factory.ts
+++ b/libs/category/driver/magento/testing/src/factories/category.factory.ts
@@ -7,6 +7,7 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 class MockMagentoCategory implements MagentoCategory {
   id = faker.random.number();
   url_path = faker.internet.url();
+  url_suffix = '.html';
   name? = faker.random.word();
   description? = faker.random.words(40);
   breadcrumbs? =  [];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The magento driver will return the category with an unqualified `uri`.


## What is the new behavior?
The magento driver will append the `url_suffix` to the end of the category `uri`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information