### PR TITLE
feat(related-products): cast main product from product response in reducer

### DIFF
--- a/libs/related-products/state/src/reducers/related-products/reducer.ts
+++ b/libs/related-products/state/src/reducers/related-products/reducer.ts
@@ -3,6 +3,7 @@ import {
   DaffProductPageActions,
   DaffProductPageActionTypes,
 } from '@daffodil/product/state';
+import { DaffRelatedProduct } from '@daffodil/related-products';
 
 import { DaffRelatedProductsReducerState } from './reducer-state.interface';
 
@@ -23,7 +24,7 @@ export function daffRelatedProductsReducer<T extends DaffProduct>(state = initia
 
       return {
         ...state,
-        relatedProductIds: product.related?.map(({ id }) => id) || [],
+        relatedProductIds: (<DaffRelatedProduct><unknown>product).related?.map(({ id }) => id) || [],
       };
     default:
       return state;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The main product is typed as a `DaffProduct` which doesn't (or soon won't) have related products on it.


## What is the new behavior?
The main product is casted to a `DaffRelatedProduct` when reducing related product IDs into state.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information