### PR TITLE
ci: remove downloaded artifcats before cache upload

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
     jobs:
       - job: Lint
         displayName: Lint
-    
+
         strategy:
           matrix:
             node_12_x:
@@ -212,6 +212,11 @@ stages:
             targetFolder: $(Build.SourcesDirectory)/coverage
             flattenFolders: true
             OverWrite: true
+
+        - task: DeleteFiles@1
+          inputs:
+            SourceFolder: $(Build.SourcesDirectory)/coverage
+            Contents: 'artifacts'
 
         - script: |
               HAS_COVERAGE="test -f coverage/cc.*.json"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
CI will upload unnecessary artifacts to the coverage cache.

## What is the new behavior?
CI deletes those extra artifacts and only uploads the actual coverage files

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information