### PR TITLE
feat(design): support text-align natively on callouts

### DIFF
--- a/apps/design-land/src/app/callout/callout.component.html
+++ b/apps/design-land/src/app/callout/callout.component.html
@@ -24,6 +24,16 @@
 
   <design-land-example-viewer-container example="callout-theming"></design-land-example-viewer-container>
 
+  <h2>Horizontal Alignment</h2>
+  <p>Callouts respect the <code>text-align</code> css property.</p>
+
+  <design-land-example-viewer-container example="callout-text-align"></design-land-example-viewer-container>
+
+  <h2>Grids inside callouts</h2>
+  <p>Callouts are flexible enough to support grids within them.</p>
+
+  <design-land-example-viewer-container example="callout-with-grid"></design-land-example-viewer-container>
+
   <h2>Layout</h2>
   <p>The <code>layout</code> property will be deprecated in v1.0.0</p>
 

--- a/apps/design-land/src/app/callout/callout.module.ts
+++ b/apps/design-land/src/app/callout/callout.module.ts
@@ -3,6 +3,7 @@ import {
   NgModule,
   Injector,
   ComponentFactoryResolver,
+  Type,
 } from '@angular/core';
 import { createCustomElement } from '@angular/elements';
 
@@ -35,7 +36,7 @@ export class DesignLandCalloutModule {
     injector: Injector,
     private componentFactoryResolver: ComponentFactoryResolver,
   ) {
-    CALLOUT_EXAMPLES.map((classConstructor) => ({
+    CALLOUT_EXAMPLES.map((classConstructor: Type<unknown>) => ({
       element: createCustomElement(classConstructor, { injector }),
       class: classConstructor,
     }))

--- a/libs/design/callout/examples/src/callout-text-align/callout-text-align.component.html
+++ b/libs/design/callout/examples/src/callout-text-align/callout-text-align.component.html
@@ -1,0 +1,12 @@
+<daff-callout [style.text-align]="textAlignControl.value">
+	<daff-container size="md">
+		<p daffCalloutTagline>Callout Tagline</p>
+		<h3 daffCalloutTitle>Callout Title</h3>
+		<p daffCalloutSubtitle>Callout subtitle</p>
+		<p>Additional content can be placed here.</p>
+	</daff-container>
+</daff-callout>
+
+<select [formControl]="textAlignControl">
+	<option *ngFor="let option of options" [value]="option.value">{{ option.label }}</option>
+</select>

--- a/libs/design/callout/examples/src/callout-text-align/callout-text-align.component.ts
+++ b/libs/design/callout/examples/src/callout-text-align/callout-text-align.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { FormControl } from '@angular/forms';
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'callout-text-align',
+  templateUrl: './callout-text-align.component.html',
+})
+export class CalloutTextAlignComponent {
+  textAlignControl: FormControl = new FormControl('');
+
+  options = [
+    { value: '', label: 'Default' },
+    { value: 'left', label: 'Left' },
+    { value: 'center', label: 'Center' },
+    { value: 'right', label: 'Right' },
+  ];
+}

--- a/libs/design/callout/examples/src/callout-text-align/callout-text-align.module.ts
+++ b/libs/design/callout/examples/src/callout-text-align/callout-text-align.module.ts
@@ -1,0 +1,25 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import {
+  DaffCalloutModule,
+  DaffContainerModule,
+  DaffAccordionModule,
+} from '@daffodil/design';
+
+import { CalloutTextAlignComponent } from './callout-text-align.component';
+
+@NgModule({
+  declarations: [
+    CalloutTextAlignComponent,
+  ],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    DaffCalloutModule,
+    DaffContainerModule,
+    DaffAccordionModule,
+  ],
+})
+export class CalloutTextAlignModule { }

--- a/libs/design/callout/examples/src/callout-with-grid/callout-with-grid.component.html
+++ b/libs/design/callout/examples/src/callout-with-grid/callout-with-grid.component.html
@@ -1,0 +1,20 @@
+<daff-callout color="theme">
+	<div class="callout-with-grid__grid">
+		<div class="callout-with-grid__image">
+			<img src="/assets/pwa-illustration.svg" alt="PWA Illustration">
+		</div>
+		<div class="callout-with-grid__content-wrapper">
+			<h3 daffCalloutTitle>Daffodil: The next great leap in ecommerce.</h3>
+			<div daffCalloutSubtitle>
+				<p>Daffodil is a frontend framework for ecommerce PWAs. It provides everything you need to create powerful and
+					flexible ecommerce experiences.</p>
+				<p>With Daffodil, ambitious businesses are able to achieve more while minimizing development and maintenance
+					costs.</p>
+			</div>
+			<div class="callout-with-grid__actions">
+				<a daff-button href="https://www.daff.io">What is Daffodil?</a>
+				<a daff-underline-button routerLink="/contact">Sign up for a demo</a>
+			</div>
+		</div>
+	</div>
+</daff-callout>

--- a/libs/design/callout/examples/src/callout-with-grid/callout-with-grid.component.scss
+++ b/libs/design/callout/examples/src/callout-with-grid/callout-with-grid.component.scss
@@ -1,0 +1,30 @@
+@import 'daff-util';
+
+.callout-with-grid {
+	&__grid {
+		display: grid;
+		grid-template:
+			'image'
+			'content' / 1fr;
+
+		@include breakpoint(tablet) {
+			grid-template:
+                'image content' / 1fr 1fr;
+			grid-gap: 48px;
+		}
+	}
+
+	&__actions {
+		display: flex;
+		align-items: center;
+		margin-top: 48px;
+
+		> * {
+			margin-right: 24px;
+
+			&:last-child {
+				margin: 0;
+			}
+		}
+	}
+}

--- a/libs/design/callout/examples/src/callout-with-grid/callout-with-grid.component.ts
+++ b/libs/design/callout/examples/src/callout-with-grid/callout-with-grid.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { FormControl } from '@angular/forms';
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'callout-with-grid',
+  templateUrl: './callout-with-grid.component.html',
+  styleUrls: ['./callout-with-grid.component.scss'],
+})
+export class CalloutWithGridComponent {
+
+}

--- a/libs/design/callout/examples/src/callout-with-grid/callout-with-grid.module.ts
+++ b/libs/design/callout/examples/src/callout-with-grid/callout-with-grid.module.ts
@@ -1,0 +1,25 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import {
+  DaffCalloutModule,
+  DaffContainerModule,
+  DaffAccordionModule,
+} from '@daffodil/design';
+
+import { CalloutWithGridComponent } from './callout-with-grid.component';
+
+@NgModule({
+  declarations: [
+    CalloutWithGridComponent,
+  ],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    DaffCalloutModule,
+    DaffContainerModule,
+    DaffAccordionModule,
+  ],
+})
+export class CalloutWithGridModule { }

--- a/libs/design/callout/examples/src/examples.ts
+++ b/libs/design/callout/examples/src/examples.ts
@@ -1,5 +1,9 @@
+import { CalloutTextAlignComponent } from './callout-text-align/callout-text-align.component';
 import { CalloutThemingComponent } from './callout-theming/callout-theming.component';
+import { CalloutWithGridComponent } from './callout-with-grid/callout-with-grid.component';
 
 export const CALLOUT_EXAMPLES = [
   CalloutThemingComponent,
+  CalloutTextAlignComponent,
+  CalloutWithGridComponent,
 ];

--- a/libs/design/callout/examples/src/public_api.ts
+++ b/libs/design/callout/examples/src/public_api.ts
@@ -1,3 +1,7 @@
 export { CalloutThemingComponent } from './callout-theming/callout-theming.component';
 export { CalloutThemingModule } from './callout-theming/callout-theming.module';
+export { CalloutTextAlignComponent } from './callout-text-align/callout-text-align.component';
+export { CalloutTextAlignModule } from './callout-text-align/callout-text-align.module';
+export { CalloutWithGridComponent } from './callout-with-grid/callout-with-grid.component';
+export { CalloutWithGridModule } from './callout-with-grid/callout-with-grid.module';
 export { CALLOUT_EXAMPLES } from './examples';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, when you try to text-align callouts, they do some superiorly dumb things in terms of layout. 


## What is the new behavior?
This makes them act more properly according to native CSS3 behavior: e.g. when left-aligned, they left-aligned, center, they center, etc. I've also added a design-land example to make this more obvious.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information