### PR TITLE
feat(external-router): don't truncate leading slash for in-memory driver resolution

### DIFF
--- a/libs/external-router/driver/in-memory/src/in-memory.service.spec.ts
+++ b/libs/external-router/driver/in-memory/src/in-memory.service.spec.ts
@@ -32,7 +32,7 @@ describe('@daffodil/external-router/driver/in-memory | DaffExternalRouterInMemor
   });
 
   it('should return a resolved route if the route lookup succeeds', () => {
-    const url = 'test';
+    const url = '/test';
     setupTest({
       resolver: u =>
         u === url ? {
@@ -47,14 +47,14 @@ describe('@daffodil/external-router/driver/in-memory | DaffExternalRouterInMemor
       const { expectObservable } = helpers;
       const expected = '(a|)';
 
-      expectObservable(service.resolve(`/${url}`)).toBe(expected, {
+      expectObservable(service.resolve('/url')).toBe(expected, {
         a: { url, type: 'PRODUCT', id: jasmine.any(String), code: jasmine.any(Number) },
       });
     });
   });
 
   it('should return a DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION if the route lookup fails', () => {
-    const url = 'test';
+    const url = '/test';
     setupTest({
       resolver: u =>
         u === url ? {

--- a/libs/external-router/driver/in-memory/src/in-memory.service.spec.ts
+++ b/libs/external-router/driver/in-memory/src/in-memory.service.spec.ts
@@ -47,7 +47,7 @@ describe('@daffodil/external-router/driver/in-memory | DaffExternalRouterInMemor
       const { expectObservable } = helpers;
       const expected = '(a|)';
 
-      expectObservable(service.resolve('/url')).toBe(expected, {
+      expectObservable(service.resolve(url)).toBe(expected, {
         a: { url, type: 'PRODUCT', id: jasmine.any(String), code: jasmine.any(Number) },
       });
     });

--- a/libs/external-router/driver/in-memory/src/in-memory.service.ts
+++ b/libs/external-router/driver/in-memory/src/in-memory.service.ts
@@ -41,7 +41,7 @@ implements DaffExternalRouterDriverInterface {
   ) {}
 
   resolve(url: string): Observable<DaffExternallyResolvableUrl> {
-    const truncatedUrl = daffUriTruncateLeadingSlash(daffUriTruncateQueryFragment(url));
+    const truncatedUrl = daffUriTruncateQueryFragment(url);
 
     return of(this.configuration.resolver(truncatedUrl) || DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The external router in-memory driver truncates the leading slash before passing the URL to the config resolver.


## What is the new behavior?

The external router in-memory driver does not truncate the leading slash before passing the URL to the config resolver.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information