### PR TITLE
feat(product): change instances of selectedProduct to currentProduct …

### DIFF
--- a/libs/product/state/src/actions/product-page.actions.ts
+++ b/libs/product/state/src/actions/product-page.actions.ts
@@ -62,7 +62,7 @@ export class DaffProductPageLoadFailure implements Action {
 }
 
 /**
- * Update the qty of the selected product.
+ * Update the qty of the current product.
  *
  * @param payload - The qty of the product.
  */

--- a/libs/product/state/src/facades/product/product-facade.interface.ts
+++ b/libs/product/state/src/facades/product/product-facade.interface.ts
@@ -12,12 +12,6 @@ export interface DaffProductFacadeInterface<T extends DaffProduct = DaffProduct>
 	 * Whether a product is being loaded.
 	 */
 	loading$: Observable<boolean>;
-	/**
-	 * deprecated - use getProduct instead.
-	 *
-	 * @deprecated use getProduct instead.
-	 */
-	product$: Observable<T>;
 
 	/**
 	 * Get a product.

--- a/libs/product/state/src/facades/product/product.facade.spec.ts
+++ b/libs/product/state/src/facades/product/product.facade.spec.ts
@@ -6,10 +6,7 @@ import {
 } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 
-import {
-  daffArrayToDict,
-  daffSubtract,
-} from '@daffodil/core';
+import { daffSubtract } from '@daffodil/core';
 import {
   DaffProductLoad,
   DaffProductLoadSuccess,
@@ -70,24 +67,6 @@ describe('DaffProductFacade', () => {
       const expected = cold('a', { a: true });
       store.dispatch(new DaffProductPageLoad('1'));
       expect(facade.loading$).toBeObservable(expected);
-    });
-  });
-
-  describe('product$', () => {
-    it('should initially be undefined', () => {
-      const initial = cold('a', { a: undefined });
-      expect(facade.product$).toBeObservable(initial);
-    });
-
-    it('should be an observable of the currently selected product', () => {
-      const product = productFactory.create();
-      const expected = cold('a', { a: product });
-      store.dispatch(new DaffProductPageLoad(product.id));
-      store.dispatch(new DaffProductPageLoadSuccess({
-        id: product.id,
-        products: [product],
-      }));
-      expect(facade.product$).toBeObservable(expected);
     });
   });
 

--- a/libs/product/state/src/facades/product/product.facade.ts
+++ b/libs/product/state/src/facades/product/product.facade.ts
@@ -27,8 +27,7 @@ export class DaffProductFacade<T extends DaffProduct = DaffProduct> implements D
 	private selectors = getDaffProductSelectors<T>();
 
 	constructor(private store: Store<DaffProductStateRootSlice<T>>) {
-	  this.loading$ = this.store.pipe(select(this.selectors.selectSelectedProductLoadingState));
-	  this.product$ = this.store.pipe(select(this.selectors.selectSelectedProduct));
+	  this.loading$ = this.store.pipe(select(this.selectors.selectCurrentProductLoadingState));
 	}
 
 	getProduct(id: T['id']): Observable<T> {

--- a/libs/product/state/src/reducers/product/product-reducer-state.interface.ts
+++ b/libs/product/state/src/reducers/product/product-reducer-state.interface.ts
@@ -2,15 +2,15 @@ import { DaffStateError } from '@daffodil/core/state';
 import { DaffProduct } from '@daffodil/product';
 
 /**
- * An interface describing product redux state. This state describes the product that is loaded for a product page.
+ * An interface describing product redux state. This state describes the current product that is loaded for a product page.
  */
 export interface DaffProductReducerState {
 	/**
-	 * The id of the currently selected product.
+	 * The id of the current product.
 	 */
-  selectedProductId: DaffProduct['id'];
+  currentProductId: DaffProduct['id'];
 	/**
-	 * The quantity chosen for the selected product.
+	 * The quantity chosen for the current product.
 	 */
   qty: number;
 	/**

--- a/libs/product/state/src/reducers/product/product.reducer.spec.ts
+++ b/libs/product/state/src/reducers/product/product.reducer.spec.ts
@@ -52,8 +52,8 @@ describe('Product | Product Reducer', () => {
       expect(result.loading).toEqual(true);
     });
 
-    it('resets selectedProductId', () => {
-      expect(result.selectedProductId).toBeNull();
+    it('resets currentProductId', () => {
+      expect(result.currentProductId).toBeNull();
     });
   });
 
@@ -70,8 +70,8 @@ describe('Product | Product Reducer', () => {
       expect(result.loading).toEqual(true);
     });
 
-    it('resets selectedProductId', () => {
-      expect(result.selectedProductId).toBeNull();
+    it('resets currentProductId', () => {
+      expect(result.currentProductId).toBeNull();
     });
   });
 
@@ -97,8 +97,8 @@ describe('Product | Product Reducer', () => {
       expect(result.loading).toEqual(false);
     });
 
-    it('sets selectedProductId to the loaded product ID', () => {
-      expect(result.selectedProductId).toEqual(product.id);
+    it('sets currentProductId to the loaded product ID', () => {
+      expect(result.currentProductId).toEqual(product.id);
     });
   });
 

--- a/libs/product/state/src/reducers/product/product.reducer.ts
+++ b/libs/product/state/src/reducers/product/product.reducer.ts
@@ -10,7 +10,7 @@ import { DaffProductReducerState } from './product-reducer-state.interface';
  * Initial values of the product state.
  */
 export const initialState: DaffProductReducerState = {
-  selectedProductId: null,
+  currentProductId: null,
   qty: 1,
   loading: false,
   errors: [],
@@ -27,9 +27,9 @@ export function daffProductReducer<T extends DaffProduct>(state = initialState, 
   switch (action.type) {
     case DaffProductPageActionTypes.ProductPageLoadAction:
     case DaffProductPageActionTypes.ProductPageLoadByUrlAction:
-      return { ...state, loading: true, selectedProductId: null };
+      return { ...state, loading: true, currentProductId: null };
     case DaffProductPageActionTypes.ProductPageLoadSuccessAction:
-      return { ...state, loading: false, selectedProductId: action.payload.id };
+      return { ...state, loading: false, currentProductId: action.payload.id };
     case DaffProductPageActionTypes.ProductPageLoadFailureAction:
       return { ...state,
         loading: false,

--- a/libs/product/state/src/selectors/product/product.selectors.spec.ts
+++ b/libs/product/state/src/selectors/product/product.selectors.spec.ts
@@ -7,10 +7,8 @@ import {
 } from '@ngrx/store';
 import { cold } from 'jasmine-marbles';
 
-import { daffArrayToDict } from '@daffodil/core';
 import { DaffProduct } from '@daffodil/product';
 import {
-  DaffProductPageLoad,
   DaffProductGridLoadSuccess,
   DaffProductStateRootSlice,
   daffProductReducers,
@@ -27,11 +25,9 @@ describe('selectProductState', () => {
   const productFactory: DaffProductFactory = new DaffProductFactory();
   let mockProduct: DaffProduct;
   const {
-    selectSelectedProductLoadingState,
-    selectSelectedProduct,
-    selectSelectedProductState,
-    selectSelectedProductId,
-    selectSelectedProductQty,
+    selectCurrentProductLoadingState,
+    selectCurrentProductState,
+    selectCurrentProductId,
   } = getDaffProductPageSelectors();
 
   beforeEach(() => {
@@ -55,65 +51,45 @@ describe('selectProductState', () => {
 
   describe('SelectedProductState', () => {
 
-    describe('selectSelectedProductState', () => {
+    describe('selectCurrentProductState', () => {
 
       let expectedProductState;
 
       beforeEach(() => {
         expectedProductState = {
-          selectedProductId: mockProduct.id,
+          currentProductId: mockProduct.id,
           qty: 1,
           loading: false,
           errors: [],
         };
       });
 
-      it('returns the selected product state', () => {
-        const selector = store.pipe(select(selectSelectedProductState));
+      it('returns the state for the current product', () => {
+        const selector = store.pipe(select(selectCurrentProductState));
         const expected = cold('a', { a: expectedProductState });
 
         expect(selector).toBeObservable(expected);
       });
     });
 
-    describe('selectSelectedProductId', () => {
+    describe('selectCurrentProductLoadingState', () => {
 
-      it('returns the selected product id', () => {
-        const selector = store.pipe(select(selectSelectedProductId));
-        const expected = cold('a', { a: mockProduct.id });
-
-        expect(selector).toBeObservable(expected);
-      });
-    });
-
-    describe('selectSelectedProductQty', () => {
-
-      it('returns the selected product qty', () => {
-        const selector = store.pipe(select(selectSelectedProductQty));
-        const expected = cold('a', { a: 1 });
-
-        expect(selector).toBeObservable(expected);
-      });
-    });
-
-    describe('selectSelectedProductLoadingState', () => {
-
-      it('selects the loading state of the selected product', () => {
-        const selector = store.pipe(select(selectSelectedProductLoadingState));
+      it('selects the loading state of the current product', () => {
+        const selector = store.pipe(select(selectCurrentProductLoadingState));
         const expected = cold('a', { a: false });
 
         expect(selector).toBeObservable(expected);
       });
     });
-  });
 
-  describe('selectSelectedProduct', () => {
+    describe('selectCurrentProductId', () => {
 
-    it('selects the selected product', () => {
-      const selector = store.pipe(select(selectSelectedProduct));
-      const expected = cold('a', { a: mockProduct });
+      it('returns the current product id', () => {
+        const selector = store.pipe(select(selectCurrentProductId));
+        const expected = cold('a', { a: mockProduct.id });
 
-      expect(selector).toBeObservable(expected);
+        expect(selector).toBeObservable(expected);
+      });
     });
   });
 });

--- a/libs/product/state/src/selectors/product/product.selectors.ts
+++ b/libs/product/state/src/selectors/product/product.selectors.ts
@@ -13,35 +13,21 @@ import { DaffProductReducerState } from '../../reducers/product/product-reducer-
 import { getDaffProductFeatureSelector } from '../product-feature.selector';
 
 /**
- * An interface for selectors related to the selected product page.
+ * An interface for selectors related to the current product page.
  */
 export interface DaffProductPageMemoizedSelectors<T extends DaffProduct = DaffProduct> {
 	/**
 	 * Selects the entire state object for the product page feature area.
 	 */
-	selectSelectedProductState: MemoizedSelector<DaffProductStateRootSlice, DaffProductReducerState>;
+	selectCurrentProductState: MemoizedSelector<DaffProductStateRootSlice, DaffProductReducerState>;
 	/**
-	 * Selects the id of the selected product.
-	 *
-	 * @deprecated
+	 * Selects the loading state of the current product.
 	 */
-	selectSelectedProductId: MemoizedSelector<DaffProductStateRootSlice, T['id']>;
+	selectCurrentProductLoadingState: MemoizedSelector<DaffProductStateRootSlice, boolean>;
 	/**
-	 * Selects the qty of the selected product.
-	 *
-	 * @deprecated
+	 * Selects the id of the current product.
 	 */
-	selectSelectedProductQty: MemoizedSelector<DaffProductStateRootSlice, number>;
-	/**
-	 * Selects the loading state of the selected product.
-	 */
-	selectSelectedProductLoadingState: MemoizedSelector<DaffProductStateRootSlice, boolean>;
-	/**
-	 * Selects the selected product, which is the product loaded for a product page.
-	 *
-	 * @deprecated
-	 */
-	selectSelectedProduct: MemoizedSelector<DaffProductStateRootSlice, T>;
+	selectCurrentProductId: MemoizedSelector<DaffProductStateRootSlice, T['id']>;
 }
 
 const createProductPageSelectors = <T extends DaffProduct = DaffProduct>(): DaffProductPageMemoizedSelectors<T> => {
@@ -50,38 +36,25 @@ const createProductPageSelectors = <T extends DaffProduct = DaffProduct>(): Daff
     selectProductState,
   } = getDaffProductFeatureSelector<T>();
 
-  const selectSelectedProductState = createSelector(
+  const selectCurrentProductState = createSelector(
     selectProductState,
     (state: DaffProductReducersState<T>) => state.product,
   );
 
-  const selectSelectedProductId = createSelector(
-    selectSelectedProductState,
-    (state: DaffProductReducerState) => state.selectedProductId,
-  );
-
-  const selectSelectedProductQty = createSelector(
-    selectSelectedProductState,
-    (state: DaffProductReducerState) => state.qty,
-  );
-
-  const selectSelectedProductLoadingState = createSelector(
-    selectSelectedProductState,
+  const selectCurrentProductLoadingState = createSelector(
+    selectCurrentProductState,
     (state: DaffProductReducerState) => state.loading,
   );
 
-  const selectSelectedProduct = createSelector(
-    selectProductState,
-    selectSelectedProductId,
-    (state: DaffProductReducersState<T>, id: T['id']) => state.products.entities[id],
+  const selectCurrentProductId = createSelector(
+    selectCurrentProductState,
+    (state: DaffProductReducerState) => state.currentProductId,
   );
 
   return {
-    selectSelectedProductState,
-    selectSelectedProductId,
-    selectSelectedProductQty,
-    selectSelectedProductLoadingState,
-    selectSelectedProduct,
+    selectCurrentProductState,
+    selectCurrentProductLoadingState,
+    selectCurrentProductId,
   };
 };
 


### PR DESCRIPTION
…and remove instances of selectedProduct that is deprecated

BREAKING CHANGE: selectors and facade fields called selectedProduct* have changed or been removed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/graycoreio/daffodil/issues/1648

## What is the new behavior?
Removed deprecated fields that are named selectedProduct*.
Changed non-deprecated fields that are named selectedProduct* to currentProduct*.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```