### PR TITLE
fix(external-router): in-memory driver returns URLs with leading slashes

### DIFF
--- a/libs/external-router/driver/in-memory/src/in-memory.service.spec.ts
+++ b/libs/external-router/driver/in-memory/src/in-memory.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { TestScheduler } from 'rxjs/testing';
 
+import { daffUriTruncateLeadingSlash } from '@daffodil/core/routing';
 import { DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION } from '@daffodil/external-router/driver';
 import {
   DaffExternalRouterDriverInMemoryConfig,
@@ -48,7 +49,7 @@ describe('@daffodil/external-router/driver/in-memory | DaffExternalRouterInMemor
       const expected = '(a|)';
 
       expectObservable(service.resolve(url)).toBe(expected, {
-        a: { url, type: 'PRODUCT', id: jasmine.any(String), code: jasmine.any(Number) },
+        a: { url: daffUriTruncateLeadingSlash(url), type: 'PRODUCT', id: jasmine.any(String), code: jasmine.any(Number) },
       });
     });
   });

--- a/libs/external-router/driver/in-memory/src/in-memory.service.ts
+++ b/libs/external-router/driver/in-memory/src/in-memory.service.ts
@@ -42,7 +42,11 @@ implements DaffExternalRouterDriverInterface {
 
   resolve(url: string): Observable<DaffExternallyResolvableUrl> {
     const truncatedUrl = daffUriTruncateQueryFragment(url);
+    const resolvedUrl = this.configuration.resolver(truncatedUrl);
 
-    return of(this.configuration.resolver(truncatedUrl) || DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION);
+    return of(resolvedUrl?.url ? {
+      ...resolvedUrl,
+      url: daffUriTruncateLeadingSlash(resolvedUrl.url),
+    } : DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #1852 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information