### PR TITLE
fix(category): in-memory driver can't get by URL

### DIFF
--- a/libs/category/driver/in-memory/src/backend/category.service.ts
+++ b/libs/category/driver/in-memory/src/backend/category.service.ts
@@ -15,6 +15,7 @@ import {
   DaffCategoryPageMetadataFactory,
 } from '@daffodil/category/testing';
 import { randomSubset } from '@daffodil/core';
+import { daffUriTruncateLeadingSlash } from '@daffodil/core/routing';
 import { DaffProduct } from '@daffodil/product';
 import { DaffInMemoryBackendProductService } from '@daffodil/product/driver/in-memory';
 
@@ -88,7 +89,7 @@ export class DaffInMemoryBackendCategoryService implements InMemoryDbService {
    */
   get(reqInfo: any) {
     // this method is overloaded for both get by ID and URL so we check both
-    const category = this.categories.filter(({ id, url }) => id === reqInfo.id || url === reqInfo.id)[0];
+    const category = this.categories.filter(({ id, url }) => id === reqInfo.id || daffUriTruncateLeadingSlash(url) === reqInfo.id)[0];
 
     if (category) {
       this._categoryPageMetadata = this.metadataFactory.create({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The in-memory backend does not truncate the category entity leading slash before comparing to the requested URL (in this case the "ID") which does not have a leading slash.


## What is the new behavior?
The requested and category URL are in the same format when comparison is made.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information