### PR TITLE
fix(cart): faker method not called for cart item URL

### DIFF
--- a/libs/cart/testing/src/factories/cart-item/cart-item.factory.ts
+++ b/libs/cart/testing/src/factories/cart-item/cart-item.factory.ts
@@ -18,7 +18,7 @@ export class DaffMockCartItem implements DaffCartItem {
 	image = <DaffProductImage>new DaffProductImageFactory().create();
   sku = 'sku';
   name = 'Product Name';
-  url = `/${faker.random.word}.html`;
+  url = `/${faker.random.word()}.html`;
   qty = faker.random.number({ min: 1, max: 100 });
   price = faker.random.number({ min: 1, max: 1500 });
   row_total = this.qty * this.price;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The cart item factory sets the URL segment to the faker function, not the return of the function call.


## What is the new behavior?
The cart item factory actually calls the faker method.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information