### PR TITLE
feat(design): create decorative icon component

### DIFF
--- a/apps/design-land/src/app/app-routing.module.ts
+++ b/apps/design-land/src/app/app-routing.module.ts
@@ -18,6 +18,7 @@ export const appRoutes: Routes = [
   { path: 'checkbox', loadChildren: () => import('./checkbox/checkbox.module').then(m => m.DesignLandCheckboxModule) },
   { path: 'color', loadChildren: () => import('./foundations/color/color.module').then(m => m.DesignLandColorModule) },
   { path: 'container', loadChildren: () => import('./container/container.module').then(m => m.DesignLandContainerModule) },
+  { path: 'decorative-icon', loadChildren: () => import('./decorative-icon/decorative-icon.module').then(m => m.DesignLandDecorativeIconModule) },
   { path: 'feature', loadChildren: () => import('./feature/feature.module').then(m => m.DesignLandFeatureModule) },
   { path: 'form', loadChildren: () => import('./form/form.module').then(m => m.DesignLandFormModule) },
   { path: 'hero', loadChildren: () => import('./hero/hero.module').then(m => m.DesignLandHeroModule) },

--- a/apps/design-land/src/app/app.component.html
+++ b/apps/design-land/src/app/app.component.html
@@ -9,6 +9,7 @@
       <div daffLinkSetHeading>Atoms</div>
       <a daff-link-set-item routerLink="button">Button</a>
       <a daff-link-set-item routerLink="checkbox">Checkbox</a>
+      <a daff-link-set-item routerLink="decorative-icon">Decorative Icon</a>
       <a daff-link-set-item routerLink="loading-icon">Loading Icon</a>
       <a daff-link-set-item routerLink="image">Image</a>
       <a daff-link-set-item routerLink="progress-indicator">Progress Indicator</a>

--- a/apps/design-land/src/app/app.component.ts
+++ b/apps/design-land/src/app/app.component.ts
@@ -11,6 +11,7 @@ import { BUTTON_EXAMPLES } from '@daffodil/design/button/examples';
 import { CALLOUT_EXAMPLES } from '@daffodil/design/callout/examples';
 import { CARD_EXAMPLES } from '@daffodil/design/card/examples';
 import { CHECKBOX_EXAMPLES } from '@daffodil/design/checkbox/examples';
+import { DECORATIVE_ICON_EXAMPLES } from '@daffodil/design/decorative-icon/examples';
 import { HERO_EXAMPLES } from '@daffodil/design/hero/examples';
 import { LIST_EXAMPLES } from '@daffodil/design/list/examples';
 import { LOADING_ICON_EXAMPLES } from '@daffodil/design/loading-icon/examples';
@@ -39,6 +40,7 @@ export class DesignLandAppComponent {
       ...CARD_EXAMPLES,
       ...CALLOUT_EXAMPLES,
       ...CHECKBOX_EXAMPLES,
+      ...DECORATIVE_ICON_EXAMPLES,
       ...HERO_EXAMPLES,
       ...LOADING_ICON_EXAMPLES,
       ...MEDIA_GALLERY_EXAMPLES,

--- a/apps/design-land/src/app/decorative-icon/decorative-icon-routing.module.ts
+++ b/apps/design-land/src/app/decorative-icon/decorative-icon-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import {
+  Routes,
+  RouterModule,
+} from '@angular/router';
+
+import { DesignLandDecorativeIconComponent } from './decorative-icon.component';
+
+export const decorativeIconRoutes: Routes = [
+  { path: '', component: DesignLandDecorativeIconComponent },
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(decorativeIconRoutes),
+  ],
+  exports: [
+    RouterModule,
+  ],
+})
+export class DesignLandDecorativeIconRoutingModule {}

--- a/apps/design-land/src/app/decorative-icon/decorative-icon.component.html
+++ b/apps/design-land/src/app/decorative-icon/decorative-icon.component.html
@@ -1,0 +1,10 @@
+<daff-article>
+	<h1 daffArticleTitle>Decorative Icon</h1>
+	<p daffArticleLead>Decorative icons are used for visual or branding reinforcement. Removing a decorative icon from a page or component should not alter a user's ability to use or understand it.</p>
+
+	<h3>Theming</h3>
+	<design-land-example-viewer-container example="decorative-icon-theming"></design-land-example-viewer-container>
+
+	<h3>Accessibility</h3>
+	<p>Decorative icons have no semantic meaning and should not be used with a <code>&lt;button&gt;</code> element to prevent it from becoming a focusable, interactive element. The <code>aria-hidden=true</code> attribute is added by default to reinforce that they are hidden from assistive technologies.</p>
+</daff-article>

--- a/apps/design-land/src/app/decorative-icon/decorative-icon.component.scss
+++ b/apps/design-land/src/app/decorative-icon/decorative-icon.component.scss
@@ -1,0 +1,3 @@
+daff-card {
+	max-width: 400px;
+}

--- a/apps/design-land/src/app/decorative-icon/decorative-icon.component.spec.ts
+++ b/apps/design-land/src/app/decorative-icon/decorative-icon.component.spec.ts
@@ -1,0 +1,31 @@
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+
+import { DesignLandDecorativeIconComponent } from './decorative-icon.component';
+
+describe('DesignLandDecorativeIconComponent', () => {
+  let component: DesignLandDecorativeIconComponent;
+  let fixture: ComponentFixture<DesignLandDecorativeIconComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        DesignLandDecorativeIconComponent,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DesignLandDecorativeIconComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/design-land/src/app/decorative-icon/decorative-icon.component.ts
+++ b/apps/design-land/src/app/decorative-icon/decorative-icon.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { faMobile } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+  selector: 'design-land-decorative-icon',
+  templateUrl: './decorative-icon.component.html',
+  styleUrls: ['./decorative-icon.component.scss'],
+})
+export class DesignLandDecorativeIconComponent {
+  faMobile = faMobile;
+}

--- a/apps/design-land/src/app/decorative-icon/decorative-icon.module.ts
+++ b/apps/design-land/src/app/decorative-icon/decorative-icon.module.ts
@@ -1,0 +1,30 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+
+import {
+  DaffArticleModule,
+  DaffDecorativeIconModule,
+} from '@daffodil/design';
+
+import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
+import { DesignLandDecorativeIconRoutingModule } from './decorative-icon-routing.module';
+import { DesignLandDecorativeIconComponent } from './decorative-icon.component';
+
+@NgModule({
+  declarations: [
+    DesignLandDecorativeIconComponent,
+  ],
+  imports: [
+    CommonModule,
+    DesignLandDecorativeIconRoutingModule,
+    DesignLandExampleViewerModule,
+    DaffArticleModule,
+    DaffDecorativeIconModule,
+
+    FontAwesomeModule,
+  ],
+})
+export class DesignLandDecorativeIconModule {
+
+}

--- a/apps/design-land/src/scss/theme.scss
+++ b/apps/design-land/src/scss/theme.scss
@@ -6,6 +6,12 @@ $tertiary: daff-configure-palette($daff-turquoise, 60);
 
 $theme: daff-configure-theme($primary, $secondary, $tertiary, 'light');
 
+$primary-dark: daff-configure-palette($daff-blue, 50);
+$secondary-dark: daff-configure-palette($daff-purple, 50);
+$tertiary-dark: daff-configure-palette($daff-turquoise, 50);
+
+$theme-dark: daff-configure-theme($primary-dark, $secondary-dark, $tertiary-dark, 'dark');
+
 $black: daff-map-deep-get($theme, 'core.black');
 $white: daff-map-deep-get($theme, 'core.white');
 

--- a/libs/design/decorative-icon/examples/ng-package.json
+++ b/libs/design/decorative-icon/examples/ng-package.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/design/examples",
+  "deleteDestPath": false,
+  "lib": {
+    "entryFile": "src/index.ts",
+    "styleIncludePaths": ["../../src/scss"]
+  }
+} 

--- a/libs/design/decorative-icon/examples/package.json
+++ b/libs/design/decorative-icon/examples/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@daffodil/design/decorative-icon/examples"
+} 

--- a/libs/design/decorative-icon/examples/src/decorative-icon-theming/decorative-icon-theming.component.html
+++ b/libs/design/decorative-icon/examples/src/decorative-icon-theming/decorative-icon-theming.component.html
@@ -1,0 +1,31 @@
+<daff-decorative-icon>
+	<fa-icon [icon]="faMobile"></fa-icon>
+</daff-decorative-icon>
+
+<daff-decorative-icon color="primary">
+	<fa-icon [icon]="faMobile"></fa-icon>
+</daff-decorative-icon>
+
+<daff-decorative-icon color="secondary">
+	<fa-icon [icon]="faMobile"></fa-icon>
+</daff-decorative-icon>
+
+<daff-decorative-icon color="tertiary">
+	<fa-icon [icon]="faMobile"></fa-icon>
+</daff-decorative-icon>
+
+<daff-decorative-icon color="black">
+	<fa-icon [icon]="faMobile"></fa-icon>
+</daff-decorative-icon>
+
+<daff-decorative-icon color="white">
+	<fa-icon [icon]="faMobile"></fa-icon>
+</daff-decorative-icon>
+
+<daff-decorative-icon color="theme">
+	<fa-icon [icon]="faMobile"></fa-icon>
+</daff-decorative-icon>
+
+<daff-decorative-icon color="theme-contrast">
+	<fa-icon [icon]="faMobile"></fa-icon>
+</daff-decorative-icon>

--- a/libs/design/decorative-icon/examples/src/decorative-icon-theming/decorative-icon-theming.component.scss
+++ b/libs/design/decorative-icon/examples/src/decorative-icon-theming/decorative-icon-theming.component.scss
@@ -1,0 +1,7 @@
+:host {
+	display: block;
+
+	> * {
+		margin: 4px;
+	}
+}

--- a/libs/design/decorative-icon/examples/src/decorative-icon-theming/decorative-icon-theming.component.ts
+++ b/libs/design/decorative-icon/examples/src/decorative-icon-theming/decorative-icon-theming.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { faMobile } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'decorative-icon-theming',
+  templateUrl: './decorative-icon-theming.component.html',
+  styleUrls: ['./decorative-icon-theming.component.scss'],
+})
+export class DecorativeIconThemingComponent {
+  faMobile = faMobile;
+}

--- a/libs/design/decorative-icon/examples/src/decorative-icon-theming/decorative-icon-theming.module.ts
+++ b/libs/design/decorative-icon/examples/src/decorative-icon-theming/decorative-icon-theming.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+
+import { DaffDecorativeIconModule } from '@daffodil/design';
+
+import { DecorativeIconThemingComponent } from './decorative-icon-theming.component';
+
+
+@NgModule({
+  declarations: [
+    DecorativeIconThemingComponent,
+  ],
+  exports: [
+    DecorativeIconThemingComponent,
+  ],
+  imports: [
+    DaffDecorativeIconModule,
+    FontAwesomeModule,
+  ],
+})
+export class DecorativeIconThemingModule { }

--- a/libs/design/decorative-icon/examples/src/index.ts
+++ b/libs/design/decorative-icon/examples/src/index.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/libs/design/decorative-icon/examples/src/public_api.ts
+++ b/libs/design/decorative-icon/examples/src/public_api.ts
@@ -1,0 +1,6 @@
+import { DecorativeIconThemingComponent } from './decorative-icon-theming/decorative-icon-theming.component';
+export { DecorativeIconThemingModule } from './decorative-icon-theming/decorative-icon-theming.module';
+
+export const DECORATIVE_ICON_EXAMPLES = [
+  DecorativeIconThemingComponent,
+];

--- a/libs/design/src/atoms/decorative-icon/README.md
+++ b/libs/design/src/atoms/decorative-icon/README.md
@@ -1,0 +1,13 @@
+# Icon
+`DaffIconComponent` is a basic 
+
+## Size
+The size of a container can be defined by using the `size` property. There is no default size set.
+- Supported sizes: `xs | sm | md | lg | xl`
+
+## Usage
+```
+<daff-container size="lg">
+  <!-- Content here -->
+</daff-container> 
+```

--- a/libs/design/src/atoms/decorative-icon/decorative-icon-theme.scss
+++ b/libs/design/src/atoms/decorative-icon/decorative-icon-theme.scss
@@ -1,0 +1,71 @@
+@mixin daff-decorative-theme-variant($background-color, $icon-color) {
+	background: $background-color;
+	color: $icon-color;
+}
+
+
+@mixin daff-decorative-icon-theme($theme) {
+	$primary: map-get($theme, primary);
+	$secondary: map-get($theme, secondary);
+	$tertiary: map-get($theme, tertiary);
+	$base: daff-map-deep-get($theme, 'core.base');
+	$base-contrast: daff-map-deep-get($theme, 'core.base-contrast');
+	$white: daff-map-deep-get($theme, 'core.white');
+	$black: daff-map-deep-get($theme, 'core.black');
+	$gray: daff-configure-palette($daff-gray, 60);
+
+	.daff-decorative-icon {
+		@include daff-decorative-theme-variant(
+			daff-illuminate($base, $daff-gray, 1),
+			daff-illuminate($base, $daff-gray, 7)
+		);
+
+		&.daff-primary {
+			@include daff-decorative-theme-variant(
+				daff-illuminate($base, $primary, 1),
+				daff-color($primary)
+			);
+		}
+
+		&.daff-secondary {
+			@include daff-decorative-theme-variant(
+				daff-illuminate($base, $secondary, 1),
+				daff-color($secondary)
+			);
+		}
+
+		&.daff-tertiary {
+			@include daff-decorative-theme-variant(
+				daff-illuminate($base, $tertiary, 1),
+				daff-color($tertiary)
+			);
+		}
+
+		&.daff-black {
+			@include daff-decorative-theme-variant(
+				$black,
+				daff-text-contrast($black)
+			);
+		}
+
+		&.daff-white {
+			@include daff-decorative-theme-variant(
+				$white,
+				daff-text-contrast($white)
+			);
+		}
+
+		&.daff-theme {
+			@include daff-decorative-theme-variant(
+				$base,
+				daff-text-contrast($base));
+		}
+
+		&.daff-theme-contrast {
+			@include daff-decorative-theme-variant(
+				$base-contrast,
+				daff-text-contrast($base-contrast)
+			);
+		}
+	}
+}

--- a/libs/design/src/atoms/decorative-icon/decorative-icon.component.scss
+++ b/libs/design/src/atoms/decorative-icon/decorative-icon.component.scss
@@ -1,0 +1,12 @@
+@import 'daff-util';
+
+:host {
+	$root: '.daff-decorative-icon';
+	display: inline-block;
+	border-radius: 50%;
+	width: 48px;
+	height: 48px;
+	vertical-align: middle;
+	text-align: center;
+	padding: 12px 0;
+}

--- a/libs/design/src/atoms/decorative-icon/decorative-icon.component.spec.ts
+++ b/libs/design/src/atoms/decorative-icon/decorative-icon.component.spec.ts
@@ -1,0 +1,75 @@
+import {
+  Component,
+  DebugElement,
+} from '@angular/core';
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { DaffPalette } from '../../core/colorable/colorable';
+import { DaffDecorativeIconComponent } from './decorative-icon.component';
+
+@Component({
+  template: `<daff-decorative-icon [color]="color"></daff-decorative-icon>`,
+})
+class WrapperComponent {
+  color: DaffPalette;
+}
+
+describe('DaffDecorativeIconComponent', () => {
+  let wrapper: WrapperComponent;
+  let component: DaffDecorativeIconComponent;
+  let de: DebugElement;
+  let fixture: ComponentFixture<WrapperComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        WrapperComponent,
+        DaffDecorativeIconComponent,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WrapperComponent);
+    wrapper = fixture.debugElement.componentInstance;
+    de = fixture.debugElement.query(By.css('daff-decorative-icon'));
+    component = de.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('<daff-decorative-icon>', () => {
+    it('should add a class of "daff-decorative-icon" to the host element', () => {
+      expect(de.classes).toEqual(jasmine.objectContaining({
+        'daff-decorative-icon': true,
+      }));
+    });
+
+    it('should set aria-hidden to true', () => {
+      expect(component.ariaHidden).toBe('true');
+    });
+  });
+
+  describe('setting the color', () => {
+    it('should not set a default color', () => {
+      de = fixture.debugElement.query(By.css('daff-decorative-icon'));
+      expect(de.nativeElement.classList.toString()).toEqual('daff-decorative-icon');
+    });
+
+    it('should add the color class on the host element for the defined color', () => {
+      wrapper.color = 'primary';
+      fixture.detectChanges();
+
+      expect(de.nativeElement.classList.contains('daff-primary')).toEqual(true);
+    });
+  });
+});

--- a/libs/design/src/atoms/decorative-icon/decorative-icon.component.ts
+++ b/libs/design/src/atoms/decorative-icon/decorative-icon.component.ts
@@ -1,0 +1,39 @@
+import {
+  Component,
+  Input,
+  ChangeDetectionStrategy,
+  HostBinding,
+  ElementRef,
+  Renderer2,
+} from '@angular/core';
+
+import {
+  daffColorMixin,
+  DaffPalette,
+  DaffColorable,
+} from '../../core/colorable/colorable';
+
+class DaffDecorativeIconBase{
+  constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
+}
+
+const _daffDecorativeIconBase = daffColorMixin(DaffDecorativeIconBase);
+
+@Component({
+  selector: 'daff-decorative-icon',
+  template: '<ng-content></ng-content>',
+  styleUrls: ['./decorative-icon.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DaffDecorativeIconComponent extends _daffDecorativeIconBase implements DaffColorable {
+
+  @HostBinding('class.daff-decorative-icon') class = true;
+
+  @HostBinding('attr.aria-hidden') ariaHidden = 'true';
+
+  @Input() color: DaffPalette;
+
+  constructor(private elementRef: ElementRef, private renderer: Renderer2) {
+    super(elementRef, renderer);
+  }
+}

--- a/libs/design/src/atoms/decorative-icon/decorative-icon.module.ts
+++ b/libs/design/src/atoms/decorative-icon/decorative-icon.module.ts
@@ -1,0 +1,17 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { DaffDecorativeIconComponent } from './decorative-icon.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+  declarations: [
+    DaffDecorativeIconComponent,
+  ],
+  exports: [
+    DaffDecorativeIconComponent,
+  ],
+})
+export class DaffDecorativeIconModule { }

--- a/libs/design/src/atoms/decorative-icon/public_api.ts
+++ b/libs/design/src/atoms/decorative-icon/public_api.ts
@@ -1,0 +1,2 @@
+export { DaffDecorativeIconComponent } from './decorative-icon.component';
+export { DaffDecorativeIconModule } from './decorative-icon.module';

--- a/libs/design/src/public_api.ts
+++ b/libs/design/src/public_api.ts
@@ -7,6 +7,7 @@ export * from './atoms/button/public_api';
 export * from './atoms/form/core/public_api';
 export * from './atoms/form/form-field/public_api';
 export * from './atoms/form/error-message/public_api';
+export * from './atoms/decorative-icon/public_api';
 export * from './atoms/image/public_api';
 export * from './atoms/form/input/public_api';
 export * from './atoms/form/select/public_api';

--- a/libs/design/src/scss/theming/_theme.scss
+++ b/libs/design/src/scss/theming/_theme.scss
@@ -1,4 +1,5 @@
 @import '../../atoms/button/button-theme';
+@import '../../atoms/decorative-icon/decorative-icon-theme';
 @import '../../atoms/form/error-message/error-message-theme';
 @import '../../atoms/form/form-field/form-field/form-field-theme';
 @import '../../atoms/form/input/input-theme';
@@ -29,6 +30,7 @@
 @mixin daff-theme($theme) {
 	//Atoms
 	@include daff-button-theme($theme);
+	@include daff-decorative-icon-theme($theme);
 	@include daff-error-message-theme($theme);
 	@include daff-form-field-theme($theme);
 	@include daff-input-theme($theme);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no component to centralize a 'decorative' icon used for visual or branding reinforcement.

Fixes: N/A


## What is the new behavior?
Create a component that can be used as decorative icon, separate from the icon button, which has semantic meaning. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information