### PR TITLE
docs(dgeni): add link tags to daffodil models, classes, etc

### DIFF
--- a/tools/dgeni/src/processors/addLinkTagToDaffodilReferences.spec.ts
+++ b/tools/dgeni/src/processors/addLinkTagToDaffodilReferences.spec.ts
@@ -1,0 +1,45 @@
+import "jasmine";
+import { AddLinkTagToDaffodilReferencesProcessor } from './addLinkTagToDaffodilReferences';
+
+describe("AddLinkTagToDaffodilReferencesProcessor", () => {
+  let processor: AddLinkTagToDaffodilReferencesProcessor = new AddLinkTagToDaffodilReferencesProcessor();
+	let stubDaffodilType;
+	let stubNonDaffodilType;
+	let processedDoc;
+
+	beforeEach(() => {
+		stubDaffodilType = 'DaffSomeModelType';
+		stubNonDaffodilType = 'SomeOtherModelType';
+		const docs = [
+			{
+				typeParams: `<T extends ${stubDaffodilType}, V extends ${stubNonDaffodilType}>`,
+				members: [
+					{
+						name: 'member1',
+						type: stubDaffodilType,
+					},
+					{
+						name: 'member2',
+						type: stubNonDaffodilType,
+					}
+				],
+			},
+		];
+
+		processedDoc = processor.$process(docs)[0];
+	});
+
+  it('should add a {@link } tag around each daffodil model reference', () => {
+    expect(processedDoc.typeParams).toEqual(`T extends {@link ${stubDaffodilType}}, V extends ${stubNonDaffodilType}`);
+    expect(processedDoc.members[0].type).toEqual(`{@link ${stubDaffodilType}}`);
+  });
+
+  it('should not add a {@link } tag around each non daffodil reference', () => {
+    expect(processedDoc.typeParams).toEqual(`T extends {@link ${stubDaffodilType}}, V extends ${stubNonDaffodilType}`);
+    expect(processedDoc.members[1].type).toEqual(stubNonDaffodilType);
+  });
+
+  it('should remove the <> from around the typeParams', () => {
+    expect(processedDoc.typeParams).toEqual(`T extends {@link ${stubDaffodilType}}, V extends ${stubNonDaffodilType}`);
+  });
+});

--- a/tools/dgeni/src/processors/addLinkTagToDaffodilReferences.spec.ts
+++ b/tools/dgeni/src/processors/addLinkTagToDaffodilReferences.spec.ts
@@ -3,43 +3,47 @@ import { AddLinkTagToDaffodilReferencesProcessor } from './addLinkTagToDaffodilR
 
 describe("AddLinkTagToDaffodilReferencesProcessor", () => {
   let processor: AddLinkTagToDaffodilReferencesProcessor = new AddLinkTagToDaffodilReferencesProcessor();
-	let stubDaffodilType;
-	let stubNonDaffodilType;
+	let stubDaffodilDefinedType;
+	let stubNonDaffodilDefinedType;
 	let processedDoc;
 
 	beforeEach(() => {
-		stubDaffodilType = 'DaffSomeModelType';
-		stubNonDaffodilType = 'SomeOtherModelType';
+		stubDaffodilDefinedType = 'DaffSomeModelType';
+		stubNonDaffodilDefinedType = 'boolean';
 		const docs = [
 			{
-				typeParams: `<T extends ${stubDaffodilType}, V extends ${stubNonDaffodilType}>`,
+				name: 'doc1',
+				typeParams: `<T extends ${stubDaffodilDefinedType}, V extends ${stubNonDaffodilDefinedType}>`,
 				members: [
 					{
 						name: 'member1',
-						type: stubDaffodilType,
+						type: stubDaffodilDefinedType,
 					},
 					{
 						name: 'member2',
-						type: stubNonDaffodilType,
+						type: stubNonDaffodilDefinedType,
 					}
 				],
+			},
+			{
+				name: stubDaffodilDefinedType
 			},
 		];
 
 		processedDoc = processor.$process(docs)[0];
 	});
 
-  it('should add a {@link } tag around each daffodil model reference', () => {
-    expect(processedDoc.typeParams).toEqual(`T extends {@link ${stubDaffodilType}}, V extends ${stubNonDaffodilType}`);
-    expect(processedDoc.members[0].type).toEqual(`{@link ${stubDaffodilType}}`);
+  it('should add a {@link } tag around each model reference in the list of docs', () => {
+    expect(processedDoc.typeParams).toEqual(`T extends {@link ${stubDaffodilDefinedType}}, V extends ${stubNonDaffodilDefinedType}`);
+    expect(processedDoc.members[0].type).toEqual(`{@link ${stubDaffodilDefinedType}}`);
   });
 
-  it('should not add a {@link } tag around each non daffodil reference', () => {
-    expect(processedDoc.typeParams).toEqual(`T extends {@link ${stubDaffodilType}}, V extends ${stubNonDaffodilType}`);
-    expect(processedDoc.members[1].type).toEqual(stubNonDaffodilType);
+  it('should not add a {@link } tag around each reference not in the list of docs', () => {
+    expect(processedDoc.typeParams).toEqual(`T extends {@link ${stubDaffodilDefinedType}}, V extends ${stubNonDaffodilDefinedType}`);
+    expect(processedDoc.members[1].type).toEqual(stubNonDaffodilDefinedType);
   });
 
   it('should remove the <> from around the typeParams', () => {
-    expect(processedDoc.typeParams).toEqual(`T extends {@link ${stubDaffodilType}}, V extends ${stubNonDaffodilType}`);
+    expect(processedDoc.typeParams).toEqual(`T extends {@link ${stubDaffodilDefinedType}}, V extends ${stubNonDaffodilDefinedType}`);
   });
 });

--- a/tools/dgeni/src/processors/addLinkTagToDaffodilReferences.ts
+++ b/tools/dgeni/src/processors/addLinkTagToDaffodilReferences.ts
@@ -1,7 +1,7 @@
 import { Processor, Document } from 'dgeni';
 
 /**
- * Inherit docs content from parent interfaces.
+ * Adds a link tag ({@link }) around daffodil models, classes, etc.
  */
 export class AddLinkTagToDaffodilReferencesProcessor implements Processor {
 	name = 'addLinkTagToDaffodilReferences';

--- a/tools/dgeni/src/processors/addLinkTagToDaffodilReferences.ts
+++ b/tools/dgeni/src/processors/addLinkTagToDaffodilReferences.ts
@@ -1,0 +1,23 @@
+import { Processor, Document } from 'dgeni';
+
+/**
+ * Inherit docs content from parent interfaces.
+ */
+export class AddLinkTagToDaffodilReferencesProcessor implements Processor {
+	name = 'addLinkTagToDaffodilReferences';
+	$runAfter = ['docs-processed'];
+	$runBefore = ['rendering-docs'];
+
+	$process(docs: Document[]): Document[] {
+		return docs.map(doc => {
+			doc.typeParams = doc.typeParams?.slice(1, doc.typeParams.length-1).replace(/(Daff([A-Z]|[a-z])*)/g, '{@link $1}');
+
+			doc.members?.map(member => {
+				member.type = member.type.replace(/(Daff([A-Z]|[a-z])*)/, '{@link $1}');
+				return member;
+			})
+
+			return doc;
+		});
+	}
+}

--- a/tools/dgeni/src/templates/api/base.template.html
+++ b/tools/dgeni/src/templates/api/base.template.html
@@ -5,6 +5,7 @@
 </header>
 {% endblock %}
 
+<p class="api-type-params">{$ doc.typeParams $}</p>
 <p class="api-subtitle">{$ doc.description $}</p>
 
 <div class="api-body">

--- a/tools/dgeni/src/transforms/daffodil-api-package/index.ts
+++ b/tools/dgeni/src/transforms/daffodil-api-package/index.ts
@@ -12,6 +12,7 @@ import { CleanSelectorsProcessor } from '../../processors/cleanSelectors';
 import { MakeTypesHtmlCompatibleProcessor } from '../../processors/makeTypesHtmlCompatible';
 import { FilterOutPrivatePropertiesProcessor } from '../../processors/filterOutPrivateProperties';
 import { AddInheritedDocsContentProcessor } from '../../processors/addInheritedDocsContent';
+import { AddLinkTagToDaffodilReferencesProcessor } from '../../processors/addLinkTagToDaffodilReferences';
 
 //List of packages to be left out of API generation
 const excludedPackages = ['branding'];
@@ -28,6 +29,7 @@ export const apiDocs =  new Package('checkout', [
   .processor(new MakeTypesHtmlCompatibleProcessor())
   .processor(new FilterOutPrivatePropertiesProcessor())
   .processor(new AddInheritedDocsContentProcessor())
+  .processor(new AddLinkTagToDaffodilReferencesProcessor())
   .processor(new GenerateApiListProcessor())
   .processor(new PackagesProcessor())
   .factory(function API_DOC_TYPES_TO_RENDER(EXPORT_DOC_TYPES) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
For api docs, any generic types for fields are just typed as `V` or `T` from the `V extends SomeModel` in the typeParameters of the doc. Furthermore, none of the daffodil member types are linked to their associated doc.

## What is the new behavior?
Type parameters are added for each model, class, etc. (this happens when they have generics). Links are added for references to other daffodil models in the member types and type parameters.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```