### PR TITLE
feat(external-router): provide full type route in providers

### DIFF
--- a/libs/external-router/routing/src/guard/existence.guard.spec.ts
+++ b/libs/external-router/routing/src/guard/existence.guard.spec.ts
@@ -40,7 +40,10 @@ describe('@daffodil/external-router/routing | DaffExternalRouterExistenceGuard',
         }),
       ],
       providers: [
-        daffProvideRouteResolvableByType(STUB_RESOLVABLE_TYPE, { redirectTo: '/' }),
+        daffProvideRouteResolvableByType({
+          type: STUB_RESOLVABLE_TYPE,
+          route: { redirectTo: '/' },
+        }),
         {
           provide: DAFF_EXTERNAL_ROUTER_CONFIG,
           useValue: {

--- a/libs/external-router/src/external-router.module.ts
+++ b/libs/external-router/src/external-router.module.ts
@@ -9,7 +9,7 @@ import {
   DAFF_EXTERNAL_ROUTER_CONFIG,
 } from './config';
 import { DaffTypeRoutePair } from './model/type-route-pair';
-import { provideRoutesResolvableByType } from './token/type-resolvable-routes.token';
+import { daffProvideRoutesResolvableByType } from './token/type-resolvable-routes.token';
 
 /**
  * The external `DaffExternalRouterModule` allows you to configure the
@@ -28,7 +28,7 @@ export class DaffExternalRouterModule {
       ngModule: DaffExternalRouterModule,
       providers: [
         { provide: DAFF_EXTERNAL_ROUTER_CONFIG, useValue: config },
-        ...provideRoutesResolvableByType(routes),
+        ...daffProvideRoutesResolvableByType(routes),
       ],
     };
   }

--- a/libs/external-router/src/token/type-resolvable-routes.token.spec.ts
+++ b/libs/external-router/src/token/type-resolvable-routes.token.spec.ts
@@ -19,8 +19,11 @@ describe('@daffodil/external-router | DAFF_EXTERNAL_ROUTER_ROUTES_RESOLVABLE_BY_
   it('allow you to provide a resolvable route type', () => {
     TestBed.configureTestingModule({
       providers: [
-        daffProvideRouteResolvableByType('some-type', {
-          redirectTo: 'somewhere',
+        daffProvideRouteResolvableByType({
+          type: 'some-type',
+          route: {
+            redirectTo: 'somewhere',
+          },
         }),
       ],
     });
@@ -42,11 +45,13 @@ describe('@daffodil/external-router | DAFF_EXTERNAL_ROUTER_ROUTES_RESOLVABLE_BY_
     TestBed.configureTestingModule({
       providers: [
         daffProvideRouteResolvableByType(
-          'some-type',
           {
-            redirectTo: 'somewhere',
+            type: 'some-type',
+            route: {
+              redirectTo: 'somewhere',
+            },
+            insertionStrategy: customStrategy,
           },
-          customStrategy,
         ),
       ],
     });

--- a/libs/external-router/src/token/type-resolvable-routes.token.spec.ts
+++ b/libs/external-router/src/token/type-resolvable-routes.token.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
+import { DaffExternalRouterInsertionStrategy } from '../model/insertion-strategy.type';
 import { DaffTypeRoutePair } from '../model/type-route-pair';
 import {
   DAFF_EXTERNAL_ROUTER_ROUTES_RESOLVABLE_BY_TYPE,
@@ -31,6 +32,33 @@ describe('@daffodil/external-router | DAFF_EXTERNAL_ROUTER_ROUTES_RESOLVABLE_BY_
         route: {
           redirectTo: 'somewhere',
         },
+      },
+    ]);
+  });
+
+  it('allow you to provide a resolvable route type with an insertionStrategy', () => {
+    const customStrategy: DaffExternalRouterInsertionStrategy = (route, routes) => routes;
+
+    TestBed.configureTestingModule({
+      providers: [
+        daffProvideRouteResolvableByType(
+          'some-type',
+          {
+            redirectTo: 'somewhere',
+          },
+          customStrategy,
+        ),
+      ],
+    });
+
+    token = TestBed.inject<DaffTypeRoutePair[]>(DAFF_EXTERNAL_ROUTER_ROUTES_RESOLVABLE_BY_TYPE);
+    expect(token).toEqual([
+      {
+        type: 'some-type',
+        route: {
+          redirectTo: 'somewhere',
+        },
+        insertionStrategy: customStrategy,
       },
     ]);
   });

--- a/libs/external-router/src/token/type-resolvable-routes.token.ts
+++ b/libs/external-router/src/token/type-resolvable-routes.token.ts
@@ -21,17 +21,11 @@ export const DAFF_EXTERNAL_ROUTER_ROUTES_RESOLVABLE_BY_TYPE = new InjectionToken
 /**
  * A provider used to connect a type to a route to enable dynamic route resolution at runtime.
  */
-export function daffProvideRouteResolvableByType(
-  type: DaffExternalRouteType,
-  route: DaffRouteWithoutPath,
-  insertionStrategy?: DaffExternalRouterInsertionStrategy,
-): Provider {
+export function daffProvideRouteResolvableByType(typeRoutePair: DaffTypeRoutePair): Provider {
   return {
     provide: DAFF_EXTERNAL_ROUTER_ROUTES_RESOLVABLE_BY_TYPE,
     multi: true,
-    useValue: { type,
-      route,
-      ...insertionStrategy ? { insertionStrategy } : {}},
+    useValue: typeRoutePair,
   };
 }
 

--- a/libs/external-router/src/token/type-resolvable-routes.token.ts
+++ b/libs/external-router/src/token/type-resolvable-routes.token.ts
@@ -30,7 +30,7 @@ export function daffProvideRouteResolvableByType(typeRoutePair: DaffTypeRoutePai
 }
 
 /**
- * A multi-provider used to connect an array of types an respective route.
+ * A multi-provider used to connect an array of types to their respective routes.
  */
 export function daffProvideRoutesResolvableByType(routes: DaffTypeRoutePair[]): Provider[] {
   return routes.map((route: DaffTypeRoutePair) => ({

--- a/libs/external-router/src/token/type-resolvable-routes.token.ts
+++ b/libs/external-router/src/token/type-resolvable-routes.token.ts
@@ -3,6 +3,7 @@ import {
   Provider,
 } from '@angular/core';
 
+import { DaffExternalRouterInsertionStrategy } from '../model/insertion-strategy.type';
 import { DaffExternalRouteType } from '../model/route-type';
 import { DaffRouteWithoutPath } from '../model/route-without-path';
 import { DaffTypeRoutePair } from '../model/type-route-pair';
@@ -23,18 +24,24 @@ export const DAFF_EXTERNAL_ROUTER_ROUTES_RESOLVABLE_BY_TYPE = new InjectionToken
 export function daffProvideRouteResolvableByType(
   type: DaffExternalRouteType,
   route: DaffRouteWithoutPath,
+  insertionStrategy?: DaffExternalRouterInsertionStrategy,
 ): Provider {
   return {
     provide: DAFF_EXTERNAL_ROUTER_ROUTES_RESOLVABLE_BY_TYPE,
     multi: true,
-    useValue: { type, route },
+    useValue: { type,
+      route,
+      ...insertionStrategy ? { insertionStrategy } : {}},
   };
 }
 
-export function provideRoutesResolvableByType(routes: DaffTypeRoutePair[]): Provider[] {
+/**
+ * A multi-provider used to connect an array of types an respective route.
+ */
+export function daffProvideRoutesResolvableByType(routes: DaffTypeRoutePair[]): Provider[] {
   return routes.map((route: DaffTypeRoutePair) => ({
     provide: DAFF_EXTERNAL_ROUTER_ROUTES_RESOLVABLE_BY_TYPE,
     multi: true,
-    useValue: { type: route.type, route: route.route },
+    useValue: route,
   }));
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, when you try to provide an insertion strategy for a type route, you can't because the provider doesn't respect it.

Fixes: N/A


## What is the new behavior?
This changes the provider to respect the full `DaffTypeRoutePair` object.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

Dependents will have to modify their provider usage (if they manually use `daffProvideRouteResolvableByType`) to match the change to the function params.

## Other information