### PR TITLE
feat(category,product): replace deprecated Magento ID with UID

### DIFF
--- a/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
@@ -58,7 +58,7 @@ describe('DaffMagentoCategoryTransformerService', () => {
         products: {
           items: [{
             __typename: 'simple',
-            id: 1,
+            uid: '1',
             name: 'name',
             sku: stubCategory.product_ids[0],
             url_key: 'url_key',

--- a/libs/product/driver/magento/src/models/bundled-product.ts
+++ b/libs/product/driver/magento/src/models/bundled-product.ts
@@ -22,7 +22,7 @@ export interface MagentoBundledProductItem {
 }
 
 export interface MagentoBundledProductItemOption {
-	id: number;
+	uid: string;
 	label: string;
 	price: number;
 	quantity: number;

--- a/libs/product/driver/magento/src/models/configurable-product.ts
+++ b/libs/product/driver/magento/src/models/configurable-product.ts
@@ -9,7 +9,7 @@ export interface MagentoConfigurableProduct extends MagentoProduct {
 export interface MagentoConfigurableProductOption {
 	attribute_code:	string;
 	attribute_id:	string;
-	id:	number;
+	uid:	number;
 	label: string;
 	position:	number;
 	product_id:	number;

--- a/libs/product/driver/magento/src/models/magento-product.ts
+++ b/libs/product/driver/magento/src/models/magento-product.ts
@@ -14,7 +14,7 @@ export enum MagentoProductStockStatusEnum {
  */
 export interface MagentoProduct {
 	__typename: string;
-  id: number;
+  uid: string;
   name: string;
   sku: string;
   url_key: string;
@@ -45,7 +45,7 @@ export interface MagentoProduct {
 		file: string;
 		position: number;
 		disabled: boolean;
-		id: number;
+		uid: string;
 	}[];
   short_description?: {
 		html: string;

--- a/libs/product/driver/magento/src/models/simple-product.ts
+++ b/libs/product/driver/magento/src/models/simple-product.ts
@@ -1,7 +1,7 @@
 import { MagentoProduct } from './magento-product';
 
 export interface MagentoSimpleProduct extends MagentoProduct {
-	id: number;
+	uid: string;
 	name: string;
 	sku: string;
 }

--- a/libs/product/driver/magento/src/product.service.ts
+++ b/libs/product/driver/magento/src/product.service.ts
@@ -43,7 +43,7 @@ export class DaffMagentoProductService implements DaffProductServiceInterface {
   ) {}
 
   /**
-   * Get an Observable of a DaffProduct by id.
+   * Get an Observable of a DaffProduct by uid.
    *
    * @param productId a product Id
    */

--- a/libs/product/driver/magento/src/queries/fragments/bundled-product.ts
+++ b/libs/product/driver/magento/src/queries/fragments/bundled-product.ts
@@ -12,7 +12,7 @@ export const magentoBundledProductFragment = gql`
 			type
 			options {
 				can_change_quantity
-				id
+				uid
 				is_default
 				label
 				position
@@ -20,7 +20,7 @@ export const magentoBundledProductFragment = gql`
 				price
 				quantity
 				product {
-					id
+					uid
 					name
 					sku
 					stock_status

--- a/libs/product/driver/magento/src/queries/fragments/configurable-product.ts
+++ b/libs/product/driver/magento/src/queries/fragments/configurable-product.ts
@@ -6,7 +6,7 @@ export const magentoConfigurableProductFragment = gql`
 		configurable_options {
 			attribute_code
 			attribute_id
-			id
+			uid
 			label
 			position
 			product_id

--- a/libs/product/driver/magento/src/queries/fragments/product.ts
+++ b/libs/product/driver/magento/src/queries/fragments/product.ts
@@ -7,7 +7,7 @@ import { magentoSimpleProductFragment } from './simple-product';
 export const magentoProductFragment = gql`
   fragment product on ProductInterface {
 		__typename
-		id
+		uid
 		url_key
     url_suffix
 		name
@@ -38,7 +38,7 @@ export const magentoProductFragment = gql`
 			file
 			position
 			disabled
-			id
+			uid
 		}
 		short_description {
 			html

--- a/libs/product/driver/magento/src/transforms/bundled-product-transformers.ts
+++ b/libs/product/driver/magento/src/transforms/bundled-product-transformers.ts
@@ -48,7 +48,7 @@ function transformMagentoBundledProductItem(item: MagentoBundledProductItem): Da
 
 function transformMagentoBundledProductItemOption(option: MagentoBundledProductItemOption): DaffCompositeProductItemOption {
   return {
-    id: option.id.toString(),
+    id: option.uid.toString(),
     name: option.label,
     price: getPrice(option.product),
     images: [],

--- a/libs/product/driver/magento/src/transforms/configurable-product-transformers.spec.ts
+++ b/libs/product/driver/magento/src/transforms/configurable-product-transformers.spec.ts
@@ -54,7 +54,7 @@ describe('DaffMagentoConfigurableProductTransformers', () => {
       const magentoConfigurableProductOption: MagentoConfigurableProductOption = {
         attribute_id: null,
         product_id: null,
-        id: null,
+        uid: null,
         position: daffConfigurableProduct.configurableAttributes[0].order,
         attribute_code: daffConfigurableProduct.configurableAttributes[0].code,
         label: daffConfigurableProduct.configurableAttributes[0].label,

--- a/libs/product/driver/magento/src/transforms/simple-product-transformers.ts
+++ b/libs/product/driver/magento/src/transforms/simple-product-transformers.ts
@@ -56,6 +56,6 @@ function transformMediaGalleryEntries(product: MagentoProduct, mediaUrl: string)
   return product.media_gallery_entries ? product.media_gallery_entries.map(image => ({
     url: mediaUrl + 'catalog/product' + image.file,
     label: image.label,
-    id: image.id.toString(),
+    id: image.uid.toString(),
   })) : [];
 }

--- a/libs/product/driver/magento/src/transforms/spec-data/magento-bundled-product.json
+++ b/libs/product/driver/magento/src/transforms/spec-data/magento-bundled-product.json
@@ -1,6 +1,6 @@
 {
 	"__typename": "BundleProduct",
-	"id": 213,
+	"uid": "213",
 	"image": {
 		"label": "image-label",
 		"url": "image-url"
@@ -37,14 +37,14 @@
 			"type": "select",
 			"options": [
 				{
-					"id": 1,
+					"uid": "1",
 					"label": "Option 1",
 					"price": 10,
 					"quantity": 1,
 					"is_default": true,
 					"product": {
 						"__typename": "name",
-						"id": 14,
+						"uid": "14",
 						"name": "name",
 						"image": {
 							"label": "image-label",
@@ -72,14 +72,14 @@
 					}
 				},
 				{
-					"id": 2,
+					"uid": "2",
 					"label": "Option 2",
 					"price": 12,
 					"quantity": 1,
 					"is_default": false,
 					"product": {
 						"__typename": "name",
-						"id": 24,
+						"uid": "24",
 						"name": "name",
 						"image": {
 							"label": "image-label",

--- a/libs/product/driver/magento/src/transforms/spec-data/magento-configurable-product.json
+++ b/libs/product/driver/magento/src/transforms/spec-data/magento-configurable-product.json
@@ -1,6 +1,6 @@
 {
   "__typename": "configurable",
-  "id": 213,
+  "uid": "213",
   "image": {
     "label": "image-label",
     "url": "image-url"
@@ -58,7 +58,7 @@
       ],
       "attribute_id": null,
       "product_id": null,
-      "id": null
+      "uid": null
     },
     {
       "position": 1,
@@ -83,7 +83,7 @@
       ],
       "attribute_id": null,
       "product_id": null,
-      "id": null
+      "uid": null
     },
     {
       "position": 2,
@@ -108,7 +108,7 @@
       ],
       "attribute_id": null,
       "product_id": null,
-      "id": null
+      "uid": null
     }
   ],
   "variants": [
@@ -148,7 +148,7 @@
           }
         },
         "sku": "22-1",
-        "id": null,
+        "uid": null,
         "name": null,
         "__typename": null,
         "url_key": null,
@@ -192,7 +192,7 @@
           }
         },
         "sku": "22-11",
-        "id": null,
+        "uid": null,
         "name": null,
         "__typename": null,
         "url_key": null,
@@ -236,7 +236,7 @@
           }
         },
         "sku": "22-12",
-        "id": null,
+        "uid": null,
         "name": null,
         "__typename": null,
         "url_key": null,
@@ -280,7 +280,7 @@
           }
         },
         "sku": "22-13",
-        "id": null,
+        "uid": null,
         "name": null,
         "__typename": null,
         "url_key": null,
@@ -324,7 +324,7 @@
           }
         },
         "sku": "22-2",
-        "id": null,
+        "uid": null,
         "name": null,
         "__typename": null,
         "url_key": null,
@@ -368,7 +368,7 @@
           }
         },
         "sku": "22-21",
-        "id": null,
+        "uid": null,
         "name": null,
         "__typename": null,
         "url_key": null,
@@ -412,7 +412,7 @@
           }
         },
         "sku": "22-22",
-        "id": null,
+        "uid": null,
         "name": null,
         "__typename": null,
         "url_key": null,
@@ -456,7 +456,7 @@
           }
         },
         "sku": "22-23",
-        "id": null,
+        "uid": null,
         "name": null,
         "__typename": null,
         "url_key": null,
@@ -500,7 +500,7 @@
           }
         },
         "sku": "22-3",
-        "id": null,
+        "uid": null,
         "name": null,
         "__typename": null,
         "url_key": null,
@@ -544,7 +544,7 @@
           }
         },
         "sku": "22-31",
-        "id": null,
+        "uid": null,
         "name": null,
         "__typename": null,
         "url_key": null,

--- a/libs/product/driver/magento/testing/src/factories/bundle/bundle.factory.spec.ts
+++ b/libs/product/driver/magento/testing/src/factories/bundle/bundle.factory.spec.ts
@@ -28,7 +28,7 @@ describe('Product | Testing | Factories | MagentoBundledProductFactory', () => {
 
     it('should return a MagentoBundledProduct with all required fields defined', () => {
       expect(result.__typename).toBeDefined();
-      expect(result.id).toBeDefined();
+      expect(result.uid).toBeDefined();
       expect(result.image.label).toBeDefined();
       expect(result.image.url).toBeDefined();
       expect(result.thumbnail.label).toBeDefined();

--- a/libs/product/driver/magento/testing/src/factories/configurable/configurable.factory.spec.ts
+++ b/libs/product/driver/magento/testing/src/factories/configurable/configurable.factory.spec.ts
@@ -31,7 +31,7 @@ describe('Product | Testing | Factories | MagentoConfigurableProductFactory', ()
 
     it('should return a MagentoConfigurableProduct with all required fields defined', () => {
       expect(result.__typename).toEqual(MagentoProductTypeEnum.ConfigurableProduct);
-      expect(result.id).toBeDefined();
+      expect(result.uid).toBeDefined();
       expect(result.image.label).toBeDefined();
       expect(result.image.url).toBeDefined();
       expect(result.thumbnail.label).toBeDefined();

--- a/libs/product/driver/magento/testing/src/factories/configurable/configurable.factory.ts
+++ b/libs/product/driver/magento/testing/src/factories/configurable/configurable.factory.ts
@@ -23,7 +23,7 @@ export class MockMagentoConfigurableProduct extends MockMagentoCoreProduct imple
 	  {
 	    attribute_code: 'color',
 	    attribute_id: faker.random.alphaNumeric(12),
-	    id: faker.random.uuid(),
+	    uid: faker.random.uuid(),
 	    label: 'Color',
 	    position: 0,
 	    product_id: faker.random.number({ min: 1, max: 1000 }),
@@ -54,7 +54,7 @@ export class MockMagentoConfigurableProduct extends MockMagentoCoreProduct imple
 	    ],
 	    product: {
 	      __typename: MagentoProductTypeEnum.SimpleProduct,
-	      id: faker.random.uuid(),
+	      uid: faker.random.uuid(),
 	      url_key: faker.random.alphaNumeric(16),
 	      url_suffix: '.html',
 	      name: faker.random.word(),
@@ -98,7 +98,7 @@ export class MockMagentoConfigurableProduct extends MockMagentoCoreProduct imple
 	    ],
 	    product: {
 	      __typename: MagentoProductTypeEnum.SimpleProduct,
-	      id: faker.random.uuid(),
+	      uid: faker.random.uuid(),
 	      url_key: faker.random.alphaNumeric(16),
 	      url_suffix: '.html',
 	      name: faker.random.word(),
@@ -141,7 +141,7 @@ export class MockMagentoConfigurableProduct extends MockMagentoCoreProduct imple
 	    ],
 	    product: {
 	      __typename: MagentoProductTypeEnum.SimpleProduct,
-	      id: faker.random.uuid(),
+	      uid: faker.random.uuid(),
 	      url_key: faker.random.alphaNumeric(16),
 	      url_suffix: '.html',
 	      name: faker.random.word(),

--- a/libs/product/driver/magento/testing/src/factories/core/product.factory.spec.ts
+++ b/libs/product/driver/magento/testing/src/factories/core/product.factory.spec.ts
@@ -28,7 +28,7 @@ describe('Product | Testing | Factories | MagentoCoreProductFactory', () => {
 
     it('should return a MagentoProduct with all required fields defined', () => {
       expect(result.__typename).toBeDefined();
-      expect(result.id).toBeDefined();
+      expect(result.uid).toBeDefined();
       expect(result.image.label).toBeDefined();
       expect(result.image.url).toBeDefined();
       expect(result.thumbnail.label).toBeDefined();

--- a/libs/product/driver/magento/testing/src/factories/core/product.factory.ts
+++ b/libs/product/driver/magento/testing/src/factories/core/product.factory.ts
@@ -10,7 +10,7 @@ import {
 
 export class MockMagentoCoreProduct implements MagentoProduct {
 	__typename = MagentoProductTypeEnum.SimpleProduct;
-  id = faker.random.uuid();
+  uid = faker.random.uuid();
   url_key = faker.random.alphaNumeric(16);
   url_suffix = '.html';
   name = faker.random.word();

--- a/libs/product/driver/magento/testing/src/factories/simple/simple.factory.spec.ts
+++ b/libs/product/driver/magento/testing/src/factories/simple/simple.factory.spec.ts
@@ -28,7 +28,7 @@ describe('Product | Testing | Factories | MagentoSimpleProductFactory', () => {
 
     it('should return a MagentoSimpleProduct with all required fields defined', () => {
       expect(result.__typename).toBeDefined();
-      expect(result.id).toBeDefined();
+      expect(result.uid).toBeDefined();
       expect(result.image.label).toBeDefined();
       expect(result.image.url).toBeDefined();
       expect(result.thumbnail.label).toBeDefined();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The product magento driver uses the deprecated `id` field and associated query filters.


## What is the new behavior?
The driver now does not use deprecated features.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information