### PR TITLE
feat(core): filter duplicate fragments in GraphQL functions

### DIFF
--- a/libs/core/graphql/src/fragments/build-fragment-definition.ts
+++ b/libs/core/graphql/src/fragments/build-fragment-definition.ts
@@ -1,5 +1,7 @@
 import { DocumentNode } from 'graphql';
 
+import { daffFilterDuplicateFragments } from './filter-duplicate-fragments';
+
 /**
  * Builds a string of fragment definitions that can be interpolated into a GraphQL query.
  * Each definition is separated by a newline character: '\n'.
@@ -7,4 +9,4 @@ import { DocumentNode } from 'graphql';
  * @param documents A list of GraphQL documents that should only contain fragments.
  */
 export const daffBuildFragmentDefinition = (...documents: DocumentNode[]): string =>
-  documents.reduce((acc, fragment) => acc.concat(`${fragment.loc.source.body}\n`), '');
+  daffFilterDuplicateFragments(...documents).reduce((acc, fragment) => acc.concat(`${fragment.loc.source.body}\n`), '');

--- a/libs/core/graphql/src/fragments/build-fragment-name-spread.ts
+++ b/libs/core/graphql/src/fragments/build-fragment-name-spread.ts
@@ -3,6 +3,8 @@ import {
   FragmentDefinitionNode,
 } from 'graphql';
 
+import { daffFilterDuplicateFragments } from './filter-duplicate-fragments';
+
 const getFragmentNames = (fragment: DocumentNode) =>
   fragment.definitions.filter(def =>
     def.kind === 'FragmentDefinition',
@@ -27,4 +29,4 @@ const daffGetFragmentNames = (...fragments: DocumentNode[]): string[] =>
  * @param fragments A list of GraphQL documents that contain fragments.
  */
 export const daffBuildFragmentNameSpread = (...fragments: DocumentNode[]): string =>
-  daffGetFragmentNames(...fragments).reduce((acc, name) => acc.concat(`...${name}\n`), '');
+  daffGetFragmentNames(...daffFilterDuplicateFragments(...fragments)).reduce((acc, name) => acc.concat(`...${name}\n`), '');

--- a/libs/core/graphql/src/fragments/filter-duplicate-fragments.spec.ts
+++ b/libs/core/graphql/src/fragments/filter-duplicate-fragments.spec.ts
@@ -1,0 +1,71 @@
+import { gql } from 'apollo-angular';
+import { DocumentNode } from 'graphql';
+
+import { daffFilterDuplicateFragments } from './filter-duplicate-fragments';
+
+describe('@daffodil/core/graphql | daffFilterDuplicateFragments', () => {
+  let mockFragment1: DocumentNode;
+  let mockFragment2: DocumentNode;
+  let mockEmptyFragment: DocumentNode;
+
+  beforeEach(() => {
+    mockFragment1 = gql`
+      fragment fragment11 on Query {
+        __typename
+      }
+      fragment fragment12 on Query {
+        __typename
+      }
+      type Taco {
+        taco: String
+      }
+      interface Foo {
+        foo: String
+      }
+    `;
+    mockFragment2 = gql`
+      fragment fragment21 on Query {
+        __typename
+      }
+      fragment fragment22 on Query {
+        __typename
+      }
+      type Bar {
+        taco: String
+      }
+    `;
+    mockEmptyFragment = gql`
+      type Random {
+        taco: String
+      }
+      interface Foo {
+        foo: String
+      }
+    `;
+  });
+
+  describe('when there are duplicate fragments passed', () => {
+    let filteredList: DocumentNode[];
+
+    beforeEach(() => {
+      filteredList = daffFilterDuplicateFragments(
+        mockFragment1,
+        mockFragment1,
+        mockFragment1,
+        mockFragment2,
+        mockEmptyFragment,
+        mockFragment2,
+        mockFragment2,
+        mockFragment1,
+        mockEmptyFragment,
+      );
+    });
+
+    it('should return a list of fragments with duplicates removed', () => {
+      expect(filteredList.length).toEqual(3);
+      expect(filteredList).toContain(mockFragment1);
+      expect(filteredList).toContain(mockFragment2);
+      expect(filteredList).toContain(mockEmptyFragment);
+    });
+  });
+});

--- a/libs/core/graphql/src/fragments/filter-duplicate-fragments.ts
+++ b/libs/core/graphql/src/fragments/filter-duplicate-fragments.ts
@@ -1,0 +1,8 @@
+import { DocumentNode } from 'graphql';
+
+/**
+ * Filters a list of fragments, removing duplicates.
+ */
+export const daffFilterDuplicateFragments = (...documents: DocumentNode[]): DocumentNode[] =>
+  // TODO(griest024): extract to core util
+  documents.filter((doc, index) => documents.slice(index + 1).indexOf(doc) === -1);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Duplicate fragments are allowed in GraphQL fragment functions, which can result in unnecessarily large queries


## What is the new behavior?
Duplicate fragments are removed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information