### PR TITLE
feat(docs-gen): compute the design docGroup from the folder path

### DIFF
--- a/tools/dgeni/src/transforms/daffodil-design-examples-package/processors/designExampleDocumentCreator.spec.ts
+++ b/tools/dgeni/src/transforms/daffodil-design-examples-package/processors/designExampleDocumentCreator.spec.ts
@@ -1,0 +1,35 @@
+
+import { DesignExampleDocumentCreatorProcessor } from './designExampleDocumentCreator';
+
+describe('DesignExampleDocumentCreatorProcessor', () => {
+
+  let processor: DesignExampleDocumentCreatorProcessor;
+
+  beforeEach(() => {
+    processor = new DesignExampleDocumentCreatorProcessor();
+  });
+
+  it('should work if docs is empty', () => {
+    expect(() => processor.$process([])).not.toThrowError();
+  });
+
+  it('should set the docGroup based upon the folder in which the example exists', () => {
+    const doc = {
+      fileInfo: {
+        relativePath: 'accordion/examples/src/basic-accordion/basic-accordion.component.html',
+      },
+    };
+    const result = processor.$process([doc]);
+    expect(result[0].docGroup).toEqual('basic-accordion');
+  });
+
+  it('should not add an additional design doc if it cannot determine a docGroup', () => {
+    const doc = {
+      fileInfo: {
+        relativePath: 'taco',
+      },
+    };
+    const result: Document[] = processor.$process([doc]);
+    expect(result.length).toEqual(1);
+  });
+});

--- a/tools/dgeni/src/transforms/daffodil-design-examples-package/processors/designExampleDocumentCreator.ts
+++ b/tools/dgeni/src/transforms/daffodil-design-examples-package/processors/designExampleDocumentCreator.ts
@@ -1,4 +1,9 @@
-import { Processor, Document } from 'dgeni';
+import {
+  Processor,
+  Document,
+} from 'dgeni';
+
+export const docGroupRegex = /examples\/src\/(.*)\//;
 
 export class DesignExampleDocumentCreatorProcessor implements Processor {
   name = 'examples';
@@ -7,14 +12,14 @@ export class DesignExampleDocumentCreatorProcessor implements Processor {
 
   private convertExtensionToLanguage(extension: string) {
     switch(extension){
-      case "ts":
-        return "typescript";
-      case "html":
-        return "html";
-      case "scss":
-          return "css";
+      case 'ts':
+        return 'typescript';
+      case 'html':
+        return 'html';
+      case 'scss':
+        return 'css';
       default:
-          return "";
+        return '';
     }
   }
 
@@ -22,21 +27,32 @@ export class DesignExampleDocumentCreatorProcessor implements Processor {
     return {
       name: doc.fileInfo.baseName + '.' + doc.fileInfo.extension,
       content: doc.fileInfo.content,
-      language: this.convertExtensionToLanguage(doc.fileInfo.extension)
+      language: this.convertExtensionToLanguage(doc.fileInfo.extension),
+    };
+  }
+
+  private getDocGroup(doc: Document) {
+    const path: string = doc.fileInfo.relativePath;
+    const match = path.match(docGroupRegex);
+
+    if(match){
+      return match[1];
     }
   }
 
   $process(docs: Document[]): Document[] {
-    let designExampleDocs = [];
+    const designExampleDocs = [];
     docs.forEach((doc) => {
-      doc.docGroup = doc.fileInfo.baseName
-        .replace(/\.component$/, '')
-        .replace(/\.module$/, '')
+      doc.docGroup = this.getDocGroup(doc);
+      if(!doc.docGroup){
+        console.warn(`Design Land Docs Generation - Group is missing for ${doc.fileInfo.relativePath}`);
+        return;
+      }
       const designExample = designExampleDocs.find((designDoc) => designDoc.id === doc.docGroup);
 
       /**
        * We need to add a new type of doc for the examples.
-       * This doc is called a `design-example`. It houses the files that make 
+       * This doc is called a `design-example`. It houses the files that make
        * up the example as well as the element name of the example.
        */
       if(!designExample){
@@ -45,15 +61,14 @@ export class DesignExampleDocumentCreatorProcessor implements Processor {
           docType: 'design-example',
           name: doc.docGroup,
           element: doc.docGroup,
-          files: [this.convertDocToDesignExampleFile(doc)]
-        })
-      } 
-      else {
+          files: [this.convertDocToDesignExampleFile(doc)],
+        });
+      } else {
         // The example already exists, so we just need to append the new file.
-        designExample.files.push(this.convertDocToDesignExampleFile(doc))
+        designExample.files.push(this.convertDocToDesignExampleFile(doc));
       }
-    });
 
+    });
     return docs.concat(designExampleDocs);
   }
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Previously, we were determining the document group of a file from its filename. When there are multiple components inside a group that don't share the same file name (see the `basic-modal` example), the differently-named files are moved into their own group.

Fixes: N/A


## What is the new behavior?
We determine from the folder path instead, which allows for a broader file-naming behavior.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information