### PR TITLE
fix(product): extra extension factory fields overwritten

### DIFF
--- a/libs/product/testing/src/factories/extension.factory.spec.ts
+++ b/libs/product/testing/src/factories/extension.factory.spec.ts
@@ -2,11 +2,15 @@ import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { DaffModelFactory } from '@daffodil/core/testing';
-import { DaffProduct } from '@daffodil/product';
+import {
+  DaffProduct,
+  DaffProductTypeEnum,
+} from '@daffodil/product';
 import {
   daffProvideProductExtraProductFactories,
   MockProduct,
   DaffProductKindFactory,
+  daffProvideProductExtraFactoryTypes,
 } from '@daffodil/product/testing';
 
 import { DaffProductExtensionFactory } from './extension.factory';
@@ -21,6 +25,20 @@ class TestMockProduct extends MockProduct {
 class TestProductFactory extends DaffModelFactory<DaffProduct> {
   constructor() {
     super(TestMockProduct);
+  }
+}
+
+class TestMockProductKind extends MockProduct {
+  type = DaffProductTypeEnum.Composite;
+  extraField = 'not extraField';
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+class TestProductKindFactory extends DaffModelFactory<DaffProduct> {
+  constructor() {
+    super(TestMockProductKind);
   }
 }
 
@@ -41,6 +59,10 @@ describe('Product | Testing | Factories | DaffProductExtensionFactory', () => {
         ...daffProvideProductExtraProductFactories(
           TestProductFactory,
         ),
+        {
+          provide: DaffProductKindFactory,
+          useExisting: TestProductKindFactory,
+        },
       ],
     });
 
@@ -59,8 +81,12 @@ describe('Product | Testing | Factories | DaffProductExtensionFactory', () => {
       result = productFactory.create();
     });
 
-    it('should include extra factories', () => {
-      expect((<TestMockProduct>result).extraField).toBeDefined();
+    it('should include extra factories and prefer the extra factory fields, except for type', () => {
+      expect((<TestMockProduct>result).extraField).toEqual('extraField');
+    });
+
+    it('should should not override the type of the product kind factory', () => {
+      expect((<TestMockProduct>result).type).toEqual(DaffProductTypeEnum.Composite);
     });
   });
 });

--- a/libs/product/testing/src/factories/extension.factory.ts
+++ b/libs/product/testing/src/factories/extension.factory.ts
@@ -31,11 +31,14 @@ export class DaffProductExtensionFactory extends DaffModelFactory<DaffProduct> {
    * This includes all the extra extension factories that may be provided by optional product packages.
    */
   create(partial = {}): DaffProduct {
+    const kind = this.productKindFactory.create(partial);
+
     return Object.assign(
       {},
+      kind,
       ...this.extraFactories.map(factory => factory.create(partial)),
-      // spread this in last to preserve type
-      this.productKindFactory.create(partial),
+      // spread this in last to preserve kind's type
+      { type: kind.type },
     );
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The extension factory spreads in the kind factory after the extra extension factories in an attempt to preserve the kind type, but this overwrites the extra fields when there is a collision.

## What is the new behavior?
The extension factory will prefer the extra fields over the kind fields.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information