### PR TITLE
fix(related-products): wrong mock class in factory

### DIFF
--- a/libs/related-products/driver/magento/testing/src/factories/product-with-related.factory.ts
+++ b/libs/related-products/driver/magento/testing/src/factories/product-with-related.factory.ts
@@ -17,6 +17,6 @@ export class MockMagentoProductWithRelated extends MockMagentoCoreProduct implem
 })
 export class MagentoProductWithRelatedFactory extends DaffModelFactory<MagentoProductWithRelated> {
   constructor(){
-    super(MockMagentoCoreProduct);
+    super(MockMagentoProductWithRelated);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The wrong class was passed to the super constructor for the Magento product with related factory.

## What is the new behavior?
The correct mock class is passed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information