### PR TITLE
feat(design): add active style to stroked button

### DIFF
--- a/libs/design/src/atoms/button/button-theme-variants/stroked.scss
+++ b/libs/design/src/atoms/button/button-theme-variants/stroked.scss
@@ -10,17 +10,24 @@
 	@if daff-contrast-ratio($focus-color, daff-text-contrast($focus-color)) < 4.5 {
 		@error 'Stroked Button Focus State: ' + map-get($wcag-aa-errors, 'text-contrast');
 	}
+
+	@if daff-contrast-ratio($focus-color, daff-text-contrast($focus-color)) < 4.5 {
+		@error 'Stroked Button Active State: ' + map-get($wcag-aa-errors, 'text-contrast');
+	}
 	border: 1px solid $base-color;
 	color: $font-color;
 	background-color: transparent;
 
-	&:hover {
+	&:hover,
+	&:focus {
 		background-color: $base-color;
+		border: 1px solid $base-color;
 		color: daff-text-contrast($base-color);
 	}
 
-	&:focus {
+	&:active {
 		background-color: $focus-color;
+		border: 1px solid $focus-color;
 		color: daff-text-contrast($focus-color);
 	}
 }

--- a/libs/design/src/atoms/button/button-theme.scss
+++ b/libs/design/src/atoms/button/button-theme.scss
@@ -329,6 +329,12 @@
 			color: daff-text-contrast(daff-illuminate($base, $daff-gray, 2));
 		}
 
+		&:active {
+			background-color: daff-illuminate($base, $daff-gray, 3);
+			border: 1px solid daff-illuminate($base, $daff-gray, 3);
+			color: daff-text-contrast(daff-illuminate($base, $daff-gray, 3));
+		}
+
 		&.daff-primary {
 			@include daff-stroked-button-theme-variant(
 				daff-color($primary),
@@ -365,7 +371,7 @@
 			@include daff-stroked-button-theme-variant(
 				$white,
 				$white,
-				daff-color($daff-gray, 10)
+				daff-color($daff-gray, 20)
 			);
 		}
 
@@ -418,7 +424,7 @@
 			@include daff-stroked-button-theme-variant(
 				daff-color($daff-green, 60),
 				daff-color($daff-green, 60),
-				daff-color($daff-bronze, 70)
+				daff-color($daff-green, 70)
 			);
 		}
 	}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no active style for stroked buttons. The success status has an incorrect `focus-color`.

Fixes: N/A


## What is the new behavior?
Added active state for stroked button, fixed focus color for success status.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information