### PR TITLE
refactor(core): daffUriTruncateQueryFragment now supports ie11

### DIFF
--- a/libs/core/routing/src/uri/truncation/query-fragment.ts
+++ b/libs/core/routing/src/uri/truncation/query-fragment.ts
@@ -2,5 +2,9 @@
  * Truncates query parameters and fragments from a URI.
  * e.g. /foo/bar/baz.html?thing=test#id -> /foo/bar/baz.html
  */
-export const daffUriTruncateQueryFragment = (uri: string): string =>
-  (new URL(`http://fakedomain.com${uri.charAt(0) === '/' ? '' : '/'}${uri}`)).pathname;
+export const daffUriTruncateQueryFragment = (uri: string): string => {
+  if(uri[0] !== '/') {
+    uri = `/${uri}`;
+  }
+  return uri.replace(/(\?.*)|(#.*)/, '');
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The url constructor in the `daffUriTruncateQueryFragment` is not supported by IE.
https://github.com/graycoreio/daffodil/issues/1644

## What is the new behavior?
The url constructor is replaced by a regex.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```