### PR TITLE
ci: move code coverage report uploading to discrete job

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -159,6 +159,39 @@ stages:
             ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
               branch: origin/$(Build.SourceBranchName)
 
+        # the publish step will fail and stop CI if the coverage folder doesn't exist
+        - script: mkdir -p $(Build.SourcesDirectory)/coverage
+          displayName: Ensure Coverage Directory is Present
+
+        - script: npx lerna run test --scope="$(name)"
+          displayName: Run tests for $(name)
+
+        - script: npx lerna run reportcoverage --scope="$(name)"
+          displayName: Report coverage for $(name)
+
+        - task: PublishPipelineArtifact@1
+          inputs:
+            # TODO: only publish cc.*.json reports, not entire folder
+            targetPath: $(Build.SourcesDirectory)/coverage
+
+      - job: upload_code_coverage
+        displayName: "Upload Code Coverage"
+        variables:
+          node_version: 12.x
+        dependsOn:
+          - test
+        steps:
+        - template: ./templates/codeclimate.yml
+        - template: ./templates/get-branch-sha.yml
+          parameters:
+            stepName: GetBuildCacheCommitSHA
+            # for PR builds, we want to use the cache from the target commit
+            ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+              branch: origin/$(System.PullRequest.TargetBranch)
+            # for non PR builds, we want to create the cache for the current commit
+            ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+              branch: origin/$(Build.SourceBranchName)
+
         - task: Cache@2
           displayName: Cache Coverage Reports
           inputs:
@@ -166,19 +199,26 @@ stages:
             path: $(Build.SourcesDirectory)/coverage
             cacheHitVar: coverageCache
 
-        - script: npx lerna run test --scope="$(name)"
-          displayName: Run tests for $(name)
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            path: $(Build.SourcesDirectory)/coverage/artifacts
 
-          # TODO(damienwebdev): coverage reporting may not work when run in parallel, I don't actually know how it accepts
-          # multiple package reports in aggregate. Needs further investigation.
-        - script: npx lerna run reportcoverage --scope="$(name)"
-          displayName: Report coverage for $(name)
+        # the coverage files are spread out in artifact subfolders so collect them in coverage root
+        - task: CopyFiles@2
+          displayName: Prepare Coverage Files
+          inputs:
+            sourceFolder: $(Build.SourcesDirectory)/coverage/artifacts
+            contents: '**/cc.*.json'
+            targetFolder: $(Build.SourcesDirectory)/coverage
+            flattenFolders: true
+            OverWrite: true
 
         - script: |
               HAS_COVERAGE="test -f coverage/cc.*.json"
+              $HAS_COVERAGE && echo 'Has Coverage'
               $HAS_COVERAGE && ./cc-test-reporter sum-coverage coverage/cc.*.json
               $HAS_COVERAGE && ./cc-test-reporter -r $token upload-coverage
-          displayName: Report Code Climate
+          displayName: Upload Code Climate Reports
           env:
             token: $(CODECLIMATE_TOKEN_DAFFODIL)
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #1797 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Hopefully this also fixes the upload coverage task failing