### PR TITLE
feat(category): normalize state URL in URI resolver before dispatching

### DIFF
--- a/libs/category/routing/src/resolvers/category-page-uri/category-page-uri.resolver.spec.ts
+++ b/libs/category/routing/src/resolvers/category-page-uri/category-page-uri.resolver.spec.ts
@@ -76,6 +76,11 @@ describe('DaffCategoryPageUriResolver', () => {
               component: TestComponent,
             },
             {
+              path: 'outlet',
+              component: TestComponent,
+              outlet: 'secondary'
+            },
+            {
               path: '**',
               component: TestComponent,
             },
@@ -98,15 +103,15 @@ describe('DaffCategoryPageUriResolver', () => {
       router.initialNavigation();
     }));
 
-    it('should dispatch a DaffCategoryPageLoadByUri action with the correct category url', fakeAsync(() => {
-      const url = `/${path}?asfgsfd=afdgsdf#asadiufy`;
+    it('should dispatch a DaffCategoryPageLoadByUri action with the normalized category url', fakeAsync(() => {
+      const url = `/${path}(secondary:outlet)`;
       router.navigateByUrl(url);
       tick();
 
       spyOn(store, 'dispatch');
       categoryResolver.resolve(route.snapshot, router.routerState.snapshot);
       expect(store.dispatch).toHaveBeenCalledWith(
-        new DaffCategoryPageLoadByUri({ uri: url, page_size: 12, kind: DaffCategoryRequestKind.URI }),
+        new DaffCategoryPageLoadByUri({ uri: `/${path}`, page_size: 12, kind: DaffCategoryRequestKind.URI }),
       );
     }));
 
@@ -162,6 +167,11 @@ describe('DaffCategoryPageUriResolver', () => {
               component: TestComponent,
             },
             {
+              path: 'outlet',
+              component: TestComponent,
+              outlet: 'secondary'
+            },
+            {
               path: '**',
               component: TestComponent,
             },
@@ -184,14 +194,14 @@ describe('DaffCategoryPageUriResolver', () => {
     }));
 
     it('should dispatch a DaffCategoryPageLoadByUri action with the correct category id', fakeAsync(() => {
-      const url = `/${path}?asfgsfd=afdgsdf#asadiufy`;
+      const url = `/${path}(secondary:outlet)`;
       router.navigateByUrl(url);
       tick();
 
       spyOn(store, 'dispatch');
       categoryResolver.resolve(route.snapshot, router.routerState.snapshot);
       expect(store.dispatch).toHaveBeenCalledWith(
-        new DaffCategoryPageLoadByUri({ uri: url, page_size: 12, kind: DaffCategoryRequestKind.URI }),
+        new DaffCategoryPageLoadByUri({ uri: `/${path}`, page_size: 12, kind: DaffCategoryRequestKind.URI }),
       );
     }));
 

--- a/libs/category/routing/src/resolvers/category-page-uri/category-page-uri.resolver.spec.ts
+++ b/libs/category/routing/src/resolvers/category-page-uri/category-page-uri.resolver.spec.ts
@@ -78,7 +78,7 @@ describe('DaffCategoryPageUriResolver', () => {
             {
               path: 'outlet',
               component: TestComponent,
-              outlet: 'secondary'
+              outlet: 'secondary',
             },
             {
               path: '**',
@@ -169,7 +169,7 @@ describe('DaffCategoryPageUriResolver', () => {
             {
               path: 'outlet',
               component: TestComponent,
-              outlet: 'secondary'
+              outlet: 'secondary',
             },
             {
               path: '**',

--- a/libs/category/routing/src/resolvers/category-page-uri/category-page-uri.resolver.ts
+++ b/libs/category/routing/src/resolvers/category-page-uri/category-page-uri.resolver.ts
@@ -48,7 +48,7 @@ export class DaffCategoryPageUriResolver implements Resolve<Observable<boolean>>
     private store: Store<DaffCategoryReducersState>,
     private dispatcher: ActionsSubject,
     private urlNormalizer: DaffRoutingUriNormalizer,
-    ) { }
+  ) { }
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
     this.store.dispatch(new DaffCategoryPageLoadByUri({

--- a/libs/category/routing/src/resolvers/category-page-uri/category-page-uri.resolver.ts
+++ b/libs/category/routing/src/resolvers/category-page-uri/category-page-uri.resolver.ts
@@ -30,11 +30,13 @@ import {
   DaffDefaultCategoryPageSize,
   DaffCategoryPageLoadByUri,
 } from '@daffodil/category/state';
+import { DaffRoutingUriNormalizer } from '@daffodil/core/routing';
 
 /**
  * Resolves category data for category pages, and will only resolve the url
  * after a category request succeeds or fails. This resolver will take a full
- * a url of the form `some/url` and attempt to resolve a category from it.
+ * a url of the form `some/url.html(secondary:outlet)?query=param#fragment` and attempt to resolve a product from it.
+ * Assumes that the URL to be resolved is the primary outlet.
  */
 @Injectable({
   providedIn: 'root',
@@ -45,11 +47,12 @@ export class DaffCategoryPageUriResolver implements Resolve<Observable<boolean>>
     @Inject(DaffDefaultCategoryPageSize) private defaultCategoryPageSize: number,
     private store: Store<DaffCategoryReducersState>,
     private dispatcher: ActionsSubject,
-  ) { }
+    private urlNormalizer: DaffRoutingUriNormalizer,
+    ) { }
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
     this.store.dispatch(new DaffCategoryPageLoadByUri({
-      uri: state.url,
+      uri: this.urlNormalizer.normalize(state.url),
       page_size: this.defaultCategoryPageSize,
       kind: DaffCategoryRequestKind.URI,
     }));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

category uri resolver will dispatch action without normalizing `state.url`, which could contain paths for other routing outlets


## What is the new behavior?
category uri resolver will normalize `state.url` before dispatching action

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information