### PR TITLE
feat(external-router): truncate driver request and response

### DIFF
--- a/libs/external-router/driver/magento/2.4.1/src/magento.service.ts
+++ b/libs/external-router/driver/magento/2.4.1/src/magento.service.ts
@@ -6,6 +6,7 @@ import { Apollo } from 'apollo-angular';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+import { daffUriTruncateQueryFragment } from '@daffodil/core/routing';
 import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
 import { DaffExternalRouterDriverInterface } from '@daffodil/external-router/driver';
 import { MagentoUrlResolverResponse } from '@daffodil/external-router/driver/magento';
@@ -29,7 +30,7 @@ implements DaffExternalRouterDriverInterface {
       .query<MagentoUrlResolverResponse>({
         query: MagentoResolveUrlv241,
         variables: {
-          url,
+          url: daffUriTruncateQueryFragment(url),
         },
       })
       .pipe(map(response => transformResolutionToResolvableUrlv241(response.data.urlResolver)));

--- a/libs/external-router/driver/magento/2.4.1/src/transforms/resolution-to-resolvable-url.spec.ts
+++ b/libs/external-router/driver/magento/2.4.1/src/transforms/resolution-to-resolvable-url.spec.ts
@@ -16,7 +16,7 @@ describe('@daffodil/external-router/driver/magento | transformResolutionToResolv
     numberId = 5;
     url = 'url';
     resolution = {
-      relative_url: `/${url}`,
+      relative_url: `/${url}?query=param#fragment`,
       type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
       redirectCode: 0,
       id: numberId,

--- a/libs/external-router/driver/magento/2.4.1/src/transforms/resolution-to-resolvable-url.spec.ts
+++ b/libs/external-router/driver/magento/2.4.1/src/transforms/resolution-to-resolvable-url.spec.ts
@@ -16,7 +16,7 @@ describe('@daffodil/external-router/driver/magento | transformResolutionToResolv
     numberId = 5;
     url = 'url';
     resolution = {
-      relative_url: url,
+      relative_url: `/${url}`,
       type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
       redirectCode: 0,
       id: numberId,

--- a/libs/external-router/driver/magento/2.4.1/src/transforms/resolution-to-resolvable-url.ts
+++ b/libs/external-router/driver/magento/2.4.1/src/transforms/resolution-to-resolvable-url.ts
@@ -1,4 +1,7 @@
-import { daffUriTruncateLeadingSlash } from '@daffodil/core/routing';
+import {
+  daffUriTruncateLeadingSlash,
+  daffUriTruncateQueryFragment,
+} from '@daffodil/core/routing';
 import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
 import { MagentoUrlResolver } from '@daffodil/external-router/driver/magento';
 
@@ -6,6 +9,6 @@ export const transformResolutionToResolvableUrlv241 = (
   resolution: MagentoUrlResolver,
 ): DaffExternallyResolvableUrl => ({
   id: resolution.id?.toString(),
-  url: daffUriTruncateLeadingSlash(resolution.relative_url),
+  url: daffUriTruncateLeadingSlash(daffUriTruncateQueryFragment(resolution.relative_url)),
   type: resolution.type,
 });

--- a/libs/external-router/driver/magento/2.4.1/src/transforms/resolution-to-resolvable-url.ts
+++ b/libs/external-router/driver/magento/2.4.1/src/transforms/resolution-to-resolvable-url.ts
@@ -1,3 +1,4 @@
+import { daffUriTruncateLeadingSlash } from '@daffodil/core/routing';
 import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
 import { MagentoUrlResolver } from '@daffodil/external-router/driver/magento';
 
@@ -5,6 +6,6 @@ export const transformResolutionToResolvableUrlv241 = (
   resolution: MagentoUrlResolver,
 ): DaffExternallyResolvableUrl => ({
   id: resolution.id?.toString(),
-  url: resolution.relative_url,
+  url: daffUriTruncateLeadingSlash(resolution.relative_url),
   type: resolution.type,
 });

--- a/libs/external-router/driver/magento/2.4.2/src/magento.service.spec.ts
+++ b/libs/external-router/driver/magento/2.4.2/src/magento.service.spec.ts
@@ -80,16 +80,5 @@ describe('@daffodil/external-router/driver/magento/2.4.2 | DaffExternalRouterMag
         data: resolution,
       });
     });
-
-    describe('when the request URL has query params and fragments', () => {
-      it('should make the request with a truncated URL', () => {
-        setupTest();
-
-        service.resolve(`${requestUrl}?with=query#fragment`).subscribe();
-
-        const op = controller.expectOne(MagentoResolveUrlv242);
-        expect(op.operation.variables.url).toEqual(requestUrl);
-      });
-    });
   });
 });

--- a/libs/external-router/driver/magento/2.4.2/src/magento.service.spec.ts
+++ b/libs/external-router/driver/magento/2.4.2/src/magento.service.spec.ts
@@ -21,7 +21,8 @@ describe('@daffodil/external-router/driver/magento/2.4.2 | DaffExternalRouterMag
   let controller: ApolloTestingController;
   let scheduler: TestScheduler;
   let id: ID;
-  let url: string;
+  let responseUrl: string;
+  let requestUrl: string;
   let resolution: MagentoUrlResolverResponse;
   let resolvableUrl: DaffExternallyResolvableUrl;
 
@@ -39,11 +40,12 @@ describe('@daffodil/external-router/driver/magento/2.4.2 | DaffExternalRouterMag
       expect(actual).toEqual(expected);
     });
 
-    url = 'url';
+    responseUrl = 'url';
+    requestUrl = `/${responseUrl}`;
     id = 'id';
     resolution = {
       urlResolver: {
-        relative_url: url,
+        relative_url: responseUrl,
         type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
         redirectCode: 0,
         entity_uid: id,
@@ -52,7 +54,7 @@ describe('@daffodil/external-router/driver/magento/2.4.2 | DaffExternalRouterMag
 
     resolvableUrl = {
       id,
-      url,
+      url:responseUrl,
       type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
     };
   };
@@ -66,9 +68,8 @@ describe('@daffodil/external-router/driver/magento/2.4.2 | DaffExternalRouterMag
     it('should return a resolvable url when using the v2.4.2', done => {
       setupTest();
 
-      service.resolve(url).subscribe(result => {
-        console.log(result);
-        expect(result.url).toEqual(url);
+      service.resolve(requestUrl).subscribe(result => {
+        expect(result.url).toEqual(responseUrl);
         expect(result.type).toEqual(MagentoUrlRewriteEntityTypeEnum.PRODUCT);
         done();
       });
@@ -77,6 +78,17 @@ describe('@daffodil/external-router/driver/magento/2.4.2 | DaffExternalRouterMag
 
       op.flush({
         data: resolution,
+      });
+    });
+
+    describe('when the request URL has query params and fragments', () => {
+      it('should make the request with a truncated URL', () => {
+        setupTest();
+
+        service.resolve(`${requestUrl}?with=query#fragment`).subscribe();
+
+        const op = controller.expectOne(MagentoResolveUrlv242);
+        expect(op.operation.variables.url).toEqual(requestUrl);
       });
     });
   });

--- a/libs/external-router/driver/magento/2.4.2/src/magento.service.ts
+++ b/libs/external-router/driver/magento/2.4.2/src/magento.service.ts
@@ -1,12 +1,10 @@
-import {
-  Injectable,
-  Inject,
-} from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Apollo } from 'apollo-angular';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 
+import { daffUriTruncateQueryFragment } from '@daffodil/core/routing';
 import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
 import { DaffExternalRouterDriverInterface } from '@daffodil/external-router/driver';
 import { MagentoUrlResolverResponse } from '@daffodil/external-router/driver/magento';
@@ -33,7 +31,7 @@ implements DaffExternalRouterDriverInterface {
       .query<MagentoUrlResolverResponse>({
         query: MagentoResolveUrlv242,
         variables: {
-          url,
+          url: daffUriTruncateQueryFragment(url),
         },
       })
       .pipe(map(response => transformResolutionToResolvableUrlv242(response.data.urlResolver)));

--- a/libs/external-router/driver/magento/2.4.2/src/magento.service.ts
+++ b/libs/external-router/driver/magento/2.4.2/src/magento.service.ts
@@ -4,7 +4,6 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 
-import { daffUriTruncateQueryFragment } from '@daffodil/core/routing';
 import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
 import { DaffExternalRouterDriverInterface } from '@daffodil/external-router/driver';
 import { MagentoUrlResolverResponse } from '@daffodil/external-router/driver/magento';
@@ -31,7 +30,7 @@ implements DaffExternalRouterDriverInterface {
       .query<MagentoUrlResolverResponse>({
         query: MagentoResolveUrlv242,
         variables: {
-          url: daffUriTruncateQueryFragment(url),
+          url,
         },
       })
       .pipe(map(response => transformResolutionToResolvableUrlv242(response.data.urlResolver)));

--- a/libs/external-router/driver/magento/2.4.2/src/transforms/resolution-to-resolvable-url.spec.ts
+++ b/libs/external-router/driver/magento/2.4.2/src/transforms/resolution-to-resolvable-url.spec.ts
@@ -17,7 +17,7 @@ describe('@daffodil/external-router/driver/magento | transformResolutionToResolv
     id = 'id';
     url = 'url';
     resolution = {
-      relative_url: url,
+      relative_url: `/${url}`,
       type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
       redirectCode: 0,
       entity_uid: id,

--- a/libs/external-router/driver/magento/2.4.2/src/transforms/resolution-to-resolvable-url.spec.ts
+++ b/libs/external-router/driver/magento/2.4.2/src/transforms/resolution-to-resolvable-url.spec.ts
@@ -17,7 +17,7 @@ describe('@daffodil/external-router/driver/magento | transformResolutionToResolv
     id = 'id';
     url = 'url';
     resolution = {
-      relative_url: `/${url}`,
+      relative_url: `/${url}?query=param#fragment`,
       type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
       redirectCode: 0,
       entity_uid: id,

--- a/libs/external-router/driver/magento/2.4.2/src/transforms/resolution-to-resolvable-url.ts
+++ b/libs/external-router/driver/magento/2.4.2/src/transforms/resolution-to-resolvable-url.ts
@@ -1,4 +1,7 @@
-import { daffUriTruncateLeadingSlash } from '@daffodil/core/routing';
+import {
+  daffUriTruncateLeadingSlash,
+  daffUriTruncateQueryFragment,
+} from '@daffodil/core/routing';
 import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
 import { MagentoUrlResolver } from '@daffodil/external-router/driver/magento';
 
@@ -7,6 +10,6 @@ export const transformResolutionToResolvableUrlv242 = (
   resolution: MagentoUrlResolver,
 ): DaffExternallyResolvableUrl => ({
   id: resolution.entity_uid,
-  url: daffUriTruncateLeadingSlash(resolution.relative_url),
+  url: daffUriTruncateLeadingSlash(daffUriTruncateQueryFragment(resolution.relative_url)),
   type: resolution.type,
 });

--- a/libs/external-router/driver/magento/2.4.2/src/transforms/resolution-to-resolvable-url.ts
+++ b/libs/external-router/driver/magento/2.4.2/src/transforms/resolution-to-resolvable-url.ts
@@ -1,3 +1,4 @@
+import { daffUriTruncateLeadingSlash } from '@daffodil/core/routing';
 import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
 import { MagentoUrlResolver } from '@daffodil/external-router/driver/magento';
 
@@ -6,6 +7,6 @@ export const transformResolutionToResolvableUrlv242 = (
   resolution: MagentoUrlResolver,
 ): DaffExternallyResolvableUrl => ({
   id: resolution.entity_uid,
-  url: resolution.relative_url,
+  url: daffUriTruncateLeadingSlash(resolution.relative_url),
   type: resolution.type,
 });

--- a/libs/external-router/driver/testing/src/testing.service.spec.ts
+++ b/libs/external-router/driver/testing/src/testing.service.spec.ts
@@ -28,16 +28,17 @@ describe('@daffodil/external-router/driver/testing | DaffExternalRouterTestingDr
   });
 
   it('should return a resolved route if the route lookup succeeds', () => {
+    const url = 'test';
     setupTest({
-      test: 'PRODUCT',
+      [url]: 'PRODUCT',
     });
 
     scheduler.run(helpers => {
       const { expectObservable } = helpers;
       const expected = '(a|)';
 
-      expectObservable(service.resolve('test')).toBe(expected, {
-        a: { url: 'test', type: 'PRODUCT', id: jasmine.any(String) },
+      expectObservable(service.resolve(`/${url}`)).toBe(expected, {
+        a: { url, type: 'PRODUCT', id: jasmine.any(String) },
       });
     });
   });
@@ -48,7 +49,7 @@ describe('@daffodil/external-router/driver/testing | DaffExternalRouterTestingDr
       const { expectObservable } = helpers;
       const expected = '#';
 
-      expectObservable(service.resolve('test')).toBe(
+      expectObservable(service.resolve('/test')).toBe(
         expected,
         null,
         `\

--- a/libs/external-router/driver/testing/src/testing.service.ts
+++ b/libs/external-router/driver/testing/src/testing.service.ts
@@ -9,6 +9,10 @@ import {
   throwError,
 } from 'rxjs';
 
+import {
+  daffUriTruncateLeadingSlash,
+  daffUriTruncateQueryFragment,
+} from '@daffodil/core/routing';
 import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
 import { DaffExternalRouterDriverInterface } from '@daffodil/external-router/driver';
 
@@ -34,16 +38,18 @@ implements DaffExternalRouterDriverInterface {
   ) {}
 
   resolve(url: string): Observable<DaffExternallyResolvableUrl> {
-    if (!this.testingConfiguration[url]) {
+    const truncatedUrl = daffUriTruncateLeadingSlash(daffUriTruncateQueryFragment(url));
+
+    if (!this.testingConfiguration[truncatedUrl]) {
       return throwError(`\
-The route '${url}' wasn't provided with a matching type by the testing driver. \
+The route '${truncatedUrl}' wasn't provided with a matching type by the testing driver. \
 Did you configure the available route types with DaffExternalRouterDriverTestingModule.forRoot(config)`);
     }
 
     return of({
       id: faker.random.uuid(),
-      url,
-      type: this.testingConfiguration[url],
+      url: truncatedUrl,
+      type: this.testingConfiguration[truncatedUrl],
     });
   }
 }

--- a/libs/external-router/routing/src/guard/existence.guard.spec.ts
+++ b/libs/external-router/routing/src/guard/existence.guard.spec.ts
@@ -6,21 +6,28 @@ import {
   PRIMARY_OUTLET,
 } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 import {
   DAFF_EXTERNAL_ROUTER_CONFIG,
   daffProvideRouteResolvableByType,
 } from '@daffodil/external-router';
+import {
+  DaffExternalRouterDriverInterface,
+  DaffExternalRouterDriver,
+} from '@daffodil/external-router/driver';
 import { DaffExternalRouterDriverTestingModule } from '@daffodil/external-router/driver/testing';
 
 import { DaffExternalRouterExistenceGuard } from './existence.guard';
 
-describe('@daffodil/external-router/routing | DaffExternalRouterTestingDriver', () => {
+describe('@daffodil/external-router/routing | DaffExternalRouterExistenceGuard', () => {
   let guard: DaffExternalRouterExistenceGuard;
   let scheduler: TestScheduler;
   let router: Router;
+  let driver: DaffExternalRouterDriverInterface;
   const stubFailedRoutePath = '/error-path';
+  const urlWithExtraInfo = '/some-resolved/path/with/file-endings.html(secondary:outlet)?query=1&two=2#fragment';
 
   const STUB_RESOLVABLE_TYPE = 'A_RESOLVABLE_TYPE';
 
@@ -44,10 +51,33 @@ describe('@daffodil/external-router/routing | DaffExternalRouterTestingDriver', 
     });
     router = TestBed.inject<Router>(Router);
     guard = TestBed.inject<DaffExternalRouterExistenceGuard>(DaffExternalRouterExistenceGuard);
+    driver = TestBed.inject(DaffExternalRouterDriver);
   });
 
   it('should be created', () => {
     expect(guard).toBeTruthy();
+  });
+
+  it('should invoke the driver with a normalized URL containing query strings, etc.', () => {
+    scheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+
+    const urlTree = router.parseUrl(urlWithExtraInfo);
+    spyOn(driver, 'resolve').and.returnValue(of({
+      url: urlTree.toString(),
+      type: STUB_RESOLVABLE_TYPE,
+      id: 'id',
+    }));
+
+    guard.canActivate(
+      <ActivatedRouteSnapshot>{
+        url: urlTree.root.children[PRIMARY_OUTLET].segments,
+      },
+      <RouterStateSnapshot>{ url: urlWithExtraInfo },
+    ).subscribe();
+
+    expect(driver.resolve).toHaveBeenCalledWith('/some-resolved/path/with/file-endings.html?query=1&two=2#fragment');
   });
 
   it('should return a UrlTree to the configured failedResolutionPath if resolution fails', () => {
@@ -75,9 +105,7 @@ describe('@daffodil/external-router/routing | DaffExternalRouterTestingDriver', 
       expect(actual).toEqual(expected);
     });
 
-    const url =
-			'/some-resolved/path/with/file-endings.html?query=1&two=2#fragment';
-    const urlTree = router.parseUrl(url);
+    const urlTree = router.parseUrl(urlWithExtraInfo);
 
     scheduler.run(helpers => {
       const { expectObservable } = helpers;
@@ -88,7 +116,7 @@ describe('@daffodil/external-router/routing | DaffExternalRouterTestingDriver', 
 					<ActivatedRouteSnapshot>{
 					  url: urlTree.root.children[PRIMARY_OUTLET].segments,
 					},
-					<RouterStateSnapshot>{ url },
+					<RouterStateSnapshot>{ url: urlWithExtraInfo },
         ),
       ).toBe(expected, { a: urlTree });
     });

--- a/libs/external-router/routing/src/guard/existence.guard.ts
+++ b/libs/external-router/routing/src/guard/existence.guard.ts
@@ -19,6 +19,7 @@ import {
   switchMap,
 } from 'rxjs/operators';
 
+import { DaffRoutingUriNormalizer } from '@daffodil/core/routing';
 import {
   DaffExternalRouter,
   DaffExternalRouterConfiguration,
@@ -28,8 +29,6 @@ import {
   DaffExternalRouterDriverInterface,
   DaffExternalRouterDriver,
 } from '@daffodil/external-router/driver';
-
-import { daffConvertToPath } from '../helper/convert-to-path';
 
 /**
  * The DaffExternalRouterExistenceGuard is responsible for guarding the wildcard route
@@ -47,13 +46,14 @@ export class DaffExternalRouterExistenceGuard implements CanActivate {
 		private router: Router,
 		@Inject(DAFF_EXTERNAL_ROUTER_CONFIG)
 		private config: DaffExternalRouterConfiguration,
+    private urlNormalizer: DaffRoutingUriNormalizer,
   ) {}
 
   canActivate(
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot,
   ): Observable<UrlTree | boolean> {
-    return this.driver.resolve(daffConvertToPath(next.url)).pipe(
+    return this.driver.resolve(this.urlNormalizer.normalize(state.url)).pipe(
       switchMap(resolvedRoute => of(this.externalRouter.add(resolvedRoute))),
       // Note that we have to use state.url as we want to ensure that we keep any fragments or query strings.
       // When we succeed, redirect to the new route.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

External router driver do not truncate the request or response


## What is the new behavior?
- Magento drivers truncate the query parameters and fragments from the request
- Magento drivers truncate the leading slash from the response
- The testing driver truncates query params, fragments, and the leading slash from the request URL before performing the lookup in its config. If the lookup succeeds, the truncated URL is used for the response.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information