### PR TITLE
fix(product): magento product previews need to transform stock status

### DIFF
--- a/libs/product/driver/magento/src/models/bundled-product.ts
+++ b/libs/product/driver/magento/src/models/bundled-product.ts
@@ -1,7 +1,5 @@
-import {
-  MagentoProduct,
-  MagentoProductStockStatusEnum,
-} from './magento-product';
+import { MagentoProduct } from './magento-product';
+import { MagentoProductStockStatusEnum } from './product-preview.interface';
 
 export enum MagentoPriceTypeEnum {
 	fixed = 'FIXED',

--- a/libs/product/driver/magento/src/models/magento-product.ts
+++ b/libs/product/driver/magento/src/models/magento-product.ts
@@ -6,11 +6,6 @@ export enum MagentoProductTypeEnum {
 	SimpleProduct = 'SimpleProduct'
 }
 
-export enum MagentoProductStockStatusEnum {
-	InStock = 'IN_STOCK',
-	OutOfStock = 'OUT_OF_STOCK'
-}
-
 /**
  * An object for defining what the product service requests and retrieves from a magento backend.
  */
@@ -18,7 +13,6 @@ export interface MagentoProduct extends MagentoProductPreview {
   meta_title?: string;
   meta_description?: string;
   canonical_url?: string;
-	stock_status?: MagentoProductStockStatusEnum;
   image?: {
 		url: string;
 		label: string;

--- a/libs/product/driver/magento/src/models/product-preview.interface.ts
+++ b/libs/product/driver/magento/src/models/product-preview.interface.ts
@@ -1,5 +1,10 @@
+export enum MagentoProductStockStatusEnum {
+	InStock = 'IN_STOCK',
+	OutOfStock = 'OUT_OF_STOCK'
+}
+
 /**
- * An stripped down version of the Magento product for related and upsell products.
+ * A stripped down version of the Magento product for related and upsell products.
  */
 export interface MagentoProductPreview {
 	__typename: string;
@@ -24,4 +29,5 @@ export interface MagentoProductPreview {
 			};
 		};
 	};
+	stock_status?: MagentoProductStockStatusEnum;
 }

--- a/libs/product/driver/magento/src/models/public_api.ts
+++ b/libs/product/driver/magento/src/models/public_api.ts
@@ -5,7 +5,7 @@ export {
   MagentoBundledProductItem,
   MagentoPriceTypeEnum,
 } from './bundled-product';
-export { MagentoProductPreview } from './product-preview.interface';
+export * from './product-preview.interface';
 export { MagentoSimpleProduct } from './simple-product';
 export * from './configurable-product';
 export { MagentoGetProductResponse } from './get-product-response.interface';

--- a/libs/product/driver/magento/src/transforms/bundled-product-transformers.ts
+++ b/libs/product/driver/magento/src/transforms/bundled-product-transformers.ts
@@ -14,7 +14,7 @@ import {
   MagentoBundledProductItemOption,
   MagentoBundledProductItemOptionProduct,
 } from '../models/bundled-product';
-import { MagentoProductStockStatusEnum } from '../models/magento-product';
+import { MagentoProductStockStatusEnum } from '../models/product-preview.interface';
 
 /**
  * Transforms the magento MagentoProduct from the magento product query into a DaffProduct.

--- a/libs/product/driver/magento/src/transforms/configurable-product-transformers.ts
+++ b/libs/product/driver/magento/src/transforms/configurable-product-transformers.ts
@@ -16,10 +16,8 @@ import {
   MagentoConfigurableProductOptionsValue,
   MagentoConfigurableProductVariant,
 } from '../models/configurable-product';
-import {
-  MagentoProduct,
-  MagentoProductStockStatusEnum,
-} from '../models/magento-product';
+import { MagentoProduct } from '../models/magento-product';
+import { MagentoProductStockStatusEnum } from '../models/product-preview.interface';
 
 /**
  * Transforms the magento MagentoProduct from the magento product query into a DaffProduct.

--- a/libs/product/driver/magento/src/transforms/product-preview.spec.ts
+++ b/libs/product/driver/magento/src/transforms/product-preview.spec.ts
@@ -15,6 +15,7 @@ import {
   MagentoProductFactory,
 } from '@daffodil/product/driver/magento/testing';
 
+import { MagentoProductStockStatusEnum } from '../models/product-preview.interface';
 import { transformMagentoProductPreview } from './product-preview';
 
 
@@ -33,7 +34,9 @@ describe('@daffodil/product/driver/magento | transformMagentoProductPreview', ()
     bundleProductFactory = TestBed.inject(MagentoBundledProductFactory);
     configProductFactory = TestBed.inject(MagentoConfigurableProductFactory);
 
-    stubMagentoProduct = productFactory.create();
+    stubMagentoProduct = productFactory.create({
+      stock_status: MagentoProductStockStatusEnum.InStock,
+    });
 
     result = transformMagentoProductPreview(stubMagentoProduct, mediaUrl);
   });
@@ -43,6 +46,7 @@ describe('@daffodil/product/driver/magento | transformMagentoProductPreview', ()
     expect(result.url).toEqual(`/${stubMagentoProduct.url_key}${stubMagentoProduct.url_suffix}`);
     expect(result.name).toEqual(stubMagentoProduct.name);
     expect(result.thumbnail).toBeDefined();
+    expect(result.in_stock).toBeTrue();
   });
 
   describe('when the product is a simple product', () => {

--- a/libs/product/driver/magento/src/transforms/product-preview.ts
+++ b/libs/product/driver/magento/src/transforms/product-preview.ts
@@ -11,7 +11,10 @@ import {
   MagentoProduct,
   MagentoProductTypeEnum,
 } from '../models/magento-product';
-import { MagentoProductPreview } from '../models/product-preview.interface';
+import {
+  MagentoProductPreview,
+  MagentoProductStockStatusEnum,
+} from '../models/product-preview.interface';
 import { transformMagentoBundledProduct } from './bundled-product-transformers';
 import { transformMagentoConfigurableProduct } from './configurable-product-transformers';
 
@@ -44,6 +47,7 @@ export function transformMagentoSimpleProductPreview(product: MagentoProductPrev
     price: getPrice(product),
     discount: getDiscount(product),
     images: transformMediaGalleryEntries(product, mediaUrl),
+    in_stock: product.stock_status === MagentoProductStockStatusEnum.InStock,
   };
 }
 

--- a/libs/product/driver/magento/src/transforms/simple-product-transformers.ts
+++ b/libs/product/driver/magento/src/transforms/simple-product-transformers.ts
@@ -7,10 +7,7 @@ import { DaffProduct } from '@daffodil/product';
 
 import { DAFF_PRODUCT_MAGENTO_PRODUCT_PREVIEW_TRANSFORM } from '../injection-tokens/transforms/product-preview/preview.token';
 import { DaffMagentoProductPreviewTransform } from '../interfaces/product-preview-transform.type';
-import {
-  MagentoProduct,
-  MagentoProductStockStatusEnum,
-} from '../models/magento-product';
+import { MagentoProduct } from '../models/magento-product';
 import { transformMagentoProductPreview } from './product-preview';
 
 /**
@@ -31,7 +28,6 @@ export class DaffMagentoSimpleProductTransformers {
     return {
       ...this.productPreviewTransform(product, mediaUrl),
 
-      in_stock: product.stock_status === MagentoProductStockStatusEnum.InStock,
       description: product.description.html,
       short_description: product.short_description.html,
       meta_title: product.meta_title,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Related and upsell products don't have a stock status, because the magento product preview transformer doesn't transform the stock status.

## What is the new behavior?
Magento product preview now has the stock_status field and the corresponding transformer transforms the stock_status.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```