### PR TITLE
fix(product): Magento driver prefixing thumbnail URL

### DIFF
--- a/libs/product/driver/magento/src/transforms/product-preview.ts
+++ b/libs/product/driver/magento/src/transforms/product-preview.ts
@@ -40,16 +40,16 @@ export function transformMagentoSimpleProductPreview(product: MagentoProductPrev
     id: product.sku,
     url: `/${product.url_key}${product.url_suffix}`,
     name: product.name,
-    thumbnail: transformImage(product.thumbnail, mediaUrl),
+    thumbnail: transformThumbnail(product.thumbnail),
     price: getPrice(product),
     discount: getDiscount(product),
     images: transformMediaGalleryEntries(product, mediaUrl),
   };
 }
 
-function transformImage(image: MagentoProduct['thumbnail'], mediaUrl: string): DaffProductImage {
+function transformThumbnail(image: MagentoProduct['thumbnail']): DaffProductImage {
   return {
-    url: `${mediaUrl}catalog/product${image.url}`,
+    url: image.url,
     label: image.label,
     id: null,
   };

--- a/libs/product/driver/magento/src/transforms/simple-product-transformers.spec.ts
+++ b/libs/product/driver/magento/src/transforms/simple-product-transformers.spec.ts
@@ -44,7 +44,7 @@ describe('DaffMagentoSimpleProductTransformerService', () => {
       },
       images: [],
       thumbnail: {
-        url: `${mediaUrl}catalog/product${stubMagentoProduct.thumbnail.url}`,
+        url: stubMagentoProduct.thumbnail.url,
         label: stubMagentoProduct.thumbnail.label,
         id: null,
       },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The Magento driver will prefix the `thumbnail` URL field with the media URL, which is already the full URL (different from media gallery entries). This will result in incorrect thumbnail URLs.

## What is the new behavior?
Thumbnail URLs are not prefixed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information