### PR TITLE
feat(cart): deprecate DaffCartCoupon.coupon_id and extend the DaffIde…

### DIFF
--- a/libs/cart/driver/magento/src/transforms/outputs/cart-coupon.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-coupon.spec.ts
@@ -12,4 +12,8 @@ describe('Driver | Magento | Cart | Transformer | MagentoCartCoupon', () => {
   it('should return an object with the correct code', () => {
     expect(result.code).toEqual(code);
   });
+
+  it('should return an object with the correct id', () => {
+    expect(result.id).toEqual(code);
+  });
 });

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-coupon.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-coupon.ts
@@ -5,6 +5,7 @@ import { MagentoCartCoupon } from '../../models/responses/public_api';
 export function daffMagentoCouponTransform(coupon: MagentoCartCoupon): DaffCartCoupon {
   return {
     ...{ magento_coupon: coupon },
+    id: coupon.code,
     code: coupon.code,
   };
 }

--- a/libs/cart/src/models/cart-coupon.ts
+++ b/libs/cart/src/models/cart-coupon.ts
@@ -1,12 +1,17 @@
-import { ID } from '@daffodil/core';
+import {
+  DaffIdentifiable,
+  ID,
+} from '@daffodil/core';
 
 /**
  * A coupon applied to the cart.
  * Also known as a promo code.
  */
-export interface DaffCartCoupon {
+export interface DaffCartCoupon extends DaffIdentifiable {
   /**
    * The coupon ID.
+   *
+   * @deprecated use id instead.
    */
   coupon_id?: ID;
   /**

--- a/libs/cart/testing/src/factories/cart-coupon.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart-coupon.factory.spec.ts
@@ -27,6 +27,7 @@ describe('Cart | Testing | Factories | CartCouponFactory', () => {
     });
 
     it('should return a CartCoupon with all required fields defined', () => {
+      expect(result.id).toBeDefined();
       expect(result.coupon_id).toBeDefined();
       expect(result.code).toBeDefined();
       expect(result.description).toBeDefined();

--- a/libs/cart/testing/src/factories/cart-coupon.factory.ts
+++ b/libs/cart/testing/src/factories/cart-coupon.factory.ts
@@ -5,7 +5,8 @@ import { DaffCartCoupon } from '@daffodil/cart';
 import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockDaffCartCoupon implements DaffCartCoupon {
-  coupon_id = faker.datatype.number({ min: 1, max: 1000 });
+  id = faker.datatype.number({ min: 1, max: 1000 });
+  coupon_id = this.id;
   code = faker.random.alphaNumeric(20);
   description = faker.random.words(5);
 };


### PR DESCRIPTION
…ntifiable interface

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/graycoreio/daffodil/issues/1656

Fixes: https://github.com/graycoreio/daffodil/issues/1656


## What is the new behavior?
`DaffCartCoupon.coupon_id` is deprecated, and the `DaffCartCoupon` now extends `DaffIdentifiable`.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

`DaffCartCoupon` has a new required field, `id`.