### PR TITLE
fix(tools-dgeni): AddInheritedDocsContentProcessor is overriding the …

### DIFF
--- a/tools/dgeni/src/processors/addInheritedDocsContent.spec.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.spec.ts
@@ -15,20 +15,21 @@ describe("AddInheritedDocsContentProcessor", () => {
 				tags: {
 					tags: [{
 						tagName: 'inheritdoc',
-						description: 'SomeInterfaceName'
 					}]
 				},
 				members: [{
 					name: 'member1',
 					description: null,
-				}]
-			},
-			{
-				tags: { tags: [] },
-				name: 'SomeInterfaceName',
-				members: [{
-					name: 'member1',
-					description: stubInterfaceMemberDescription
+				}],
+				implementsClauses: [{
+					doc: {
+						members: [
+							{
+								name: 'member1',
+								description: stubInterfaceMemberDescription
+							}
+						]
+					}
 				}]
 			},
 		];
@@ -43,61 +44,20 @@ describe("AddInheritedDocsContentProcessor", () => {
 				members: [{
 					name: 'member1',
 					description: null,
-				}]
-			},
-			{
-				tags: { tags: [] },
-				name: 'SomeInterfaceName',
-				members: [{
-					name: 'member1',
-					description: stubInterfaceMemberDescription
+				}],
+				implementsClauses: [{
+					doc: {
+						members: [
+							{
+								name: 'member1',
+								description: stubInterfaceMemberDescription
+							}
+						]
+					}
 				}]
 			},
 		];
 
     expect(processor.$process(docs)[0].members[0].description).toEqual(null);
   });
-
-	it('should inherit doc descriptions from multiple tagged interfaces', () => {
-		const stubSecondInterfaceDescription = 'some other description';
-		let docs = [
-			{
-				tags: {
-					tags: [{
-						tagName: 'inheritdoc',
-						description: 'SomeInterfaceName, SomeOtherInterfaceName'
-					}]
-				},
-				members: [
-					{
-						name: 'member1',
-						description: null,
-					},
-					{
-						name: 'member2',
-						description: null
-					}
-				]
-			},
-			{
-				tags: { tags: [] },
-				name: 'SomeInterfaceName',
-				members: [{
-					name: 'member1',
-					description: stubInterfaceMemberDescription
-				}]
-			},
-			{
-				tags: { tags: [] },
-				name: 'SomeOtherInterfaceName',
-				members: [{
-					name: 'member2',
-					description: stubSecondInterfaceDescription
-				}]
-			},
-		];
-
-		expect(processor.$process(docs)[0].members[0].description).toEqual(stubInterfaceMemberDescription);
-    expect(processor.$process(docs)[0].members[1].description).toEqual(stubSecondInterfaceDescription);
-	});
 });

--- a/tools/dgeni/src/processors/addInheritedDocsContent.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.ts
@@ -2,6 +2,10 @@ import { Processor, Document } from 'dgeni';
 
 /**
  * Inherit docs content from parent interfaces.
+ * 
+ * Usage:
+ * Single Interface: @inheritdoc SomeInterface
+ * Multiple Interfaces: @inheritdoc SomeInterface, SomeOtherInterface
  */
 export class AddInheritedDocsContentProcessor implements Processor {
 	name = 'addInheritedDocsContent';
@@ -10,15 +14,17 @@ export class AddInheritedDocsContentProcessor implements Processor {
 
 	$process(docs: Document[]): Document[] {
 		return docs.map(doc => {
-			if(!doc.members || !doc.tags.tags.filter(tag => tag.tagName === 'inheritdoc').length) return doc;
+			const inheritdocTag = doc.tags.tags.filter(tag => tag.tagName === 'inheritdoc');
+			if(!doc.members || !inheritdocTag.length) return doc;
+			//get the names of the interfaces which should be inherited.
+			const inheritedInterface = inheritdocTag[0].description.split(',').map(e => e.trim());
 
-			//get all interfaces that the doc implements.
-			doc.moduleDoc.exports.filter(e => e.docType === 'interface')
-				.map(i => {
-					i.members.map(member => {
-						//copy over the description from the interface to the doc.
-						const memberMatch = doc.members.find(m => m.name === member.name);
-						if(memberMatch) memberMatch.description = member.description;
+			//find all interfaces from which the doc should inherit.
+			docs.filter(doc => inheritedInterface.findIndex(i => i === doc.name) > -1)
+				.map(matchedDoc => {
+					matchedDoc.members.map(member => {
+						const matchedMember = doc.members.find(m => m.name === member.name);
+						if(matchedMember) matchedMember.description = member.description;
 					})
 				})
 			return doc;

--- a/tools/dgeni/src/processors/addInheritedDocsContent.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.ts
@@ -4,7 +4,7 @@ import { Processor, Document } from 'dgeni';
  * Inherit docs content from parent interfaces.
  */
 export class AddInheritedDocsContentProcessor implements Processor {
-	name = 'filterOutPrivateProperties';
+	name = 'addInheritedDocsContent';
 	$runAfter = ['docs-processed'];
 	$runBefore = ['rendering-docs'];
 

--- a/tools/dgeni/src/processors/addInheritedDocsContent.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.ts
@@ -3,9 +3,7 @@ import { Processor, Document } from 'dgeni';
 /**
  * Inherit docs content from parent interfaces.
  * 
- * Usage:
- * Single Interface: @inheritdoc SomeInterface
- * Multiple Interfaces: @inheritdoc SomeInterface, SomeOtherInterface
+ * Usage: @inheritdoc
  */
 export class AddInheritedDocsContentProcessor implements Processor {
 	name = 'addInheritedDocsContent';
@@ -14,19 +12,20 @@ export class AddInheritedDocsContentProcessor implements Processor {
 
 	$process(docs: Document[]): Document[] {
 		return docs.map(doc => {
-			const inheritdocTag = doc.tags.tags.filter(tag => tag.tagName === 'inheritdoc');
-			if(!doc.members || !inheritdocTag.length) return doc;
-			//get the names of the interfaces which should be inherited.
-			const inheritedInterface = inheritdocTag[0].description.split(',').map(e => e.trim());
+			if(!doc.members || !doc.tags.tags.filter(tag => tag.tagName === 'inheritdoc').length) return doc;
 
-			//find all interfaces from which the doc should inherit.
-			docs.filter(doc => inheritedInterface.findIndex(i => i === doc.name) > -1)
-				.map(matchedDoc => {
-					matchedDoc.members.map(member => {
-						const matchedMember = doc.members.find(m => m.name === member.name);
-						if(matchedMember) matchedMember.description = member.description;
-					})
+			doc.implementsClauses.map(i => {
+				if(!i.doc) return i;
+				i.doc.members.map(member => {
+					const matchedMember = doc.members.find(m => m.name === member.name);
+					if(matchedMember) {
+						matchedMember.description = matchedMember.description ? 
+							`${member.description} ${matchedMember.description}`:
+							member.description;
+					}
 				})
+			})
+
 			return doc;
 		});
 	}

--- a/tools/dgeni/src/processors/packages.spec.ts
+++ b/tools/dgeni/src/processors/packages.spec.ts
@@ -19,4 +19,12 @@ describe("PackagesProcessor", () => {
       jasmine.objectContaining(processedDocs)
     ]);
   });
+
+  it('should ensure the id and name trim absolute paths', () => {
+    let docs = [{docType: 'module', id: 'Users/root/daffodil/libs/driver/src'}];
+    let processedDocs = {docType: 'package', id: 'driver', name: '@daffodil/driver'};
+    expect(processor.$process(docs)).toEqual([
+      jasmine.objectContaining(processedDocs)
+    ]);
+  });
 });

--- a/tools/dgeni/src/processors/packages.ts
+++ b/tools/dgeni/src/processors/packages.ts
@@ -8,7 +8,9 @@ export class PackagesProcessor implements Processor {
   $process(docs: Document[]): Document[] {
     return docs.map(doc => {
       if (doc.docType === 'module') {
-        doc.id = doc.id.replace(/\/src$/, '');
+        doc.id = doc.id
+					.replace(/\/src$/, '')
+					.replace(/^.*libs\//, '');
         doc.docType = 'package';
         // The name is actually the full id
         doc.name = `@daffodil/${doc.id}`;

--- a/tools/dgeni/src/transforms/daffodil-api-package/index.ts
+++ b/tools/dgeni/src/transforms/daffodil-api-package/index.ts
@@ -34,8 +34,8 @@ export const apiDocs =  new Package('checkout', [
   //Configure our package
   .config(function(readFilesProcessor, readTypeScriptModules, tsParser) {
 
-    // Tell TypeScript how to load modules that start with with `@daffodil`
-    tsParser.options.paths = { '@daffodil/*': [API_SOURCE_PATH + '/*'] };
+    // Tell TypeScript how to load modules that start with `@daffodil`
+		tsParser.options.paths = { '@daffodil/*': [API_SOURCE_PATH + '/*/src'] };
     tsParser.options.baseUrl = '.';
 
     // The typescriptPackage only uses the 'readTypeScriptModules' processor, so disable readFilesProcessor.


### PR DESCRIPTION
…FilterOutPrivatePropertiesProcessor

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
TLDR: There were a number of bugs with the `AddInheritedDocsContentProcessor`. This PR makes the inheritdoc tag usage a lot more robust by requiring the names of the interfaces from which you want the class to inherit.

1. The AddInheritedDocsContentProcessor has the wrong name and it is overriding the FilterOutPrivatePropertiesProcessor.
2. Dgeni does not include interfaces in generated documentation objects for classes in which they are implemented if those interfaces are defined before the classes.
3. Dgeni includes too many interfaces as related to classes for some reason; e.g. the DaffProductFacade has every type of product facade interface associated with it (`DaffConfigurableProductFacadeInterface`, `DaffCompositeProductFacadeInterface`, etc). This results in shared fields (like `loading$`) being overwritten by the last interface when docs are generated. This must be resolved by either finding a better list of implemented interfaces within the dgeni-docs generated Doc object (which I couldn't find), or by searching for each interface name specifically (which makes sense because I needed to address problem #2 anyway).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

Notes:
The new inheritdoc tag usage is:
For a single interface: `@inheritdoc SomeInterfaceName`
For multiple interfaces: `@inheritdoc SomeInterfaceName, SomeOtherInterfaceName`

This dgeni processor will search for those interfaces in the global list of generated docs, then add member descriptions for any member matches that are found between the interface and class.