### PR TITLE
feat(product): reset product ID on load and set on load success

### DIFF
--- a/libs/product/state/src/reducers/product/product.reducer.spec.ts
+++ b/libs/product/state/src/reducers/product/product.reducer.spec.ts
@@ -50,6 +50,10 @@ describe('Product | Product Reducer', () => {
     it('sets loading state to true', () => {
       expect(result.loading).toEqual(true);
     });
+
+    it('resets selectedProductId', () => {
+      expect(result.selectedProductId).toBeNull();
+    });
   });
 
   describe('when ProductLoadAction is triggered', () => {
@@ -65,8 +69,8 @@ describe('Product | Product Reducer', () => {
       expect(result.loading).toEqual(true);
     });
 
-    it('sets selectedProductId to the product id', () => {
-      expect(result.selectedProductId).toEqual(productId);
+    it('resets selectedProductId', () => {
+      expect(result.selectedProductId).toBeNull();
     });
   });
 
@@ -87,6 +91,10 @@ describe('Product | Product Reducer', () => {
 
     it('sets loading to false', () => {
       expect(result.loading).toEqual(false);
+    });
+
+    it('sets selectedProductId to the loaded product ID', () => {
+      expect(result.selectedProductId).toEqual(product.id);
     });
   });
 

--- a/libs/product/state/src/reducers/product/product.reducer.ts
+++ b/libs/product/state/src/reducers/product/product.reducer.ts
@@ -27,9 +27,9 @@ export function daffProductReducer<T extends DaffProduct>(state = initialState, 
   switch (action.type) {
     case DaffProductPageActionTypes.ProductPageLoadAction:
     case DaffProductPageActionTypes.ProductPageLoadByUrlAction:
-      return { ...state, loading: true, selectedProductId: action.payload };
+      return { ...state, loading: true, selectedProductId: null };
     case DaffProductPageActionTypes.ProductPageLoadSuccessAction:
-      return { ...state, loading: false };
+      return { ...state, loading: false, selectedProductId: action.payload.id };
     case DaffProductPageActionTypes.ProductPageLoadFailureAction:
       return { ...state,
         loading: false,

--- a/libs/product/state/src/selectors/product/product.selectors.spec.ts
+++ b/libs/product/state/src/selectors/product/product.selectors.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '@daffodil/product/state';
 import { DaffProductFactory } from '@daffodil/product/testing';
 
+import { DaffProductPageLoadSuccess } from '../../actions/public_api';
 import { getDaffProductPageSelectors } from './product.selectors';
 
 describe('selectProductState', () => {
@@ -45,7 +46,7 @@ describe('selectProductState', () => {
     store = TestBed.inject(Store);
 
     store.dispatch(new DaffProductGridLoadSuccess(new Array(mockProduct)));
-    store.dispatch(new DaffProductPageLoad(mockProduct.id));
+    store.dispatch(new DaffProductPageLoadSuccess(mockProduct));
   });
 
   describe('SelectedProductState', () => {
@@ -58,7 +59,7 @@ describe('selectProductState', () => {
         expectedProductState = {
           selectedProductId: mockProduct.id,
           qty: 1,
-          loading: true,
+          loading: false,
           errors: [],
         };
       });
@@ -95,7 +96,7 @@ describe('selectProductState', () => {
 
       it('selects the loading state of the selected product', () => {
         const selector = store.pipe(select(selectSelectedProductLoadingState));
-        const expected = cold('a', { a: true });
+        const expected = cold('a', { a: false });
 
         expect(selector).toBeObservable(expected);
       });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

product reducer set ID in state on load (which would incorrectly be the URL in the getByUrl case) and never set ID on load success


## What is the new behavior?
product reducer clears selected product ID on page load and sets it to the loaded product ID on page load success

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information