### PR TITLE
feat(category): remove the category ID filter from response

### DIFF
--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
@@ -126,6 +126,22 @@ describe('DaffMagentoCategoryPageConfigTransformerService', () => {
       });
     });
 
+    describe('when the aggregate is for category_id', () => {
+      beforeEach(() => {
+        aggregation = selectAggregateFactory.create({
+          attribute_code: 'category_id',
+        });
+        result = service.transform({
+          ...completeCategoryResponse,
+          aggregates: [aggregation],
+        });
+      });
+
+      it('should not include that filter in the result', () => {
+        expect(result.filters['category_id']).toBeUndefined();
+      });
+    });
+
     describe('when the aggregate is a select', () => {
       beforeEach(() => {
         aggregation = selectAggregateFactory.create();

--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.ts
@@ -15,13 +15,15 @@ import { coerceDefaultSortOptionFirst } from './pure/sort-default-option-first';
 export class DaffMagentoCategoryPageConfigTransformerService {
 
   transform(categoryResponse: MagentoCompleteCategoryResponse): DaffCategoryPageMetadata {
+    const aggregatesWithoutCategories = categoryResponse.aggregates.filter(aggregate => aggregate.attribute_code !== 'category_id');
+
     return {
       id: categoryResponse.category.uid,
       page_size: categoryResponse.page_info.page_size,
       current_page: categoryResponse.page_info.current_page,
       total_pages: categoryResponse.page_info.total_pages,
       total_products: categoryResponse.total_count,
-      filters: daffCategoryFilterArrayToDict(categoryResponse.aggregates.map(transformAggregate)),
+      filters: daffCategoryFilterArrayToDict(aggregatesWithoutCategories.map(transformAggregate)),
       sort_options: {
         default: categoryResponse.sort_fields.default,
         options: coerceDefaultSortOptionFirst(categoryResponse.sort_fields).options,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The category filter list will include `category_id` when using Magento, which therefore breaks subsequent category product calls beacuse `category_id` and `category_uid` are both used.

## What is the new behavior?
`category_id` is removed from the filter list in the Magento driver.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information