### PR TITLE
feat(design): define a type for an exported component example

### DIFF
--- a/libs/design/src/examples/examples.ts
+++ b/libs/design/src/examples/examples.ts
@@ -1,0 +1,14 @@
+import { Type } from '@angular/core';
+
+/**
+ * An example of a component with a specified module.
+ */
+export interface ComponentExampleWithModule {
+  component: Type<any>;
+  module: any;
+}
+
+/**
+ * An example of a component
+ */
+export type ComponentExample = ComponentExampleWithModule | Type<any>;

--- a/libs/design/src/examples/public_api.ts
+++ b/libs/design/src/examples/public_api.ts
@@ -1,0 +1,4 @@
+export {
+  ComponentExampleWithModule,
+  ComponentExample,
+} from './examples';

--- a/libs/design/src/public_api.ts
+++ b/libs/design/src/public_api.ts
@@ -41,3 +41,6 @@ export * from './molecules/card/public_api';
 
 // Core
 export * from './core/public_api';
+
+// Examples
+export * from './examples/public_api';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Previously, when we export components for rendering in design-land, we didn't define the module (and associated injector) that should be used for the particular component. This led to strange injector hierarchies where, in certain instances, expected providers were missing.

## What is the new behavior?
I've backward-compatibly defined a type that we can use in design-land to strictly type our Angular elements used to preview component examples.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```