### PR TITLE
feat(category): create categories on init in in-memory backend

### DIFF
--- a/libs/category/driver/in-memory/src/backend/category.service.ts
+++ b/libs/category/driver/in-memory/src/backend/category.service.ts
@@ -87,7 +87,8 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
    * @param reqInfo
    */
   get(reqInfo: any) {
-    const category = this.categories.filter(({ id }) => id === reqInfo.id)[0];
+    // this method is overloaded for both get by ID and URL so we check both
+    const category = this.categories.filter(({ id, url }) => id === reqInfo.id || url === reqInfo.id)[0];
 
     if (category) {
       this._categoryPageMetadata = this.metadataFactory.create({

--- a/libs/category/driver/in-memory/src/backend/category.service.ts
+++ b/libs/category/driver/in-memory/src/backend/category.service.ts
@@ -97,6 +97,7 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
         current_page: this.getCurrentPageParam(reqInfo),
         total_pages: this.getTotalPages(category.product_ids, this.generatePageSize(reqInfo)),
         product_ids: this.trimProductIdsToSinglePage(category.product_ids, this.getCurrentPageParam(reqInfo), this.generatePageSize(reqInfo)),
+        total_products: category.total_products,
       });
 
       return reqInfo.utils.createResponse$(() => ({

--- a/libs/category/driver/in-memory/src/backend/category.service.ts
+++ b/libs/category/driver/in-memory/src/backend/category.service.ts
@@ -25,8 +25,8 @@ import { DaffInMemoryBackendProductService } from '@daffodil/product/driver/in-m
   providedIn: 'root',
 })
 export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
-  private _categories: DaffCategory[] = [];
-  private _categoryPageMetadata: DaffCategoryPageMetadata;
+  protected _categories: DaffCategory[] = [];
+  protected _categoryPageMetadata: DaffCategoryPageMetadata;
 
   /**
    * The collection of categories in the backend.
@@ -116,11 +116,11 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
 
   }
 
-  private getTotalPages(allIds: DaffProduct['id'][], pageSize: number) {
+  protected getTotalPages(allIds: DaffProduct['id'][], pageSize: number) {
     return Math.ceil(allIds.length/pageSize);
   }
 
-  private trimProductIdsToSinglePage(allIds: any[], currentPage: number, pageSize: number) {
+  protected trimProductIdsToSinglePage(allIds: any[], currentPage: number, pageSize: number) {
     const tempIds = [...allIds];
     tempIds.splice(0, (currentPage-1) * pageSize);
     tempIds.splice(pageSize, tempIds.length-pageSize);
@@ -128,18 +128,18 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
     return tempIds;
   }
 
-  private generateProductIdSubset(products: DaffProduct[]): DaffProduct['id'][] {
+  protected generateProductIdSubset(products: DaffProduct[]): DaffProduct['id'][] {
     return randomSubset(products).map(product => product.id);
   }
 
-  private generatePageSize(reqInfo) {
+  protected generatePageSize(reqInfo) {
     if(reqInfo.req.params.map && reqInfo.req.params.map.get('page_size') && reqInfo.req.params.map.get('page_size')[0]) {
       return parseInt(reqInfo.req.params.map.get('page_size')[0], 10);
     }
     return 10;
   }
 
-  private getCurrentPageParam(reqInfo) {
+  protected getCurrentPageParam(reqInfo) {
     if(reqInfo.req.params.map && reqInfo.req.params.map.get('current_page') && reqInfo.req.params.map.get('current_page')[0]) {
       return parseInt(reqInfo.req.params.map.get('current_page')[0], 10);
     }

--- a/libs/category/driver/in-memory/src/drivers/category.service.spec.ts
+++ b/libs/category/driver/in-memory/src/drivers/category.service.spec.ts
@@ -63,22 +63,72 @@ describe('@daffodil/category/driver/in-memory | DaffInMemoryCategoryService', ()
   });
 
   describe('getByUrl | getting a single category by URL', () => {
+    let url: string;
+
+    beforeEach(() => {
+      url = 'url';
+    });
+
+    it('should not send an HTTP request containing double slashes', () => {
+      const mockCategory = categoryFactory.create();
+      const mockProducts = productFactory.createMany(3);
+
+      categoryService.getByUrl({ url: `/${url}`, kind: DaffCategoryRequestKind.URL }).subscribe();
+
+      const req = httpMock.expectOne(request => request.method === 'GET' && request.url.includes(categoryService.url));
+      expect(req.request.url).not.toContain('//');
+
+      req.flush({ category: mockCategory, products: mockProducts });
+    });
+
+    it('should set current page', () => {
+      const mockCategory = categoryFactory.create();
+      const mockProducts = productFactory.createMany(3);
+
+      categoryService.getByUrl({ url: `/${url}`, kind: DaffCategoryRequestKind.URL }).subscribe();
+
+      const req = httpMock.expectOne(request => request.method === 'GET' && request.url.includes(categoryService.url));
+      expect(req.request.params.has('current_page')).toBeTruthy();
+
+      req.flush({ category: mockCategory, products: mockProducts });
+    });
+
+    it('should set page size', () => {
+      const mockCategory = categoryFactory.create();
+      const mockProducts = productFactory.createMany(3);
+
+      categoryService.getByUrl({ url: `/${url}`, kind: DaffCategoryRequestKind.URL }).subscribe();
+
+      const req = httpMock.expectOne(request => request.method === 'GET' && request.url.includes(categoryService.url));
+      expect(req.request.params.has('page_size')).toBeTruthy();
+
+      req.flush({ category: mockCategory, products: mockProducts });
+    });
 
     it('should send a get request', () => {
       const mockCategory = categoryFactory.create();
       const mockProducts = productFactory.createMany(3);
 
-      categoryService.getByUrl({ url: mockCategory.url, kind: DaffCategoryRequestKind.URL }).subscribe(categoryResponse => {
+      categoryService.getByUrl({ url: `/${url}`, kind: DaffCategoryRequestKind.URL }).subscribe();
+
+      const req = httpMock.expectOne(request => request.method === 'GET' && request.url.includes(categoryService.url));
+      expect(req.request.method).toBe('GET');
+
+      req.flush({ category: mockCategory, products: mockProducts });
+    });
+
+    it('should return the HTTP response', () => {
+      const mockCategory = categoryFactory.create();
+      const mockProducts = productFactory.createMany(3);
+
+      categoryService.getByUrl({ url: `/${url}`, kind: DaffCategoryRequestKind.URL }).subscribe(categoryResponse => {
         expect(categoryResponse).toEqual(jasmine.objectContaining({
           category: mockCategory,
           products: mockProducts,
         }));
       });
 
-      const req = httpMock.expectOne(request => request.method === 'GET' && request.url.includes(`${categoryService.url}`));
-      expect(req.request.params.has('page_size')).toBeTruthy();
-      expect(req.request.params.has('current_page')).toBeTruthy();
-      expect(req.request.method).toBe('GET');
+      const req = httpMock.expectOne(request => request.method === 'GET' && request.url.includes(categoryService.url));
 
       req.flush({ category: mockCategory, products: mockProducts });
     });

--- a/libs/category/driver/in-memory/src/drivers/category.service.ts
+++ b/libs/category/driver/in-memory/src/drivers/category.service.ts
@@ -11,6 +11,7 @@ import {
   DaffCategoryUrlRequest,
 } from '@daffodil/category';
 import { DaffCategoryServiceInterface } from '@daffodil/category/driver';
+import { daffUriTruncateLeadingSlash } from '@daffodil/core/routing';
 
 /**
  * The category in memory driver for mocking the {@link DaffCategoryDriver} with in memory data.
@@ -38,6 +39,6 @@ export class DaffInMemoryCategoryService implements DaffCategoryServiceInterface
       .set('page_size', categoryRequest.page_size ? categoryRequest.page_size.toString() : null)
       .set('current_page', categoryRequest.current_page ? categoryRequest.current_page.toString() : null);
 
-    return this.http.get<DaffGetCategoryResponse>(`${this.url}${categoryRequest.url}`, { params });
+    return this.http.get<DaffGetCategoryResponse>(`${this.url}${daffUriTruncateLeadingSlash(categoryRequest.url)}`, { params });
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: removes the writable `category` field on `DaffInMemoryBackendCategoryService` and replaced it with readonly `categories`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #1840, #1839 

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Removes `DaffInMemoryBackendCategoryService#category`

## Other information
Also splits the driver tests to be more precise