### PR TITLE
feat(external-router): pass normalized state URL to driver

### DIFF
--- a/libs/external-router/routing/src/guard/existence.guard.spec.ts
+++ b/libs/external-router/routing/src/guard/existence.guard.spec.ts
@@ -6,21 +6,28 @@ import {
   PRIMARY_OUTLET,
 } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 import {
   DAFF_EXTERNAL_ROUTER_CONFIG,
   daffProvideRouteResolvableByType,
 } from '@daffodil/external-router';
+import {
+  DaffExternalRouterDriverInterface,
+  DaffExternalRouterDriver,
+} from '@daffodil/external-router/driver';
 import { DaffExternalRouterDriverTestingModule } from '@daffodil/external-router/driver/testing';
 
 import { DaffExternalRouterExistenceGuard } from './existence.guard';
 
-describe('@daffodil/external-router/routing | DaffExternalRouterTestingDriver', () => {
+describe('@daffodil/external-router/routing | DaffExternalRouterExistenceGuard', () => {
   let guard: DaffExternalRouterExistenceGuard;
   let scheduler: TestScheduler;
   let router: Router;
+  let driver: DaffExternalRouterDriverInterface;
   const stubFailedRoutePath = '/error-path';
+  const urlWithExtraInfo = '/some-resolved/path/with/file-endings.html(secondary:outlet)?query=1&two=2#fragment';
 
   const STUB_RESOLVABLE_TYPE = 'A_RESOLVABLE_TYPE';
 
@@ -44,10 +51,33 @@ describe('@daffodil/external-router/routing | DaffExternalRouterTestingDriver', 
     });
     router = TestBed.inject<Router>(Router);
     guard = TestBed.inject<DaffExternalRouterExistenceGuard>(DaffExternalRouterExistenceGuard);
+    driver = TestBed.inject(DaffExternalRouterDriver);
   });
 
   it('should be created', () => {
     expect(guard).toBeTruthy();
+  });
+
+  it('should invoke the driver with a normalized URL containing query strings, etc.', () => {
+    scheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+
+    const urlTree = router.parseUrl(urlWithExtraInfo);
+    spyOn(driver, 'resolve').and.returnValue(of({
+      url: urlTree.toString(),
+      type: STUB_RESOLVABLE_TYPE,
+      id: 'id',
+    }));
+
+    guard.canActivate(
+      <ActivatedRouteSnapshot>{
+        url: urlTree.root.children[PRIMARY_OUTLET].segments,
+      },
+      <RouterStateSnapshot>{ url: urlWithExtraInfo },
+    ).subscribe();
+
+    expect(driver.resolve).toHaveBeenCalledWith('/some-resolved/path/with/file-endings.html?query=1&two=2#fragment');
   });
 
   it('should return a UrlTree to the configured failedResolutionPath if resolution fails', () => {
@@ -75,9 +105,7 @@ describe('@daffodil/external-router/routing | DaffExternalRouterTestingDriver', 
       expect(actual).toEqual(expected);
     });
 
-    const url =
-			'/some-resolved/path/with/file-endings.html?query=1&two=2#fragment';
-    const urlTree = router.parseUrl(url);
+    const urlTree = router.parseUrl(urlWithExtraInfo);
 
     scheduler.run(helpers => {
       const { expectObservable } = helpers;
@@ -88,7 +116,7 @@ describe('@daffodil/external-router/routing | DaffExternalRouterTestingDriver', 
 					<ActivatedRouteSnapshot>{
 					  url: urlTree.root.children[PRIMARY_OUTLET].segments,
 					},
-					<RouterStateSnapshot>{ url },
+					<RouterStateSnapshot>{ url: urlWithExtraInfo },
         ),
       ).toBe(expected, { a: urlTree });
     });

--- a/libs/external-router/routing/src/guard/existence.guard.ts
+++ b/libs/external-router/routing/src/guard/existence.guard.ts
@@ -19,6 +19,7 @@ import {
   switchMap,
 } from 'rxjs/operators';
 
+import { DaffRoutingUriNormalizer } from '@daffodil/core/routing';
 import {
   DaffExternalRouter,
   DaffExternalRouterConfiguration,
@@ -28,8 +29,6 @@ import {
   DaffExternalRouterDriverInterface,
   DaffExternalRouterDriver,
 } from '@daffodil/external-router/driver';
-
-import { daffConvertToPath } from '../helper/convert-to-path';
 
 /**
  * The DaffExternalRouterExistenceGuard is responsible for guarding the wildcard route
@@ -47,13 +46,14 @@ export class DaffExternalRouterExistenceGuard implements CanActivate {
 		private router: Router,
 		@Inject(DAFF_EXTERNAL_ROUTER_CONFIG)
 		private config: DaffExternalRouterConfiguration,
+    private urlNormalizer: DaffRoutingUriNormalizer,
   ) {}
 
   canActivate(
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot,
   ): Observable<UrlTree | boolean> {
-    return this.driver.resolve(daffConvertToPath(next.url)).pipe(
+    return this.driver.resolve(this.urlNormalizer.normalize(state.url)).pipe(
       switchMap(resolvedRoute => of(this.externalRouter.add(resolvedRoute))),
       // Note that we have to use state.url as we want to ensure that we keep any fragments or query strings.
       // When we succeed, redirect to the new route.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The guard will pass an inappropriately formed URL to the driver layer.


## What is the new behavior?
The guard will normalize the state URL before passing it to the driver.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information