### PR TITLE
feat(category): prefix category URLs with a leading slash

### DIFF
--- a/libs/category/driver/in-memory/src/backend/category.service.ts
+++ b/libs/category/driver/in-memory/src/backend/category.service.ts
@@ -61,7 +61,7 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
     ].map(id => {
       const allCategoryProductIds = this.generateProductIdSubset(this.productInMemoryBackendService.products);
 
-      return this.categoryFactory.create({ id, url: id, product_ids: allCategoryProductIds, total_products: allCategoryProductIds.length });
+      return this.categoryFactory.create({ id, url: `/${id}`, product_ids: allCategoryProductIds, total_products: allCategoryProductIds.length });
     });
   }
 

--- a/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
@@ -30,7 +30,7 @@ describe('DaffMagentoCategoryTransformerService', () => {
     url = 'url';
     stubCategory = categoryFactory.create({
       id: '1',
-      url: `${url}.html`,
+      url: `/${url}.html`,
     });
   });
 
@@ -123,6 +123,10 @@ describe('DaffMagentoCategoryTransformerService', () => {
       }];
 
       expect(service.transform(magentoCategory).breadcrumbs).toEqual(expectedBreadcrumbs);
+    });
+
+    it('should set a leading slash for the URL', () => {
+      expect(service.transform(magentoCategory).url[0]).toEqual('/');
     });
   });
 });

--- a/libs/category/driver/magento/src/transformers/category-transformer.service.ts
+++ b/libs/category/driver/magento/src/transformers/category-transformer.service.ts
@@ -18,7 +18,7 @@ export class DaffMagentoCategoryTransformerService {
   transform(category: MagentoCategory): DaffCategory {
     return {
       id: category.uid,
-      url: `${category.url_path}${category.url_suffix}`,
+      url: `/${category.url_path}${category.url_suffix}`,
       canonicalUrl: category.canonical_url,
       name: category.name,
       description: category.description,

--- a/libs/category/driver/magento/testing/src/factories/category.factory.ts
+++ b/libs/category/driver/magento/testing/src/factories/category.factory.ts
@@ -6,7 +6,7 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 
 class MockMagentoCategory implements MagentoCategory {
   uid = faker.random.alphaNumeric(10);
-  url_path = faker.internet.url();
+  url_path = faker.random.word();
   url_suffix = '.html';
   canonical_url = faker.internet.url();
   name? = faker.random.word();

--- a/libs/category/testing/src/factories/category.factory.spec.ts
+++ b/libs/category/testing/src/factories/category.factory.spec.ts
@@ -41,17 +41,9 @@ describe('Category | Testing | Factories | DaffCategoryFactory', () => {
       expect(result.product_ids).toBeDefined();
       expect(result.breadcrumbs).toBeDefined();
     });
-  });
 
-  describe('createMany', () => {
-    let result: DaffCategory[];
-
-    it('should create as many categories as desired', () => {
-      result = categoryFactory.createMany(2);
-      expect(result.length).toEqual(2);
-
-      result = categoryFactory.createMany(3);
-      expect(result.length).toEqual(3);
+    it('should set a leading slash for the URL', () => {
+      expect(result.url[0]).toEqual('/');
     });
   });
 });

--- a/libs/category/testing/src/factories/category.factory.ts
+++ b/libs/category/testing/src/factories/category.factory.ts
@@ -6,7 +6,7 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class MockCategory implements DaffCategory {
   id = faker.datatype.uuid();
-  url = faker.internet.url();
+	url = `/${faker.random.word()}.html`;
   canonicalUrl = faker.internet.url();
 	name = faker.commerce.productMaterial();
 	description = faker.random.words(Math.floor(Math.random() * 20));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
Category URLs, in Daffodil factories and driver transformers, are prefixed with a leading slash.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information