### PR TITLE
fix(related-products,upsell-products): mock facade field not initialized

### DIFF
--- a/libs/related-products/state/testing/src/mock-related-products.facade.ts
+++ b/libs/related-products/state/testing/src/mock-related-products.facade.ts
@@ -11,6 +11,6 @@ import { DaffRelatedProductsFacadeInterface } from '@daffodil/related-products/s
  */
 @Injectable({ providedIn: 'root' })
 export class MockDaffRelatedProductsFacade implements DaffRelatedProductsFacadeInterface {
-  relatedProducts$: BehaviorSubject<DaffProduct[]>;
+  relatedProducts$ = new BehaviorSubject<DaffProduct[]>([]);
   dispatch(action) {};
 }

--- a/libs/upsell-products/state/testing/src/mock-upsell-products.facade.ts
+++ b/libs/upsell-products/state/testing/src/mock-upsell-products.facade.ts
@@ -11,6 +11,6 @@ import { DaffUpsellProductsFacadeInterface } from '@daffodil/upsell-products/sta
  */
 @Injectable({ providedIn: 'root' })
 export class MockDaffUpsellProductsFacade implements DaffUpsellProductsFacadeInterface {
-  upsellProducts$: BehaviorSubject<DaffProduct[]>;
+  upsellProducts$ = new BehaviorSubject<DaffProduct[]>([]);
   dispatch(action) {};
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`MockDaffUpsellProductsFacade#upsellProducts$` and `MockDaffRelatedProductsFacade#relatedProducts$` were not initialized.


## What is the new behavior?
These fields are now initialized.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information