### PR TITLE
fix(product): add workaround for magento not returning bundled produc…

### DIFF
--- a/libs/product/driver/magento/src/transforms/bundled-product-transformers.spec.ts
+++ b/libs/product/driver/magento/src/transforms/bundled-product-transformers.spec.ts
@@ -21,15 +21,32 @@ describe('DaffMagentoBundledProductTransformers', () => {
   });
 
   describe('transform', () => {
-    const magentoBundledProduct: MagentoBundledProduct = {
-      ...magentoBundledProductData,
-      stock_status: MagentoProductStockStatusEnum.InStock,
-    };
-    magentoBundledProduct.items[0].options[0].product.stock_status = MagentoProductStockStatusEnum.InStock;
-    magentoBundledProduct.items[0].options[1].product.stock_status = MagentoProductStockStatusEnum.InStock;
+    let magentoBundledProduct: MagentoBundledProduct;
+
+    beforeEach(() => {
+      magentoBundledProduct = {
+        ...magentoBundledProductData,
+        stock_status: MagentoProductStockStatusEnum.InStock,
+      };
+      magentoBundledProduct.items[0].options[0].product.stock_status = MagentoProductStockStatusEnum.InStock;
+      magentoBundledProduct.items[0].options[1].product.stock_status = MagentoProductStockStatusEnum.InStock;
+    });
 
     it('should transform a MagentoBundledProduct to a DaffCompositeProduct', () => {
       expect(transformMagentoBundledProduct(simpleProductService.transformMagentoSimpleProduct(magentoBundledProduct, mediaUrl), magentoBundledProduct)).toEqual(jasmine.objectContaining(daffCompositeProductData));
+    });
+
+    it('should replace the base prices with 0 when bundled product items are present', () => {
+      expect(
+        transformMagentoBundledProduct(simpleProductService.transformMagentoSimpleProduct(magentoBundledProduct, mediaUrl), magentoBundledProduct).price,
+      ).toEqual(0);
+    });
+
+    it('should add the base prices to the transformed product when bundled product items are missing', () => {
+      magentoBundledProduct.items = [];
+      expect(
+        transformMagentoBundledProduct(simpleProductService.transformMagentoSimpleProduct(magentoBundledProduct, mediaUrl), magentoBundledProduct).price,
+      ).toEqual(magentoBundledProduct.price_range.maximum_price.regular_price.value);
     });
   });
 });

--- a/libs/product/driver/magento/src/transforms/bundled-product-transformers.ts
+++ b/libs/product/driver/magento/src/transforms/bundled-product-transformers.ts
@@ -29,11 +29,13 @@ export function transformMagentoBundledProduct(
 ): DaffCompositeProduct {
   return {
     ...daffProduct,
-    price: 0,
-    discount: {
-      amount: 0,
-      percent: 0,
-    },
+    ...items.length > 0 ? {
+      price: 0,
+      discount: {
+        amount: 0,
+        percent: 0,
+      },
+    } : {},
     type: DaffProductTypeEnum.Composite,
     items: items.map(transformMagentoBundledProductItem),
   };


### PR DESCRIPTION
…t items in related/upsell products

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Magento doesn't return bundled product items for related and upsell fragments. This is likely a bug magento-side, since the only other way to get a price is through the price on the base product. But this base product price is actually just the price of the product when the default bundled item options are chosen.

## What is the new behavior?
The base product prices (price and discounts) will be used only when magento doesn't return bundled product items (in related and upsell fragments). Otherwise, the prices will be derived from the item options like they did before.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```