### PR TITLE
feat(tools-dgeni): generate documentation for subpackages

### DIFF
--- a/tools/dgeni/src/transforms/daffodil-api-package/index.ts
+++ b/tools/dgeni/src/transforms/daffodil-api-package/index.ts
@@ -45,7 +45,12 @@ export const apiDocs =  new Package('checkout', [
 
     // Specify collections of source files that should contain the documentation to extract
     readTypeScriptModules.sourceFiles = [
-      excludedPackagesRegex + '/src/index.ts'
+      excludedPackagesRegex + '/src/index.ts',
+			excludedPackagesRegex + '/state/src/index.ts',
+			excludedPackagesRegex + '/driver/src/index.ts',
+			excludedPackagesRegex + '/driver/magento/src/index.ts',
+			excludedPackagesRegex + '/routing/src/index.ts',
+			excludedPackagesRegex + '/testing/src/index.ts',
     ];
   })
   .config(function(computePathsProcessor, EXPORT_DOC_TYPES, generateApiList) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
dgeni docs are only configured to generate docs for `@daffodil/package-name/src/index.ts`, so when we sharded the packages, lots of docs were no longer generated.

## What is the new behavior?
Docs are now generated for all subpackages.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```