### PR TITLE
feat(cart): deprecate DaffCartItem.item_id and extend DaffIdentifiabl…

### DIFF
--- a/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.spec.ts
@@ -97,14 +97,14 @@ describe('DaffInMemoryBackendCartItemsService', () => {
     let itemId;
 
     beforeEach(() => {
-      itemId = mockCartItems[0].item_id;
+      itemId = mockCartItems[0].id;
       reqInfoStub.url = `${cartUrl}${itemId}`;
 
       result = service.get(reqInfoStub);
     });
 
     it('should return the cart item', () => {
-      expect(result.body.item_id).toEqual(itemId);
+      expect(result.body.id).toEqual(itemId);
     });
   });
 
@@ -143,7 +143,7 @@ describe('DaffInMemoryBackendCartItemsService', () => {
     let itemId;
 
     beforeEach(() => {
-      itemId = mockCartItems[0].item_id;
+      itemId = mockCartItems[0].id;
       reqInfoStub.url = `${cartUrl}${itemId}`;
       qty = mockCartItems[0].qty + 1;
       reqInfoStub.req.body = { qty };
@@ -165,14 +165,14 @@ describe('DaffInMemoryBackendCartItemsService', () => {
     let itemId;
 
     beforeEach(() => {
-      itemId = mockCartItems[0].item_id;
+      itemId = mockCartItems[0].id;
       reqInfoStub.url = `${cartUrl}${itemId}`;
 
       result = service.delete(reqInfoStub);
     });
 
     it('should remove the cart item from the cart', () => {
-      expect(result.body.items.find(({ item_id }) => itemId === item_id)).toBeFalsy();
+      expect(result.body.items.find(({ id }) => itemId === id)).toBeFalsy();
     });
 
     it('should set extra_attributes to the value returned by the provided hook function', () => {

--- a/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-items/cart-items.service.ts
@@ -94,17 +94,17 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
     return this.getCart(reqInfo).items;
   }
 
-  private getItem(reqInfo: RequestInfo, itemId: DaffCartItem['item_id']): DaffCartItem {
+  private getItem(reqInfo: RequestInfo, itemId: DaffCartItem['id']): DaffCartItem {
     const cart = this.getCart(reqInfo);
 
-    return cart.items.find(({ item_id }) => itemId === item_id);
+    return cart.items.find(({ id }) => itemId === id);
   }
 
-  private updateItem(reqInfo: RequestInfo, itemId: DaffCartItem['item_id']): DaffCart {
+  private updateItem(reqInfo: RequestInfo, itemId: DaffCartItem['id']): DaffCart {
     const cart = this.getCart(reqInfo);
     const cartIndex = reqInfo.collection.findIndex(c => c.id === reqInfo.id);
     const itemChanges = reqInfo.utils.getJsonBody(reqInfo.req);
-    const itemIndex = cart.items.findIndex((item) => itemId === item.item_id);
+    const itemIndex = cart.items.findIndex((item) => itemId === item.id);
     reqInfo.collection[cartIndex] = {
       ...cart,
       items: cart.items.map(
@@ -150,9 +150,9 @@ export class DaffInMemoryBackendCartItemsService implements DaffInMemoryDataServ
     return reqInfo.collection[cartIndex];
   }
 
-  private deleteItem(reqInfo: RequestInfo, itemId: DaffCartItem['item_id']): DaffCart {
+  private deleteItem(reqInfo: RequestInfo, itemId: DaffCartItem['id']): DaffCart {
     const cart = this.getCart(reqInfo);
-    const itemIndex = cart.items.findIndex(({ item_id }) => itemId === item_id);
+    const itemIndex = cart.items.findIndex(({ id }) => itemId === id);
     const cartIndex = reqInfo.collection.findIndex(c => c.id === reqInfo.id);
     reqInfo.collection[cartIndex] = {
       ...cart,

--- a/libs/cart/driver/in-memory/src/backend/cart-root.service.integration.spec.ts
+++ b/libs/cart/driver/in-memory/src/backend/cart-root.service.integration.spec.ts
@@ -44,7 +44,7 @@ describe('DaffInMemoryBackendCartRootService | Integration', () => {
   let mockShippingMethod: DaffCartShippingRate;
   let mockShippingInformation: DaffCartShippingInformation;
   let cartId: DaffCart['id'];
-  let itemId: DaffCartItem['item_id'];
+  let itemId: DaffCartItem['id'];
 
   beforeEach(done => {
     TestBed.configureTestingModule({
@@ -75,7 +75,7 @@ describe('DaffInMemoryBackendCartRootService | Integration', () => {
       address_id: null,
     };
     cartId = mockCart.id;
-    itemId = mockCartItem.item_id;
+    itemId = mockCartItem.id;
     mockCart.items.push(mockCartItem);
     mockCart.coupons.push(mockCartCoupon);
     mockCart.shipping_address = mockShippingAddress;

--- a/libs/cart/driver/in-memory/src/drivers/cart-item/cart-item.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/drivers/cart-item/cart-item.service.spec.ts
@@ -48,7 +48,7 @@ describe('Driver | In Memory | Cart | CartItemService', () => {
     mockCartItem = cartItemFactory.create();
     mockCart.items = [mockCartItem];
     cartId = mockCart.id;
-    itemId = mockCartItem.item_id;
+    itemId = mockCartItem.id;
   });
 
   afterEach(() => {
@@ -121,7 +121,7 @@ describe('Driver | In Memory | Cart | CartItemService', () => {
 
     beforeEach(() => {
       newCartItem = cartItemFactory.create();
-      newCartItem.item_id = itemId;
+      newCartItem.id = itemId;
       mockCart.items = [newCartItem];
     });
 

--- a/libs/cart/driver/in-memory/src/drivers/cart-item/cart-item.service.ts
+++ b/libs/cart/driver/in-memory/src/drivers/cart-item/cart-item.service.ts
@@ -28,7 +28,7 @@ export class DaffInMemoryCartItemService implements DaffCartItemServiceInterface
     return this.http.get<DaffCartItem[]>(`${this.url}/${cartId}/`);
   }
 
-  get(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<DaffCartItem> {
+  get(cartId: DaffCart['id'], itemId: DaffCartItem['id']): Observable<DaffCartItem> {
     return this.http.get<DaffCartItem>(`${this.url}/${cartId}/${itemId}`);
   }
 
@@ -38,13 +38,13 @@ export class DaffInMemoryCartItemService implements DaffCartItemServiceInterface
 
   update(
     cartId: DaffCart['id'],
-    itemId: DaffCartItem['item_id'],
+    itemId: DaffCartItem['id'],
     item: Partial<DaffCartItem>,
   ): Observable<Partial<DaffCart>> {
     return this.http.put<Partial<DaffCart>>(`${this.url}/${cartId}/${itemId}`, item);
   }
 
-  delete(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<Partial<DaffCart>> {
+  delete(cartId: DaffCart['id'], itemId: DaffCartItem['id']): Observable<Partial<DaffCart>> {
     return this.http.delete<Partial<DaffCart>>(`${this.url}/${cartId}/${itemId}`);
   }
 }

--- a/libs/cart/driver/magento/src/cart-item.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart-item.service.spec.ts
@@ -126,7 +126,7 @@ describe('Driver | Magento | Cart | CartItemService', () => {
     mockMagentoCartItem = magentoCartItemFactory.create();
 
     cartId = mockDaffCart.id;
-    itemId = mockDaffCartItem.item_id;
+    itemId = mockDaffCartItem.id;
     sku = mockDaffCartItem.sku;
     mockMagentoCartItem.id = itemId;
     mockDaffCart.items = [mockDaffCartItem];
@@ -197,7 +197,7 @@ describe('Driver | Magento | Cart | CartItemService', () => {
     it('should return the correct value', done => {
       service.list(cartId).subscribe(result => {
         expect(result).toEqual([jasmine.objectContaining({
-          item_id: mockMagentoCartItem.id,
+          id: mockMagentoCartItem.id,
           type: DaffCartItemInputType.Simple,
           image: {
             id: mockMagentoCartItem.product.thumbnail.label,
@@ -235,7 +235,7 @@ describe('Driver | Magento | Cart | CartItemService', () => {
     });
 
     it('should return the correct value', done => {
-      service.get(cartId, mockDaffCartItem.item_id).subscribe(result => {
+      service.get(cartId, mockDaffCartItem.id).subscribe(result => {
         expect(result).toEqual(jasmine.objectContaining(mockDaffCartItem));
         done();
       });
@@ -306,7 +306,7 @@ describe('Driver | Magento | Cart | CartItemService', () => {
     });
 
     it('should return the correct value', done => {
-      service.update(cartId, mockDaffCartItem.item_id, mockDaffCartItem).subscribe(result => {
+      service.update(cartId, mockDaffCartItem.id, mockDaffCartItem).subscribe(result => {
         expect(result.items[0].qty).toEqual(qty);
         done();
       });
@@ -330,9 +330,9 @@ describe('Driver | Magento | Cart | CartItemService', () => {
     });
 
     it('should return the cart without the cart item', done => {
-      service.delete(cartId, mockDaffCartItem.item_id).subscribe(result => {
-        expect(result.items.find(({ item_id }) =>
-          item_id === mockDaffCartItem.item_id,
+      service.delete(cartId, mockDaffCartItem.id).subscribe(result => {
+        expect(result.items.find(({ id }) =>
+          id === mockDaffCartItem.id,
         )).toBeFalsy();
         done();
       });

--- a/libs/cart/driver/magento/src/cart-item.service.ts
+++ b/libs/cart/driver/magento/src/cart-item.service.ts
@@ -66,9 +66,9 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
     );
   }
 
-  get(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<DaffCartItem> {
+  get(cartId: DaffCart['id'], itemId: DaffCartItem['id']): Observable<DaffCartItem> {
     return this.list(cartId).pipe(
-      map(items => items.find(item => item.item_id === itemId)),
+      map(items => items.find(item => item.id === itemId)),
     );
   }
 
@@ -83,14 +83,14 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
     }
   }
 
-  update(cartId: DaffCart['id'], itemId: DaffCartItem['item_id'], changes: Partial<DaffCartItem>): Observable<Partial<DaffCart>> {
+  update(cartId: DaffCart['id'], itemId: DaffCartItem['id'], changes: Partial<DaffCartItem>): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoUpdateCartItemResponse>({
       mutation: updateCartItem(this.extraCartFragments),
       variables: {
         cartId,
         input: this.cartItemUpdateInputTransformer.transform({
           ...changes,
-          item_id: itemId,
+          id: itemId,
         }),
       },
     }).pipe(
@@ -98,7 +98,7 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
     );
   }
 
-  delete(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<Partial<DaffCart>> {
+  delete(cartId: DaffCart['id'], itemId: DaffCartItem['id']): Observable<Partial<DaffCart>> {
     return this.mutationQueue.mutate<MagentoRemoveCartItemResponse>({
       mutation: removeCartItem(this.extraCartFragments),
       variables: {

--- a/libs/cart/driver/magento/src/cart.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart.service.spec.ts
@@ -95,7 +95,7 @@ describe('Driver | Magento | Cart | CartService', () => {
     mockMagentoCartItem = magentoCartItemFactory.create();
     mockDaffCartItem = daffCartItemFactory.create();
 
-    mockMagentoCartItem.id = mockDaffCartItem.item_id;
+    mockMagentoCartItem.id = mockDaffCartItem.id;
     cartId = mockDaffCart.id;
     mockMagentoCart.items = [mockMagentoCartItem];
     mockDaffCart.items = [mockDaffCartItem];
@@ -111,7 +111,7 @@ describe('Driver | Magento | Cart | CartService', () => {
     magentoCartItemSpy.list.and.returnValue(of(mockDaffCart.items));
     magentoCartItemSpy.delete.and.callFake((_, itemId) => of({
       ...mockDaffCart,
-      items: mockDaffCart.items.filter(({ item_id }) => item_id !== itemId),
+      items: mockDaffCart.items.filter(({ id }) => id !== itemId),
     }));
   });
 
@@ -156,7 +156,7 @@ describe('Driver | Magento | Cart | CartService', () => {
       spyOn(service, 'get').and.returnValue(of(mockDaffCart));
       service.clear(cartId).subscribe(() => {
         mockDaffCart.items.forEach(item => {
-          expect(magentoCartItemSpy.delete).toHaveBeenCalledWith(cartId, item.item_id);
+          expect(magentoCartItemSpy.delete).toHaveBeenCalledWith(cartId, item.id);
         });
         done();
       });

--- a/libs/cart/driver/magento/src/cart.service.ts
+++ b/libs/cart/driver/magento/src/cart.service.ts
@@ -83,7 +83,7 @@ export class DaffMagentoCartService implements DaffCartServiceInterface<DaffCart
     return this.cartItemDriver.list(cartId).pipe(
       switchMap(items =>
         forkJoin(...items.map(item =>
-          this.cartItemDriver.delete(cartId, item.item_id),
+          this.cartItemDriver.delete(cartId, item.id),
         )),
       ),
       switchMap(() => this.get(cartId)),

--- a/libs/cart/driver/magento/src/transforms/inputs/cart-item-update.service.ts
+++ b/libs/cart/driver/magento/src/transforms/inputs/cart-item-update.service.ts
@@ -11,7 +11,7 @@ export class DaffMagentoCartItemUpdateInputTransformer {
   transform(item: Partial<DaffCartItem>): MagentoCartItemUpdateInput {
     return {
       quantity: item.qty,
-      cart_item_id: Number(item.item_id),
+      cart_item_id: Number(item.id),
     };
   }
 }

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-item/simple-cart-item-transformer.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-item/simple-cart-item-transformer.ts
@@ -18,6 +18,7 @@ export function transformMagentoSimpleCartItem(cartItem: MagentoCartItem): DaffC
     // base
     type: DaffCartItemInputType.Simple,
     item_id: cartItem.id,
+    id: cartItem.id,
     url: `/${cartItem.product.url_key}${cartItem.product.url_suffix}`,
     sku: cartItem.product.sku,
     name: cartItem.product.name,

--- a/libs/cart/driver/src/interfaces/cart-item-service.interface.ts
+++ b/libs/cart/driver/src/interfaces/cart-item-service.interface.ts
@@ -23,7 +23,7 @@ export interface DaffCartItemServiceInterface<
 	/**
 	 * Get a specific cart item of a cart.
 	 */
-	get(cartId: V['id'], item_id: DaffCartItem['item_id']): Observable<T>;
+	get(cartId: V['id'], item_id: DaffCartItem['id']): Observable<T>;
 
 	/**
 	 * Add something to a cart.
@@ -35,14 +35,14 @@ export interface DaffCartItemServiceInterface<
 	 */
 	update(
 		cartId: V['id'],
-		itemId: T['item_id'],
+		itemId: T['id'],
 		changes: Partial<T>,
 	): Observable<Partial<V>>;
 
 	/**
 	 * Remove an item from a cart.
 	 */
-	delete(cartId: V['id'], itemId: T['item_id']): Observable<Partial<V>>;
+	delete(cartId: V['id'], itemId: T['id']): Observable<Partial<V>>;
 }
 
 export const DaffCartItemDriver = new InjectionToken<

--- a/libs/cart/driver/testing/src/drivers/cart-item/cart-item.service.spec.ts
+++ b/libs/cart/driver/testing/src/drivers/cart-item/cart-item.service.spec.ts
@@ -40,7 +40,7 @@ describe('Driver | Testing | Cart | CartItemService', () => {
     mockCartItem = cartItemFactory.create();
     mockCart.items = [mockCartItem];
     cartId = mockCart.id;
-    itemId = mockCartItem.item_id;
+    itemId = mockCartItem.id;
   });
 
   it('should be created', () => {
@@ -89,7 +89,7 @@ describe('Driver | Testing | Cart | CartItemService', () => {
 
     beforeEach(() => {
       newCartItem = cartItemFactory.create();
-      newCartItem.item_id = itemId;
+      newCartItem.id = itemId;
       mockCart.items = [newCartItem];
     });
 

--- a/libs/cart/driver/testing/src/drivers/cart-item/cart-item.service.ts
+++ b/libs/cart/driver/testing/src/drivers/cart-item/cart-item.service.ts
@@ -31,7 +31,7 @@ export class DaffTestingCartItemService implements DaffCartItemServiceInterface 
     return of(this.cartItemFactory.createMany(3));
   }
 
-  get(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<DaffCartItem> {
+  get(cartId: DaffCart['id'], itemId: DaffCartItem['id']): Observable<DaffCartItem> {
     return of(this.cartItemFactory.create());
   }
 
@@ -41,13 +41,13 @@ export class DaffTestingCartItemService implements DaffCartItemServiceInterface 
 
   update(
     cartId: DaffCart['id'],
-    itemId: DaffCartItem['item_id'],
+    itemId: DaffCartItem['id'],
     item: Partial<DaffCartItem>,
   ): Observable<Partial<DaffCart>> {
     return of(this.cartFactory.create());
   }
 
-  delete(cartId: DaffCart['id'], itemId: DaffCartItem['item_id']): Observable<Partial<DaffCart>> {
+  delete(cartId: DaffCart['id'], itemId: DaffCartItem['id']): Observable<Partial<DaffCart>> {
     return of(this.cartFactory.create());
   }
 }

--- a/libs/cart/src/models/cart-item.ts
+++ b/libs/cart/src/models/cart-item.ts
@@ -1,6 +1,7 @@
 import {
   ID,
   DaffLocatable,
+	DaffIdentifiable,
 } from '@daffodil/core';
 import {
   DaffProductImage,
@@ -14,7 +15,10 @@ export interface DaffCartItemDiscount {
   label: string;
 }
 
-export interface DaffCartItem extends DaffLocatable {
+export interface DaffCartItem extends DaffLocatable, DaffIdentifiable {
+	/**
+	 * @deprecated use id instead.
+	 */
 	item_id: ID;
 	type: DaffCartItemInputType;
   image?: DaffProductImage;

--- a/libs/cart/src/models/cart-item.ts
+++ b/libs/cart/src/models/cart-item.ts
@@ -1,7 +1,7 @@
 import {
   ID,
   DaffLocatable,
-	DaffIdentifiable,
+  DaffIdentifiable,
 } from '@daffodil/core';
 import {
   DaffProductImage,

--- a/libs/cart/state/src/actions/cart-item.actions.ts
+++ b/libs/cart/state/src/actions/cart-item.actions.ts
@@ -46,7 +46,7 @@ export class DaffCartItemListFailure implements Action {
 export class DaffCartItemLoad<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemLoadAction;
 
-  constructor(public itemId: T['item_id']) {}
+  constructor(public itemId: T['id']) {}
 }
 
 export class DaffCartItemLoadSuccess<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
@@ -58,13 +58,13 @@ export class DaffCartItemLoadSuccess<T extends DaffStatefulCartItem = DaffStatef
 export class DaffCartItemLoadFailure<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemLoadFailureAction;
 
-  constructor(public payload: DaffStateError, public itemId: T['item_id']) {}
+  constructor(public payload: DaffStateError, public itemId: T['id']) {}
 }
 
 export class DaffCartItemUpdate<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemUpdateAction;
 
-  constructor(public itemId: T['item_id'], public changes: Partial<T>) {}
+  constructor(public itemId: T['id'], public changes: Partial<T>) {}
 }
 
 export class DaffCartItemUpdateSuccess<
@@ -73,13 +73,13 @@ export class DaffCartItemUpdateSuccess<
 > implements Action {
   readonly type = DaffCartItemActionTypes.CartItemUpdateSuccessAction;
 
-  constructor(public payload: Partial<T>, public itemId: V['item_id']) {}
+  constructor(public payload: Partial<T>, public itemId: V['id']) {}
 }
 
 export class DaffCartItemUpdateFailure<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemUpdateFailureAction;
 
-  constructor(public payload: DaffStateError, public itemId: T['item_id']) {}
+  constructor(public payload: DaffStateError, public itemId: T['id']) {}
 }
 
 export class DaffCartItemAdd<T extends DaffCartItemInput = DaffCartItemInput> implements Action {
@@ -103,7 +103,7 @@ export class DaffCartItemAddFailure implements Action {
 export class DaffCartItemDelete<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemDeleteAction;
 
-  constructor(public itemId: T['item_id']) {}
+  constructor(public itemId: T['id']) {}
 }
 
 export class DaffCartItemDeleteSuccess<T extends DaffCart = DaffCart> implements Action {
@@ -115,7 +115,7 @@ export class DaffCartItemDeleteSuccess<T extends DaffCart = DaffCart> implements
 export class DaffCartItemDeleteFailure<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemDeleteFailureAction;
 
-  constructor(public payload: DaffStateError, public itemId: T['item_id']) {}
+  constructor(public payload: DaffStateError, public itemId: T['id']) {}
 }
 
 export class DaffCartItemStateReset implements Action {

--- a/libs/cart/state/src/effects/cart-item.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-item.effects.spec.ts
@@ -161,7 +161,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
     let cartItemLoadAction;
 
     beforeEach(() => {
-      cartItemLoadAction = new DaffCartItemLoad(mockCartItem.item_id);
+      cartItemLoadAction = new DaffCartItemLoad(mockCartItem.id);
     });
 
     describe('and the call to CartItemService is successful', () => {
@@ -182,7 +182,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
         const error: DaffStateError = { code: 'code', message: 'Failed to load cart item' };
         const response = cold('#', {}, error);
         driverGetSpy.and.returnValue(response);
-        const cartItemLoadFailureAction = new DaffCartItemLoadFailure(error, mockCartItem.item_id);
+        const cartItemLoadFailureAction = new DaffCartItemLoadFailure(error, mockCartItem.id);
         actions$ = hot('--a', { a: cartItemLoadAction });
         expected = cold('--b', { b: cartItemLoadFailureAction });
       });
@@ -241,8 +241,8 @@ describe('Daffodil | Cart | CartItemEffects', () => {
     beforeEach(() => {
       qty = mockCartItem.qty + 1;
       mockCartItem.qty = qty;
-      cartItemUpdateAction = new DaffCartItemUpdate(mockCartItem.item_id, mockCartItem);
-      cartItemUpdateSuccessAction = new DaffCartItemUpdateSuccess(mockCart, mockCartItem.item_id);
+      cartItemUpdateAction = new DaffCartItemUpdate(mockCartItem.id, mockCartItem);
+      cartItemUpdateSuccessAction = new DaffCartItemUpdateSuccess(mockCart, mockCartItem.id);
     });
 
     describe('and the call to CartItemService is successful', () => {
@@ -262,8 +262,8 @@ describe('Daffodil | Cart | CartItemEffects', () => {
       it('should not cancel the first observable', () => {
         const mockCartItem2 = new DaffCartItemFactory().create();
         driverUpdateSpy.and.returnValue(cold('--a', { a: mockCart }));
-        const cartItemUpdateAction2 = new DaffCartItemUpdate(mockCartItem2.item_id, mockCartItem2);
-        const cartItemUpdateSuccessAction2 = new DaffCartItemUpdateSuccess(mockCart, mockCartItem2.item_id);
+        const cartItemUpdateAction2 = new DaffCartItemUpdate(mockCartItem2.id, mockCartItem2);
+        const cartItemUpdateSuccessAction2 = new DaffCartItemUpdateSuccess(mockCart, mockCartItem2.id);
         actions$ = hot('ab', { a: cartItemUpdateAction, b: cartItemUpdateAction2 });
         expected = cold('--cd', { c: cartItemUpdateSuccessAction, d: cartItemUpdateSuccessAction2 });
 
@@ -276,7 +276,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
         const error: DaffStateError = { code: 'code', message: 'Failed to update cart item' };
         const response = cold('#', {}, error);
         driverUpdateSpy.and.returnValue(response);
-        const cartItemUpdateFailureAction = new DaffCartItemUpdateFailure(error, mockCartItem.item_id);
+        const cartItemUpdateFailureAction = new DaffCartItemUpdateFailure(error, mockCartItem.id);
         actions$ = hot('--a', { a: cartItemUpdateAction });
         expected = cold('--b', { b: cartItemUpdateFailureAction });
       });
@@ -316,7 +316,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
         });
         testScheduler.run(helpers => {
           const expectedMarble = '4000ms a';
-          const cartItemUpdateSuccess = new DaffCartItemUpdateSuccess(mockCart, mockCartItem.item_id);
+          const cartItemUpdateSuccess = new DaffCartItemUpdateSuccess(mockCart, mockCartItem.id);
           const shopCartItemReset = new DaffCartItemStateReset();
           actions$ = helpers.hot('a', { a: cartItemUpdateSuccess });
           expectedObservable = { a: shopCartItemReset };
@@ -333,7 +333,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
     let cartItemDeleteSuccessAction;
 
     beforeEach(() => {
-      cartItemDeleteAction = new DaffCartItemDelete(mockCartItem.item_id);
+      cartItemDeleteAction = new DaffCartItemDelete(mockCartItem.id);
       cartItemDeleteSuccessAction = new DaffCartItemDeleteSuccess(mockCart);
     });
 
@@ -355,7 +355,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
       it('should not cancel the first observable', () => {
         const mockCartItem2 = new DaffCartItemFactory().create();
         driverDeleteSpy.and.returnValue(cold('--a', { a: mockCart }));
-        const cartItemDeleteAction2 = new DaffCartItemDelete(mockCartItem2.item_id);
+        const cartItemDeleteAction2 = new DaffCartItemDelete(mockCartItem2.id);
         actions$ = hot('ab', { a: cartItemDeleteAction, b: cartItemDeleteAction2 });
         expected = cold('--cd', { c: cartItemDeleteSuccessAction, d: cartItemDeleteSuccessAction });
 
@@ -368,7 +368,7 @@ describe('Daffodil | Cart | CartItemEffects', () => {
         const error: DaffStateError = { code: 'code', message: 'Failed to remove the cart item' };
         const response = cold('#', {}, error);
         driverDeleteSpy.and.returnValue(response);
-        const cartItemRemoveCartFailureAction = new DaffCartItemDeleteFailure(error, mockCartItem.item_id);
+        const cartItemRemoveCartFailureAction = new DaffCartItemDeleteFailure(error, mockCartItem.id);
         actions$ = hot('--a', { a: cartItemDeleteAction });
         expected = cold('--b', { b: cartItemRemoveCartFailureAction });
       });

--- a/libs/cart/state/src/facades/cart/cart-facade.interface.ts
+++ b/libs/cart/state/src/facades/cart/cart-facade.interface.ts
@@ -242,39 +242,39 @@ export interface DaffCartFacadeInterface<
 	orderResultCartId$: Observable<V['cartId']>;
   hasOrderResult$: Observable<boolean>;
 
-	getConfiguredCartItemAttributes(itemId: U['item_id']): Observable<DaffConfigurableCartItemAttribute[]>;
-	getCompositeCartItemOptions(itemId: U['item_id']): Observable<DaffCompositeCartItemOption[]>;
-	isCartItemOutOfStock(itemId: U['item_id']): Observable<boolean>;
+	getConfiguredCartItemAttributes(itemId: U['id']): Observable<DaffConfigurableCartItemAttribute[]>;
+	getCompositeCartItemOptions(itemId: U['id']): Observable<DaffCompositeCartItemOption[]>;
+	isCartItemOutOfStock(itemId: U['id']): Observable<boolean>;
 	/**
 	 * The state of a cart item.
 	 */
-  getCartItemState(itemId: U['item_id']): Observable<DaffCartItemStateEnum>;
+  getCartItemState(itemId: U['id']): Observable<DaffCartItemStateEnum>;
   /**
    * Selects the specified item's price.
    * Zero by default.
    * This includes any discounts and sales that apply to the product or category.
    * This excludes cart discounts.
    */
-	getCartItemPrice(itemId: U['item_id']): Observable<number>;
+	getCartItemPrice(itemId: U['id']): Observable<number>;
   /**
    * Selects the specified item's quantity.
    * Zero by default.
    */
-	getCartItemQuantity(itemId: U['item_id']): Observable<number>;
+	getCartItemQuantity(itemId: U['id']): Observable<number>;
   /**
    * Selects the specified item's row total.
    * Zero by default.
    * This includes any discounts and sales that apply to the product or category.
    * This excludes cart discounts.
    */
-	getCartItemRowTotal(itemId: U['item_id']): Observable<number>;
+	getCartItemRowTotal(itemId: U['id']): Observable<number>;
   /**
    * Selects the specified item's array of cart (not product) discounts.
    */
-	getCartItemDiscounts(itemId: U['item_id']): Observable<DaffCartItemDiscount[]>;
+	getCartItemDiscounts(itemId: U['id']): Observable<DaffCartItemDiscount[]>;
   /**
    * Selects the specified item's sum of all cart (not product) discounts for the entire row.
    * Zero by default.
    */
-	getCartItemTotalDiscount(itemId: U['item_id']): Observable<number>;
+	getCartItemTotalDiscount(itemId: U['id']): Observable<number>;
 }

--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -1112,7 +1112,7 @@ describe('DaffCartFacade', () => {
         a:
           statefulCartItems.reduce((acc, item) => ({
             ...acc,
-            [item.item_id]: item,
+            [item.id]: item,
           }), {}),
       });
       facade.dispatch(new DaffCartItemListSuccess(statefulCartItems));
@@ -1491,7 +1491,7 @@ describe('DaffCartFacade', () => {
       });
       const expected = cold('a', { a: cartItems[0].attributes });
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      expect(facade.getConfiguredCartItemAttributes(cart.items[0].item_id)).toBeObservable(expected);
+      expect(facade.getConfiguredCartItemAttributes(cart.items[0].id)).toBeObservable(expected);
     });
   });
 
@@ -1504,7 +1504,7 @@ describe('DaffCartFacade', () => {
       });
       const expected = cold('a', { a: cartItems[0].options });
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      expect(facade.getCompositeCartItemOptions(cart.items[0].item_id)).toBeObservable(expected);
+      expect(facade.getCompositeCartItemOptions(cart.items[0].id)).toBeObservable(expected);
     });
   });
 
@@ -1516,7 +1516,7 @@ describe('DaffCartFacade', () => {
       });
       const expected = cold('a', { a: !cart.items[0].in_stock });
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      expect(facade.isCartItemOutOfStock(cart.items[0].item_id)).toBeObservable(expected);
+      expect(facade.isCartItemOutOfStock(cart.items[0].id)).toBeObservable(expected);
     });
   });
 
@@ -1529,7 +1529,7 @@ describe('DaffCartFacade', () => {
       });
       const expected = cold('a', { a: statefulCartItem.daffState });
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      expect(facade.getCartItemState(statefulCartItem.item_id)).toBeObservable(expected);
+      expect(facade.getCartItemState(statefulCartItem.id)).toBeObservable(expected);
     });
   });
 
@@ -1650,7 +1650,7 @@ describe('DaffCartFacade', () => {
       });
       const expected = cold('a', { a: cart.items[0].price });
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      expect(facade.getCartItemPrice(cart.items[0].item_id)).toBeObservable(expected);
+      expect(facade.getCartItemPrice(cart.items[0].id)).toBeObservable(expected);
     });
   });
 
@@ -1662,7 +1662,7 @@ describe('DaffCartFacade', () => {
       });
       const expected = cold('a', { a: cart.items[0].qty });
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      expect(facade.getCartItemQuantity(cart.items[0].item_id)).toBeObservable(expected);
+      expect(facade.getCartItemQuantity(cart.items[0].id)).toBeObservable(expected);
     });
   });
 
@@ -1674,7 +1674,7 @@ describe('DaffCartFacade', () => {
       });
       const expected = cold('a', { a: cart.items[0].row_total });
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      expect(facade.getCartItemRowTotal(cart.items[0].item_id)).toBeObservable(expected);
+      expect(facade.getCartItemRowTotal(cart.items[0].id)).toBeObservable(expected);
     });
   });
 
@@ -1686,7 +1686,7 @@ describe('DaffCartFacade', () => {
       });
       const expected = cold('a', { a: cart.items[0].discounts });
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      expect(facade.getCartItemDiscounts(cart.items[0].item_id)).toBeObservable(expected);
+      expect(facade.getCartItemDiscounts(cart.items[0].id)).toBeObservable(expected);
     });
   });
 
@@ -1698,7 +1698,7 @@ describe('DaffCartFacade', () => {
       });
       const expected = cold('a', { a: cart.items[0].discounts.reduce((acc, { amount }) => acc + amount, 0) });
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      expect(facade.getCartItemTotalDiscount(cart.items[0].item_id)).toBeObservable(expected);
+      expect(facade.getCartItemTotalDiscount(cart.items[0].id)).toBeObservable(expected);
     });
   });
 });

--- a/libs/cart/state/src/facades/cart/cart.facade.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.ts
@@ -352,39 +352,39 @@ export class DaffCartFacade<
     this.hasOrderResult$ = this.store.pipe(select(selectHasOrderResult));
   }
 
-  getConfiguredCartItemAttributes(itemId: U['item_id']): Observable<DaffConfigurableCartItemAttribute[]> {
+  getConfiguredCartItemAttributes(itemId: U['id']): Observable<DaffConfigurableCartItemAttribute[]> {
     return this.store.pipe(select(this._selectCartItemConfiguredAttributes(itemId)));
   };
 
-  getCompositeCartItemOptions(itemId: U['item_id']): Observable<DaffCompositeCartItemOption[]> {
+  getCompositeCartItemOptions(itemId: U['id']): Observable<DaffCompositeCartItemOption[]> {
     return this.store.pipe(select(this._selectCartItemCompositeOptions(itemId)));
   };
 
-  isCartItemOutOfStock(itemId: U['item_id']): Observable<boolean> {
+  isCartItemOutOfStock(itemId: U['id']): Observable<boolean> {
     return this.store.pipe(select(this._selectIsCartItemOutOfStock(itemId)));
   }
 
-  getCartItemState(itemId: U['item_id']): Observable<DaffCartItemStateEnum> {
+  getCartItemState(itemId: U['id']): Observable<DaffCartItemStateEnum> {
     return this.store.pipe(select(this._selectCartItemState(itemId)));
   }
 
-  getCartItemPrice(itemId: U['item_id']): Observable<number> {
+  getCartItemPrice(itemId: U['id']): Observable<number> {
     return this.store.pipe(select(this._selectCartItemPrice(itemId)));
   }
 
-  getCartItemQuantity(itemId: U['item_id']): Observable<number> {
+  getCartItemQuantity(itemId: U['id']): Observable<number> {
     return this.store.pipe(select(this._selectCartItemQuantity(itemId)));
   }
 
-  getCartItemRowTotal(itemId: U['item_id']): Observable<number> {
+  getCartItemRowTotal(itemId: U['id']): Observable<number> {
     return this.store.pipe(select(this._selectCartItemRowTotal(itemId)));
   }
 
-  getCartItemDiscounts(itemId: U['item_id']): Observable<DaffCartItemDiscount[]> {
+  getCartItemDiscounts(itemId: U['id']): Observable<DaffCartItemDiscount[]> {
     return this.store.pipe(select(this._selectCartItemDiscounts(itemId)));
   }
 
-  getCartItemTotalDiscount(itemId: U['item_id']): Observable<number> {
+  getCartItemTotalDiscount(itemId: U['id']): Observable<number> {
     return this.store.pipe(select(this._selectCartItemTotalDiscount(itemId)));
   }
 

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities-reducer-adapter.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities-reducer-adapter.ts
@@ -11,5 +11,5 @@ import { DaffStatefulCartItem } from '../../models/stateful-cart-item';
 export const daffCartItemEntitiesAdapter = (() => {
   let cache;
   return <T extends DaffStatefulCartItem>(): EntityAdapter<T> =>
-    cache = cache || createEntityAdapter<T>({ selectId: item => item.item_id });
+    cache = cache || createEntityAdapter<T>({ selectId: item => item.id });
 })();

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -54,12 +54,12 @@ describe('Cart | Cart Item Entities Reducer', () => {
 
     beforeEach(() => {
       stubStatefulCartItem = new DaffStatefulCartItemFactory().create({
-        item_id: 'id',
+        id: 'id',
       });
       initialStateWithCartItem = {
         ...initialState,
         entities: {
-          [stubStatefulCartItem.item_id]: {
+          [stubStatefulCartItem.id]: {
             ...stubStatefulCartItem,
             daffState: DaffCartItemStateEnum.New,
           },
@@ -74,7 +74,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
       }]);
 
       result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartItemListSuccess);
-      expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+      expect(result.entities[stubStatefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.New);
     });
 
     it('should retain the existing daffState when a CartItemLoadSuccessAction is triggered', () => {
@@ -84,34 +84,34 @@ describe('Cart | Cart Item Entities Reducer', () => {
       });
 
       result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartItemLoadSuccess);
-      expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+      expect(result.entities[stubStatefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.New);
     });
 
     it('should retain the existing daffState when a CartItemDeleteSuccessAction is triggered', () => {
       const cartItemDeleteSuccess = new DaffCartItemDeleteSuccess(new DaffCartFactory().create({
-        items: [new DaffCartItemFactory().create({ item_id: stubStatefulCartItem.item_id })],
+        items: [new DaffCartItemFactory().create({ id: stubStatefulCartItem.id })],
       }));
 
       result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartItemDeleteSuccess);
-      expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+      expect(result.entities[stubStatefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.New);
     });
 
     it('should retain the existing daffState when a CartLoadSuccessAction is triggered', () => {
       const cartLoadSuccess = new DaffCartLoadSuccess(new DaffCartFactory().create({
-        items: [new DaffCartItemFactory().create({ item_id: stubStatefulCartItem.item_id })],
+        items: [new DaffCartItemFactory().create({ id: stubStatefulCartItem.id })],
       }));
 
       result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartLoadSuccess);
-      expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+      expect(result.entities[stubStatefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.New);
     });
 
     it('should retain the existing daffState when a CartClearSuccessAction is triggered', () => {
       const cartClearSuccess = new DaffCartClearSuccess(new DaffCartFactory().create({
-        items: [new DaffCartItemFactory().create({ item_id: stubStatefulCartItem.item_id })],
+        items: [new DaffCartItemFactory().create({ id: stubStatefulCartItem.id })],
       }));
 
       result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartClearSuccess);
-      expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+      expect(result.entities[stubStatefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.New);
     });
 
     it('should retain the existing daffState when a CartItemUpdateSuccessAction is triggered', () => {
@@ -121,10 +121,10 @@ describe('Cart | Cart Item Entities Reducer', () => {
           stubStatefulCartItem,
           cartItem,
         ],
-      }), cartItem.item_id);
+      }), cartItem.id);
       result = daffCartItemEntitiesReducer(initialStateWithCartItem, cartItemUpdateSuccess);
 
-      expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+      expect(result.entities[stubStatefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.New);
     });
   });
 
@@ -145,7 +145,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('sets expected statefulCartItem on state', () => {
-      expect(result.entities[cartItems[0].item_id]).toEqual(cartItems[0]);
+      expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
     });
   });
 
@@ -162,7 +162,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('sets expected statefulCartItem on state', () => {
-      expect(result.entities[statefulCartItem.item_id]).toEqual(statefulCartItem);
+      expect(result.entities[statefulCartItem.id]).toEqual(statefulCartItem);
     });
   });
 
@@ -177,7 +177,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
       cart = new DaffCartFactory().create({
         items: cartItems,
       });
-      const cartItemUpdateSuccess = new DaffCartItemUpdateSuccess(cart, cartItems[0].item_id);
+      const cartItemUpdateSuccess = new DaffCartItemUpdateSuccess(cart, cartItems[0].id);
 
       result = daffCartItemEntitiesReducer(initialState, cartItemUpdateSuccess);
     });
@@ -187,11 +187,11 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('sets expected cart item on state', () => {
-      expect(result.entities[cartItems[0].item_id].item_id).toEqual(cartItems[0].item_id);
+      expect(result.entities[cartItems[0].id].id).toEqual(cartItems[0].id);
     });
 
     it('sets the state of the updated cart item to Updated', () => {
-      expect(result.entities[cartItems[0].item_id].daffState).toEqual(DaffCartItemStateEnum.Updated);
+      expect(result.entities[cartItems[0].id].daffState).toEqual(DaffCartItemStateEnum.Updated);
     });
   });
 
@@ -216,11 +216,11 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('sets expected cart item on state', () => {
-      expect(result.entities[statefulCartItem.item_id].item_id).toEqual(statefulCartItem.item_id);
+      expect(result.entities[statefulCartItem.id].id).toEqual(statefulCartItem.id);
     });
 
     it('sets the new cart item\'s state to New', () => {
-      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.New);
+      expect(result.entities[statefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.New);
     });
   });
 
@@ -246,13 +246,13 @@ describe('Cart | Cart Item Entities Reducer', () => {
       result = daffCartItemEntitiesReducer({
         ...initialState,
         entities: {
-          [statefulCartItem.item_id]: statefulCartItem,
+          [statefulCartItem.id]: statefulCartItem,
         },
       }, cartItemAddSuccess);
     });
 
     it('sets the cart item\'s state to Updated', () => {
-      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Updated);
+      expect(result.entities[statefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.Updated);
     });
   });
 
@@ -277,7 +277,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('sets expected cart item on state', () => {
-      expect(result.entities[cartItems[0].item_id]).toEqual(cartItems[0]);
+      expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
     });
   });
 
@@ -302,7 +302,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('sets expected cart item on state', () => {
-      expect(result.entities[cartItems[0].item_id]).toEqual(cartItems[0]);
+      expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
     });
   });
 
@@ -327,7 +327,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('sets expected cart item on state', () => {
-      expect(result.entities[cartItems[0].item_id]).toEqual(cartItems[0]);
+      expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
     });
   });
 
@@ -359,9 +359,9 @@ describe('Cart | Cart Item Entities Reducer', () => {
     beforeEach(() => {
       stubCartItem = new DaffStatefulCartItemFactory().create();
       testInitialState = {
-        ids: [stubCartItem.item_id.toString()],
+        ids: [stubCartItem.id.toString()],
         entities: {
-          [stubCartItem.item_id]: {
+          [stubCartItem.id]: {
             ...stubCartItem,
             daffState: DaffCartItemStateEnum.New,
           },
@@ -373,7 +373,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
 
     it('resets the state of all the cart items to default', () => {
-      expect(result.entities[stubCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Default);
+      expect(result.entities[stubCartItem.id].daffState).toEqual(DaffCartItemStateEnum.Default);
     });
   });
 
@@ -386,18 +386,18 @@ describe('Cart | Cart Item Entities Reducer', () => {
     beforeEach(() => {
       stubStatefulCartItem = new DaffStatefulCartItemFactory().create();
       testInitialState = {
-        ids: [stubStatefulCartItem.item_id.toString()],
+        ids: [stubStatefulCartItem.id.toString()],
         entities: {
-          [stubStatefulCartItem.item_id]: stubStatefulCartItem,
+          [stubStatefulCartItem.id]: stubStatefulCartItem,
         },
       };
-      const cartItemUpdateAction = new DaffCartItemUpdate(stubStatefulCartItem.item_id, { qty: 4 });
+      const cartItemUpdateAction = new DaffCartItemUpdate(stubStatefulCartItem.id, { qty: 4 });
 
       result = daffCartItemEntitiesReducer(testInitialState, cartItemUpdateAction);
     });
 
     it('sets the updating cart item state to mutating', () => {
-      expect(result.entities[stubStatefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Mutating);
+      expect(result.entities[stubStatefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.Mutating);
     });
   });
 
@@ -410,18 +410,18 @@ describe('Cart | Cart Item Entities Reducer', () => {
     beforeEach(() => {
       stubCartItem = new DaffStatefulCartItemFactory().create();
       testInitialState = {
-        ids: [stubCartItem.item_id.toString()],
+        ids: [stubCartItem.id.toString()],
         entities: {
-          [stubCartItem.item_id]: stubCartItem,
+          [stubCartItem.id]: stubCartItem,
         },
       };
-      const cartItemDeleteAction = new DaffCartItemDelete(stubCartItem.item_id);
+      const cartItemDeleteAction = new DaffCartItemDelete(stubCartItem.id);
 
       result = daffCartItemEntitiesReducer(testInitialState, cartItemDeleteAction);
     });
 
     it('sets the cart item state to mutating', () => {
-      expect(result.entities[stubCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Mutating);
+      expect(result.entities[stubCartItem.id].daffState).toEqual(DaffCartItemStateEnum.Mutating);
     });
   });
 
@@ -437,13 +437,13 @@ describe('Cart | Cart Item Entities Reducer', () => {
       };
       statefulCartItem = statefulCartItemFactory.create();
       const cartItemLoadSuccess = new DaffCartItemLoadSuccess(statefulCartItem);
-      const cartItemLoadFailure = new DaffCartItemLoadFailure(error, statefulCartItem.item_id);
+      const cartItemLoadFailure = new DaffCartItemLoadFailure(error, statefulCartItem.id);
 
       result = daffCartItemEntitiesReducer(daffCartItemEntitiesReducer(initialState, cartItemLoadSuccess), cartItemLoadFailure);
     });
 
     it('should reset daffState on the cart item', () => {
-      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Error);
+      expect(result.entities[statefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.Error);
     });
   });
 
@@ -459,13 +459,13 @@ describe('Cart | Cart Item Entities Reducer', () => {
       };
       statefulCartItem = statefulCartItemFactory.create();
       const cartItemLoadSuccess = new DaffCartItemLoadSuccess(statefulCartItem);
-      const cartItemDeleteFailure = new DaffCartItemDeleteFailure(error, statefulCartItem.item_id);
+      const cartItemDeleteFailure = new DaffCartItemDeleteFailure(error, statefulCartItem.id);
 
       result = daffCartItemEntitiesReducer(daffCartItemEntitiesReducer(initialState, cartItemLoadSuccess), cartItemDeleteFailure);
     });
 
     it('should reset daffState on the cart item', () => {
-      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Error);
+      expect(result.entities[statefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.Error);
     });
   });
 
@@ -481,13 +481,13 @@ describe('Cart | Cart Item Entities Reducer', () => {
       };
       statefulCartItem = statefulCartItemFactory.create();
       const cartItemLoadSuccess = new DaffCartItemLoadSuccess(statefulCartItem);
-      const cartItemUpdateFailure = new DaffCartItemUpdateFailure(error, statefulCartItem.item_id);
+      const cartItemUpdateFailure = new DaffCartItemUpdateFailure(error, statefulCartItem.id);
 
       result = daffCartItemEntitiesReducer(daffCartItemEntitiesReducer(initialState, cartItemLoadSuccess), cartItemUpdateFailure);
     });
 
     it('should reset daffState on the cart item', () => {
-      expect(result.entities[statefulCartItem.item_id].daffState).toEqual(DaffCartItemStateEnum.Error);
+      expect(result.entities[statefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.Error);
     });
   });
 });

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -39,12 +39,12 @@ export function daffCartItemEntitiesReducer<
     case DaffCartItemActionTypes.CartItemListSuccessAction:
       return adapter.addAll(action.payload.map(item => ({
         ...item,
-        daffState: getDaffState(state.entities[item.item_id]) || DaffCartItemStateEnum.Default,
+        daffState: getDaffState(state.entities[item.id]) || DaffCartItemStateEnum.Default,
       })), state);
     case DaffCartItemActionTypes.CartItemLoadSuccessAction:
       return adapter.upsertOne({
         ...action.payload,
-        daffState: getDaffState(state.entities[action.payload.item_id]) || DaffCartItemStateEnum.Default,
+        daffState: getDaffState(state.entities[action.payload.id]) || DaffCartItemStateEnum.Default,
       }, state);
     case DaffCartItemActionTypes.CartItemAddSuccessAction:
       return adapter.addAll(
@@ -69,7 +69,7 @@ export function daffCartItemEntitiesReducer<
     case DaffCartActionTypes.CartClearSuccessAction:
       return adapter.addAll(<T[]><unknown>action.payload.items.map(item => ({
         ...item,
-        daffState: getDaffState(state.entities[item.item_id]) || DaffCartItemStateEnum.Default,
+        daffState: getDaffState(state.entities[item.id]) || DaffCartItemStateEnum.Default,
       })), state);
     case DaffCartItemActionTypes.CartItemStateResetAction:
       return adapter.addAll(Object.keys(state.entities).map(key => ({
@@ -93,7 +93,7 @@ function getDaffState<T extends DaffStatefulCartItem>(item: T): DaffCartItemStat
 
 function updateAddedCartItemState<T extends DaffStatefulCartItem>(oldCartItems: Dictionary<T>, newCartItems: T[]): T[] {
   return newCartItems.map(newItem => {
-    const oldItem = oldCartItems[newItem.item_id];
+    const oldItem = oldCartItems[newItem.id];
     switch(true) {
       case !oldItem:
         return { ...newItem, daffState: DaffCartItemStateEnum.New };
@@ -105,8 +105,8 @@ function updateAddedCartItemState<T extends DaffStatefulCartItem>(oldCartItems: 
   });
 }
 
-function updateMutatedCartItemState<T extends DaffStatefulCartItem>(responseItems: T[], stateItems: Dictionary<T>, itemId: T['item_id']): T[] {
-  return responseItems.map(item => item.item_id === itemId ?
+function updateMutatedCartItemState<T extends DaffStatefulCartItem>(responseItems: T[], stateItems: Dictionary<T>, itemId: T['id']): T[] {
+  return responseItems.map(item => item.id === itemId ?
     { ...item, daffState: DaffCartItemStateEnum.Updated } :
-    { ...item, daffState: getDaffState(stateItems[item.item_id]) || DaffCartItemStateEnum.Default });
+    { ...item, daffState: getDaffState(stateItems[item.id]) || DaffCartItemStateEnum.Default });
 }

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
@@ -106,7 +106,7 @@ describe('Cart | Reducer | Cart Item', () => {
         },
       };
 
-      const cartItemUpdateFailure = new DaffCartItemUpdateFailure(error, cartItem.item_id);
+      const cartItemUpdateFailure = new DaffCartItemUpdateFailure(error, cartItem.id);
 
       result = cartItemReducer(state, cartItemUpdateFailure);
     });
@@ -169,7 +169,7 @@ describe('Cart | Reducer | Cart Item', () => {
         },
       };
 
-      const cartItemRemoveFailure = new DaffCartItemDeleteFailure(error, cartItem.item_id);
+      const cartItemRemoveFailure = new DaffCartItemDeleteFailure(error, cartItem.id);
 
       result = cartItemReducer(state, cartItemRemoveFailure);
     });
@@ -333,7 +333,7 @@ describe('Cart | Reducer | Cart Item', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartItemLoadFailure = new DaffCartItemLoadFailure(error, cartItem.item_id);
+      const cartItemLoadFailure = new DaffCartItemLoadFailure(error, cartItem.id);
 
       result = cartItemReducer(state, cartItemLoadFailure);
     });

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
@@ -52,7 +52,7 @@ export function cartItemReducer<T extends DaffCart>(
         cart: {
           ...state.cart,
           items: state.cart.items.map(item =>
-            item.item_id === action.payload.item_id
+            item.id === action.payload.id
               ? action.payload
               : item,
           ),

--- a/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.spec.ts
+++ b/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.spec.ts
@@ -82,7 +82,7 @@ describe('selectCartItemEntitiesState', () => {
 
       it('selects cart item ids', () => {
         const selector = store.pipe(select(selectCartItemIds));
-        const expected = cold('a', { a: [mockCartItems[0].item_id, mockCartItems[1].item_id]});
+        const expected = cold('a', { a: [mockCartItems[0].id, mockCartItems[1].id]});
 
         expect(selector).toBeObservable(expected);
       });
@@ -93,7 +93,7 @@ describe('selectCartItemEntitiesState', () => {
       it('selects product entities as a dictionary object', () => {
         const expectedDictionary = mockCartItems.reduce((acc, item) => ({
           ...acc,
-          [item.item_id]: item,
+          [item.id]: item,
         }), {});
 
         const selector = store.pipe(select(selectCartItemEntities));
@@ -127,7 +127,7 @@ describe('selectCartItemEntitiesState', () => {
   describe('selectCartItem', () => {
 
     it('should select the product of the given id', () => {
-      const selector = store.pipe(select(selectCartItem(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItem(mockCartItems[0].id)));
       const expected = cold('a', { a: mockCartItems[0] });
 
       expect(selector).toBeObservable(expected);
@@ -135,7 +135,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should not emit when an unrelated piece of state changes', () => {
       const spy = jasmine.createSpy();
-      const selector = store.pipe(select(selectCartItem(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItem(mockCartItems[0].id)));
 
       selector.subscribe(spy);
 
@@ -158,7 +158,7 @@ describe('selectCartItemEntitiesState', () => {
   describe('selectCartItemConfiguredAttributes', () => {
 
     it('should return null when the given cart item is not configurable', () => {
-      const selector = store.pipe(select(selectCartItemConfiguredAttributes(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemConfiguredAttributes(mockCartItems[0].id)));
       const expected = cold('a', { a: null });
 
       expect(selector).toBeObservable(expected);
@@ -166,7 +166,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should return the configured attributes of a configurable cart item', () => {
       store.dispatch(new DaffCartItemListSuccess(mockStatefulConfigurableCartItems));
-      const selector = store.pipe(select(selectCartItemConfiguredAttributes(mockStatefulConfigurableCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemConfiguredAttributes(mockStatefulConfigurableCartItems[0].id)));
       const expected = cold('a', { a: mockStatefulConfigurableCartItems[0].attributes });
 
       expect(selector).toBeObservable(expected);
@@ -174,7 +174,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should not emit when an unrelated piece of state changes', () => {
       const spy = jasmine.createSpy();
-      const selector = store.pipe(select(selectCartItemConfiguredAttributes(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemConfiguredAttributes(mockCartItems[0].id)));
 
       selector.subscribe(spy);
 
@@ -187,7 +187,7 @@ describe('selectCartItemEntitiesState', () => {
   describe('selectCartItemCompositeOptions', () => {
 
     it('should return null when the given cart item is not composite', () => {
-      const selector = store.pipe(select(selectCartItemCompositeOptions(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemCompositeOptions(mockCartItems[0].id)));
       const expected = cold('a', { a: null });
 
       expect(selector).toBeObservable(expected);
@@ -195,7 +195,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should return the item options of a composite cart item', () => {
       store.dispatch(new DaffCartItemListSuccess(mockStatefulCompositeCartItems));
-      const selector = store.pipe(select(selectCartItemCompositeOptions(mockStatefulCompositeCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemCompositeOptions(mockStatefulCompositeCartItems[0].id)));
       const expected = cold('a', { a: mockStatefulCompositeCartItems[0].options });
 
       expect(selector).toBeObservable(expected);
@@ -203,7 +203,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should not emit when an unrelated piece of state changes', () => {
       const spy = jasmine.createSpy();
-      const selector = store.pipe(select(selectCartItemCompositeOptions(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemCompositeOptions(mockCartItems[0].id)));
 
       selector.subscribe(spy);
 
@@ -217,14 +217,14 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should return whether the given cart item is out of stock', () => {
       store.dispatch(new DaffCartItemListSuccess(mockCartItems));
-      const selector = store.pipe(select(selectIsCartItemOutOfStock(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectIsCartItemOutOfStock(mockCartItems[0].id)));
       const expected = cold('a', { a: !mockCartItems[0].in_stock });
 
       expect(selector).toBeObservable(expected);
     });
 
     it('should return null if the cart item is not in state', () => {
-      const selector = store.pipe(select(selectIsCartItemOutOfStock(mockCartItems[0].item_id + 'notId')));
+      const selector = store.pipe(select(selectIsCartItemOutOfStock(mockCartItems[0].id + 'notId')));
       const expected = cold('a', { a: null });
 
       expect(selector).toBeObservable(expected);
@@ -232,7 +232,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should not emit when an unrelated piece of state changes', () => {
       const spy = jasmine.createSpy();
-      const selector = store.pipe(select(selectIsCartItemOutOfStock(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectIsCartItemOutOfStock(mockCartItems[0].id)));
 
       selector.subscribe(spy);
 
@@ -246,7 +246,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should return true when a cart item is mutating', () => {
       store.dispatch(new DaffCartItemListSuccess(mockCartItems));
-      store.dispatch(new DaffCartItemUpdate(mockCartItems[0].item_id, { qty: 2 }));
+      store.dispatch(new DaffCartItemUpdate(mockCartItems[0].id, { qty: 2 }));
       const selector = store.pipe(select(selectCartItemMutating));
       const expected = cold('a', { a: true });
 
@@ -265,14 +265,14 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should return the state of the cart item', () => {
       store.dispatch(new DaffCartItemListSuccess(mockCartItems));
-      const selector = store.pipe(select(selectCartItemState(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemState(mockCartItems[0].id)));
       const expected = cold('a', { a: mockCartItems[0].daffState });
 
       expect(selector).toBeObservable(expected);
     });
 
     it('should return null if the cart item is not in state', () => {
-      const selector = store.pipe(select(selectCartItemState(mockCartItems[0].item_id + 'notId')));
+      const selector = store.pipe(select(selectCartItemState(mockCartItems[0].id + 'notId')));
       const expected = cold('a', { a: null });
 
       expect(selector).toBeObservable(expected);
@@ -280,7 +280,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should not emit when an unrelated piece of state changes', () => {
       const spy = jasmine.createSpy();
-      const selector = store.pipe(select(selectCartItemState(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemState(mockCartItems[0].id)));
 
       selector.subscribe(spy);
 
@@ -294,14 +294,14 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should return the price of the cart item', () => {
       store.dispatch(new DaffCartItemListSuccess(mockCartItems));
-      const selector = store.pipe(select(selectCartItemPrice(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemPrice(mockCartItems[0].id)));
       const expected = cold('a', { a: mockCartItems[0].price });
 
       expect(selector).toBeObservable(expected);
     });
 
     it('should return 0 if the cart item is not in state', () => {
-      const selector = store.pipe(select(selectCartItemPrice(mockCartItems[0].item_id + 'notId')));
+      const selector = store.pipe(select(selectCartItemPrice(mockCartItems[0].id + 'notId')));
       const expected = cold('a', { a: 0 });
 
       expect(selector).toBeObservable(expected);
@@ -309,7 +309,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should not emit when an unrelated piece of state changes', () => {
       const spy = jasmine.createSpy();
-      const selector = store.pipe(select(selectCartItemPrice(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemPrice(mockCartItems[0].id)));
 
       selector.subscribe(spy);
 
@@ -323,14 +323,14 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should return the quantity of the cart item', () => {
       store.dispatch(new DaffCartItemListSuccess(mockCartItems));
-      const selector = store.pipe(select(selectCartItemQuantity(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemQuantity(mockCartItems[0].id)));
       const expected = cold('a', { a: mockCartItems[0].qty });
 
       expect(selector).toBeObservable(expected);
     });
 
     it('should return 0 if the cart item is not in state', () => {
-      const selector = store.pipe(select(selectCartItemQuantity(mockCartItems[0].item_id + 'notId')));
+      const selector = store.pipe(select(selectCartItemQuantity(mockCartItems[0].id + 'notId')));
       const expected = cold('a', { a: 0 });
 
       expect(selector).toBeObservable(expected);
@@ -338,7 +338,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should not emit when an unrelated piece of state changes', () => {
       const spy = jasmine.createSpy();
-      const selector = store.pipe(select(selectCartItemQuantity(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemQuantity(mockCartItems[0].id)));
 
       selector.subscribe(spy);
 
@@ -352,14 +352,14 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should return the row total of the cart item', () => {
       store.dispatch(new DaffCartItemListSuccess(mockCartItems));
-      const selector = store.pipe(select(selectCartItemRowTotal(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemRowTotal(mockCartItems[0].id)));
       const expected = cold('a', { a: mockCartItems[0].row_total });
 
       expect(selector).toBeObservable(expected);
     });
 
     it('should return 0 if the cart item is not in state', () => {
-      const selector = store.pipe(select(selectCartItemRowTotal(mockCartItems[0].item_id + 'notId')));
+      const selector = store.pipe(select(selectCartItemRowTotal(mockCartItems[0].id + 'notId')));
       const expected = cold('a', { a: 0 });
 
       expect(selector).toBeObservable(expected);
@@ -367,7 +367,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should not emit when an unrelated piece of state changes', () => {
       const spy = jasmine.createSpy();
-      const selector = store.pipe(select(selectCartItemRowTotal(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemRowTotal(mockCartItems[0].id)));
 
       selector.subscribe(spy);
 
@@ -381,14 +381,14 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should return the discounts of the cart item', () => {
       store.dispatch(new DaffCartItemListSuccess(mockCartItems));
-      const selector = store.pipe(select(selectCartItemDiscounts(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemDiscounts(mockCartItems[0].id)));
       const expected = cold('a', { a: mockCartItems[0].discounts });
 
       expect(selector).toBeObservable(expected);
     });
 
     it('should return an empty array if the cart item is not in state', () => {
-      const selector = store.pipe(select(selectCartItemDiscounts(mockCartItems[0].item_id + 'notId')));
+      const selector = store.pipe(select(selectCartItemDiscounts(mockCartItems[0].id + 'notId')));
       const expected = cold('a', { a: []});
 
       expect(selector).toBeObservable(expected);
@@ -396,7 +396,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should not emit when an unrelated piece of state changes', () => {
       const spy = jasmine.createSpy();
-      const selector = store.pipe(select(selectCartItemDiscounts(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemDiscounts(mockCartItems[0].id)));
 
       selector.subscribe(spy);
 
@@ -410,14 +410,14 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should return the sum of all discounts of the cart item', () => {
       store.dispatch(new DaffCartItemListSuccess(mockCartItems));
-      const selector = store.pipe(select(selectCartItemTotalDiscount(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemTotalDiscount(mockCartItems[0].id)));
       const expected = cold('a', { a: mockCartItems[0].discounts.reduce((acc, { amount }) => acc + amount, 0) });
 
       expect(selector).toBeObservable(expected);
     });
 
     it('should return 0 if the cart item is not in state', () => {
-      const selector = store.pipe(select(selectCartItemTotalDiscount(mockCartItems[0].item_id + 'notId')));
+      const selector = store.pipe(select(selectCartItemTotalDiscount(mockCartItems[0].id + 'notId')));
       const expected = cold('a', { a: 0 });
 
       expect(selector).toBeObservable(expected);
@@ -425,7 +425,7 @@ describe('selectCartItemEntitiesState', () => {
 
     it('should not emit when an unrelated piece of state changes', () => {
       const spy = jasmine.createSpy();
-      const selector = store.pipe(select(selectCartItemTotalDiscount(mockCartItems[0].item_id)));
+      const selector = store.pipe(select(selectCartItemTotalDiscount(mockCartItems[0].id)));
 
       selector.subscribe(spy);
 

--- a/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.ts
+++ b/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.ts
@@ -39,41 +39,41 @@ export interface DaffCartItemEntitiesMemoizedSelectors<
 	selectCartItemEntities: MemoizedSelector<DaffCartStateRootSlice<T, V, U>, EntityState<U>['entities']>;
 	selectAllCartItems: MemoizedSelector<DaffCartStateRootSlice<T, V, U>, U[]>;
 	selectCartItemTotal: MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
-	selectCartItem: (id: U['item_id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, U>;
+	selectCartItem: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, U>;
 	selectTotalNumberOfCartItems: MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
-	selectCartItemConfiguredAttributes: (id: U['item_id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, DaffConfigurableCartItemAttribute[]>;
-	selectCartItemCompositeOptions: (id: U['item_id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, DaffCompositeCartItemOption[]>;
-	selectIsCartItemOutOfStock: (id: U['item_id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, boolean>;
+	selectCartItemConfiguredAttributes: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, DaffConfigurableCartItemAttribute[]>;
+	selectCartItemCompositeOptions: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, DaffCompositeCartItemOption[]>;
+	selectIsCartItemOutOfStock: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, boolean>;
 	selectCartItemMutating: MemoizedSelector<DaffCartStateRootSlice<T, V, U>, boolean>;
-	selectCartItemState: (id: U['item_id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, DaffCartItemStateEnum>;
+	selectCartItemState: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, DaffCartItemStateEnum>;
   /**
    * Selects the specified item's price.
    * Zero by default.
    * This includes any discounts and sales that apply to the product or category.
    * This excludes cart discounts.
    */
-	selectCartItemPrice: (id: U['item_id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
+	selectCartItemPrice: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
   /**
    * Selects the specified item's quantity.
    * Zero by default.
    */
-	selectCartItemQuantity: (id: U['item_id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
+	selectCartItemQuantity: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
   /**
    * Selects the specified item's row total.
    * Zero by default.
    * This includes any discounts and sales that apply to the product or category.
    * This excludes cart discounts.
    */
-	selectCartItemRowTotal: (id: U['item_id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
+	selectCartItemRowTotal: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
   /**
    * Selects the specified item's array of cart (not product) discounts for the entire row.
    */
-	selectCartItemDiscounts: (id: U['item_id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, DaffCartItemDiscount[]>;
+	selectCartItemDiscounts: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, DaffCartItemDiscount[]>;
   /**
    * Selects the specified item's sum of all cart (not product) discounts for the entire row.
    * Zero by default.
    */
-	selectCartItemTotalDiscount: (id: U['item_id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
+	selectCartItemTotalDiscount: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
 }
 
 const createCartItemEntitiesSelectors = <
@@ -133,7 +133,7 @@ const createCartItemEntitiesSelectors = <
     adapterSelectors.selectTotal,
   );
 
-  const selectCartItem = defaultMemoize((itemId: U['item_id']) => createSelector(
+  const selectCartItem = defaultMemoize((itemId: U['id']) => createSelector(
     selectCartItemEntities,
     cartItems => cartItems[itemId],
   )).memoized;
@@ -146,7 +146,7 @@ const createCartItemEntitiesSelectors = <
     (cartItems) => cartItems.reduce((acc, cartItem) => acc + cartItem.qty, 0),
   );
 
-  const selectCartItemConfiguredAttributes = defaultMemoize((itemId: U['item_id']) => createSelector(
+  const selectCartItemConfiguredAttributes = defaultMemoize((itemId: U['id']) => createSelector(
     selectCartItem(itemId),
     (cartItem: DaffConfigurableCartItem) => {
       if(cartItem.type !== DaffCartItemInputType.Configurable) {
@@ -157,7 +157,7 @@ const createCartItemEntitiesSelectors = <
     },
   )).memoized;
 
-  const selectCartItemCompositeOptions = defaultMemoize((itemId: U['item_id']) => createSelector(
+  const selectCartItemCompositeOptions = defaultMemoize((itemId: U['id']) => createSelector(
     selectCartItem(itemId),
     (cartItem: DaffCompositeCartItem) => {
       if(cartItem.type !== DaffCartItemInputType.Composite) {
@@ -168,7 +168,7 @@ const createCartItemEntitiesSelectors = <
     },
   )).memoized;
 
-  const selectIsCartItemOutOfStock = defaultMemoize((itemId: U['item_id']) => createSelector(
+  const selectIsCartItemOutOfStock = defaultMemoize((itemId: U['id']) => createSelector(
     selectCartItem(itemId),
     (cartItem: U) => cartItem ? !cartItem.in_stock : null,
   )).memoized;
@@ -180,32 +180,32 @@ const createCartItemEntitiesSelectors = <
       acc || item.daffState === DaffCartItemStateEnum.Mutating, false),
   );
 
-  const selectCartItemState = defaultMemoize((itemId: U['item_id']) => createSelector(
+  const selectCartItemState = defaultMemoize((itemId: U['id']) => createSelector(
     selectCartItem(itemId),
     (cartItem: U) => cartItem?.daffState || null,
   )).memoized;
 
-  const selectCartItemQuantity = defaultMemoize((itemId: U['item_id']) => createSelector(
+  const selectCartItemQuantity = defaultMemoize((itemId: U['id']) => createSelector(
     selectCartItem(itemId),
     (cartItem: U) => cartItem?.qty || 0,
   )).memoized;
 
-  const selectCartItemRowTotal = defaultMemoize((itemId: U['item_id']) => createSelector(
+  const selectCartItemRowTotal = defaultMemoize((itemId: U['id']) => createSelector(
     selectCartItem(itemId),
     (cartItem: U) => cartItem?.row_total || 0,
   )).memoized;
 
-  const selectCartItemPrice = defaultMemoize((itemId: U['item_id']) => createSelector(
+  const selectCartItemPrice = defaultMemoize((itemId: U['id']) => createSelector(
     selectCartItem(itemId),
     (cartItem: U) => cartItem?.price || 0,
   )).memoized;
 
-  const selectCartItemDiscounts = defaultMemoize((itemId: U['item_id']) => createSelector(
+  const selectCartItemDiscounts = defaultMemoize((itemId: U['id']) => createSelector(
     selectCartItem(itemId),
     (cartItem: U) => cartItem?.discounts || [],
   )).memoized;
 
-  const selectCartItemTotalDiscount = defaultMemoize((itemId: U['item_id']) => createSelector(
+  const selectCartItemTotalDiscount = defaultMemoize((itemId: U['id']) => createSelector(
     selectCartItemDiscounts(itemId),
     (discounts: U['discounts']) => discounts?.reduce((acc, { amount }) => daffAdd(acc, amount), 0) || 0,
   )).memoized;

--- a/libs/cart/state/testing/src/factories/stateful-cart-item.factory.spec.ts
+++ b/libs/cart/state/testing/src/factories/stateful-cart-item.factory.spec.ts
@@ -30,6 +30,7 @@ describe('Cart | State | Testing | Factories | StatefulCartItemFactory', () => {
 
     it('should return a StatefulCartItem with all required fields defined', () => {
       expect(result.item_id).not.toBeNull();
+      expect(result.id).not.toBeNull();
       expect(result.product_id).not.toBeNull();
       expect(result.parent_item_id).not.toBeNull();
       expect(result.image).not.toBeNull();

--- a/libs/cart/state/testing/src/factories/stateful-composite-cart-item.spec.ts
+++ b/libs/cart/state/testing/src/factories/stateful-composite-cart-item.spec.ts
@@ -30,6 +30,7 @@ describe('Cart | State | Testing | Factories | StatefulCompositeCartItemFactory'
 
     it('should return a StatefulCompositeCartItem with all required fields defined', () => {
       expect(result.item_id).not.toBeNull();
+      expect(result.id).not.toBeNull();
       expect(result.product_id).not.toBeNull();
       expect(result.parent_item_id).not.toBeNull();
       expect(result.image).not.toBeNull();

--- a/libs/cart/state/testing/src/factories/stateful-configurable-cart-item.spec.ts
+++ b/libs/cart/state/testing/src/factories/stateful-configurable-cart-item.spec.ts
@@ -30,6 +30,7 @@ describe('Cart | State | Testing | Factories | StatefulConfigurableCartItemFacto
 
     it('should return a StatefulConfigurableCartItem with all required fields defined', () => {
       expect(result.item_id).not.toBeNull();
+      expect(result.id).not.toBeNull();
       expect(result.product_id).not.toBeNull();
       expect(result.parent_item_id).not.toBeNull();
       expect(result.image).not.toBeNull();

--- a/libs/cart/state/testing/src/mock-cart-facade.ts
+++ b/libs/cart/state/testing/src/mock-cart-facade.ts
@@ -115,39 +115,39 @@ export class MockDaffCartFacade implements DaffCartFacadeInterface {
 	orderResultCartId$ = new BehaviorSubject<DaffCartOrderResult['cartId']>(null);
 	hasOrderResult$ = new BehaviorSubject<boolean>(false);
 
-	getCartItemPrice(itemId: DaffCartItem['item_id']): BehaviorSubject<number> {
+	getCartItemPrice(itemId: DaffCartItem['id']): BehaviorSubject<number> {
 	  return new BehaviorSubject(0);
 	}
 
-	getCartItemQuantity(itemId: DaffCartItem['item_id']): BehaviorSubject<number> {
+	getCartItemQuantity(itemId: DaffCartItem['id']): BehaviorSubject<number> {
 	  return new BehaviorSubject(0);
 	}
 
-	getCartItemRowTotal(itemId: DaffCartItem['item_id']): BehaviorSubject<number> {
+	getCartItemRowTotal(itemId: DaffCartItem['id']): BehaviorSubject<number> {
 	  return new BehaviorSubject(0);
 	}
 
-	getConfiguredCartItemAttributes(itemId: DaffCartItem['item_id']): BehaviorSubject<DaffConfigurableCartItemAttribute[]> {
+	getConfiguredCartItemAttributes(itemId: DaffCartItem['id']): BehaviorSubject<DaffConfigurableCartItemAttribute[]> {
 	  return new BehaviorSubject([]);
 	}
 
-	getCompositeCartItemOptions(itemId: DaffCartItem['item_id']): BehaviorSubject<DaffCompositeCartItemOption[]> {
+	getCompositeCartItemOptions(itemId: DaffCartItem['id']): BehaviorSubject<DaffCompositeCartItemOption[]> {
 	  return new BehaviorSubject([]);
 	}
 
-	isCartItemOutOfStock(itemId: DaffCartItem['item_id']): BehaviorSubject<boolean> {
+	isCartItemOutOfStock(itemId: DaffCartItem['id']): BehaviorSubject<boolean> {
 	  return new BehaviorSubject(false);
 	}
 
-	getCartItemState(itemId: DaffCartItem['item_id']): BehaviorSubject<DaffCartItemStateEnum> {
+	getCartItemState(itemId: DaffCartItem['id']): BehaviorSubject<DaffCartItemStateEnum> {
 	  return new BehaviorSubject(DaffCartItemStateEnum.Default);
 	}
 
-	getCartItemDiscounts(itemId: DaffCartItem['item_id']): BehaviorSubject<DaffCartItemDiscount[]> {
+	getCartItemDiscounts(itemId: DaffCartItem['id']): BehaviorSubject<DaffCartItemDiscount[]> {
 	  return new BehaviorSubject([]);
 	}
 
-	getCartItemTotalDiscount(itemId: DaffCartItem['item_id']): BehaviorSubject<number> {
+	getCartItemTotalDiscount(itemId: DaffCartItem['id']): BehaviorSubject<number> {
 	  return new BehaviorSubject(0);
 	}
 

--- a/libs/cart/testing/src/factories/cart-item/cart-item.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart-item/cart-item.factory.spec.ts
@@ -30,6 +30,7 @@ describe('Cart | Testing | Factories | CartItemFactory', () => {
 
     it('should return a CartItem with all required fields defined', () => {
       expect(result.item_id).not.toBeNull();
+      expect(result.id).not.toBeNull();
       expect(result.product_id).not.toBeNull();
       expect(result.parent_item_id).not.toBeNull();
       expect(result.image).not.toBeNull();

--- a/libs/cart/testing/src/factories/cart-item/cart-item.factory.ts
+++ b/libs/cart/testing/src/factories/cart-item/cart-item.factory.ts
@@ -11,8 +11,8 @@ import { DaffProductImage } from '@daffodil/product';
 import { DaffProductImageFactory } from '@daffodil/product/testing';
 
 export class DaffMockCartItem implements DaffCartItem {
-	item_id = faker.datatype.uuid();
 	id = faker.datatype.uuid();
+	item_id = this.id;
 	type = DaffCartItemInputType.Simple;
   product_id = faker.datatype.uuid();
 	parent_item_id = faker.datatype.uuid();

--- a/libs/cart/testing/src/factories/cart-item/cart-item.factory.ts
+++ b/libs/cart/testing/src/factories/cart-item/cart-item.factory.ts
@@ -12,6 +12,7 @@ import { DaffProductImageFactory } from '@daffodil/product/testing';
 
 export class DaffMockCartItem implements DaffCartItem {
 	item_id = faker.datatype.uuid();
+	id = faker.datatype.uuid();
 	type = DaffCartItemInputType.Simple;
   product_id = faker.datatype.uuid();
 	parent_item_id = faker.datatype.uuid();

--- a/libs/cart/testing/src/factories/cart-item/composite-cart-item.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart-item/composite-cart-item.factory.spec.ts
@@ -30,6 +30,7 @@ describe('Cart | Testing | Factories | CompositeCartItemFactory', () => {
 
     it('should return a DaffCompositeCartItem with all required fields defined', () => {
       expect(result.item_id).not.toBeNull();
+      expect(result.id).not.toBeNull();
       expect(result.product_id).not.toBeNull();
       expect(result.parent_item_id).not.toBeNull();
       expect(result.image).not.toBeNull();

--- a/libs/cart/testing/src/factories/cart-item/configurable-cart-item.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart-item/configurable-cart-item.factory.spec.ts
@@ -30,6 +30,7 @@ describe('Cart | Testing | Factories | ConfigurableCartItemFactory', () => {
 
     it('should return a DaffConfigurableCartItem with all required fields defined', () => {
       expect(result.item_id).not.toBeNull();
+      expect(result.id).not.toBeNull();
       expect(result.product_id).not.toBeNull();
       expect(result.parent_item_id).not.toBeNull();
       expect(result.image).not.toBeNull();


### PR DESCRIPTION
…e instead

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `DaffCartItem` has an id field that is named `item_id`. It could just be `id` instead and extend the `DaffIdentifiable` interface.

## What is the new behavior?
`DaffCartItem.item_id` is deprecated and `DaffCartItem` extends `DaffIdentifiable`. All instances of the `item_id` usages are replaced by `id`, but `item_id` is still populated.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```