### PR TITLE
docs(design): add example docs for accordions

### DIFF
--- a/apps/design-land/src/app/accordion/accordion.component.html
+++ b/apps/design-land/src/app/accordion/accordion.component.html
@@ -1,60 +1,13 @@
-<div class="design-land-accordion-example">
-	<h1>Daff Accordion</h1>
+<daff-article>
+	<h1 daffArticleTitle>Accordion</h1>
 
-	<daff-accordion>
-		<daff-accordion-item initiallyActive="true">
-			<h3 daffAccordionItemTitle>Details</h3>
-			<div daffAccordionItemContent>
-					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent commodo 
-					lacus ut sapien consectetur, et ultricies leo rutrum. Integer iaculis ultrices nunc, 
-					et maximus quam efficitur sed. Maecenas iaculis nisl neque, maximus sagittis libero sagittis eget.
-					<a>Learn More.</a>
-			</div>
-		</daff-accordion-item>
-		<daff-accordion-item>
-			<h3 daffAccordionItemTitle>Details</h3>
-			<div daffAccordionItemContent>
-					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent commodo 
-					lacus ut sapien consectetur, et ultricies leo rutrum. Integer iaculis ultrices nunc, 
-					et maximus quam efficitur sed. Maecenas iaculis nisl neque, maximus sagittis libero sagittis eget.
-					<a>Learn More.</a>
-			</div>
-		</daff-accordion-item>
-		<daff-accordion-item>
-			<h3 daffAccordionItemTitle>Details</h3>
-			<div daffAccordionItemContent>
-					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent commodo 
-					lacus ut sapien consectetur, et ultricies leo rutrum. Integer iaculis ultrices nunc, 
-					et maximus quam efficitur sed. Maecenas iaculis nisl neque, maximus sagittis libero sagittis eget.
-					<a>Learn More.</a>
-			</div>
-		</daff-accordion-item>
-	</daff-accordion>
-</div>
+	<h3>Types</h3>
+  <p><code>daff-accordion-item</code> - An accordion that typically holds content.</p>
+  <p><code>daff-nav-accordion-item</code> — An accordion that is used for navigation whose content is nested daff-nav-accordion-items.</p>
 
-<div class="design-land-accordion-example">
-	<h1>Daff Nav Accordion</h1>
-	<daff-accordion>
-		<daff-nav-accordion-item>
-			<h3 daffAccordionItemTitle>Details</h3>
-				<daff-nav-accordion-item>
-					<h3 daffAccordionItemTitle>Details</h3>
-						<daff-nav-accordion-item>
-							<a daffAccordionItemTitle>Details</a>
-						</daff-nav-accordion-item>
-						<daff-nav-accordion-item>
-							<a daffAccordionItemTitle>Details</a>
-						</daff-nav-accordion-item>
-				</daff-nav-accordion-item>
-				<daff-nav-accordion-item>
-					<h3 daffAccordionItemTitle>Details</h3>
-						<daff-nav-accordion-item>
-							<a daffAccordionItemTitle>Details</a>
-						</daff-nav-accordion-item>
-						<daff-nav-accordion-item>
-							<a daffAccordionItemTitle>Details</a>
-						</daff-nav-accordion-item>
-				</daff-nav-accordion-item>
-		</daff-nav-accordion-item>
-	</daff-accordion>
-</div>
+	<h3>Content Accordion Item</h3>
+	<design-land-example-viewer-container example="basic-accordion"></design-land-example-viewer-container>
+	
+	<h3>Navigation Accordion Item</h3>
+	<design-land-example-viewer-container example="nav-accordion"></design-land-example-viewer-container>
+</daff-article>

--- a/apps/design-land/src/app/accordion/accordion.module.ts
+++ b/apps/design-land/src/app/accordion/accordion.module.ts
@@ -1,10 +1,13 @@
-import { NgModule } from '@angular/core';
+import { ComponentFactoryResolver, Injector, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { AccordionComponent } from './accordion.component';
 import { DesignLandAccordionRoutingModule } from './accordion-routing.module';
 
-import { DaffAccordionModule } from '@daffodil/design';
+import { DaffAccordionModule, DaffArticleModule } from '@daffodil/design';
+import { ACCORDION_EXAMPLES } from '@daffodil/design/accordion/examples';
+import { createCustomElement } from '@angular/elements';
+import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 
 
 @NgModule({
@@ -14,8 +17,27 @@ import { DaffAccordionModule } from '@daffodil/design';
   imports: [
     CommonModule,
     DesignLandAccordionRoutingModule,
-
+		DesignLandExampleViewerModule,
     DaffAccordionModule,
+		DaffArticleModule
   ],
 })
-export class AccordionModule { }
+export class AccordionModule { 
+	constructor(
+    injector: Injector,
+    private componentFactoryResolver: ComponentFactoryResolver,
+  ) {
+    ACCORDION_EXAMPLES
+      .map((classConstructor) => ({
+        element: createCustomElement(classConstructor, { injector }),
+        class: classConstructor,
+      }))
+      .map((customElement) => {
+        // Register the custom element with the browser.
+        customElements.define(
+          this.componentFactoryResolver.resolveComponentFactory<unknown>(customElement.class).selector + '-example',
+          customElement.element,
+        );
+      });
+  }
+}

--- a/libs/design/accordion/examples/ng-package.json
+++ b/libs/design/accordion/examples/ng-package.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/design/examples",
+  "deleteDestPath": false,
+  "lib": {
+    "entryFile": "src/index.ts",
+    "styleIncludePaths": ["../../src/scss"]
+  }
+} 

--- a/libs/design/accordion/examples/package.json
+++ b/libs/design/accordion/examples/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@daffodil/design/accordion/examples"
+} 

--- a/libs/design/accordion/examples/src/basic-accordion/basic-accordion.component.html
+++ b/libs/design/accordion/examples/src/basic-accordion/basic-accordion.component.html
@@ -1,0 +1,29 @@
+<daff-accordion>
+	<daff-accordion-item initiallyActive="true">
+		<h3 daffAccordionItemTitle>Details</h3>
+		<div daffAccordionItemContent>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent commodo 
+				lacus ut sapien consectetur, et ultricies leo rutrum. Integer iaculis ultrices nunc, 
+				et maximus quam efficitur sed. Maecenas iaculis nisl neque, maximus sagittis libero sagittis eget.
+				<a>Learn More.</a>
+		</div>
+	</daff-accordion-item>
+	<daff-accordion-item>
+		<h3 daffAccordionItemTitle>Details</h3>
+		<div daffAccordionItemContent>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent commodo 
+				lacus ut sapien consectetur, et ultricies leo rutrum. Integer iaculis ultrices nunc, 
+				et maximus quam efficitur sed. Maecenas iaculis nisl neque, maximus sagittis libero sagittis eget.
+				<a>Learn More.</a>
+		</div>
+	</daff-accordion-item>
+	<daff-accordion-item>
+		<h3 daffAccordionItemTitle>Details</h3>
+		<div daffAccordionItemContent>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent commodo 
+				lacus ut sapien consectetur, et ultricies leo rutrum. Integer iaculis ultrices nunc, 
+				et maximus quam efficitur sed. Maecenas iaculis nisl neque, maximus sagittis libero sagittis eget.
+				<a>Learn More.</a>
+		</div>
+	</daff-accordion-item>
+</daff-accordion>

--- a/libs/design/accordion/examples/src/basic-accordion/basic-accordion.component.ts
+++ b/libs/design/accordion/examples/src/basic-accordion/basic-accordion.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'basic-accordion',
+  templateUrl: './basic-accordion.component.html',
+})
+export class BasicAccordionComponent {}

--- a/libs/design/accordion/examples/src/basic-accordion/basic-accordion.module.ts
+++ b/libs/design/accordion/examples/src/basic-accordion/basic-accordion.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+
+import { DaffAccordionModule } from '@daffodil/design';
+
+import { BasicAccordionComponent } from './basic-accordion.component';
+
+
+@NgModule({
+  declarations: [
+    BasicAccordionComponent,
+  ],
+  exports: [
+    BasicAccordionComponent,
+  ],
+  imports: [
+    DaffAccordionModule,
+  ],
+})
+export class BasicAccordionModule { }

--- a/libs/design/accordion/examples/src/index.ts
+++ b/libs/design/accordion/examples/src/index.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/libs/design/accordion/examples/src/nav-accordion/nav-accordion.component.html
+++ b/libs/design/accordion/examples/src/nav-accordion/nav-accordion.component.html
@@ -1,0 +1,23 @@
+<daff-accordion>
+	<daff-nav-accordion-item>
+		<h3 daffAccordionItemTitle>Details</h3>
+		<daff-nav-accordion-item>
+			<h3 daffAccordionItemTitle>Details</h3>
+			<daff-nav-accordion-item>
+				<a daffAccordionItemTitle>Details</a>
+			</daff-nav-accordion-item>
+			<daff-nav-accordion-item>
+				<a daffAccordionItemTitle>Details</a>
+			</daff-nav-accordion-item>
+		</daff-nav-accordion-item>
+		<daff-nav-accordion-item>
+			<h3 daffAccordionItemTitle>Details</h3>
+			<daff-nav-accordion-item>
+				<a daffAccordionItemTitle>Details</a>
+			</daff-nav-accordion-item>
+			<daff-nav-accordion-item>
+				<a daffAccordionItemTitle>Details</a>
+			</daff-nav-accordion-item>
+		</daff-nav-accordion-item>
+	</daff-nav-accordion-item>
+</daff-accordion>

--- a/libs/design/accordion/examples/src/nav-accordion/nav-accordion.component.ts
+++ b/libs/design/accordion/examples/src/nav-accordion/nav-accordion.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'nav-accordion',
+  templateUrl: './nav-accordion.component.html',
+})
+export class NavAccordionComponent {}

--- a/libs/design/accordion/examples/src/nav-accordion/nav-accordion.module.ts
+++ b/libs/design/accordion/examples/src/nav-accordion/nav-accordion.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+
+import { DaffAccordionModule } from '@daffodil/design';
+
+import { NavAccordionComponent } from './nav-accordion.component';
+
+
+@NgModule({
+  declarations: [
+    NavAccordionComponent,
+  ],
+  exports: [
+    NavAccordionComponent,
+  ],
+  imports: [
+    DaffAccordionModule,
+  ],
+})
+export class NavAccordionModule { }

--- a/libs/design/accordion/examples/src/public_api.ts
+++ b/libs/design/accordion/examples/src/public_api.ts
@@ -1,0 +1,9 @@
+import { BasicAccordionComponent } from './basic-accordion/basic-accordion.component';
+export { BasicAccordionModule } from './basic-accordion/basic-accordion.module';
+import { NavAccordionComponent } from './nav-accordion/nav-accordion.component';
+export { NavAccordionModule } from './nav-accordion/nav-accordion.module';
+
+export const ACCORDION_EXAMPLES = [
+  BasicAccordionComponent,
+  NavAccordionComponent,
+];

--- a/libs/design/src/molecules/accordion/nav-accordion-item/nav-accordion-item.component.html
+++ b/libs/design/src/molecules/accordion/nav-accordion-item/nav-accordion-item.component.html
@@ -1,9 +1,9 @@
 <div class="daff-nav-accordion-item__header" (click)="toggleActive()">
   <ng-content select="[daffAccordionItemTitle]"></ng-content>
-  <span [hidden]="_open" daffSuffix *ngIf="_navAccordionItemChild">
+  <span [hidden]="_open" daffSuffix *ngIf="_navAccordionItemChild.toArray().length">
     <fa-icon [icon]="faChevronDown"></fa-icon>
   </span>
-  <span [hidden]="!_open" daffSuffix *ngIf="_navAccordionItemChild">
+  <span [hidden]="!_open" daffSuffix *ngIf="_navAccordionItemChild.toArray().length">
     <fa-icon [icon]="faChevronUp"></fa-icon>
   </span>
 </div>

--- a/libs/design/src/molecules/accordion/nav-accordion-item/nav-accordion-item.component.scss
+++ b/libs/design/src/molecules/accordion/nav-accordion-item/nav-accordion-item.component.scss
@@ -1,16 +1,16 @@
 @import 'daff-util';
 
-:host(.daff-nav-accordion-item__level-1) {
+:host(.daff-nav-accordion-item--level-1) {
 	.daff-nav-accordion-item__header {
 		padding-left: 15px;
 	}
 }
-:host(.daff-nav-accordion-item__level-2) {
+:host(.daff-nav-accordion-item--level-2) {
 	.daff-nav-accordion-item__header {
 		padding-left: 30px;
 	}
 }
-:host(.daff-nav-accordion-item__level-3) {
+:host(.daff-nav-accordion-item--level-3) {
 	.daff-nav-accordion-item__header {
 		padding-left: 45px;
 	}

--- a/libs/design/src/molecules/accordion/nav-accordion-item/nav-accordion-item.component.ts
+++ b/libs/design/src/molecules/accordion/nav-accordion-item/nav-accordion-item.component.ts
@@ -5,7 +5,8 @@ import {
   HostBinding,
   SkipSelf,
   Optional,
-  ContentChild,
+  ContentChildren,
+  QueryList,
 } from '@angular/core';
 import {
   faChevronDown,
@@ -45,14 +46,14 @@ export class DaffNavAccordionItemComponent implements OnInit {
 	@HostBinding('class') get classes() {
     return [
       'daff-nav-accordion-item',
-      'daff-nav-accordion-item__level-' + this._level,
+      'daff-nav-accordion-item--level-' + this._level,
     ];
   }
 
 	@Input() initiallyActive: boolean;
 
-	@ContentChild(DaffNavAccordionItemComponent, { static: true })
-	_navAccordionItemChild: DaffNavAccordionItemComponent;
+	@ContentChildren(DaffNavAccordionItemComponent, { descendants: true })
+	_navAccordionItemChild: QueryList<DaffNavAccordionItemComponent>;
 
 	/**
 	 * @docs-private


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
- Added example docs for two accordion types.
- Switched to using `ContentChildren` rather than `ContentChild`, so `daff-nav-accordion-item` children can be found through descendants.
- Made some minor changes to internal css class names in the `daff-nav-accordion-item`.