### PR TITLE
feat(cart): deprecate DaffCompositeCartItemOption.option_id in favor …

### DIFF
--- a/libs/cart/driver/magento/src/transforms/outputs/cart-item/bundle-cart-item-transformer.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-item/bundle-cart-item-transformer.spec.ts
@@ -15,6 +15,7 @@ describe('transformMagentoBundleCartItem', () => {
 
   it('should return the expected composite product', () => {
     expect(transformedCartItem.options[0].option_id).toEqual(String(stubMagentoBundleCartItem.bundle_options[0].values[0].id));
+    expect(transformedCartItem.options[0].id).toEqual(String(stubMagentoBundleCartItem.bundle_options[0].values[0].id));
     expect(transformedCartItem.options[0].option_label).toEqual(stubMagentoBundleCartItem.bundle_options[0].label);
     expect(transformedCartItem.options[0].value_label).toEqual(stubMagentoBundleCartItem.bundle_options[0].values[0].label);
   });

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-item/bundle-cart-item-transformer.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-item/bundle-cart-item-transformer.ts
@@ -10,6 +10,7 @@ import { transformMagentoSimpleCartItem } from './simple-cart-item-transformer';
 function transformBundleCartItemOption(option: MagentoBundleCartItem['bundle_options'][0]): DaffCompositeCartItemOption {
   return {
     option_id: String(option.values[0].id),
+    id: String(option.values[0].id),
     option_label: option.label,
     value_label: option.values[0].label,
   };

--- a/libs/cart/src/models/composite-cart-item.ts
+++ b/libs/cart/src/models/composite-cart-item.ts
@@ -1,4 +1,7 @@
-import { ID } from '@daffodil/core';
+import {
+  DaffIdentifiable,
+  ID,
+} from '@daffodil/core';
 
 import { DaffCartItem } from './cart-item';
 
@@ -6,7 +9,10 @@ export interface DaffCompositeCartItem extends DaffCartItem {
 	options: DaffCompositeCartItemOption[];
 }
 
-export interface DaffCompositeCartItemOption {
+export interface DaffCompositeCartItemOption extends DaffIdentifiable {
+	/**
+	 * @deprecated use id instead.
+	 */
 	option_id: ID;
 	option_label: string;
 	value_label: string;

--- a/libs/cart/state/testing/src/factories/stateful-composite-cart-item.spec.ts
+++ b/libs/cart/state/testing/src/factories/stateful-composite-cart-item.spec.ts
@@ -40,6 +40,7 @@ describe('Cart | State | Testing | Factories | StatefulCompositeCartItemFactory'
       expect(result.price).not.toBeNull();
       expect(result.row_total).not.toBeNull();
       expect(result.options[0].option_id).not.toBeNull();
+      expect(result.options[0].id).not.toBeNull();
       expect(result.options[0].option_label).not.toBeNull();
       expect(result.options[0].value_label).not.toBeNull();
       expect(result.daffState).not.toBeNull();

--- a/libs/cart/testing/src/factories/cart-item/composite-cart-item.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart-item/composite-cart-item.factory.spec.ts
@@ -40,6 +40,7 @@ describe('Cart | Testing | Factories | CompositeCartItemFactory', () => {
       expect(result.price).not.toBeNull();
       expect(result.row_total).not.toBeNull();
       expect(result.options[0].option_id).not.toBeNull();
+      expect(result.options[0].id).not.toBeNull();
       expect(result.options[0].option_label).not.toBeNull();
       expect(result.options[0].value_label).not.toBeNull();
     });

--- a/libs/cart/testing/src/factories/cart-item/composite-cart-item.factory.ts
+++ b/libs/cart/testing/src/factories/cart-item/composite-cart-item.factory.ts
@@ -10,15 +10,19 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 import { DaffMockCartItem } from './cart-item.factory';
 
 export class DaffMockCompositeCartItem extends DaffMockCartItem implements DaffCompositeCartItem {
+	private optionId1 = faker.datatype.number(1000).toString();
+	private optionId2 = faker.datatype.number(1000).toString();
 	type = DaffCartItemInputType.Composite;
 	options = [
 	  {
-	    option_id: faker.datatype.number(1000).toString(),
+	    id: this.optionId1,
+	    option_id: this.optionId1,
 	    option_label: faker.random.word(),
 	    value_label: faker.random.word(),
 	  },
 	  {
-	    option_id: faker.datatype.number(1000).toString(),
+	    id: this.optionId2,
+	    option_id: this.optionId2,
 	    option_label: faker.random.word(),
 	    value_label: faker.random.word(),
 	  },


### PR DESCRIPTION
…of DaffIdentifiable

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
`DaffCompositeCartItemOption.option_id` is deprecated in favor of extending the `DaffIdentifiable` interface.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```