### PR TITLE
feat(category): add extra preview fragments to category products query

### DIFF
--- a/libs/category/driver/magento/src/category.service.spec.ts
+++ b/libs/category/driver/magento/src/category.service.spec.ts
@@ -204,7 +204,7 @@ describe('Driver | Magento | Category | CategoryService', () => {
 
       const categoryOp = controller.expectOne(MagentoGetCategoryQuery);
       const filterTypesOp = controller.expectOne(MagentoGetCategoryFilterTypes);
-      const productsOp = controller.expectOne(MagentoGetProductsQuery);
+      const productsOp = controller.expectOne(MagentoGetProductsQuery());
 
       categoryOp.flushData(mockGetCategoryResponse);
       filterTypesOp.flushData(mockGetFilterTypesResponse);
@@ -246,7 +246,7 @@ describe('Driver | Magento | Category | CategoryService', () => {
 
         const categoryOp = controller.expectOne(MagentoGetCategoryQuery);
         const filterTypesOp = controller.expectOne(MagentoGetCategoryFilterTypes);
-        const productsOp = controller.expectOne(MagentoGetProductsQuery);
+        const productsOp = controller.expectOne(MagentoGetProductsQuery());
 
         categoryOp.flushData(mockGetCategoryResponse);
         filterTypesOp.flushData(mockGetFilterTypesResponse);
@@ -284,7 +284,7 @@ describe('Driver | Magento | Category | CategoryService', () => {
 
       tick();
 
-      const productsOp = controller.expectOne(MagentoGetProductsQuery);
+      const productsOp = controller.expectOne(MagentoGetProductsQuery());
       productsOp.flushData(mockGetProductsResponse);
     }));
 
@@ -299,7 +299,7 @@ describe('Driver | Magento | Category | CategoryService', () => {
 
       tick();
 
-      const productsOp = controller.expectOne(MagentoGetProductsQuery);
+      const productsOp = controller.expectOne(MagentoGetProductsQuery());
       productsOp.flushData(mockGetProductsResponse);
 
       expect(categoryOp.operation.variables.filters.url_path.eq).toEqual('test/url');
@@ -318,7 +318,7 @@ describe('Driver | Magento | Category | CategoryService', () => {
 
       tick();
 
-      const productsOp = controller.expectOne(MagentoGetProductsQuery);
+      const productsOp = controller.expectOne(MagentoGetProductsQuery());
       productsOp.flushData(mockGetProductsResponse);
 
       expect(productsOp.operation.variables.filter.category_uid.eq).toEqual(mockMagentoCategory.uid);
@@ -366,7 +366,7 @@ describe('Driver | Magento | Category | CategoryService', () => {
 
         tick();
 
-        const productsOp = controller.expectOne(MagentoGetProductsQuery);
+        const productsOp = controller.expectOne(MagentoGetProductsQuery());
         productsOp.flushData(mockGetProductsResponse);
       }));
     });

--- a/libs/category/driver/magento/src/category.service.ts
+++ b/libs/category/driver/magento/src/category.service.ts
@@ -3,6 +3,7 @@ import {
   Inject,
 } from '@angular/core';
 import { Apollo } from 'apollo-angular';
+import { DocumentNode } from 'graphql';
 import {
   Observable,
   combineLatest,
@@ -23,6 +24,7 @@ import {
 import { DaffCategoryServiceInterface } from '@daffodil/category/driver';
 import {
   DaffProductMagentoDriverConfig,
+  DAFF_PRODUCT_MAGENTO_EXTRA_PRODUCT_PREVIEW_FRAGMENTS,
   MAGENTO_PRODUCT_CONFIG_TOKEN,
 } from '@daffodil/product/driver/magento';
 
@@ -73,6 +75,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
 		private magentoAppliedSortTransformer: DaffMagentoAppliedSortOptionTransformService,
     @Inject(MAGENTO_CATEGORY_CONFIG_TOKEN) private config: DaffCategoryMagentoDriverConfig,
     @Inject(MAGENTO_PRODUCT_CONFIG_TOKEN) private productConfig: DaffProductMagentoDriverConfig,
+    @Inject(DAFF_PRODUCT_MAGENTO_EXTRA_PRODUCT_PREVIEW_FRAGMENTS) private extraPreviewFragments: DocumentNode[],
   ) {}
 
   //todo the MagentoGetCategoryQuery needs to get its own product ids.
@@ -86,7 +89,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
         query: MagentoGetCategoryFilterTypes,
       }),
       this.apollo.query<MagentoGetProductsResponse>({
-        query: MagentoGetProductsQuery,
+        query: MagentoGetProductsQuery(this.extraPreviewFragments),
         variables: this.getProductsQueryVariables(categoryRequest),
       }),
     ]).pipe(
@@ -120,7 +123,7 @@ export class DaffMagentoCategoryService implements DaffCategoryServiceInterface 
         category,
         filterTypes,
       ]) => this.apollo.query<MagentoGetProductsResponse>({
-        query: MagentoGetProductsQuery,
+        query: MagentoGetProductsQuery(this.extraPreviewFragments),
         variables: this.getProductsQueryVariables({
           ...categoryRequest,
           id: category.data.categoryList[0]?.uid,

--- a/libs/category/driver/magento/src/queries/get-products.ts
+++ b/libs/category/driver/magento/src/queries/get-products.ts
@@ -1,5 +1,10 @@
 import { gql } from 'apollo-angular';
+import { DocumentNode } from 'graphql';
 
+import {
+  daffBuildFragmentDefinition,
+  daffBuildFragmentNameSpread,
+} from '@daffodil/core/graphql';
 import { magentoProductFragment } from '@daffodil/product/driver/magento';
 
 export const DAFF_MAGENTO_GET_PRODUCTS_QUERY_NAME = 'MagentoGetProducts';
@@ -7,7 +12,7 @@ export const DAFF_MAGENTO_GET_PRODUCTS_QUERY_NAME = 'MagentoGetProducts';
  * This query only exists because products and their associated aggregations/filter cannot
  * be retrieved through a category call.
  */
-export const MagentoGetProductsQuery = gql`
+export const MagentoGetProductsQuery = (extraProductFragments: DocumentNode[] = []) => gql`
 query ${DAFF_MAGENTO_GET_PRODUCTS_QUERY_NAME}($filter: ProductAttributeFilterInput!, $search: String, $pageSize: Int, $currentPage: Int, $sort: ProductAttributeSortInput)
 {
 	products(filter: $filter, search: $search, pageSize: $pageSize, currentPage: $currentPage, sort: $sort)
@@ -15,6 +20,7 @@ query ${DAFF_MAGENTO_GET_PRODUCTS_QUERY_NAME}($filter: ProductAttributeFilterInp
 		total_count
 		items {
 			...product
+      ${daffBuildFragmentNameSpread(...extraProductFragments)}
 		}
 		page_info {
 			page_size
@@ -41,4 +47,5 @@ query ${DAFF_MAGENTO_GET_PRODUCTS_QUERY_NAME}($filter: ProductAttributeFilterInp
 	}
 }
 ${magentoProductFragment}
+${daffBuildFragmentDefinition(...extraProductFragments)}
 `;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The category get products query does not spread in extra product preview fragments. Optional product features that provide to extra product preview fragments (composite, configurable) will therefore be missing from the category products response.


## What is the new behavior?
The extra product preview fragments are spread in and the category products response includes all the info needed to render product preview cards.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information