### PR TITLE
feat(design): make image component lazy loaded by default

### DIFF
--- a/libs/design/src/atoms/image/image.component.html
+++ b/libs/design/src/atoms/image/image.component.html
@@ -1,3 +1,3 @@
 <div class="daff-image__wrapper" [style.paddingTop]="_paddingTop">
-	<img [src]="src" [alt]="alt" (load)="load.emit" />
+	<img [src]="src" [alt]="alt" (load)="load.emit" loading="lazy"/>
 </div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no lazy loading on the image component.

Fixes: N/A


## What is the new behavior?
Lazy loading is now enabled on the image component.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information