### PR TITLE
fix(product): the bundled product option uid from magento is not uniq…

### DIFF
--- a/libs/product/driver/magento/src/transforms/bundled-product-transformers.ts
+++ b/libs/product/driver/magento/src/transforms/bundled-product-transformers.ts
@@ -49,7 +49,7 @@ function transformMagentoBundledProductItem(item: MagentoBundledProductItem): Da
 
 function transformMagentoBundledProductItemOption(option: MagentoBundledProductItemOption): DaffCompositeProductItemOption {
   return {
-		//todo: this should be option.uid.toString() but this is not a unique id at the time of Magento 2.4.
+    //todo: this should be option.uid.toString() but this is not a unique id at the time of Magento 2.4.
     id: option.product.uid.toString(),
     url: null,
     name: option.label,

--- a/libs/product/driver/magento/src/transforms/bundled-product-transformers.ts
+++ b/libs/product/driver/magento/src/transforms/bundled-product-transformers.ts
@@ -49,7 +49,8 @@ function transformMagentoBundledProductItem(item: MagentoBundledProductItem): Da
 
 function transformMagentoBundledProductItemOption(option: MagentoBundledProductItemOption): DaffCompositeProductItemOption {
   return {
-    id: option.uid.toString(),
+		//todo: this should be option.uid.toString() but this is not a unique id at the time of Magento 2.4.
+    id: option.product.uid.toString(),
     url: null,
     name: option.label,
     price: getPrice(option.product),

--- a/libs/product/driver/magento/src/transforms/spec-data/daff-composite-product.json
+++ b/libs/product/driver/magento/src/transforms/spec-data/daff-composite-product.json
@@ -19,7 +19,7 @@
 			"input_type": "select",
 			"options": [
 				{
-					"id": "1",
+					"id": "14",
           "url": null,
 					"name": "Option 1",
 					"price": 5,
@@ -33,7 +33,7 @@
 					"in_stock": true
 				},
 				{
-					"id": "2",
+					"id": "24",
           "url": null,
 					"name": "Option 2",
 					"price": 2,


### PR DESCRIPTION
…ue like it should be

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The Magento docs claim that the bunded product option uid is a unique identifier (https://devdocs.magento.com/guides/v2.4/graphql/interfaces/bundle-product.html), but it isn't.

## What is the new behavior?
This sets the id for the `DaffCompositeProductOptionItem` to the product id attached to the bundled product item option, which is unique between options. I added a todo to change this back if magento fixes this in the future.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```