### PR TITLE
feat(cart): throw out of stock error in the item update call

### DIFF
--- a/libs/cart/driver/magento/src/cart-item.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart-item.service.spec.ts
@@ -6,7 +6,9 @@ import {
   ApolloTestingModule,
   APOLLO_TESTING_CACHE,
 } from 'apollo-angular/testing';
+import { GraphQLError } from 'graphql';
 import { of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 import {
   DaffCart,
@@ -16,6 +18,10 @@ import {
   DaffConfigurableCartItemInput,
   DaffSimpleCartItemInput,
 } from '@daffodil/cart';
+import {
+  DaffCartNotFoundError,
+  DaffProductOutOfStockError,
+} from '@daffodil/cart/driver';
 import {
   DaffMagentoCartTransformer,
   DaffMagentoCartItemUpdateInputTransformer,
@@ -40,6 +46,7 @@ import {
   DaffCartFactory,
   DaffCartItemFactory,
 } from '@daffodil/cart/testing';
+import { DaffBadInputError } from '@daffodil/driver';
 import { schema } from '@daffodil/driver/magento';
 import {
   DaffProduct,
@@ -296,25 +303,101 @@ describe('Driver | Magento | Cart | CartItemService', () => {
 
 
   describe('update | updates a cart item', () => {
-    let qty;
+    describe('when the call to the Magento API is successful', () => {
+      let qty;
 
-    beforeEach(() => {
-      qty = 5;
+      beforeEach(() => {
+        qty = 5;
 
-      mockMagentoCartItem.quantity = qty;
-      mockDaffCartItem.qty = qty;
-    });
-
-    it('should return the correct value', done => {
-      service.update(cartId, mockDaffCartItem.id, mockDaffCartItem).subscribe(result => {
-        expect(result.items[0].qty).toEqual(qty);
-        done();
+        mockMagentoCartItem.quantity = qty;
+        mockDaffCartItem.qty = qty;
       });
 
-      const op = controller.expectOne(addTypenameToDocument(updateCartItem([])));
+      it('should return the correct value', done => {
+        service.update(cartId, mockDaffCartItem.id, mockDaffCartItem).subscribe(result => {
+          expect(result.items[0].qty).toEqual(qty);
+          done();
+        });
 
-      op.flush({
-        data: mockUpdateCartItemResponse,
+        const op = controller.expectOne(addTypenameToDocument(updateCartItem([])));
+
+        op.flush({
+          data: mockUpdateCartItemResponse,
+        });
+      });
+    });
+
+    fdescribe('when the call to the Magento API is unsuccessful', () => {
+      describe('because of a graphql-no-such-entity error', () => {
+        it('should throw a DaffCartNotFoundError', done => {
+          service.update(cartId, mockDaffCartItem.id, mockDaffCartItem).pipe(
+            catchError(err => {
+              expect(err).toEqual(jasmine.any(DaffCartNotFoundError));
+              done();
+              return [];
+            }),
+          ).subscribe();
+
+          const op = controller.expectOne(addTypenameToDocument(updateCartItem([])));
+
+          op.graphqlErrors([new GraphQLError(
+            'Can\'t find a cart with that ID.',
+            null,
+            null,
+            null,
+            null,
+            null,
+            { category: 'graphql-no-such-entity' },
+          )]);
+        });
+      });
+
+      describe('because of a graphql-input error', () => {
+        it('should throw a DaffBadInputError', done => {
+          service.update(cartId, mockDaffCartItem.id, mockDaffCartItem).pipe(
+            catchError(err => {
+              expect(err).toEqual(jasmine.any(DaffBadInputError));
+              done();
+              return [];
+            }),
+          ).subscribe();
+
+          const op = controller.expectOne(addTypenameToDocument(updateCartItem([])));
+
+          op.graphqlErrors([new GraphQLError(
+            'Item ID cannot be empty.',
+            null,
+            null,
+            null,
+            null,
+            null,
+            { category: 'graphql-input' },
+          )]);
+        });
+      });
+
+      describe('because the there is insufficient stock of the requested product', () => {
+        it('should throw a DaffProductOutOfStockError with the coupon code', done => {
+          service.update(cartId, mockDaffCartItem.id, mockDaffCartItem).pipe(
+            catchError((err: DaffProductOutOfStockError) => {
+              expect(err).toEqual(jasmine.any(DaffProductOutOfStockError));
+              done();
+              return [];
+            }),
+          ).subscribe();
+
+          const op = controller.expectOne(addTypenameToDocument(updateCartItem([])));
+
+          op.graphqlErrors([new GraphQLError(
+            'The requested qty is not available',
+            null,
+            null,
+            null,
+            null,
+            null,
+            { category: 'graphql-no-such-entity' },
+          )]);
+        });
       });
     });
 

--- a/libs/cart/driver/magento/src/cart-item.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart-item.service.spec.ts
@@ -327,7 +327,7 @@ describe('Driver | Magento | Cart | CartItemService', () => {
       });
     });
 
-    fdescribe('when the call to the Magento API is unsuccessful', () => {
+    describe('when the call to the Magento API is unsuccessful', () => {
       describe('because of a graphql-no-such-entity error', () => {
         it('should throw a DaffCartNotFoundError', done => {
           service.update(cartId, mockDaffCartItem.id, mockDaffCartItem).pipe(

--- a/libs/cart/driver/magento/src/cart-item.service.ts
+++ b/libs/cart/driver/magento/src/cart-item.service.ts
@@ -4,8 +4,14 @@ import {
 } from '@angular/core';
 import { Apollo } from 'apollo-angular';
 import { DocumentNode } from 'graphql';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {
+  Observable,
+  throwError,
+} from 'rxjs';
+import {
+  catchError,
+  map,
+} from 'rxjs/operators';
 
 import {
   DaffCartItem,
@@ -18,6 +24,7 @@ import {
 import { DaffCartItemServiceInterface } from '@daffodil/cart/driver';
 import { DaffQueuedApollo } from '@daffodil/core/graphql';
 
+import { transformCartMagentoError } from './errors/transform';
 import { DAFF_MAGENTO_CART_MUTATION_QUEUE } from './injection-tokens/cart-mutation-queue.token';
 import { DAFF_CART_MAGENTO_EXTRA_CART_FRAGMENTS } from './injection-tokens/public_api';
 import { MagentoCartItemInput } from './models/requests/cart-item';
@@ -95,6 +102,7 @@ export class DaffMagentoCartItemService implements DaffCartItemServiceInterface 
       },
     }).pipe(
       map(result => this.cartTransformer.transform(result.data.updateCartItems.cart)),
+      catchError(err => throwError(transformCartMagentoError(err))),
     );
   }
 

--- a/libs/cart/driver/magento/src/errors/map.ts
+++ b/libs/cart/driver/magento/src/errors/map.ts
@@ -14,4 +14,5 @@ export const DaffCartMagentoErrorMap: DaffErrorCodeMap = {
 
 export const DaffCartMagentoErrorMessageRegexMap = {
   [DaffCartDriverErrorCodes.INVALID_COUPON_CODE]: /The coupon code isn\'t valid/,
+  [DaffCartDriverErrorCodes.PRODUCT_OUT_OF_STOCK]: /The requested qty is not available/,
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
Item updates that fail from an insufficient stock error will throw a `DaffProductOutOfStockError`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information