### PR TITLE
feat(core): handle missing leading slash in query fragment truncation

### DIFF
--- a/libs/core/routing/src/uri/truncation/query-fragment.spec.ts
+++ b/libs/core/routing/src/uri/truncation/query-fragment.spec.ts
@@ -15,6 +15,17 @@ describe('@daffodil/core/routing | daffUriTruncateQueryFragment', () => {
     });
   });
 
+  describe('when the string does not have a leading slash', () => {
+    beforeEach(() => {
+      testStr = 'foo';
+      result = daffUriTruncateQueryFragment(testStr);
+    });
+
+    it('should return the original string with a leading slash', () => {
+      expect(result).toEqual(`/${testStr}`);
+    });
+  });
+
   describe('when the string has query parameters', () => {
     beforeEach(() => {
       testStr = '/foo?test=thing';

--- a/libs/core/routing/src/uri/truncation/query-fragment.ts
+++ b/libs/core/routing/src/uri/truncation/query-fragment.ts
@@ -1,7 +1,6 @@
 /**
  * Truncates query parameters and fragments from a URI.
  * e.g. /foo/bar/baz.html?thing=test#id -> /foo/bar/baz.html
- * Note that this will not work as expected unless `uri` has a leading slash.
  */
 export const daffUriTruncateQueryFragment = (uri: string): string =>
-  (new URL(`http://fakedomain.com${uri}`)).pathname;
+  (new URL(`http://fakedomain.com${uri.charAt(0) === '/' ? '' : '/'}${uri}`)).pathname;

--- a/libs/core/routing/src/uri/truncation/query-fragment.ts
+++ b/libs/core/routing/src/uri/truncation/query-fragment.ts
@@ -1,6 +1,7 @@
 /**
  * Truncates query parameters and fragments from a URI.
  * e.g. /foo/bar/baz.html?thing=test#id -> /foo/bar/baz.html
+ * Note that this will not work as expected unless `uri` has a leading slash.
  */
 export const daffUriTruncateQueryFragment = (uri: string): string =>
   (new URL(`http://fakedomain.com${uri}`)).pathname;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

query param truncation fails if the uri does not have a leading slash


## What is the new behavior?

query param truncation works as expected if the uri does not have a leading slash

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information