### PR TITLE
feat(category): reset category state ID and reduce load by URI

### DIFF
--- a/libs/category/state/src/reducers/category/category.reducer.ts
+++ b/libs/category/state/src/reducers/category/category.reducer.ts
@@ -46,6 +46,7 @@ export function daffCategoryReducer<U extends DaffGenericCategory<U>, W extends 
 ): DaffCategoryReducerState {
   switch (action.type) {
     case DaffCategoryPageActionTypes.CategoryPageLoadAction:
+    case DaffCategoryPageActionTypes.CategoryPageLoadByUriAction:
       return {
         ...state,
         categoryLoading: true,
@@ -54,7 +55,7 @@ export function daffCategoryReducer<U extends DaffGenericCategory<U>, W extends 
         categoryPageMetadata: {
           ...initialState.categoryPageMetadata,
           ...buildMetadataFromRequest(action.request),
-          id: action.request.id,
+          id: null,
         },
       };
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- category never reduces the load by URI action
- category sets category page metadata ID on page load

## What is the new behavior?
- category resets the metadata ID on page load
- category reduces load by URI in an identical way as load by ID

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information