### PR TITLE
feat(product): DaffProduct.images is a required field

### DIFF
--- a/libs/product/src/models/product.ts
+++ b/libs/product/src/models/product.ts
@@ -33,7 +33,7 @@ export interface DaffProduct extends DaffLocatable, DaffIdentifiable {
   /**
    * An array of images for the product.
    */
-  images?: DaffProductImage[];
+  images: DaffProductImage[];
   /**
    * A list of related products.
    */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`DaffProduct.images` is not a required field, though it is set in all current drivers.

Fixes: https://github.com/graycoreio/daffodil/issues/1115

## What is the new behavior?
`DaffProduct.images` cannot be set as null in any future product driver transformers.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```