### PR TITLE
feat(product): add magento productByUri query to the cached query set

### DIFF
--- a/libs/product/driver/magento/src/product-driver.module.ts
+++ b/libs/product/driver/magento/src/product-driver.module.ts
@@ -15,6 +15,7 @@ import {
 import { DaffMagentoProductService } from './product.service';
 import { DAFF_MAGENTO_GET_ALL_PRODUCTS_QUERY_NAME } from './queries/get-all-products';
 import { DAFF_MAGENTO_GET_A_PRODUCT_QUERY_NAME } from './queries/get-product';
+import { DAFF_MAGENTO_GET_A_PRODUCT_BY_URL_QUERY_NAME } from './queries/get-product-by-url';
 
 @NgModule({
   imports: [
@@ -38,6 +39,11 @@ export class DaffProductMagentoDriverModule {
         {
           provide: DAFF_MAGENTO_CACHEABLE_OPERATIONS,
           useValue: DAFF_MAGENTO_GET_A_PRODUCT_QUERY_NAME,
+          multi: true,
+        },
+        {
+          provide: DAFF_MAGENTO_CACHEABLE_OPERATIONS,
+          useValue: DAFF_MAGENTO_GET_A_PRODUCT_BY_URL_QUERY_NAME,
           multi: true,
         },
         {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, we are getting a cache miss on `getProductByUrl` since we didn't add the query to the list of cached queries for the Magento driver.

Fixes: N/A


## What is the new behavior?
We now cache the query.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```