### PR TITLE
feat(category): change wording of selectedCategory to currentCategory

### DIFF
--- a/libs/category/state/src/actions/category-page-filter.actions.ts
+++ b/libs/category/state/src/actions/category-page-filter.actions.ts
@@ -15,9 +15,9 @@ export enum DaffCategoryPageFilterActionTypes {
 }
 
 /**
- * An action for changing the filters for the selected category.
+ * An action for changing the filters for the current category.
  *
- * @param filters - Filters to be changed to the selected category.
+ * @param filters - Filters to be changed on the current category.
  * @deprecated use {@link DaffCategoryPageReplaceFilters} or {@link DaffCategoryPageApplyFilters}
  */
 export class DaffCategoryPageChangeFilters implements Action {
@@ -27,10 +27,10 @@ export class DaffCategoryPageChangeFilters implements Action {
 }
 
 /**
- * An action for replacing the filters for the selected category.
+ * An action for replacing the filters for the current category.
  * All existing filters will be removed and the specified filters will be applied.
  *
- * @param filters - Filters to be set to the selected category.
+ * @param filters - Filters to be set on the current category.
  */
 export class DaffCategoryPageReplaceFilters implements Action {
   readonly type = DaffCategoryPageFilterActionTypes.CategoryPageReplaceFiltersAction;
@@ -39,9 +39,9 @@ export class DaffCategoryPageReplaceFilters implements Action {
 }
 
 /**
- * An action for applying the specified filters for the selected category.
+ * An action for applying the specified filters for the current category.
  *
- * @param filters - Filters to be applied to the selected category.
+ * @param filters - Filters to be applied to the current category.
  */
 export class DaffCategoryPageApplyFilters implements Action {
   readonly type = DaffCategoryPageFilterActionTypes.CategoryPageApplyFiltersAction;
@@ -50,9 +50,9 @@ export class DaffCategoryPageApplyFilters implements Action {
 }
 
 /**
- * An action for removing the specified filters for the selected category.
+ * An action for removing the specified filters for the current category.
  *
- * @param filters - Filters to be removed from the selected category.
+ * @param filters - Filters to be removed from the current category.
  */
 export class DaffCategoryPageRemoveFilters implements Action {
   readonly type = DaffCategoryPageFilterActionTypes.CategoryPageRemoveFiltersAction;
@@ -61,16 +61,16 @@ export class DaffCategoryPageRemoveFilters implements Action {
 }
 
 /**
- * An action for removing all the filters for the selected category.
+ * An action for removing all the filters for the current category.
  */
 export class DaffCategoryPageClearFilters implements Action {
   readonly type = DaffCategoryPageFilterActionTypes.CategoryPageClearFiltersAction;
 }
 
 /**
- * An action for toggling a filters for the selected category.
+ * An action for toggling a filters for the current category.
  *
- * @param filter - Filter to be toggled on the selected category.
+ * @param filter - Filter to be toggled on the current category.
  */
 export class DaffCategoryPageToggleFilter implements Action {
   readonly type = DaffCategoryPageFilterActionTypes.CategoryPageToggleFilterAction;

--- a/libs/category/state/src/facades/category-facade.interface.ts
+++ b/libs/category/state/src/facades/category-facade.interface.ts
@@ -13,7 +13,6 @@ import {
   DaffSortDirectionEnum,
   DaffSortOption,
   DaffStateError,
-  DaffState,
 } from '@daffodil/core/state';
 import { DaffProduct } from '@daffodil/product';
 
@@ -28,27 +27,27 @@ export interface DaffCategoryFacadeInterface<
 	 */
   category$: Observable<V>;
   /**
-   * The page metadata for the current selected selected category.
+   * The page metadata for the current category.
    */
   metadata$: Observable<DaffCategoryPageMetadata>;
   /**
-   * The current loading state of the selected category page.
+   * The loading state of the current category page.
    */
   pageLoadingState$: Observable<DaffCategoryReducerState['daffState']>;
   /**
-   * Whether the selected category is in a mutating state.
+   * Whether the current category is in a mutating state.
    */
   isPageMutating$: Observable<boolean>;
   /**
-   * Whether the selected category is in a resolving state.
+   * Whether the current category is in a resolving state.
    */
   isPageResolving$: Observable<boolean>;
   /**
-   * The current page of products for the selected category.
+   * The current page of products for the current category.
    */
   currentPage$: Observable<number>;
   /**
-   * The number of pages of product for the selected category.
+   * The number of pages of products available in the current category.
    */
 	totalPages$: Observable<number>;
 	/**
@@ -56,31 +55,31 @@ export interface DaffCategoryFacadeInterface<
 	 */
 	totalProducts$: Observable<number>;
   /**
-   * The number of products per page for the selected category.
+   * The number of products per page for the current category.
    */
   pageSize$: Observable<number>;
   /**
-   * The filters available for the products of the selected category.
+   * The filters available for the products of the current category.
    */
   filters$: Observable<Dict<DaffCategoryFilter>>;
   /**
-   * The sort options available for the products of the selected category.
+   * The sort options available for the products of the current category.
    */
   sortOptions$: Observable<DaffSortOption[]>;
   /**
-   * The sort options available for the products of the selected category.
+   * The sort options available for the products of the current category.
    */
   appliedFilters$: Observable<Dict<DaffCategoryFilter>>;
   /**
-   * The sort options available for the products of the selected category.
+   * The sort options available for the products of the current category.
    */
   appliedSortOption$: Observable<string>;
   /**
-   * The sort options available for the products of the selected category.
+   * The sort options available for the products of the current category.
    */
   appliedSortDirection$: Observable<DaffSortDirectionEnum>;
   /**
-   * Products of the currently selected category.
+   * Products of the current category.
    */
   products$: Observable<W[]>;
   /**

--- a/libs/category/state/src/facades/category.facade.spec.ts
+++ b/libs/category/state/src/facades/category.facade.spec.ts
@@ -132,7 +132,7 @@ describe('DaffCategoryFacade', () => {
       expect(facade.currentPage$).toBeObservable(expected);
     });
 
-    it('should return an observable of the current page for the selected category', () => {
+    it('should return an observable of the current page for the current category', () => {
       const expected = cold('a', { a: stubCategoryMetadata.current_page });
       store.dispatch(new DaffCategoryPageLoadSuccess({ category: stubCategory, categoryPageMetadata: stubCategoryMetadata, products: [stubProduct]}));
       expect(facade.currentPage$).toBeObservable(expected);
@@ -145,7 +145,7 @@ describe('DaffCategoryFacade', () => {
       expect(facade.totalPages$).toBeObservable(expected);
     });
 
-    it('should return an observable of the total number of pages for the selected category', () => {
+    it('should return an observable of the total number of pages for the current category', () => {
       const expected = cold('a', { a: stubCategoryMetadata.total_pages });
       store.dispatch(new DaffCategoryPageLoadSuccess({ category: stubCategory, categoryPageMetadata: stubCategoryMetadata, products: [stubProduct]}));
       expect(facade.totalPages$).toBeObservable(expected);
@@ -158,7 +158,7 @@ describe('DaffCategoryFacade', () => {
       expect(facade.totalProducts$).toBeObservable(expected);
     });
 
-    it('should return an observable of the total number of pages for the selected category', () => {
+    it('should return an observable of the total number of pages for the current category', () => {
       const expected = cold('a', { a: stubCategoryMetadata.total_products });
       store.dispatch(new DaffCategoryPageLoadSuccess({ category: stubCategory, categoryPageMetadata: stubCategoryMetadata, products: [stubProduct]}));
       expect(facade.totalProducts$).toBeObservable(expected);
@@ -171,7 +171,7 @@ describe('DaffCategoryFacade', () => {
       expect(facade.pageSize$).toBeObservable(expected);
     });
 
-    it('should return an observable of the page size for the selected category page configuration', () => {
+    it('should return an observable of the page size for the current category page configuration', () => {
       const expected = cold('a', { a: stubCategoryMetadata.page_size });
       store.dispatch(new DaffCategoryPageLoadSuccess({ category: stubCategory, categoryPageMetadata: stubCategoryMetadata, products: [stubProduct]}));
       expect(facade.pageSize$).toBeObservable(expected);
@@ -184,7 +184,7 @@ describe('DaffCategoryFacade', () => {
       expect(facade.filters$).toBeObservable(expected);
     });
 
-    it('should return an observable of the filters for the selected category', () => {
+    it('should return an observable of the filters for the current category', () => {
       const expected = cold('a', { a: stubCategoryMetadata.filters });
       store.dispatch(new DaffCategoryPageLoadSuccess({ category: stubCategory, categoryPageMetadata: stubCategoryMetadata, products: [stubProduct]}));
       expect(facade.filters$).toBeObservable(expected);
@@ -197,7 +197,7 @@ describe('DaffCategoryFacade', () => {
       expect(facade.sortOptions$).toBeObservable(expected);
     });
 
-    it('should return an observable of the sort options for the selected category', () => {
+    it('should return an observable of the sort options for the current category', () => {
       const expected = cold('a', { a: stubCategoryMetadata.sort_options.options });
       store.dispatch(new DaffCategoryPageLoadSuccess({ category: stubCategory, categoryPageMetadata: stubCategoryMetadata, products: [stubProduct]}));
       expect(facade.sortOptions$).toBeObservable(expected);
@@ -206,7 +206,7 @@ describe('DaffCategoryFacade', () => {
 
   describe('appliedFilters$', () => {
 
-    it('should return an observable of the applied filters on the selected category', () => {
+    it('should return an observable of the applied filters on the current category', () => {
       const expectedFilters: Dict<DaffCategoryFilter> = {};
 
       const expected = cold('a', { a: expectedFilters });
@@ -221,7 +221,7 @@ describe('DaffCategoryFacade', () => {
       expect(facade.appliedSortOption$).toBeObservable(expected);
     });
 
-    it('should return an observable of the applied sort option on the selected category', () => {
+    it('should return an observable of the applied sort option on the current category', () => {
       const expected = cold('a', { a: stubCategoryMetadata.applied_sort_option });
       store.dispatch(new DaffCategoryPageLoadSuccess({ category: stubCategory, categoryPageMetadata: stubCategoryMetadata, products: [stubProduct]}));
       expect(facade.appliedSortOption$).toBeObservable(expected);
@@ -234,7 +234,7 @@ describe('DaffCategoryFacade', () => {
       expect(facade.appliedSortDirection$).toBeObservable(expected);
     });
 
-    it('should return an observable of the applied sort direction on the selected category', () => {
+    it('should return an observable of the applied sort direction on the current category', () => {
       const expected = cold('a', { a: stubCategoryMetadata.applied_sort_direction });
       store.dispatch(new DaffCategoryPageLoadSuccess({ category: stubCategory, categoryPageMetadata: stubCategoryMetadata, products: [stubProduct]}));
       expect(facade.appliedSortDirection$).toBeObservable(expected);

--- a/libs/category/state/src/facades/category.facade.ts
+++ b/libs/category/state/src/facades/category.facade.ts
@@ -91,7 +91,7 @@ export class DaffCategoryFacade<
 	}
 
 	constructor(private store: Store<DaffCategoryStateRootSlice<V, W>>) {
-	  this.category$ = this.store.pipe(select(this.categorySelectors.selectSelectedCategory));
+	  this.category$ = this.store.pipe(select(this.categorySelectors.selectCurrentCategory));
 	  this.products$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageProducts));
 	  this.totalProducts$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageTotalProducts));
 	  this.metadata$ = this.store.pipe(select(this.categorySelectors.selectCategoryPageMetadata));

--- a/libs/category/state/src/selectors/category-page/category-page.selector.spec.ts
+++ b/libs/category/state/src/selectors/category-page/category-page.selector.spec.ts
@@ -278,10 +278,10 @@ describe('DaffCategoryPageSelectors', () => {
     });
   });
 
-  describe('selectSelectedCategoryId', () => {
+  describe('selectCurrentCategoryId', () => {
 
-    it('selects the id of the selected category', () => {
-      const selector = store.pipe(select(categorySelectors.selectSelectedCategoryId));
+    it('selects the id of the current category', () => {
+      const selector = store.pipe(select(categorySelectors.selectCurrentCategoryId));
       const expected = cold('a', { a: stubCategory.id });
       expect(selector).toBeObservable(expected);
     });
@@ -307,7 +307,7 @@ describe('DaffCategoryPageSelectors', () => {
 
   describe('selectCategoryErrors', () => {
 
-    it('returns the selected category id', () => {
+    it('returns errors associated with loading the category page', () => {
       const selector = store.pipe(select(categorySelectors.selectCategoryErrors));
       const expected = cold('a', { a: []});
       expect(selector).toBeObservable(expected);

--- a/libs/category/state/src/selectors/category-page/category-page.selector.ts
+++ b/libs/category/state/src/selectors/category-page/category-page.selector.ts
@@ -44,7 +44,7 @@ export interface DaffCategoryPageMemoizedSelectors<
 	selectCategoryPageAppliedSortOption: MemoizedSelector<DaffCategoryStateRootSlice<V>, DaffCategoryPageMetadata['applied_sort_option']>;
 	selectCategoryPageAppliedSortDirection: MemoizedSelector<DaffCategoryStateRootSlice<V>, DaffCategoryPageMetadata['applied_sort_direction']>;
 	selectCategoryPageState: MemoizedSelector<DaffCategoryStateRootSlice<V>, DaffCategoryReducerState['daffState']>;
-	selectSelectedCategoryId: MemoizedSelector<DaffCategoryStateRootSlice<V>, DaffCategoryPageMetadata['id']>;
+	selectCurrentCategoryId: MemoizedSelector<DaffCategoryStateRootSlice<V>, DaffCategoryPageMetadata['id']>;
   /**
    * @deprecated Use selectIsCategoryPageResolving instead
    */
@@ -141,9 +141,9 @@ const createCategoryPageSelectors = <V extends DaffGenericCategory<V>>(): DaffCa
   );
 
   /**
-   * Selected Category Id State
+   * Current Category Id State
    */
-  const selectSelectedCategoryId = createSelector(
+  const selectCurrentCategoryId = createSelector(
     selectCategoryPageMetadata,
     (state: DaffCategoryPageMetadata) => state.id,
   );
@@ -197,7 +197,7 @@ const createCategoryPageSelectors = <V extends DaffGenericCategory<V>>(): DaffCa
     selectCategoryPageAppliedSortOption,
     selectCategoryPageAppliedSortDirection,
     selectCategoryPageState,
-    selectSelectedCategoryId,
+    selectCurrentCategoryId,
     selectCategoryLoading,
     selectCategoryProductsLoading,
     selectCategoryErrors,

--- a/libs/category/state/src/selectors/category.selector.spec.ts
+++ b/libs/category/state/src/selectors/category.selector.spec.ts
@@ -101,17 +101,17 @@ describe('DaffCategorySelectors', () => {
     store.dispatch(new DaffProductGridLoadSuccess([product]));
   });
 
-  describe('selectSelectedCategory', () => {
+  describe('selectCurrentCategory', () => {
 
-    it('selects the selected category', () => {
-      const selector = store.pipe(select(categorySelectors.selectSelectedCategory));
+    it('selects the current category', () => {
+      const selector = store.pipe(select(categorySelectors.selectCurrentCategory));
       const expected = cold('a', { a: stubCategory });
       expect(selector).toBeObservable(expected);
     });
   });
 
   describe('selectCategoryPageProducts', () => {
-    it('selects the products of the selected category', () => {
+    it('selects the products of the current category', () => {
       const selector = store.pipe(select(categorySelectors.selectCategoryPageProducts));
       const expected = cold('a', { a: [product]});
       expect(selector).toBeObservable(expected);

--- a/libs/category/state/src/selectors/category.selector.ts
+++ b/libs/category/state/src/selectors/category.selector.ts
@@ -31,7 +31,7 @@ export interface DaffCategoryMemoizedSelectors<
   DaffCategoryFeatureMemoizedSelectors<V>,
   DaffCategoryPageMemoizedSelectors<V>,
   DaffCategoryEntitiesMemoizedSelectors<V> {
-  selectSelectedCategory: MemoizedSelector<DaffCategoryStateRootSlice<V>, V>;
+  selectCurrentCategory: MemoizedSelector<DaffCategoryStateRootSlice<V>, V>;
   selectCategoryPageProducts: MemoizedSelector<DaffCategoryStateRootSlice<V, W>, W[]>;
   selectCategory: (categoryId: V['id']) => MemoizedSelector<DaffCategoryStateRootSlice<V>, V>;
   selectProductsByCategory: (categoryId: V['id']) => MemoizedSelector<DaffCategoryStateRootSlice<V, W>, W[]>;
@@ -45,16 +45,16 @@ const createCategorySelectors = <V extends DaffGenericCategory<V>, W extends Daf
     selectCategoryEntities,
   } = getDaffCategoryEntitiesSelectors<V>();
   const {
-    selectSelectedCategoryId,
+    selectCurrentCategoryId,
     selectCategoryPageProductIds,
   } = getDaffCategoryPageSelectors<V>();
   /**
    * Combinatoric Category Selectors
    */
-  const selectSelectedCategory = createSelector(
+  const selectCurrentCategory = createSelector(
     selectCategoryEntities,
-    selectSelectedCategoryId,
-    (entities: Dictionary<V>, selectedCategoryId: V['id']) => entities[selectedCategoryId],
+    selectCurrentCategoryId,
+    (entities: Dictionary<V>, currentCategoryId: V['id']) => entities[currentCategoryId],
   );
 
   const selectCategoryPageProducts = createSelector<DaffCategoryStateRootSlice<V, W>, string[], Dictionary<W>, W[]>(
@@ -86,7 +86,7 @@ const createCategorySelectors = <V extends DaffGenericCategory<V>, W extends Daf
     ...getDaffCategoryFeatureSelector<V>(),
     ...getDaffCategoryEntitiesSelectors<V>(),
     ...getDaffCategoryPageSelectors<V>(),
-    selectSelectedCategory,
+    selectCurrentCategory,
     selectCategoryPageProducts,
     selectCategory,
     selectProductsByCategory,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/graycoreio/daffodil/issues/1648

Fixes: https://github.com/graycoreio/daffodil/issues/1648


## What is the new behavior?
The wording around the docs and api for "selected category" is changed to "current category".

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information
BREAKING CHANGE: the api around the "selected" category has changed to "current" category.