### PR TITLE
feat(core,product,category)!: type model factory create partial

### DIFF
--- a/libs/cart-store-credit/testing/src/factories/cart-with-store-credit.factory.ts
+++ b/libs/cart-store-credit/testing/src/factories/cart-with-store-credit.factory.ts
@@ -20,7 +20,7 @@ export class MockDaffCartWithStoreCredit extends MockCart implements DaffCartWit
 @Injectable({
   providedIn: 'root',
 })
-export class DaffCartWithStoreCreditFactory extends DaffModelFactory<DaffCartWithStoreCredit>{
+export class DaffCartWithStoreCreditFactory extends DaffModelFactory<DaffCartWithStoreCredit, typeof MockDaffCartWithStoreCredit>{
   constructor(
     totalFactory: DaffCartTotalFactory,
     shippingInformationFactory: DaffCartShippingInformationFactory,

--- a/libs/category/driver/in-memory/src/backend/category.service.spec.ts
+++ b/libs/category/driver/in-memory/src/backend/category.service.spec.ts
@@ -71,13 +71,13 @@ describe('@daffodil/category/driver/in-memory | DaffInMemoryBackendCategoryServi
       });
 
       it('should set totalPages', () => {
-        const totalProducts = result.body.category.count;
+        const totalProducts = result.body.categoryPageMetadata.count;
         const pageSize = result.body.categoryPageMetadata.pageSize;
         expect(result.body.categoryPageMetadata.totalPages).toEqual(Math.ceil(totalProducts/pageSize));
       });
 
       it('should set no more products on the category than the pageSize', () => {
-        expect(result.body.categoryPageMetadata.product_ids.length).toBeLessThanOrEqual(result.body.categoryPageMetadata.pageSize);
+        expect(result.body.categoryPageMetadata.ids.length).toBeLessThanOrEqual(result.body.categoryPageMetadata.pageSize);
       });
 
       it('should set pageSize when the pageSize is provided', () => {

--- a/libs/category/driver/in-memory/src/backend/category.service.ts
+++ b/libs/category/driver/in-memory/src/backend/category.service.ts
@@ -62,7 +62,7 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
     ].map(id => {
       const allCategoryProductIds = this.generateProductIdSubset(this.productInMemoryBackendService.products);
 
-      return this.categoryFactory.create({ id, url: `/${id}`, product_ids: allCategoryProductIds, count: allCategoryProductIds.length });
+      return this.categoryFactory.create({ id, url: `/${id}`, product_ids: allCategoryProductIds, total_products: allCategoryProductIds.length });
     });
   }
 
@@ -97,7 +97,7 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
         pageSize: this.generatePageSize(reqInfo),
         currentPage: this.getCurrentPageParam(reqInfo),
         totalPages: this.getTotalPages(category.product_ids, this.generatePageSize(reqInfo)),
-        product_ids: this.trimProductIdsToSinglePage(category.product_ids, this.getCurrentPageParam(reqInfo), this.generatePageSize(reqInfo)),
+        ids: this.trimProductIdsToSinglePage(category.product_ids, this.getCurrentPageParam(reqInfo), this.generatePageSize(reqInfo)),
         count: category.total_products,
       });
 

--- a/libs/category/driver/magento/src/category.service.spec.ts
+++ b/libs/category/driver/magento/src/category.service.spec.ts
@@ -133,11 +133,6 @@ describe('@daffodil/category/driver/magento | DaffMagentoCategoryService', () =>
     mockMagentoProduct = magentoProductFactory.create();
     mockMagentoCategory = magentoCategoryFactory.create({
       uid: mockCategory.id,
-      products: {
-        items: [
-          mockMagentoProduct,
-        ],
-      },
     });
     mockMagentoProductSortFields = magentoSortFieldsFactory.create();
     mockMagentoPriceAggregation = priceAggregateFactory.create();

--- a/libs/core/testing/src/factories/factory.ts
+++ b/libs/core/testing/src/factories/factory.ts
@@ -49,7 +49,7 @@ export abstract class DaffModelFactory<T extends Record<string, any>> implements
     this._instantiationArgs = args;
   }
 
-  create(partial = {}): T {
+  create(partial: Partial<T> = {}): T {
     if (!this.type) {
       throw new Error('`type` is required if `create` is not overriden.');
     }
@@ -59,7 +59,7 @@ export abstract class DaffModelFactory<T extends Record<string, any>> implements
     };
   }
 
-  createMany(qty = 1, partial = {}): T[] {
+  createMany(qty = 1, partial: Partial<T> = {}): T[] {
     return range(0, qty - 1).map(() => this.create(partial));
   }
 }

--- a/libs/core/testing/src/factories/factory.ts
+++ b/libs/core/testing/src/factories/factory.ts
@@ -39,12 +39,12 @@ import { IDaffModelFactory } from './factory.interface';
  * }
  * ```
  */
-export abstract class DaffModelFactory<T extends Record<string, any>> implements IDaffModelFactory<T> {
-  _instantiationArgs: ConstructorParameters<Constructable<T>>;
+export abstract class DaffModelFactory<T extends Record<string, any>, Klass extends Constructable<T> = Constructable<T>> implements IDaffModelFactory<T> {
+  _instantiationArgs: ConstructorParameters<Klass>;
 
   constructor(
-    public type?: Constructable<T>,
-    ...args: ConstructorParameters<Constructable<T>>
+    public type?: Klass,
+    ...args: ConstructorParameters<Klass>
   ) {
     this._instantiationArgs = args;
   }

--- a/libs/payment/driver/in-memory/src/backend/payment.service.spec.ts
+++ b/libs/payment/driver/in-memory/src/backend/payment.service.spec.ts
@@ -1,27 +1,15 @@
-import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import {
-  RequestInfo,
-  STATUS,
-} from 'angular-in-memory-web-api';
 import {
   Observable,
   of,
 } from 'rxjs';
 
-import { DaffPaymentResponse } from '@daffodil/payment';
-import {
-  DaffPaymentResponseFactory,
-  DaffPaymentTestingModule,
-} from '@daffodil/payment/testing';
+import { DaffPaymentTestingModule } from '@daffodil/payment/testing';
 
 import { DaffPaymentInMemoryBackendService } from './payment.service';
 
 describe('@daffodil/payment/driver/in-memory | DaffPaymentInMemoryBackendService', () => {
   let service: DaffPaymentInMemoryBackendService;
-  let resultFactory: DaffPaymentResponseFactory;
-  let mockResults1: DaffPaymentResponse[];
-  let mockResults2: DaffPaymentResponse[];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -34,10 +22,6 @@ describe('@daffodil/payment/driver/in-memory | DaffPaymentInMemoryBackendService
     });
 
     service = TestBed.inject(DaffPaymentInMemoryBackendService);
-    resultFactory = TestBed.inject(DaffPaymentResponseFactory);
-
-    mockResults1 = resultFactory.createMany(3, { kind: 'TestBackend1' });
-    mockResults2 = resultFactory.createMany(3, { kind: 'TestBackend2' });
   });
 
   it('should be created', () => {

--- a/libs/payment/testing/src/factories/payment-response.factory.ts
+++ b/libs/payment/testing/src/factories/payment-response.factory.ts
@@ -17,7 +17,7 @@ export class MockPaymentResponse implements DaffPaymentResponse {
 @Injectable({
   providedIn: 'root',
 })
-export class DaffPaymentResponseFactory extends DaffModelFactory<DaffPaymentResponse>{
+export class DaffPaymentResponseFactory extends DaffModelFactory<DaffPaymentResponse, typeof MockPaymentResponse>{
   constructor() {
     super(MockPaymentResponse);
   }

--- a/libs/product/testing/src/factories/extension.factory.ts
+++ b/libs/product/testing/src/factories/extension.factory.ts
@@ -30,7 +30,7 @@ export class DaffProductExtensionFactory<T extends DaffProduct = DaffProduct> ex
    * Includes extra product types that may be provided by optional product packages.
    * This includes all the extra extension factories that may be provided by optional product packages.
    */
-  create(partial = {}): T {
+  create(partial: Partial<T> = {}): T {
     const kind = this.productKindFactory.create(partial);
 
     return Object.assign(

--- a/libs/product/testing/src/factories/kind.factory.ts
+++ b/libs/product/testing/src/factories/kind.factory.ts
@@ -33,7 +33,7 @@ export class DaffProductKindFactory extends DaffModelFactory<DaffProduct> {
    * Creates a mock product of random kind.
    * Includes extra product kinds that may be provided by optional product packages.
    */
-  create(partial = {}): DaffProduct {
+  create(partial: Partial<DaffProduct> = {}): DaffProduct {
     return this._randomFactory.create(partial);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Model factories do not type the `partial` parameter of the `create` method.
Fixes: #1779

## What is the new behavior?
- Model factories type the partial.
- Mock class constructor args typed through model factory superclass constructor args

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Ensure that `partial` arguments do not violate the model type.

## Other information
Relies on #1834 