### PR TITLE
fix(product, category): product images from category calls have a bad…

### DIFF
--- a/libs/category/driver/magento/src/category.service.ts
+++ b/libs/category/driver/magento/src/category.service.ts
@@ -21,6 +21,10 @@ import {
   DaffCategoryIdRequest,
 } from '@daffodil/category';
 import { DaffCategoryServiceInterface } from '@daffodil/category/driver';
+import {
+  DaffProductMagentoDriverConfig,
+  MAGENTO_PRODUCT_CONFIG_TOKEN,
+} from '@daffodil/product/driver/magento';
 
 import {
   MAGENTO_CATEGORY_CONFIG_TOKEN,
@@ -66,6 +70,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
 		private magentoAppliedFiltersTransformer: DaffMagentoAppliedFiltersTransformService,
 		private magentoAppliedSortTransformer: DaffMagentoAppliedSortOptionTransformService,
     @Inject(MAGENTO_CATEGORY_CONFIG_TOKEN) private config: DaffCategoryMagentoDriverConfig,
+    @Inject(MAGENTO_PRODUCT_CONFIG_TOKEN) private productConfig: DaffProductMagentoDriverConfig,
   ) {}
 
   //todo the MagentoGetCategoryQuery needs to get its own product ids.
@@ -92,7 +97,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
         category,
         filterTypes,
         products,
-      ]) => this.transformCategory(category.data, filterTypes.data, products.data)),
+      ]) => this.transformCategory(category.data, filterTypes.data, products.data, this.productConfig.baseMediaUrl)),
       map(result => categoryRequest.filter_requests
         ? applyFiltersOnResponse(categoryRequest.filter_requests, result)
         : result,
@@ -125,7 +130,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
           kind: DaffCategoryRequestKind.ID,
         }),
       }).pipe(
-        map(products => this.transformCategory(category.data, filterTypes.data, products.data)),
+        map(products => this.transformCategory(category.data, filterTypes.data, products.data, this.productConfig.baseMediaUrl)),
         map(result => categoryRequest.filter_requests
           ? applyFiltersOnResponse(categoryRequest.filter_requests, result)
           : result,
@@ -155,6 +160,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
     categoryResponse: MagentoGetACategoryResponse,
     filterTypesResponse: MagentoGetCategoryFilterTypesResponse,
     productsResponse: MagentoGetProductsResponse,
+    mediaUrl: string,
   ): DaffGetCategoryResponse {
     const aggregations = addMetadataTypesToAggregates(filterTypesResponse, productsResponse);
     const completeCategory = {
@@ -166,6 +172,6 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
       page_info: productsResponse.products.page_info,
     };
 
-    return this.magentoCategoryResponseTransformer.transform(completeCategory);
+    return this.magentoCategoryResponseTransformer.transform(completeCategory, mediaUrl);
   }
 }

--- a/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
@@ -18,7 +18,10 @@ import {
   DaffCategoryFactory,
   DaffCategoryPageMetadataFactory,
 } from '@daffodil/category/testing';
-import { transformManyMagentoProducts } from '@daffodil/product/driver/magento';
+import {
+  MAGENTO_PRODUCT_CONFIG_TOKEN,
+  transformManyMagentoProducts,
+} from '@daffodil/product/driver/magento';
 import { MagentoProductFactory } from '@daffodil/product/driver/magento/testing';
 import { DaffProductFactory } from '@daffodil/product/testing';
 
@@ -40,6 +43,7 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
 
   let magentoCategoryTransformerServiceSpy: jasmine.SpyObj<DaffMagentoCategoryTransformerService>;
   let magentoCategoryPageConfigurationTransformerServiceSpy: jasmine.SpyObj<DaffMagentoCategoryPageConfigTransformerService>;
+  const stubMediaUrl = 'mediaUrl';
 
   beforeEach(() => {
     magentoCategoryTransformerServiceSpy = jasmine.createSpyObj('DaffMagentoCategoryTransformerService', ['transform']);
@@ -50,6 +54,7 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
         DaffMagentoCategoryResponseTransformService,
         { provide: DaffMagentoCategoryTransformerService, useValue: magentoCategoryTransformerServiceSpy },
         { provide: DaffMagentoCategoryPageConfigTransformerService, useValue: magentoCategoryPageConfigurationTransformerServiceSpy },
+        { provide: MAGENTO_PRODUCT_CONFIG_TOKEN, useValue: { baseMediaUrl: stubMediaUrl }},
       ],
     });
 
@@ -119,34 +124,34 @@ describe('DaffMagentoCategoryResponseTransformService', () => {
     });
 
     it('should call transform on the magentoCategoryTransformerService', () => {
-      service.transform(completeCategory);
+      service.transform(completeCategory, stubMediaUrl);
 
       expect(magentoCategoryTransformerServiceSpy.transform).toHaveBeenCalledWith(completeCategory.category);
     });
 
     it('should call transform on the magentoCategoryPageConfigurationService', () => {
-      service.transform(completeCategory);
+      service.transform(completeCategory, stubMediaUrl);
 
       expect(magentoCategoryPageConfigurationTransformerServiceSpy.transform).toHaveBeenCalledWith(completeCategory);
     });
 
     it('should return the same number of products it receives', () => {
-      expect(service.transform(completeCategory).products.length).toEqual(completeCategory.products.length);
+      expect(service.transform(completeCategory, stubMediaUrl).products.length).toEqual(completeCategory.products.length);
     });
 
     it('should return a DaffGetCategoryResponse', () => {
-      expect(service.transform(completeCategory)).toEqual(
+      expect(service.transform(completeCategory, stubMediaUrl)).toEqual(
         {
           ...{ magentoCompleteCategoryResponse: completeCategory },
           category: stubCategory,
-          products: transformManyMagentoProducts(completeCategory.products),
+          products: transformManyMagentoProducts(completeCategory.products, stubMediaUrl),
           categoryPageMetadata: stubCategoryPageMetadata,
         },
       );
     });
 
     it('should return the magento MagentoCompleteCategoryResponse on the daffodil response', () => {
-      expect((<any>service.transform(completeCategory)).magentoCompleteCategoryResponse).toEqual(completeCategory);
+      expect((<any>service.transform(completeCategory, stubMediaUrl)).magentoCompleteCategoryResponse).toEqual(completeCategory);
     });
   });
 });

--- a/libs/category/driver/magento/src/transformers/category-response-transform.service.ts
+++ b/libs/category/driver/magento/src/transformers/category-response-transform.service.ts
@@ -17,12 +17,12 @@ export class DaffMagentoCategoryResponseTransformService {
     private magentoCategoryPageConfigurationTransformerService: DaffMagentoCategoryPageConfigTransformerService,
   ) {}
 
-  transform(completeCategory: MagentoCompleteCategoryResponse): DaffGetCategoryResponse {
+  transform(completeCategory: MagentoCompleteCategoryResponse, mediaUrl: string): DaffGetCategoryResponse {
     return {
       ...{ magentoCompleteCategoryResponse: completeCategory },
       category: this.magentoCategoryTransformerService.transform(completeCategory.category),
       categoryPageMetadata: this.magentoCategoryPageConfigurationTransformerService.transform(completeCategory),
-      products: transformManyMagentoProducts(completeCategory.products),
+      products: transformManyMagentoProducts(completeCategory.products, mediaUrl),
     };
   }
 }

--- a/libs/product/driver/magento/src/transforms/product-transformers.ts
+++ b/libs/product/driver/magento/src/transforms/product-transformers.ts
@@ -29,6 +29,6 @@ export function transformMagentoProduct(product: MagentoProduct, mediaUrl?: stri
 /**
  * Transforms many magento MagentoProducts from the magento product query into DaffProducts.
  */
-export function transformManyMagentoProducts(products: MagentoProduct[], mediaUrl?: string): DaffProduct[] {
+export function transformManyMagentoProducts(products: MagentoProduct[], mediaUrl: string): DaffProduct[] {
   return products.map(product => transformMagentoProduct(product, mediaUrl));
 }


### PR DESCRIPTION
… url

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The category driver never actually called the `transformManyMagentoProducts` function with the mediaUrl, so every product image loaded into state, except for the first image, was never correct. The reason the first image was correct is because it wasn't built with the mediaUrl. So the first image would be correct and all subsequent image urls would be broken. Then when we loaded a product page, that product would be built correctly and would overwrite the bad image urls. This bug was revealed by the recent removal of the duplicate images for products, which removed that first image that was working.

## What is the new behavior?
The `transformManyMagentoProducts` is called with the baseMediaUrl from the `MAGENTO_PRODUCT_CONFIG_TOKEN` from the `@daffodil/category` package. I also made the `mediaUrl` a required parameter of the `transformManyMagentoProducts` function.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
Just wanted to note that I haven't added a great test to verify this. In order to do this I'd need to do a multi-package test where I check product state after the category driver is flushed with data. And I didn't think it would be worth it to spend the time to test this.