### PR TITLE
feat(product): add kind and extension factories

### DIFF
--- a/libs/product/testing/src/factories/composite-product.factory.ts
+++ b/libs/product/testing/src/factories/composite-product.factory.ts
@@ -8,7 +8,7 @@ import {
   DaffCompositeProductItemInputEnum,
 } from '@daffodil/product';
 
-import { MockProduct } from './product.factory';
+import { MockProduct } from './default-product.factory';
 
 /**
  * Mocked DaffCompositeProduct object.

--- a/libs/product/testing/src/factories/configurable-product.factory.ts
+++ b/libs/product/testing/src/factories/configurable-product.factory.ts
@@ -7,7 +7,7 @@ import {
   DaffProductTypeEnum,
 } from '@daffodil/product';
 
-import { MockProduct } from './product.factory';
+import { MockProduct } from './default-product.factory';
 
 /**
  * Mocked DaffConfigurableProduct object.

--- a/libs/product/testing/src/factories/default-product.factory.spec.ts
+++ b/libs/product/testing/src/factories/default-product.factory.spec.ts
@@ -2,18 +2,20 @@ import { TestBed } from '@angular/core/testing';
 
 import { DaffProduct } from '@daffodil/product';
 
-import { DaffProductFactory } from './product.factory';
+import { DaffDefaultProductFactory } from './default-product.factory';
 
-describe('Product | Testing | Factories | DaffProductFactory', () => {
+describe('Product | Testing | Factories | DaffDefaultProductFactory', () => {
 
   let productFactory;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [DaffProductFactory],
+      providers: [
+        DaffDefaultProductFactory,
+      ],
     });
 
-    productFactory = TestBed.inject(DaffProductFactory);
+    productFactory = TestBed.inject(DaffDefaultProductFactory);
   });
 
   it('should be created', () => {
@@ -49,18 +51,6 @@ describe('Product | Testing | Factories | DaffProductFactory', () => {
 
     it('should the percentage as a whole number', () => {
       expect(result.discount.percent % 1).toEqual(0);
-    });
-  });
-
-  describe('createMany', () => {
-    let result: DaffProduct[];
-
-    it('should create as many products as desired', () => {
-      result = productFactory.createMany(2);
-      expect(result.length).toEqual(2);
-
-      result = productFactory.createMany(3);
-      expect(result.length).toEqual(3);
     });
   });
 });

--- a/libs/product/testing/src/factories/default-product.factory.ts
+++ b/libs/product/testing/src/factories/default-product.factory.ts
@@ -42,8 +42,8 @@ export class MockProduct implements DaffProduct {
 @Injectable({
   providedIn: 'root',
 })
-export class DaffProductFactory extends DaffModelFactory<DaffProduct>{
-  constructor(){
+export class DaffDefaultProductFactory extends DaffModelFactory<DaffProduct> {
+  constructor() {
     super(MockProduct);
   }
 }

--- a/libs/product/testing/src/factories/default-product.factory.ts
+++ b/libs/product/testing/src/factories/default-product.factory.ts
@@ -37,7 +37,7 @@ export class MockProduct implements DaffProduct {
 }
 
 /**
- * Factory for creating DaffProducts.
+ * Factory for creating simple `DaffProduct`s of no special kind.
  */
 @Injectable({
   providedIn: 'root',

--- a/libs/product/testing/src/factories/extension.factory.spec.ts
+++ b/libs/product/testing/src/factories/extension.factory.spec.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { DaffModelFactory } from '@daffodil/core/testing';
+import { DaffProduct } from '@daffodil/product';
+import {
+  daffProvideProductExtraProductFactories,
+  MockProduct,
+  DaffProductKindFactory,
+} from '@daffodil/product/testing';
+
+import { DaffProductExtensionFactory } from './extension.factory';
+
+class TestMockProduct extends MockProduct {
+  extraField = 'extraField';
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+class TestProductFactory extends DaffModelFactory<DaffProduct> {
+  constructor() {
+    super(TestMockProduct);
+  }
+}
+
+describe('Product | Testing | Factories | DaffProductExtensionFactory', () => {
+  let productKindFactorySpy: jasmine.SpyObj<DaffProductKindFactory>;
+  let productFactory;
+
+  beforeEach(() => {
+    productKindFactorySpy = jasmine.createSpyObj('DaffProductKindFactory', ['create']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        DaffProductExtensionFactory,
+        {
+          provide: DaffProductKindFactory,
+          useValue: productKindFactorySpy,
+        },
+        ...daffProvideProductExtraProductFactories(
+          TestProductFactory,
+        ),
+      ],
+    });
+
+    productFactory = TestBed.inject(DaffProductExtensionFactory);
+  });
+
+  it('should be created', () => {
+    expect(productFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+
+    let result: DaffProduct;
+
+    beforeEach(() => {
+      result = productFactory.create();
+    });
+
+    it('should include extra factories', () => {
+      expect((<TestMockProduct>result).extraField).toBeDefined();
+    });
+  });
+});

--- a/libs/product/testing/src/factories/extension.factory.ts
+++ b/libs/product/testing/src/factories/extension.factory.ts
@@ -11,7 +11,8 @@ import { MockProduct } from './default-product.factory';
 import { DaffProductKindFactory } from './kind.factory';
 
 /**
- * Factory for creating DaffProducts.
+ * Factory for creating `DaffProduct`s with extension fields.
+ * This includes all the extra extension factories that may be provided by optional product packages.
  */
 @Injectable({
   providedIn: 'root',

--- a/libs/product/testing/src/factories/extension.factory.ts
+++ b/libs/product/testing/src/factories/extension.factory.ts
@@ -1,0 +1,40 @@
+import {
+  Injectable,
+  Inject,
+} from '@angular/core';
+
+import { DaffModelFactory } from '@daffodil/core/testing';
+import { DaffProduct } from '@daffodil/product';
+
+import { DAFF_PRODUCT_EXTRA_FACTORIES } from '../injection-tokens/public_api';
+import { MockProduct } from './default-product.factory';
+import { DaffProductKindFactory } from './kind.factory';
+
+/**
+ * Factory for creating DaffProducts.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffProductExtensionFactory extends DaffModelFactory<DaffProduct> {
+  constructor(
+    @Inject(DAFF_PRODUCT_EXTRA_FACTORIES) private extraFactories: DaffModelFactory<DaffProduct>[],
+    private productKindFactory: DaffProductKindFactory,
+  ) {
+    super(MockProduct);
+  }
+
+  /**
+   * Creates a mock product of random type.
+   * Includes extra product types that may be provided by optional product packages.
+   * This includes all the extra extension factories that may be provided by optional product packages.
+   */
+  create(partial = {}): DaffProduct {
+    return Object.assign(
+      {},
+      ...this.extraFactories.map(factory => factory.create(partial)),
+      // spread this in last to preserve type
+      this.productKindFactory.create(partial),
+    );
+  }
+}

--- a/libs/product/testing/src/factories/kind.factory.spec.ts
+++ b/libs/product/testing/src/factories/kind.factory.spec.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { DaffModelFactory } from '@daffodil/core/testing';
+import { DaffProduct } from '@daffodil/product';
+import {
+  MockProduct,
+  daffProvideProductExtraFactoryTypes,
+} from '@daffodil/product/testing';
+
+import { DaffProductKindFactory } from './kind.factory';
+
+class TestMockProduct extends MockProduct {
+  extraField = 'extraField';
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+class TestProductFactory extends DaffModelFactory<DaffProduct> {
+  constructor() {
+    super(TestMockProduct);
+  }
+}
+
+describe('Product | Testing | Factories | DaffProductKindFactory', () => {
+
+  let productFactory;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DaffProductKindFactory,
+        ...daffProvideProductExtraFactoryTypes(
+          TestProductFactory,
+        ),
+      ],
+    });
+
+    productFactory = TestBed.inject(DaffProductKindFactory);
+  });
+
+  it('should be created', () => {
+    expect(productFactory).toBeTruthy();
+  });
+
+  describe('create', () => {
+
+    let result: DaffProduct;
+
+    beforeEach(() => {
+      result = productFactory.create();
+    });
+
+    it('should include extra factory types', () => {
+      expect((<TestMockProduct>result).extraField).toBeDefined();
+    });
+  });
+});

--- a/libs/product/testing/src/factories/kind.factory.ts
+++ b/libs/product/testing/src/factories/kind.factory.ts
@@ -3,7 +3,7 @@ import {
   Inject,
 } from '@angular/core';
 
-import { randomSlice } from '@daffodil/core';
+import { sample } from '@daffodil/core';
 import { DaffModelFactory } from '@daffodil/core/testing';
 import { DaffProduct } from '@daffodil/product';
 
@@ -26,8 +26,7 @@ export class DaffProductKindFactory extends DaffModelFactory<DaffProduct> {
   }
 
   private get _randomFactory(): DaffModelFactory<DaffProduct> {
-    // TODO(griest024): change to `sample`
-    return randomSlice(this.productTypeFactories, 1)[0];
+    return sample(this.productTypeFactories);
   }
 
   /**

--- a/libs/product/testing/src/factories/kind.factory.ts
+++ b/libs/product/testing/src/factories/kind.factory.ts
@@ -1,0 +1,39 @@
+import {
+  Injectable,
+  Inject,
+} from '@angular/core';
+
+import { daffRandomElement } from '@daffodil/core';
+import { DaffModelFactory } from '@daffodil/core/testing';
+import { DaffProduct } from '@daffodil/product';
+
+import { DAFF_PRODUCT_TYPE_FACTORIES } from '../injection-tokens/public_api';
+import { MockProduct } from './default-product.factory';
+
+/**
+ * Factory for creating DaffProducts.
+ * This will create a random product kind,
+ * including extra product kinds that may be provided by optional product packages.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffProductKindFactory extends DaffModelFactory<DaffProduct> {
+  constructor(
+    @Inject(DAFF_PRODUCT_TYPE_FACTORIES) private productTypeFactories: DaffModelFactory<DaffProduct>[],
+  ) {
+    super(MockProduct);
+  }
+
+  private get _randomFactory(): DaffModelFactory<DaffProduct> {
+    return daffRandomElement(this.productTypeFactories);
+  }
+
+  /**
+   * Creates a mock product of random kind.
+   * Includes extra product kinds that may be provided by optional product packages.
+   */
+  create(partial = {}): DaffProduct {
+    return this._randomFactory.create(partial);
+  }
+}

--- a/libs/product/testing/src/factories/kind.factory.ts
+++ b/libs/product/testing/src/factories/kind.factory.ts
@@ -3,7 +3,7 @@ import {
   Inject,
 } from '@angular/core';
 
-import { daffRandomElement } from '@daffodil/core';
+import { randomSlice } from '@daffodil/core';
 import { DaffModelFactory } from '@daffodil/core/testing';
 import { DaffProduct } from '@daffodil/product';
 
@@ -26,7 +26,8 @@ export class DaffProductKindFactory extends DaffModelFactory<DaffProduct> {
   }
 
   private get _randomFactory(): DaffModelFactory<DaffProduct> {
-    return daffRandomElement(this.productTypeFactories);
+    // TODO(griest024): change to `sample`
+    return randomSlice(this.productTypeFactories, 1)[0];
   }
 
   /**

--- a/libs/product/testing/src/factories/public_api.ts
+++ b/libs/product/testing/src/factories/public_api.ts
@@ -1,4 +1,8 @@
 export * from './composite-product.factory';
 export * from './configurable-product.factory';
 export * from './product-image.factory';
-export * from './product.factory';
+export * from './extension.factory';
+export * from './kind.factory';
+export * from './default-product.factory';
+
+export { DaffDefaultProductFactory as DaffProductFactory } from './default-product.factory';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Product factory injection tokens are not used by the product factories.


## What is the new behavior?
- Adds the product kind factory for creating different product types (composite, configurable, etc.)
- Adds the product extension factory for creating full product data of different kinds
- Renames the `DaffProductFactory` to `DaffDefaultProductFactory`, although the class is still aliased to its original name in `public_api`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Relies on #1786