### PR TITLE
feat(category,navigation): replace category ID with UID in magento driver

### DIFF
--- a/libs/category/driver/magento/src/category.service.spec.ts
+++ b/libs/category/driver/magento/src/category.service.spec.ts
@@ -197,8 +197,8 @@ describe('Driver | Magento | Category | CategoryService', () => {
 
     it('should return a category with the correct info', done => {
       result.subscribe(res => {
-        expect(res.category.id).toEqual(String(mockMagentoCategory.id));
-        expect(res.category.name).toEqual(String(mockMagentoCategory.name));
+        expect(res.category.id).toEqual(mockMagentoCategory.uid);
+        expect(res.category.name).toEqual(mockMagentoCategory.name);
         done();
       });
 
@@ -271,8 +271,8 @@ describe('Driver | Magento | Category | CategoryService', () => {
 
     it('should return a category with the correct info', fakeAsync(() => {
       result.subscribe(res => {
-        expect(res.category.id).toEqual(String(mockMagentoCategory.id));
-        expect(res.category.name).toEqual(String(mockMagentoCategory.name));
+        expect(res.category.id).toEqual(mockMagentoCategory.uid);
+        expect(res.category.name).toEqual(mockMagentoCategory.name);
         flush();
       });
 
@@ -363,7 +363,7 @@ describe('Driver | Magento | Category | CategoryService', () => {
       const productsOp = controller.expectOne(MagentoGetProductsQuery);
       productsOp.flushData(mockGetProductsResponse);
 
-      expect(productsOp.operation.variables.filter.category_id.eq).toEqual(String(mockMagentoCategory.id));
+      expect(productsOp.operation.variables.filter.category_id.eq).toEqual(mockMagentoCategory.uid);
 
       flush();
     }));

--- a/libs/category/driver/magento/src/category.service.ts
+++ b/libs/category/driver/magento/src/category.service.ts
@@ -75,7 +75,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
     return combineLatest([
       this.apollo.query<MagentoGetACategoryResponse>({
         query: MagentoGetCategoryQuery,
-        variables: { filters: { ids: { eq: categoryRequest.id }}},
+        variables: { filters: { category_uid: { eq: categoryRequest.id }}},
       }),
       this.apollo.query<MagentoGetCategoryFilterTypesResponse>({
         query: MagentoGetCategoryFilterTypes,
@@ -118,7 +118,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
         query: MagentoGetProductsQuery,
         variables: this.getProductsQueryVariables({
           ...categoryRequest,
-          id: category.data.categoryList[0]?.id?.toString(),
+          id: category.data.categoryList[0]?.uid,
           kind: DaffCategoryRequestKind.ID,
         }),
       }).pipe(

--- a/libs/category/driver/magento/src/models/category.ts
+++ b/libs/category/driver/magento/src/models/category.ts
@@ -1,7 +1,7 @@
 import { MagentoProduct } from '@daffodil/product/driver/magento';
 
 export interface MagentoCategory {
-  id: number;
+  uid: string;
   url_path: string;
   url_suffix: string;
 	name?: string;
@@ -16,8 +16,8 @@ export interface MagentoCategory {
 }
 
 export interface MagentoBreadcrumb {
-  category_id: number;
-  category_name: string;
-  category_level: number;
+  category_uid: MagentoCategory['uid'];
+  category_name: MagentoCategory['name'];
+  category_level: MagentoCategory['level'];
   category_url_key: string;
 }

--- a/libs/category/driver/magento/src/queries/get-category.ts
+++ b/libs/category/driver/magento/src/queries/get-category.ts
@@ -5,14 +5,14 @@ export const DAFF_MAGENTO_GET_CATEGORY_QUERY_NAME = 'MagentoGetCategoryQuery';
 export const MagentoGetCategoryQuery = gql`
 query ${DAFF_MAGENTO_GET_CATEGORY_QUERY_NAME}($filters: CategoryFilterInput){
 	categoryList(filters: $filters) {
-		id
+		uid
     url_path
     url_suffix
 		name
 		level
 		description
 		breadcrumbs {
-			category_id
+			category_uid
 			category_name
 			category_level
 			category_url_key

--- a/libs/category/driver/magento/src/transformers/applied-filter-transformer.service.ts
+++ b/libs/category/driver/magento/src/transformers/applied-filter-transformer.service.ts
@@ -19,7 +19,7 @@ export class DaffMagentoAppliedFiltersTransformService {
   transform(categoryId: DaffCategory['id'], daffFilters: DaffCategoryFilterRequest[]): MagentoCategoryFilters {
     const magentoFilters: MagentoCategoryFilters = {
       category_id: {
-        [MagentoCategoryFilterActionEnum.Equal]: String(categoryId),
+        [MagentoCategoryFilterActionEnum.Equal]: categoryId,
       },
     };
 

--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
@@ -80,12 +80,12 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
 
     beforeEach(() => {
       category = {
-        id: Number(stubCategory.id),
+        uid: stubCategory.id,
         url_path: stubCategory.uri,
         url_suffix: '.html',
         name: stubCategory.name,
         breadcrumbs: [{
-          category_id: Number(stubCategory.breadcrumbs[0].categoryId),
+          category_uid: stubCategory.breadcrumbs[0].categoryId,
           category_name: stubCategory.breadcrumbs[0].categoryName,
           category_level: stubCategory.breadcrumbs[0].categoryLevel,
           category_url_key: stubCategory.breadcrumbs[0].categoryUrlKey,

--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.ts
@@ -16,7 +16,7 @@ export class DaffMagentoCategoryPageConfigTransformerService {
 
   transform(categoryResponse: MagentoCompleteCategoryResponse): DaffCategoryPageMetadata {
     return {
-      id: String(categoryResponse.category.id),
+      id: categoryResponse.category.uid,
       page_size: categoryResponse.page_info.page_size,
       current_page: categoryResponse.page_info.current_page,
       total_pages: categoryResponse.page_info.total_pages,

--- a/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
@@ -81,12 +81,12 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
       magentoCategoryPageConfigurationTransformerServiceSpy.transform.and.returnValue(stubCategoryPageMetadata);
 
       const category: MagentoCategory = {
-        id: Number(stubCategory.id),
         url_path: uri,
         url_suffix: '.html',
+        uid: stubCategory.id,
         name: stubCategory.name,
         breadcrumbs: [{
-          category_id: Number(stubCategory.breadcrumbs[0].categoryId),
+          category_uid: stubCategory.breadcrumbs[0].categoryId,
           category_name: stubCategory.breadcrumbs[0].categoryName,
           category_level: stubCategory.breadcrumbs[0].categoryLevel,
           category_url_key: stubCategory.breadcrumbs[0].categoryUrlKey,

--- a/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
@@ -44,12 +44,12 @@ describe('DaffMagentoCategoryTransformerService', () => {
 
     beforeEach(() => {
       magentoCategory = {
-        id: Number(stubCategory.id),
+        uid: stubCategory.id,
         url_path: uri,
         url_suffix: '.html',
         name: stubCategory.name,
         breadcrumbs: [{
-          category_id: Number(stubCategory.breadcrumbs[0].categoryId),
+          category_uid: stubCategory.breadcrumbs[0].categoryId,
           category_name: stubCategory.breadcrumbs[0].categoryName,
           category_level: stubCategory.breadcrumbs[0].categoryLevel,
           category_url_key: stubCategory.breadcrumbs[0].categoryUrlKey,
@@ -81,19 +81,19 @@ describe('DaffMagentoCategoryTransformerService', () => {
 
     it('should return breadcrumbs in order of category_level', () => {
       magentoCategory.breadcrumbs = [{
-        category_id: 3,
+        category_uid: '3',
         category_name: 'category3',
         category_level: 3,
         category_url_key: 'urlKey3',
       },
       {
-        category_id: 1,
+        category_uid: '1',
         category_name: 'category1',
         category_level: 1,
         category_url_key: 'urlKey1',
       },
       {
-        category_id: 2,
+        category_uid: '2',
         category_name: 'category2',
         category_level: 2,
         category_url_key: 'urlKey2',

--- a/libs/category/driver/magento/src/transformers/category-transformer.service.ts
+++ b/libs/category/driver/magento/src/transformers/category-transformer.service.ts
@@ -17,7 +17,7 @@ export class DaffMagentoCategoryTransformerService {
 
   transform(category: MagentoCategory): DaffCategory {
     return {
-      id: String(category.id),
+      id: category.uid,
       uri: `${category.url_path}${category.url_suffix}`,
       name: category.name,
       description: category.description,
@@ -32,7 +32,7 @@ export class DaffMagentoCategoryTransformerService {
 
   private transformBreadcrumb(breadcrumb: MagentoBreadcrumb): DaffCategoryBreadcrumb {
     return {
-      categoryId: String(breadcrumb.category_id),
+      categoryId: breadcrumb.category_uid,
       categoryName: breadcrumb.category_name,
       categoryLevel: breadcrumb.category_level,
       categoryUrlKey: breadcrumb.category_url_key,

--- a/libs/category/driver/magento/testing/src/factories/category.factory.spec.ts
+++ b/libs/category/driver/magento/testing/src/factories/category.factory.spec.ts
@@ -32,7 +32,7 @@ describe('Category | Driver | Magento | Testing | Factories | DaffCategoryDriver
     });
 
     it('should return a category', () => {
-      expect(result.id).toBeDefined();
+      expect(result.uid).toBeDefined();
       expect(result.url_path).toBeDefined();
       expect(result.url_suffix).toBeDefined();
       expect(result.name).toBeDefined();

--- a/libs/category/driver/magento/testing/src/factories/category.factory.ts
+++ b/libs/category/driver/magento/testing/src/factories/category.factory.ts
@@ -5,7 +5,7 @@ import { MagentoCategory } from '@daffodil/category/driver/magento';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 class MockMagentoCategory implements MagentoCategory {
-  id = faker.random.number();
+  uid = faker.random.alphaNumeric(10);
   url_path = faker.internet.url();
   url_suffix = '.html';
   name? = faker.random.word();

--- a/libs/category/src/models/category-breadcrumb.ts
+++ b/libs/category/src/models/category-breadcrumb.ts
@@ -1,12 +1,12 @@
-import { ID } from '@daffodil/core';
+import { DaffCategory } from './category';
 
 /**
  * A breadcrumb describing a traversal down a tree of categories, often found in an array
  * describing the traversal to a particular category within a tree of categories.
  */
 export interface DaffCategoryBreadcrumb {
-  categoryId: ID;
-  categoryName: string;
+  categoryId: DaffCategory['id'];
+  categoryName: DaffCategory['name'];
   categoryLevel: number;
   categoryUrlKey: string;
 }

--- a/libs/category/src/models/category-request.ts
+++ b/libs/category/src/models/category-request.ts
@@ -1,6 +1,7 @@
 import { ID } from '@daffodil/core';
 import { DaffSortDirectionEnum } from '@daffodil/core/state';
 
+import { DaffCategory } from './category';
 import { DaffCategoryFilterRequest } from './filters/public_api';
 
 /**
@@ -52,7 +53,7 @@ export type DaffCategoryRequest = DaffCategoryIdRequest | DaffCategoryUriRequest
  * A request used to retrieve a category by its uid.
  */
 export interface DaffCategoryIdRequest extends DaffCategoryBaseRequest {
-  id: ID;
+  id: DaffCategory['id'];
   kind: DaffCategoryRequestKind.ID;
 }
 
@@ -60,6 +61,10 @@ export interface DaffCategoryIdRequest extends DaffCategoryBaseRequest {
  * A request used to retrieve a category by its URI.
  */
 export interface DaffCategoryUriRequest extends DaffCategoryBaseRequest {
-  uri: string;
+  /**
+   * The qualified URI without domain.
+   * e.g. a/path/to/the/category.html
+   */
+  uri: DaffCategory['uri'];
   kind: DaffCategoryRequestKind.URI;
 };

--- a/libs/category/testing/src/factories/category.factory.ts
+++ b/libs/category/testing/src/factories/category.factory.ts
@@ -10,7 +10,7 @@ export class MockCategory implements DaffCategory {
 	name = faker.commerce.productMaterial();
 	description = faker.random.words(Math.floor(Math.random() * 20));
   breadcrumbs = [{
-    categoryId: String(faker.random.number({ min: 1, max: 100 })),
+    categoryId: faker.random.uuid(),
     categoryName: faker.commerce.productMaterial(),
     categoryLevel: faker.random.number({ min: 1, max: 5 }),
     categoryUrlKey: faker.commerce.productMaterial(),

--- a/libs/navigation/driver/magento/src/models/category-node.ts
+++ b/libs/navigation/driver/magento/src/models/category-node.ts
@@ -1,6 +1,6 @@
 export interface CategoryNode {
   __typename?: string;
-  id: number;
+  uid: string;
   name?: string;
   include_in_menu: boolean;
   product_count: number;
@@ -12,8 +12,8 @@ export interface CategoryNode {
 }
 
 export interface MagentoBreadcrumb {
-  category_id: number;
-  category_name: string;
-  category_level: number;
+  category_uid: CategoryNode['uid'];
+  category_name: CategoryNode['name'];
+  category_level: CategoryNode['level'];
   category_url_key: string;
 }

--- a/libs/navigation/driver/magento/src/navigation.service.spec.ts
+++ b/libs/navigation/driver/magento/src/navigation.service.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '@daffodil/navigation/driver/magento';
 import { DaffNavigationTreeFactory } from '@daffodil/navigation/testing';
 
+import { GetCategoryTreeResponse } from './models/public_api';
 import { DaffMagentoNavigationService } from './navigation.service';
 
 describe('Driver | Magento | Navigation | NavigationService', () => {
@@ -60,6 +61,20 @@ describe('Driver | Magento | Navigation | NavigationService', () => {
   describe('get | getting a single navigation', () => {
     it('should return an observable single navigation', done => {
       const navigation = navigationTreeFactory.create();
+      const response: GetCategoryTreeResponse = {
+        categoryList: [{
+          __typename: 'CategoryTree',
+          uid: navigation.id,
+          name: navigation.name,
+          include_in_menu: true,
+          level: 0,
+          position: 1,
+          product_count: navigation.total_products,
+          children_count: navigation.children_count,
+          children: [],
+          breadcrumbs: [],
+        }],
+      };
 
       navigationService.get(navigation.id).subscribe((result) => {
         expect(result.id).toEqual(navigation.id);
@@ -71,23 +86,10 @@ describe('Driver | Magento | Navigation | NavigationService', () => {
 
       const op = controller.expectOne(addTypenameToDocument(daffMagentoGetCategoryTree(queryDepth)));
 
-      expect(op.operation.variables.filters).toEqual({ ids: { eq: navigation.id }});
+      expect(op.operation.variables.filters).toEqual({ category_uid: { eq: navigation.id }});
 
       op.flush({
-        data: {
-          categoryList: [{
-            __typename: 'CategoryTree',
-            id: navigation.id,
-            name: navigation.name,
-            include_in_menu: true,
-            level: 0,
-            position: 1,
-            product_count: navigation.total_products,
-            children_count: navigation.children_count,
-            children: [],
-            breadcrumbs: [],
-          }],
-        },
+        data: response,
       });
     });
 

--- a/libs/navigation/driver/magento/src/navigation.service.ts
+++ b/libs/navigation/driver/magento/src/navigation.service.ts
@@ -32,7 +32,7 @@ export class DaffMagentoNavigationService implements DaffNavigationServiceInterf
     return this.apollo.query<GetCategoryTreeResponse>({
       query: daffMagentoGetCategoryTree(this.categoryTreeQueryDepth),
       variables: {
-        filters: { ids: { eq: categoryId }},
+        filters: { category_uid: { eq: categoryId }},
       },
     }).pipe(
       map(result => this.transformer.transform(result.data.categoryList[0])),

--- a/libs/navigation/driver/magento/src/queries/fragments/category-node.spec.ts
+++ b/libs/navigation/driver/magento/src/queries/fragments/category-node.spec.ts
@@ -20,9 +20,9 @@ import { CategoryNode } from '@daffodil/navigation/driver/magento';
 
 import { getCategoryNodeFragment } from './category-node';
 
-const generateMagentoCategoryTree = (id): CategoryNode => ({
+const generateMagentoCategoryTree = (id: CategoryNode['uid']): CategoryNode => ({
   __typename: 'CategoryTree',
-  id,
+  uid: id,
   name: 'name',
   include_in_menu: true,
   level: 0,
@@ -60,22 +60,22 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
     apollo = TestBed.inject(Apollo);
     controller = TestBed.inject(ApolloTestingController);
 
-    childlessNavigationTree = generateMagentoCategoryTree(1);
+    childlessNavigationTree = generateMagentoCategoryTree('1');
     delete childlessNavigationTree.children;
     delete childlessNavigationTree.children_count;
     depth1NavigationTree = {
-      ...generateMagentoCategoryTree(2),
+      ...generateMagentoCategoryTree('2'),
       children_count: 1,
       children: [childlessNavigationTree],
     };
     depth3NavigationTree = {
-      ...generateMagentoCategoryTree(3),
+      ...generateMagentoCategoryTree('3'),
       children_count: 1,
       children: [{
-        ...generateMagentoCategoryTree(4),
+        ...generateMagentoCategoryTree('4'),
         children_count: 1,
         children: [{
-          ...generateMagentoCategoryTree(5),
+          ...generateMagentoCategoryTree('5'),
           children_count: 1,
           children: [childlessNavigationTree],
         }],
@@ -202,7 +202,7 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
   //This test only exists to test the workaround.
   it('should not use nested fragments', () => {
     const expectedFields = [
-      'id',
+      'uid',
       'level',
       'name',
       'include_in_menu',

--- a/libs/navigation/driver/magento/src/queries/fragments/category-node.ts
+++ b/libs/navigation/driver/magento/src/queries/fragments/category-node.ts
@@ -6,12 +6,12 @@ import { DocumentNode } from 'graphql';
  * A category tree fragment with no nested children.
  */
 const categoryNodeFragment = `
-	id
+	uid
 	level
 	name
 	include_in_menu
 	breadcrumbs {
-		category_id
+		category_uid
 		category_name
 		category_level
 		category_url_key

--- a/libs/navigation/driver/magento/src/transformers/navigation-transformer.spec.ts
+++ b/libs/navigation/driver/magento/src/transformers/navigation-transformer.spec.ts
@@ -19,7 +19,7 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
     service = TestBed.inject(DaffMagentoNavigationTransformerService);
 
     categoryNode = {
-      id: 1,
+      uid: '1',
       name: 'Root Category',
       include_in_menu: true,
       product_count: 10,
@@ -27,7 +27,7 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
       children_count: 0,
       children: [
         {
-          id: 2,
+          uid: '2',
           include_in_menu: true,
           name: 'Subcategory',
           product_count: 10,
@@ -36,13 +36,13 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
           position: 2,
           breadcrumbs: [
             {
-              category_id: 2,
+              category_uid: '2',
               category_level: 2,
               category_name: 'name2',
               category_url_key: 'url2',
             },
             {
-              category_id: 1,
+              category_uid: '1',
               category_level: 1,
               category_name: 'name',
               category_url_key: 'url',
@@ -50,7 +50,7 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
           ],
         },
         {
-          id: 3,
+          uid: '3',
           include_in_menu: false,
           name: 'Subcategory',
           product_count: 10,
@@ -60,7 +60,7 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
           breadcrumbs: [],
         },
         {
-          id: 5,
+          uid: '5',
           include_in_menu: true,
           name: 'Subcategory',
           product_count: 10,
@@ -130,8 +130,8 @@ describe('Driver | Magento | Navigation | Transformers | DaffMagentoNavigationTr
 
   it('should order the categories by position', () => {
     const categoryResult = service.transform(categoryNode);
-    expect(categoryResult.children[0].id).toEqual(categoryNode.children[2].id.toString());
-    expect(categoryResult.children[1].id).toEqual(categoryNode.children[0].id.toString());
+    expect(categoryResult.children[0].id).toEqual(categoryNode.children[2].uid.toString());
+    expect(categoryResult.children[1].id).toEqual(categoryNode.children[0].uid.toString());
   });
 
   it('should order the breadcrumbs by level', () => {

--- a/libs/navigation/driver/magento/src/transformers/navigation-transformer.ts
+++ b/libs/navigation/driver/magento/src/transformers/navigation-transformer.ts
@@ -17,7 +17,7 @@ import {
 export class DaffMagentoNavigationTransformerService implements DaffNavigationTransformerInterface<DaffNavigationTree> {
 
   transform(node: CategoryNode): DaffNavigationTree {
-    const id = String(node.id);
+    const id = node.uid;
     return {
       id,
       path: id,
@@ -36,7 +36,7 @@ export class DaffMagentoNavigationTransformerService implements DaffNavigationTr
 
   private transformBreadcrumb(breadcrumb: MagentoBreadcrumb): DaffNavigationBreadcrumb {
     return {
-      categoryId: String(breadcrumb.category_id),
+      categoryId: breadcrumb.category_uid,
       categoryName: breadcrumb.category_name,
       categoryLevel: breadcrumb.category_level,
       categoryUrlKey: breadcrumb.category_url_key,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The category and navigation magento drivers use the deprecated category `id`.


## What is the new behavior?
Those drivers use the new `uid` field and query the category with `category_uid`. Many string coercions were removed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information