### PR TITLE
Revert "feat(cart): transform expired payment token error in magento driver"

### DIFF
--- a/libs/cart/driver/magento/src/cart-order.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart-order.service.spec.ts
@@ -10,10 +10,7 @@ import {
   DaffCart,
   DaffCartPaymentMethod,
 } from '@daffodil/cart';
-import {
-  DaffCartExpiredPaymentTokenError,
-  DaffCartNotFoundError,
-} from '@daffodil/cart/driver';
+import { DaffCartNotFoundError } from '@daffodil/cart/driver';
 import {
   MagentoPlaceOrderResponse,
   placeOrder,
@@ -129,30 +126,6 @@ describe('Driver | Magento | Cart | CartOrderService', () => {
 
           op.graphqlErrors([new GraphQLError(
             'Guest email for cart is missing.',
-            null,
-            null,
-            null,
-            null,
-            null,
-            { category: 'graphql-input' },
-          )]);
-        });
-      });
-
-      describe('because of an expired payment method error', () => {
-        it('should throw a DaffCartExpiredPaymentTokenError', done => {
-          service.placeOrder(cartId, mockDaffCartPayment).pipe(
-            catchError(err => {
-              expect(err).toEqual(jasmine.any(DaffCartExpiredPaymentTokenError));
-              done();
-              return [];
-            }),
-          ).subscribe();
-
-          const op = controller.expectOne(placeOrder);
-
-          op.graphqlErrors([new GraphQLError(
-            'Unable to place order: Authorize.Net CIM Gateway: Invalid token. Please re-enter your payment info. (E00114)',
             null,
             null,
             null,

--- a/libs/cart/driver/magento/src/errors/map.ts
+++ b/libs/cart/driver/magento/src/errors/map.ts
@@ -15,5 +15,4 @@ export const DaffCartMagentoErrorMap: DaffErrorCodeMap = {
 export const DaffCartMagentoErrorMessageRegexMap = {
   [DaffCartDriverErrorCodes.INVALID_COUPON_CODE]: /The coupon code isn\'t valid/,
   [DaffCartDriverErrorCodes.PRODUCT_OUT_OF_STOCK]: /The requested qty is not available/,
-  [DaffCartDriverErrorCodes.EXPIRED_PAYMENT_METHOD]: /Invalid token\. Please re-enter your payment info\. \(E00114\)/,
 };


### PR DESCRIPTION
Reverts graycoreio/daffodil#1881

This error message is specific to authorize.net, it can't be used for matching purposes