### PR TITLE
refactor(core): replace regex.group in daffUriTruncateFileExtension f…

### DIFF
--- a/libs/core/routing/src/uri/truncation/file-extension.ts
+++ b/libs/core/routing/src/uri/truncation/file-extension.ts
@@ -6,8 +6,4 @@ export const DAFF_TRUNCATE_FILE_EXTENSION_REGEX = /(.*)(?=\.)/;
 /**
  * Truncates the file extension from the end of the URI.
  */
-export const daffUriTruncateFileExtension = (uri: string): string => {
-  const uriMatch = uri.match(DAFF_TRUNCATE_FILE_EXTENSION_REGEX);
-
-  return uriMatch ? uriMatch[0] : uri;
-};
+export const daffUriTruncateFileExtension = (uri: string): string => uri.match(DAFF_TRUNCATE_FILE_EXTENSION_REGEX)?.[0] || uri;

--- a/libs/core/routing/src/uri/truncation/file-extension.ts
+++ b/libs/core/routing/src/uri/truncation/file-extension.ts
@@ -2,9 +2,12 @@
  * Truncates the file extension from the end of the URI.
  * Captures the truncated URI in the `uri` named group.
  */
-export const DAFF_TRUNCATE_FILE_EXTENSION_REGEX = /(?<uri>.+)\.(.*)$/;
+export const DAFF_TRUNCATE_FILE_EXTENSION_REGEX = /(.*)(?=\.)/;
 /**
  * Truncates the file extension from the end of the URI.
  */
-export const daffUriTruncateFileExtension = (uri: string): string =>
-  uri.match(DAFF_TRUNCATE_FILE_EXTENSION_REGEX)?.groups.uri || uri;
+export const daffUriTruncateFileExtension = (uri: string): string => {
+  const uriMatch = uri.match(DAFF_TRUNCATE_FILE_EXTENSION_REGEX);
+
+  return uriMatch ? uriMatch[0] : uri;
+};


### PR DESCRIPTION
…or ie compatibility

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/graycoreio/daffodil/issues/1644

Fixes: https://github.com/graycoreio/daffodil/issues/1644


## What is the new behavior?
`daffUriTruncateFileExtension` no longer uses regex.group.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```