### PR TITLE
feat(daffio): add table of contents for guide docs

### DIFF
--- a/apps/daffio/src/app/app-routing.module.ts
+++ b/apps/daffio/src/app/app-routing.module.ts
@@ -26,6 +26,9 @@ export const appRoutes: Routes = [
 @NgModule({
   imports: [
     RouterModule.forRoot(appRoutes, {
+      anchorScrolling: 'enabled',
+      //this ensures that clicking on the same fragment route a second time will scroll to the associated id.
+      onSameUrlNavigation: 'reload',
       scrollPositionRestoration: 'enabled',
     }),
   ],

--- a/apps/daffio/src/app/app-routing.module.ts
+++ b/apps/daffio/src/app/app-routing.module.ts
@@ -26,10 +26,11 @@ export const appRoutes: Routes = [
 @NgModule({
   imports: [
     RouterModule.forRoot(appRoutes, {
+      initialNavigation: 'enabled',
+      scrollPositionRestoration: 'enabled',
       anchorScrolling: 'enabled',
       //this ensures that clicking on the same fragment route a second time will scroll to the associated id.
       onSameUrlNavigation: 'reload',
-      scrollPositionRestoration: 'enabled',
     }),
   ],
   exports: [

--- a/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.html
+++ b/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.html
@@ -1,2 +1,6 @@
-<daffio-doc-viewer [doc]="doc"></daffio-doc-viewer>
-<daffio-guide-table-of-contents [doc]="doc"></daffio-guide-table-of-contents>
+<daff-container size="lg">
+	<div class="daffio-guide-viewer__grid">
+		<daffio-doc-viewer class="daffio-guide-viewer__content" [doc]="doc"></daffio-doc-viewer>
+		<daffio-guide-table-of-contents class="daffio-guide-viewer__table-of-contents" [doc]="doc"></daffio-guide-table-of-contents>
+	</div>
+</daff-container>

--- a/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.html
+++ b/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.html
@@ -1,1 +1,2 @@
 <daffio-doc-viewer [doc]="doc"></daffio-doc-viewer>
+<daffio-guide-table-of-contents [doc]="doc"></daffio-guide-table-of-contents>

--- a/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.html
+++ b/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.html
@@ -1,6 +1,6 @@
 <daff-container size="lg">
 	<div class="daffio-guide-viewer__grid">
 		<daffio-doc-viewer class="daffio-guide-viewer__content" [doc]="doc"></daffio-doc-viewer>
-		<daffio-guide-table-of-contents class="daffio-guide-viewer__table-of-contents" [doc]="doc"></daffio-guide-table-of-contents>
+		<daffio-guide-table-of-contents class="daffio-guide-viewer__table-of-contents" [tableOfContents]="doc.tableOfContents"></daffio-guide-table-of-contents>
 	</div>
 </daff-container>

--- a/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.html
+++ b/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.html
@@ -1,6 +1,6 @@
 <daff-container size="lg">
 	<div class="daffio-guide-viewer__grid">
 		<daffio-doc-viewer class="daffio-guide-viewer__content" [doc]="doc"></daffio-doc-viewer>
-		<daffio-guide-table-of-contents class="daffio-guide-viewer__table-of-contents" [tableOfContents]="doc.tableOfContents"></daffio-guide-table-of-contents>
+		<daffio-guide-table-of-contents class="daffio-guide-viewer__table-of-contents" [tableOfContents]="doc.tableOfContents.json"></daffio-guide-table-of-contents>
 	</div>
 </daff-container>

--- a/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.scss
+++ b/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.scss
@@ -1,0 +1,4 @@
+:host {
+	display: flex;
+	flex-direction: row;
+}

--- a/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.scss
+++ b/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.scss
@@ -1,13 +1,36 @@
-:host {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
+@import 'utilities';
 
-	& daffio-doc-viewer {
-		flex: 4;
+:host {
+	display: block;
+}
+
+.daffio-guide-viewer {
+	&__grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		grid-template-areas:
+			'content';
+		padding: 48px;
+		
+		@include breakpoint(big-tablet) {
+			grid-template-columns: minmax(0px, 960px) 240px;
+			grid-template-areas:
+				'content table-of-contents';
+			padding: 48px;
+			grid-gap: 48px;
+		}
 	}
-	
-	& daffio-guide-table-of-contents {
-		flex: 1;
+
+	&__content {
+		grid-area: content;
+	}
+
+	&__table-of-contents {
+		display: none;
+		
+		@include breakpoint(big-tablet) {
+			display: block;
+			grid-area: table-of-contents;
+		}
 	}
 }

--- a/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.scss
+++ b/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.scss
@@ -1,4 +1,13 @@
 :host {
 	display: flex;
 	flex-direction: row;
+	justify-content: space-between;
+
+	& daffio-doc-viewer {
+		flex: 4;
+	}
+	
+	& daffio-guide-table-of-contents {
+		flex: 1;
+	}
 }

--- a/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.ts
+++ b/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.component.ts
@@ -9,6 +9,7 @@ import { DaffioDoc } from '../../../shared/models/doc';
 @Component({
   selector: 'daffio-guide-viewer',
   templateUrl: './guide-viewer.component.html',
+  styleUrls: ['./guide-viewer.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DaffioGuideViewerComponent {

--- a/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.module.ts
+++ b/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { DaffLinkSetModule } from '@daffodil/design';
+import { DaffContainerModule } from '@daffodil/design';
 
 import { DaffioDocViewerModule } from '../../../shared/components/doc-viewer/doc-viewer.module';
 import { DaffioGuideTableOfContentsModule } from '../table-of-contents/table-of-contents.module';
@@ -17,9 +17,9 @@ import { DaffioGuideViewerComponent } from './guide-viewer.component';
   ],
   imports: [
     CommonModule,
-    DaffioDocViewerModule,
-    DaffLinkSetModule,
     RouterModule,
+    DaffioDocViewerModule,
+    DaffContainerModule,
     DaffioGuideTableOfContentsModule,
   ],
 })

--- a/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.module.ts
+++ b/apps/daffio/src/app/docs/guide-docs/components/guide-viewer/guide-viewer.module.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 import { DaffLinkSetModule } from '@daffodil/design';
 
 import { DaffioDocViewerModule } from '../../../shared/components/doc-viewer/doc-viewer.module';
+import { DaffioGuideTableOfContentsModule } from '../table-of-contents/table-of-contents.module';
 import { DaffioGuideViewerComponent } from './guide-viewer.component';
 
 @NgModule({
@@ -19,6 +20,7 @@ import { DaffioGuideViewerComponent } from './guide-viewer.component';
     DaffioDocViewerModule,
     DaffLinkSetModule,
     RouterModule,
+    DaffioGuideTableOfContentsModule,
   ],
 })
 export class DaffioGuideViewerModule { }

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents-theme.scss
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents-theme.scss
@@ -1,0 +1,17 @@
+@mixin daffio-table-of-contents-theme($theme){
+	$primary: map-get($theme, primary);
+	$secondary: map-get($theme, secondary);
+	$tertiary: map-get($theme, tertiary);
+	$base: daff-map-deep-get($theme, "core.base");
+	$base-contrast: daff-map-deep-get($theme, "core.base-contrast");
+
+	.daffio-table-of-contents {
+		&__item {
+			color: daff-illuminate($base-contrast, $daff-gray, 4);
+
+			&:first-of-type {
+				border-bottom: 1px solid daff-illuminate($base, $daff-gray, 3);
+			}
+		}
+	}
+}

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.html
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.html
@@ -1,5 +1,5 @@
 <aside class="daffio-table-of-contents">
-	<div *ngFor="let entry of doc.tableOfContents.json" class="daffio-table-of-contents__item">
-		<a class="daffio-table-of-contents__item--level-{{entry.lvl}}" routerLink="/{{doc.id}}" [fragment]="entry.slug">{{ entry.content }}</a>
+	<div *ngFor="let entry of tableOfContents.json" class="daffio-table-of-contents__item">
+		<a class="daffio-table-of-contents__item--level-{{entry.lvl}}" routerLink="./" [fragment]="entry.slug">{{ entry.content }}</a>
 	</div>
 </aside>

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.html
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.html
@@ -1,3 +1,5 @@
-<div *ngFor="let entry of doc.tableOfContents.json" class="table-of-contents__item">
-	<a class="table-of-contents__item--level{{entry.lvl}}" routerLink="/{{doc.id}}" [fragment]="entry.slug">{{ entry.content }}</a>
-</div>
+<aside class="daffio-table-of-contents">
+	<div *ngFor="let entry of doc.tableOfContents.json" class="daffio-table-of-contents__item">
+		<a class="daffio-table-of-contents__item--level-{{entry.lvl}}" routerLink="/{{doc.id}}" [fragment]="entry.slug">{{ entry.content }}</a>
+	</div>
+</aside>

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.html
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.html
@@ -1,5 +1,5 @@
 <aside class="daffio-table-of-contents">
-	<div *ngFor="let entry of tableOfContents.json" class="daffio-table-of-contents__item">
+	<div *ngFor="let entry of tableOfContents" class="daffio-table-of-contents__item">
 		<a class="daffio-table-of-contents__item--level-{{entry.lvl}}" routerLink="./" [fragment]="entry.slug">{{ entry.content }}</a>
 	</div>
 </aside>

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.html
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.html
@@ -1,0 +1,3 @@
+<div *ngFor="let entry of doc.tableOfContents.json" class="table-of-contents__item">
+	<a class="table-of-contents__item--level{{entry.lvl}}" routerLink="/{{doc.id}}" [fragment]="entry.slug">{{ entry.content }}</a>
+</div>

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.scss
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.scss
@@ -1,29 +1,44 @@
 @import 'utilities';
 
 :host {
-	display: none;
-
-  @include breakpoint(tablet) {
-		display: block;
-	}
-	
-	a {
-		text-decoration: none;
-	}
+	display: block;
 }
 
-.table-of-contents__item {
-	display: flex;
+.daffio-table-of-contents {
+	position: sticky;
+	max-height: 100vh;
+	overflow: auto;
+	top: 48px;
+}
 
-	&--level2 {
-		padding-left: 20px;
-	}
+.daffio-table-of-contents {
+	&__item {
+		display: block;
 
-	&--level3 {
-		padding-left: 40px;
-	}
+		&:first-of-type {
+			@include embolden();
+			padding: 0 0 8px;
+			margin: 0 0 16px;
+		}
 
-	&--level4 {
-		padding-left: 60px;
+		a {
+			text-decoration: none;
+		}
+
+		&--level-1 {
+			padding: 0;
+		}
+
+		&--level-2 {
+			padding: 0;
+		}
+	
+		&--level-3 {
+			padding: 0 0 0 16px;
+		}
+	
+		&--level-4 {
+			padding: 0 0 0 32px;
+		}
 	}
 }

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.scss
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.scss
@@ -1,4 +1,11 @@
+@import 'utilities';
+
 :host {
+	display: none;
+
+  @include breakpoint(tablet) {
+		display: block;
+	}
 	
 	a {
 		text-decoration: none;
@@ -6,7 +13,7 @@
 }
 
 .table-of-contents__item {
-	width: 350px;
+	display: flex;
 
 	&--level2 {
 		padding-left: 20px;

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.scss
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.scss
@@ -1,0 +1,22 @@
+:host {
+	
+	a {
+		text-decoration: none;
+	}
+}
+
+.table-of-contents__item {
+	width: 350px;
+
+	&--level2 {
+		padding-left: 20px;
+	}
+
+	&--level3 {
+		padding-left: 40px;
+	}
+
+	&--level4 {
+		padding-left: 60px;
+	}
+}

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.spec.ts
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.spec.ts
@@ -32,7 +32,7 @@ describe('DaffioGuideTableOfContentsComponent', () => {
     fixture = TestBed.createComponent(DaffioGuideTableOfContentsComponent);
     component = fixture.componentInstance;
     stubDaffioDoc = new DaffioDocFactory().create();
-    component.doc = stubDaffioDoc;
+    component.tableOfContents = stubDaffioDoc.tableOfContents;
     fixture.detectChanges();
   });
 
@@ -41,14 +41,14 @@ describe('DaffioGuideTableOfContentsComponent', () => {
   });
 
   it('should render a table-of-contents__item for each entry in the table of contents', () => {
-    const tocItems = fixture.debugElement.queryAll(By.css('.table-of-contents__item'));
+    const tocItems = fixture.debugElement.queryAll(By.css('.daffio-table-of-contents__item'));
     expect(tocItems.length).toEqual(stubDaffioDoc.tableOfContents.json.length);
   });
 
   it('should label each toc__item with an indent level based on its toc level', () => {
-    const tocLevel1 = fixture.debugElement.queryAll(By.css('.table-of-contents__item--level1'));
-    const tocLevel2 = fixture.debugElement.queryAll(By.css('.table-of-contents__item--level2'));
-    const tocLevel3 = fixture.debugElement.queryAll(By.css('.table-of-contents__item--level3'));
+    const tocLevel1 = fixture.debugElement.queryAll(By.css('.daffio-table-of-contents__item--level-1'));
+    const tocLevel2 = fixture.debugElement.queryAll(By.css('.daffio-table-of-contents__item--level-2'));
+    const tocLevel3 = fixture.debugElement.queryAll(By.css('.daffio-table-of-contents__item--level-3'));
     expect(tocLevel1.length).toEqual(stubDaffioDoc.tableOfContents.json.filter(content => content.lvl === 1).length);
     expect(tocLevel2.length).toEqual(stubDaffioDoc.tableOfContents.json.filter(content => content.lvl === 2).length);
     expect(tocLevel3.length).toEqual(stubDaffioDoc.tableOfContents.json.filter(content => content.lvl === 3).length);

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.spec.ts
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.spec.ts
@@ -32,7 +32,7 @@ describe('DaffioGuideTableOfContentsComponent', () => {
     fixture = TestBed.createComponent(DaffioGuideTableOfContentsComponent);
     component = fixture.componentInstance;
     stubDaffioDoc = new DaffioDocFactory().create();
-    component.tableOfContents = stubDaffioDoc.tableOfContents;
+    component.tableOfContents = stubDaffioDoc.tableOfContents.json;
     fixture.detectChanges();
   });
 

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.spec.ts
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.spec.ts
@@ -1,0 +1,56 @@
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { DaffLinkSetModule } from '@daffodil/design';
+
+import { DaffioDoc } from '../../../shared/models/doc';
+import { DaffioDocFactory } from '../../../testing/factories/doc.factory';
+import { DaffioGuideTableOfContentsComponent } from './table-of-contents.component';
+
+describe('DaffioGuideTableOfContentsComponent', () => {
+  let component: DaffioGuideTableOfContentsComponent;
+  let fixture: ComponentFixture<DaffioGuideTableOfContentsComponent>;
+  let stubDaffioDoc: DaffioDoc;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [DaffioGuideTableOfContentsComponent],
+      imports: [
+        RouterTestingModule,
+        DaffLinkSetModule,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DaffioGuideTableOfContentsComponent);
+    component = fixture.componentInstance;
+    stubDaffioDoc = new DaffioDocFactory().create();
+    component.doc = stubDaffioDoc;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render a table-of-contents__item for each entry in the table of contents', () => {
+    const tocItems = fixture.debugElement.queryAll(By.css('.table-of-contents__item'));
+    expect(tocItems.length).toEqual(stubDaffioDoc.tableOfContents.json.length);
+  });
+
+  it('should label each toc__item with an indent level based on its toc level', () => {
+    const tocLevel1 = fixture.debugElement.queryAll(By.css('.table-of-contents__item--level1'));
+    const tocLevel2 = fixture.debugElement.queryAll(By.css('.table-of-contents__item--level2'));
+    const tocLevel3 = fixture.debugElement.queryAll(By.css('.table-of-contents__item--level3'));
+    expect(tocLevel1.length).toEqual(stubDaffioDoc.tableOfContents.json.filter(content => content.lvl === 1).length);
+    expect(tocLevel2.length).toEqual(stubDaffioDoc.tableOfContents.json.filter(content => content.lvl === 2).length);
+    expect(tocLevel3.length).toEqual(stubDaffioDoc.tableOfContents.json.filter(content => content.lvl === 3).length);
+  });
+});

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.ts
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.ts
@@ -16,5 +16,5 @@ export class DaffioGuideTableOfContentsComponent {
   /**
    * The doc to render
    */
-	@Input() tableOfContents: DaffioDoc['tableOfContents'];
+	@Input() tableOfContents: DaffioDoc['tableOfContents']['json'];
 }

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.ts
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.ts
@@ -1,0 +1,20 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+} from '@angular/core';
+
+import { DaffioDoc } from '../../../shared/models/doc';
+
+@Component({
+  selector: 'daffio-guide-table-of-contents',
+  templateUrl: './table-of-contents.component.html',
+  styleUrls: ['table-of-contents.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DaffioGuideTableOfContentsComponent {
+  /**
+   * The doc to render
+   */
+	@Input() doc: DaffioDoc;
+}

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.ts
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.component.ts
@@ -16,5 +16,5 @@ export class DaffioGuideTableOfContentsComponent {
   /**
    * The doc to render
    */
-	@Input() doc: DaffioDoc;
+	@Input() tableOfContents: DaffioDoc['tableOfContents'];
 }

--- a/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.module.ts
+++ b/apps/daffio/src/app/docs/guide-docs/components/table-of-contents/table-of-contents.module.ts
@@ -1,0 +1,29 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import {
+  DaffListModule,
+  DaffLinkSetModule,
+  DaffAccordionModule,
+} from '@daffodil/design';
+
+import { DaffioGuideTableOfContentsComponent } from './table-of-contents.component';
+
+
+@NgModule({
+  declarations: [
+    DaffioGuideTableOfContentsComponent,
+  ],
+  exports: [
+    DaffioGuideTableOfContentsComponent,
+  ],
+  imports: [
+    CommonModule,
+    DaffLinkSetModule,
+    DaffListModule,
+    RouterModule,
+    DaffAccordionModule,
+  ],
+})
+export class DaffioGuideTableOfContentsModule { }

--- a/apps/daffio/src/app/docs/guide-docs/views/guide-view.component.spec.ts
+++ b/apps/daffio/src/app/docs/guide-docs/views/guide-view.component.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { cold } from 'jasmine-marbles';
 import { BehaviorSubject } from 'rxjs';
 
@@ -26,6 +27,7 @@ describe('DaffioGuideViewComponent', () => {
       declarations: [DaffioGuideViewComponent],
       imports: [
         DaffioGuideViewerModule,
+        RouterTestingModule,
       ],
       providers: [
         { provide: ActivatedRoute, useValue: stubActivatedRoute },

--- a/apps/daffio/src/app/docs/guide-docs/views/guide-view.component.spec.ts
+++ b/apps/daffio/src/app/docs/guide-docs/views/guide-view.component.spec.ts
@@ -1,4 +1,8 @@
 import {
+  Component,
+  Input,
+} from '@angular/core';
+import {
   ComponentFixture,
   TestBed,
   waitForAsync,
@@ -11,8 +15,12 @@ import { BehaviorSubject } from 'rxjs';
 
 import { DaffioDoc } from '../../shared/models/doc';
 import { DaffioDocFactory } from '../../testing/factories/doc.factory';
-import { DaffioGuideViewerModule } from '../components/guide-viewer/guide-viewer.module';
 import { DaffioGuideViewComponent } from './guide-view.component';
+
+@Component({ selector: 'daffio-guide-viewer', template: '' })
+class MockDaffioGuideViewerComponent {
+	@Input() doc: DaffioDoc;
+}
 
 describe('DaffioGuideViewComponent', () => {
   let component: DaffioGuideViewComponent;
@@ -24,9 +32,11 @@ describe('DaffioGuideViewComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [DaffioGuideViewComponent],
+      declarations: [
+        DaffioGuideViewComponent,
+        MockDaffioGuideViewerComponent,
+      ],
       imports: [
-        DaffioGuideViewerModule,
         RouterTestingModule,
       ],
       providers: [
@@ -39,6 +49,7 @@ describe('DaffioGuideViewComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DaffioGuideViewComponent);
     component = fixture.componentInstance;
+    console.log(doc);
     stubActivatedRoute.data.next({ doc });
     fixture.detectChanges();
   });

--- a/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.html
+++ b/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.html
@@ -1,1 +1,2 @@
-<div class="doc-viewer" [innerHtml]="sanitizedContent"></div>
+<daff-article [innerHtml]="sanitizedContent">
+</daff-article>

--- a/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.html
+++ b/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.html
@@ -1,1 +1,1 @@
-<div class="doc-viewer" [innerHtml]="doc.contents"></div>
+<div class="doc-viewer" [innerHtml]="sanitizedContent"></div>

--- a/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.spec.ts
+++ b/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.spec.ts
@@ -3,6 +3,7 @@ import {
   async,
   ComponentFixture,
   TestBed,
+  waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -22,7 +23,7 @@ describe('DaffioDocViewerComponent', () => {
   let wrapper: WrapperComponent;
   const docFactory = new DaffioDocFactory();
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [WrapperComponent, DaffioDocViewerComponent],
     })
@@ -45,12 +46,5 @@ describe('DaffioDocViewerComponent', () => {
     fixture.detectChanges();
     const componentEl = <HTMLElement>fixture.debugElement.query(By.css('.doc-viewer')).nativeElement;
     expect(componentEl.innerHTML).toEqual(wrapper.doc.contents);
-  });
-
-  it('should rely on Angular mechanisms to prevent rendering of malicious code', () => {
-    wrapper.doc = docFactory.create({ contents: '<script>alert("Malicious")</script>' });
-    fixture.detectChanges();
-    const componentEl = <HTMLElement>fixture.debugElement.query(By.css('.doc-viewer')).nativeElement;
-    expect(componentEl.innerHTML).toEqual('');
   });
 });

--- a/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.spec.ts
+++ b/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.spec.ts
@@ -7,6 +7,8 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { DaffArticleModule } from '@daffodil/design';
+
 import { DaffioDocFactory } from '../../../testing/factories/doc.factory';
 import { DaffioDoc } from '../../models/doc';
 import { DaffioDocViewerComponent } from './doc-viewer.component';
@@ -25,6 +27,7 @@ describe('DaffioDocViewerComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      imports: [DaffArticleModule],
       declarations: [WrapperComponent, DaffioDocViewerComponent],
     })
       .compileComponents();
@@ -44,7 +47,7 @@ describe('DaffioDocViewerComponent', () => {
   it('should render the contents of the doc as innerhtml', () => {
     wrapper.doc = docFactory.create({ contents: 'Some Content' });
     fixture.detectChanges();
-    const componentEl = <HTMLElement>fixture.debugElement.query(By.css('.daffio-doc-viewer')).nativeElement;
-    expect(componentEl.innerHTML).toEqual(wrapper.doc.contents);
+    const articleElement = fixture.debugElement.query(By.css('daff-article')).nativeElement;
+    expect(articleElement.innerHTML).toEqual(wrapper.doc.contents);
   });
 });

--- a/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.spec.ts
+++ b/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.spec.ts
@@ -44,7 +44,7 @@ describe('DaffioDocViewerComponent', () => {
   it('should render the contents of the doc as innerhtml', () => {
     wrapper.doc = docFactory.create({ contents: 'Some Content' });
     fixture.detectChanges();
-    const componentEl = <HTMLElement>fixture.debugElement.query(By.css('.doc-viewer')).nativeElement;
+    const componentEl = <HTMLElement>fixture.debugElement.query(By.css('.daffio-doc-viewer')).nativeElement;
     expect(componentEl.innerHTML).toEqual(wrapper.doc.contents);
   });
 });

--- a/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.ts
+++ b/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.ts
@@ -1,9 +1,13 @@
 import {
   Component,
-  OnInit,
   Input,
   ChangeDetectionStrategy,
+  OnChanges,
 } from '@angular/core';
+import {
+  DomSanitizer,
+  SafeHtml,
+} from '@angular/platform-browser';
 
 import { DaffioDoc } from '../../models/doc';
 
@@ -12,11 +16,18 @@ import { DaffioDoc } from '../../models/doc';
   templateUrl: './doc-viewer.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DaffioDocViewerComponent {
+export class DaffioDocViewerComponent implements OnChanges {
+
+  constructor(private sanitizer: DomSanitizer) {}
 
   /**
    * The doc to render
    */
   @Input() doc: DaffioDoc;
 
+	sanitizedContent: SafeHtml;
+
+	ngOnChanges() {
+	  this.sanitizedContent = this.sanitizer.bypassSecurityTrustHtml(this.doc.contents);
+	}
 }

--- a/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.ts
+++ b/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.component.ts
@@ -28,6 +28,7 @@ export class DaffioDocViewerComponent implements OnChanges {
 	sanitizedContent: SafeHtml;
 
 	ngOnChanges() {
+	  //It is necessary to bypass the default angular sanitization to keep id tags in the injected html. These id tags are used for fragment routing.
 	  this.sanitizedContent = this.sanitizer.bypassSecurityTrustHtml(this.doc.contents);
 	}
 }

--- a/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.module.ts
+++ b/apps/daffio/src/app/docs/shared/components/doc-viewer/doc-viewer.module.ts
@@ -1,6 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { DaffArticleModule } from '@daffodil/design';
+
 import { DaffioDocViewerComponent } from './doc-viewer.component';
 
 @NgModule({
@@ -12,6 +14,7 @@ import { DaffioDocViewerComponent } from './doc-viewer.component';
   ],
   imports: [
     CommonModule,
+    DaffArticleModule,
   ],
 })
 export class DaffioDocViewerModule { }

--- a/apps/daffio/src/app/docs/shared/models/doc.ts
+++ b/apps/daffio/src/app/docs/shared/models/doc.ts
@@ -2,4 +2,11 @@ export interface DaffioDoc {
   id: string;
   title: string;
   contents: string;
+	tableOfContents?: {
+		json: {
+			content: string;
+			lvl: number;
+			slug: string;
+		}[];
+	};
 }

--- a/apps/daffio/src/app/docs/shared/resolvers/doc-resolver.service.ts
+++ b/apps/daffio/src/app/docs/shared/resolvers/doc-resolver.service.ts
@@ -14,6 +14,8 @@ import {
   catchError,
 } from 'rxjs/operators';
 
+import { daffUriTruncateQueryFragment } from '@daffodil/core/routing';
+
 import { DaffioDoc } from '../models/doc';
 import { DaffioGuideList } from '../models/guide-list';
 import { DaffioDocService } from '../services/docs.service';
@@ -28,7 +30,7 @@ export class DocResolver<T extends DaffioDoc, V extends DaffioGuideList> impleme
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<T> {
     return this.docService
     //remove any route fragment and initial slash from the route.
-      .get(state.url.split('#')[0].substring(1))
+      .get(daffUriTruncateQueryFragment(state.url))
       .pipe(
         take(1),
         catchError(() => {

--- a/apps/daffio/src/app/docs/shared/resolvers/doc-resolver.service.ts
+++ b/apps/daffio/src/app/docs/shared/resolvers/doc-resolver.service.ts
@@ -7,14 +7,11 @@ import {
 } from '@angular/router';
 import {
   Observable,
-  of,
   EMPTY,
 } from 'rxjs';
 import {
   take,
-  mergeMap,
   catchError,
-  tap,
 } from 'rxjs/operators';
 
 import { DaffioDoc } from '../models/doc';
@@ -30,7 +27,8 @@ export class DocResolver<T extends DaffioDoc, V extends DaffioGuideList> impleme
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<T> {
     return this.docService
-      .get(state.url.substring(1))
+    //remove any route fragment and initial slash from the route.
+      .get(state.url.split('#')[0].substring(1))
       .pipe(
         take(1),
         catchError(() => {

--- a/apps/daffio/src/app/docs/testing/factories/doc.factory.spec.ts
+++ b/apps/daffio/src/app/docs/testing/factories/doc.factory.spec.ts
@@ -17,5 +17,8 @@ describe('DaffioDocFactory', () => {
     expect(Object.keys(doc)).toContain('id');
     expect(Object.keys(doc)).toContain('title');
     expect(Object.keys(doc)).toContain('contents');
+    expect(Object.keys(doc.tableOfContents.json[0])).toContain('content');
+    expect(Object.keys(doc.tableOfContents.json[0])).toContain('lvl');
+    expect(Object.keys(doc.tableOfContents.json[0])).toContain('slug');
   });
 });

--- a/apps/daffio/src/app/docs/testing/factories/doc.factory.ts
+++ b/apps/daffio/src/app/docs/testing/factories/doc.factory.ts
@@ -9,6 +9,35 @@ export class MockDoc implements DaffioDoc {
   id = String(faker.datatype.number(1000));
   title = faker.lorem.words();
   contents = faker.lorem.paragraph();
+	tableOfContents = {
+	  json: [
+	    {
+	      content: faker.lorem.words(),
+	      lvl: 1,
+	      slug: faker.random.word(),
+	    },
+	    {
+	      content: faker.lorem.words(),
+	      lvl: 2,
+	      slug: faker.random.word(),
+	    },
+	    {
+	      content: faker.lorem.words(),
+	      lvl: 3,
+	      slug: faker.random.word(),
+	    },
+	    {
+	      content: faker.lorem.words(),
+	      lvl: 3,
+	      slug: faker.random.word(),
+	    },
+	    {
+	      content: faker.lorem.words(),
+	      lvl: 2,
+	      slug: faker.random.word(),
+	    },
+	  ],
+	};
 };
 
 @Injectable({

--- a/apps/daffio/src/scss/styles.scss
+++ b/apps/daffio/src/scss/styles.scss
@@ -15,6 +15,7 @@
 @import "../app/content/pwa/pages/pwa/pwa-theme";
 @import "../app/core/footer/simple-footer/simple-footer-theme";
 @import "../app/core/footer/sub-footer/sub-footer-theme";
+@import '../app/docs/guide-docs//components/table-of-contents/table-of-contents-theme';
 
 @import "theme";
 
@@ -27,6 +28,11 @@
 @include daffio-simple-footer-theme($theme);
 @include daffio-sub-footer-theme($theme);
 @include daffio-feature-comparison-theme($theme);
+@include daffio-table-of-contents-theme($theme);
+
+html {
+	scroll-behavior: smooth;
+}
 
 body {
   margin: 0;

--- a/tools/dgeni/src/templates/guides/guide.template.html
+++ b/tools/dgeni/src/templates/guides/guide.template.html
@@ -1,5 +1,1 @@
-{% block content %}
-<div class="content">
 {$ doc.content | marked $}
-</div>
-{% endblock %}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
A functioning (though ugly) table of contents has been added to all guide doc pages.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
This is only for the functionality. I didn't bother even trying to add a nice design. I also bypass angular sanitation so the ids are preserved for fragment navigation. This should be fine, since this is just a documentation app.