### PR TITLE
fix(tools-dgeni): the generated guide list should not include the toc

### DIFF
--- a/tools/dgeni/src/transforms/daffodil-guides-package/helpers/navigation-trie.ts
+++ b/tools/dgeni/src/transforms/daffodil-guides-package/helpers/navigation-trie.ts
@@ -29,7 +29,7 @@ export class NavigationTrie {
   ) {
     this.id = key;
     this.title = title;
-		this.tableOfContents = tableOfContents;
+		this.tableOfContents = '';
     if (path) {
       this.path = path;
     }
@@ -78,7 +78,7 @@ export class NavigationTrie {
 
     //If no child exists, simply append the word
     if (!child) {
-      this.appendChild(new NavigationTrie(path, doc.title, doc.path, doc.tableOfContents));
+      this.appendChild(new NavigationTrie(path, doc.title, doc.path, ''));
       return;
     }
 
@@ -86,7 +86,7 @@ export class NavigationTrie {
     if (child.children.length != 0) {
       child.title = doc.title;
 			child.tableOfContents = doc.tableOfContents;
-      child.appendChild(new NavigationTrie('', 'Overview', doc.path, doc.tableOfContents));
+      child.appendChild(new NavigationTrie('', 'Overview', doc.path, ''));
       return;
     }
 
@@ -120,7 +120,7 @@ export class NavigationTrie {
     //If there is a child, and it is a 'word' node, transform that
     //node into a true word node.
     else if (child && child.children.length == 0) {
-      const node = new NavigationTrie('', 'Overview', child.path, child.tableOfContents);
+      const node = new NavigationTrie('', 'Overview', child.path, '');
       delete (child.path);
 			child.appendChild(node);
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/graycoreio/daffodil/issues/1628

Fixes: https://github.com/graycoreio/daffodil/issues/1628


## What is the new behavior?
The table of contents is no longer included in the guidesList.json.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```