### PR TITLE
feat(tools-dgeni): add processor for the @inheritdoc tag

### DIFF
--- a/tools/dgeni/src/processors/addInheritedDocsContent.spec.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.spec.ts
@@ -14,13 +14,45 @@ describe("AddInheritedDocsContentProcessor", () => {
 			},
 			moduleDoc: {
 				exports: [{
-					symbol: {
-						escapedName: 'SomeInterface',
-					},
+					docType: 'interface',
 					members: [{
 						name: 'member1',
 						description: copiedDescription
 					}]
+				}]
+			},
+			members: [{
+				name: 'member1',
+				description: null,
+			}]
+		}];
+
+    expect(processor.$process(docs)[0].members[0].description).toEqual(copiedDescription);
+  });
+
+	//this is needed, because sometimes dgeni thinks an interface is implemented by a class when it isn't.
+	//E.g. DaffCategoryMemoizedSelectors is listed as an interface for DaffCategoryFacade by dgeni.
+  it("should not throw an error if the member in the interface does not exist in the original class", () => {
+		const copiedDescription = 'some member description';
+    let docs = [{
+			tags: {
+				tags: [{
+					tagName: 'inheritdoc',
+				}]
+			},
+			moduleDoc: {
+				exports: [{
+					docType: 'interface',
+					members: [
+						{
+							name: 'member1',
+							description: copiedDescription
+						},
+						{
+							name: 'non-matching member name',
+							description: 'some description'
+						}
+					]
 				}]
 			},
 			members: [{
@@ -40,9 +72,7 @@ describe("AddInheritedDocsContentProcessor", () => {
 			},
 			moduleDoc: {
 				exports: [{
-					symbol: {
-						escapedName: 'SomeInterface',
-					},
+					docType: 'interface',
 					members: [{
 						name: 'member1',
 						description: copiedDescription

--- a/tools/dgeni/src/processors/addInheritedDocsContent.spec.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.spec.ts
@@ -32,7 +32,7 @@ describe("AddInheritedDocsContentProcessor", () => {
     expect(processor.$process(docs)[0].members[0].description).toEqual(copiedDescription);
   });
 
-  it("should copy member descriptions from inherited docs without the 'inheritdoc' tag", () => {
+  it("should not copy member descriptions from implements interfaces without the 'inheritdoc' tag", () => {
 		const copiedDescription = 'some member description';
     let docs = [{
 			tags: {

--- a/tools/dgeni/src/processors/addInheritedDocsContent.spec.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.spec.ts
@@ -1,0 +1,60 @@
+import "jasmine";
+import { AddInheritedDocsContentProcessor } from './addInheritedDocsContent';
+
+describe("AddInheritedDocsContentProcessor", () => {
+  let processor: AddInheritedDocsContentProcessor = new AddInheritedDocsContentProcessor();
+
+  it("should copy member descriptions from inherited docs", () => {
+		const copiedDescription = 'some member description';
+    let docs = [{
+			tags: {
+				tags: [{
+					tagName: 'inheritdoc',
+				}]
+			},
+			moduleDoc: {
+				exports: [{
+					symbol: {
+						escapedName: 'SomeInterface',
+					},
+					members: [{
+						name: 'member1',
+						description: copiedDescription
+					}]
+				}]
+			},
+			members: [{
+				name: 'member1',
+				description: null,
+			}]
+		}];
+
+    expect(processor.$process(docs)[0].members[0].description).toEqual(copiedDescription);
+  });
+
+  it("should copy member descriptions from inherited docs without the 'inheritdoc' tag", () => {
+		const copiedDescription = 'some member description';
+    let docs = [{
+			tags: {
+				tags: []
+			},
+			moduleDoc: {
+				exports: [{
+					symbol: {
+						escapedName: 'SomeInterface',
+					},
+					members: [{
+						name: 'member1',
+						description: copiedDescription
+					}]
+				}]
+			},
+			members: [{
+				name: 'member1',
+				description: null,
+			}]
+		}];
+
+    expect(processor.$process(docs)[0].members[0].description).toEqual(null);
+  });
+});

--- a/tools/dgeni/src/processors/addInheritedDocsContent.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.ts
@@ -1,0 +1,26 @@
+import { Processor, Document } from 'dgeni';
+
+/**
+ * Inherit docs content from parent interfaces.
+ */
+export class AddInheritedDocsContentProcessor implements Processor {
+	name = 'filterOutPrivateProperties';
+	$runAfter = ['docs-processed'];
+	$runBefore = ['rendering-docs'];
+
+	$process(docs: Document[]): Document[] {
+		return docs.map(doc => {
+			if(!doc.members || !doc.tags.tags.filter(tag => tag.tagName === 'inheritdoc').length) return doc;
+
+			//get all interfaces that the doc implements.
+			doc.moduleDoc.exports.filter(e => e.symbol.escapedName.includes('Interface'))
+				.map(i => {
+					i.members.map(member => {
+						//copy over the description from the interface to the doc.
+						doc.members.find(m => m.name === member.name).description = member.description;
+					})
+				})
+			return doc;
+		});
+	}
+}

--- a/tools/dgeni/src/processors/addInheritedDocsContent.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.ts
@@ -13,11 +13,12 @@ export class AddInheritedDocsContentProcessor implements Processor {
 			if(!doc.members || !doc.tags.tags.filter(tag => tag.tagName === 'inheritdoc').length) return doc;
 
 			//get all interfaces that the doc implements.
-			doc.moduleDoc.exports.filter(e => e.symbol.escapedName.includes('Interface'))
+			doc.moduleDoc.exports.filter(e => e.docType === 'interface')
 				.map(i => {
 					i.members.map(member => {
 						//copy over the description from the interface to the doc.
-						doc.members.find(m => m.name === member.name).description = member.description;
+						const memberMatch = doc.members.find(m => m.name === member.name);
+						if(memberMatch) memberMatch.description = member.description;
 					})
 				})
 			return doc;

--- a/tools/dgeni/src/transforms/daffodil-api-package/index.ts
+++ b/tools/dgeni/src/transforms/daffodil-api-package/index.ts
@@ -10,6 +10,7 @@ import { FilterContainedDocsProcessor } from '../../processors/filterDocs';
 import { CleanSelectorsProcessor } from '../../processors/cleanSelectors';
 import { MakeTypesHtmlCompatibleProcessor } from '../../processors/makeTypesHtmlCompatible';
 import { FilterOutPrivatePropertiesProcessor } from '../../processors/filterOutPrivateProperties';
+import { AddInheritedDocsContentProcessor } from '../../processors/addInheritedDocsContent';
 
 //List of packages to be left out of API generation
 const excludedPackages = ['branding'];
@@ -24,6 +25,7 @@ export const apiDocs =  new Package('checkout', [
   .processor(new CleanSelectorsProcessor())
   .processor(new MakeTypesHtmlCompatibleProcessor())
   .processor(new FilterOutPrivatePropertiesProcessor())
+  .processor(new AddInheritedDocsContentProcessor())
   .processor(new GenerateApiListProcessor())
   .processor(new PackagesProcessor())
   .factory(function API_DOC_TYPES_TO_RENDER(EXPORT_DOC_TYPES) {
@@ -70,7 +72,8 @@ export const apiDocs =  new Package('checkout', [
 	})
 	.config(function(parseTagsProcessor: any) {
 		parseTagsProcessor.tagDefinitions = parseTagsProcessor.tagDefinitions.concat([
-			{name: 'docs-private'}
+			{name: 'docs-private'},
+			{name: 'inheritdoc'}
 		])
 	})
   .config(function(convertToJson, API_DOC_TYPES_TO_RENDER) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The jsdoc `@inheritdoc` tag doesn't do anything right now.

## What is the new behavior?
The jsdoc `@inheritdoc` tag now causes dgeni to copy member descriptions from the interface to the class that implements it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
While there is a dgeni-packages for jsdoc, there is no processor in it for the `@inheritdoc` tag. See the list of supported tags here: https://github.com/angular/dgeni-packages/tree/master/jsdoc/tag-defs
I also tried using it anyway just to see if it would process them secretly, but it doesn't. So I wrote a custom processor that looks for the `@inheritdoc` tag. An example of this working is on the daff.io app with the `DaffCategoryFacade`.