### PR TITLE
feat(design): create `daffArticleEncapsulatedMixin` to prevent article styles from cascading down to nested @daffodil/design components

### DIFF
--- a/apps/design-land/src/app/accordion/accordion.component.html
+++ b/apps/design-land/src/app/accordion/accordion.component.html
@@ -1,13 +1,11 @@
-<daff-article>
-	<h1 daffArticleTitle>Accordion</h1>
+<h1 daffArticleTitle>Accordion</h1>
 
-	<h3>Types</h3>
-  <p><code>daff-accordion-item</code> - An accordion that typically holds content.</p>
-  <p><code>daff-nav-accordion-item</code> — An accordion that is used for navigation whose content is nested daff-nav-accordion-items.</p>
+<h3>Types</h3>
+<p><code>daff-accordion-item</code> - An accordion that typically holds content.</p>
+<p><code>daff-nav-accordion-item</code> — An accordion that is used for navigation whose content is nested daff-nav-accordion-items.</p>
 
-	<h3>Content Accordion Item</h3>
-	<design-land-example-viewer-container example="basic-accordion"></design-land-example-viewer-container>
-	
-	<h3>Navigation Accordion Item</h3>
-	<design-land-example-viewer-container example="nav-accordion"></design-land-example-viewer-container>
-</daff-article>
+<h3>Content Accordion Item</h3>
+<design-land-example-viewer-container example="basic-accordion"></design-land-example-viewer-container>
+
+<h3>Navigation Accordion Item</h3>
+<design-land-example-viewer-container example="nav-accordion"></design-land-example-viewer-container>

--- a/apps/design-land/src/app/app.component.html
+++ b/apps/design-land/src/app/app.component.html
@@ -41,6 +41,8 @@
     </daff-link-set>
   </daff-sidebar>
   <div class="design-land__content">
-    <router-outlet></router-outlet>
+    <daff-article>
+      <router-outlet></router-outlet>
+    </daff-article>
   </div>
 </daff-sidebar-viewport>

--- a/apps/design-land/src/app/article/article.component.html
+++ b/apps/design-land/src/app/article/article.component.html
@@ -1,47 +1,45 @@
-<daff-article>
-	<h1 daffArticleTitle>Article</h1>
-	<p daffArticleLead>Article provides styles to common element selectors to create an article in a content page.</p>
+<h1 daffArticleTitle>Article</h1>
+<p daffArticleLead>Article provides styles to common element selectors to create an article in a content page.</p>
 
-	<h2>Overview</h2>
-	<p>Article can be used on any content page that displays large blocks of text-driven information. It's meant to be used as a standalone element and should not be nested inside any other components that may change the background color from the anticipated one. In the event that you must nest an article inside another component, please ensure that you set the article's background color to the default body color.</p>
+<h2>Overview</h2>
+<p>Article can be used on any content page that displays large blocks of text-driven information. It's meant to be used as a standalone element and should not be nested inside any other components that may change the background color from the anticipated one. In the event that you must nest an article inside another component, please ensure that you set the article's background color to the default body color.</p>
 
-	<h2>Headings</h2>
-	<design-land-example-viewer-container example="article-headings"></design-land-example-viewer-container>
+<h2>Headings</h2>
+<design-land-example-viewer-container example="article-headings"></design-land-example-viewer-container>
 
-	<h2>Article Lead</h2>
-	<p>Lead is used as the opening paragraph to provide a summary or leading information for an article. Lead is a custom directive of article and is not a native element selector. To use it, add the <code>daffArticleLead</code> attribute to a paragraph (<code>&lt;p&gt;</code>).</p>
-	<design-land-example-viewer-container example="article-lead"></design-land-example-viewer-container>
+<h2>Article Lead</h2>
+<p>Lead is used as the opening paragraph to provide a summary or leading information for an article. Lead is a custom directive of article and is not a native element selector. To use it, add the <code>daffArticleLead</code> attribute to a paragraph (<code>&lt;p&gt;</code>).</p>
+<design-land-example-viewer-container example="article-lead"></design-land-example-viewer-container>
 
-	<h2>Article Meta</h2>
-	<p>Meta is used if there is metadata information about your article (i.e. author name, date, etc). Meta is a custom directive of article and is not a native element selector. To use it, add <code>daffArticleMeta</code> to a paragraph (<code>&lt;p&gt;</code>).</p>
-	<design-land-example-viewer-container example="article-meta"></design-land-example-viewer-container>
+<h2>Article Meta</h2>
+<p>Meta is used if there is metadata information about your article (i.e. author name, date, etc). Meta is a custom directive of article and is not a native element selector. To use it, add <code>daffArticleMeta</code> to a paragraph (<code>&lt;p&gt;</code>).</p>
+<design-land-example-viewer-container example="article-meta"></design-land-example-viewer-container>
 
-	<h2>Link</h2>
-	<p>The link style in an article uses the default browser link style.</p>
-	<design-land-example-viewer-container example="article-link"></design-land-example-viewer-container>
+<h2>Link</h2>
+<p>The link style in an article uses the default browser link style.</p>
+<design-land-example-viewer-container example="article-link"></design-land-example-viewer-container>
 
-	<h2>Table</h2>
-	<design-land-example-viewer-container example="article-table"></design-land-example-viewer-container>
+<h2>Table</h2>
+<design-land-example-viewer-container example="article-table"></design-land-example-viewer-container>
 
-	<h2>Lists</h2>
-	<h3>Unordered List</h3>
-	<design-land-example-viewer-container example="article-ul"></design-land-example-viewer-container>
+<h2>Lists</h2>
+<h3>Unordered List</h3>
+<design-land-example-viewer-container example="article-ul"></design-land-example-viewer-container>
 
-	<h3>Ordered List</h3>
-	<design-land-example-viewer-container example="article-ol"></design-land-example-viewer-container>
+<h3>Ordered List</h3>
+<design-land-example-viewer-container example="article-ol"></design-land-example-viewer-container>
 
-	<h2>Code</h2>
-	<p>These are styles for inline and multiline blocks of code.</p>
+<h2>Code</h2>
+<p>These are styles for inline and multiline blocks of code.</p>
 
-	<h3>Inline code</h3>
-	<design-land-example-viewer-container example="article-code-inline"></design-land-example-viewer-container>
+<h3>Inline code</h3>
+<design-land-example-viewer-container example="article-code-inline"></design-land-example-viewer-container>
 
-	<h3>Code blocks</h3>
-	<design-land-example-viewer-container example="article-code-block"></design-land-example-viewer-container>
+<h3>Code blocks</h3>
+<design-land-example-viewer-container example="article-code-block"></design-land-example-viewer-container>
 
-	<h2>Horizontal Rules</h2>
-	<design-land-example-viewer-container example="article-hr"></design-land-example-viewer-container>
+<h2>Horizontal Rules</h2>
+<design-land-example-viewer-container example="article-hr"></design-land-example-viewer-container>
 
-	<h2>Blockquote</h2>
-	<design-land-example-viewer-container example="article-blockquote"></design-land-example-viewer-container>
-</daff-article>
+<h2>Blockquote</h2>
+<design-land-example-viewer-container example="article-blockquote"></design-land-example-viewer-container>

--- a/apps/design-land/src/app/button/button.component.html
+++ b/apps/design-land/src/app/button/button.component.html
@@ -1,59 +1,57 @@
-<daff-article>
-  <h1 daffArticleTitle>Button</h1>
-  <p daffArticleLead>
-    The button is used for making actions apparent to the end-user. It can be used to navigate users to a different page or to perform an action. Buttons can contain text, icons, or both.
-  </p>
+<h1 daffArticleTitle>Button</h1>
+<p daffArticleLead>
+  The button is used for making actions apparent to the end-user. It can be used to navigate users to a different page or to perform an action. Buttons can contain text, icons, or both.
+</p>
 
-  <h3>About</h3>
-  <p>
-    Native <code>&lt;button&gt;</code> or <code>&lt;a&gt;</code> elements are always used in order to provide an easy, accessible experience for users.
-  </p>
-  <ul>
-    <li><code>&lt;button&gt;</code> should be used when a clickable action is performed within the same page.</li>
-    <li><code>&lt;a&gt;</code> should be used for interactions that will navigate users to a new page or to a different target on the same page.</li>
-  </ul>
+<h3>About</h3>
+<p>
+  Native <code>&lt;button&gt;</code> or <code>&lt;a&gt;</code> elements are always used in order to provide an easy, accessible experience for users.
+</p>
+<ul>
+  <li><code>&lt;button&gt;</code> should be used when a clickable action is performed within the same page.</li>
+  <li><code>&lt;a&gt;</code> should be used for interactions that will navigate users to a new page or to a different target on the same page.</li>
+</ul>
 
-  <h3>Types</h3>
-  <p><code>daff-button</code> — Rectangular contained button with background color</p>
-  <p><code>daff-icon-button</code> — Icon button used with icon fonts</p>
-  <p><code>daff-raised-button</code> — Rectangular contained button with background color and elevation</p>
-  <p><code>daff-stroked-button</code> — Rectangular outlined button with no background color</p>
+<h3>Types</h3>
+<p><code>daff-button</code> — Rectangular contained button with background color</p>
+<p><code>daff-icon-button</code> — Icon button used with icon fonts</p>
+<p><code>daff-raised-button</code> — Rectangular contained button with background color and elevation</p>
+<p><code>daff-stroked-button</code> — Rectangular outlined button with no background color</p>
 
-  <h3>Basic Button</h3>
-  <design-land-example-viewer-container example="basic-button"></design-land-example-viewer-container>
+<h3>Basic Button</h3>
+<design-land-example-viewer-container example="basic-button"></design-land-example-viewer-container>
 
-  <h3>Stroked Button</h3>
-  <design-land-example-viewer-container example="stroked-button"></design-land-example-viewer-container>
+<h3>Stroked Button</h3>
+<design-land-example-viewer-container example="stroked-button"></design-land-example-viewer-container>
 
-  <h3>Raised Button</h3>
-  <design-land-example-viewer-container example="raised-button"></design-land-example-viewer-container>
+<h3>Raised Button</h3>
+<design-land-example-viewer-container example="raised-button"></design-land-example-viewer-container>
 
-  <h3>Icon Button</h3>
-  <design-land-example-viewer-container example="icon-button"></design-land-example-viewer-container>
+<h3>Icon Button</h3>
+<design-land-example-viewer-container example="icon-button"></design-land-example-viewer-container>
 
-  <h3>Underline Button</h3>
-  <design-land-example-viewer-container example="underline-button"></design-land-example-viewer-container>
+<h3>Underline Button</h3>
+<design-land-example-viewer-container example="underline-button"></design-land-example-viewer-container>
 
-  <h3>Sizes</h3>
-  <p>The size of a button can be updated by using the <code>size</code> property. The size of all the button variants will default to <code>md</code> if no size is defined. This can be updated to the three sizes buttons support.</p>
-  <p>Supported Sizes: <code>sm | md | lg</code></p>
+<h3>Sizes</h3>
+<p>The size of a button can be updated by using the <code>size</code> property. The size of all the button variants will default to <code>md</code> if no size is defined. This can be updated to the three sizes buttons support.</p>
+<p>Supported Sizes: <code>sm | md | lg</code></p>
 
-  <design-land-example-viewer-container example="sizeable-button"></design-land-example-viewer-container>
+<design-land-example-viewer-container example="sizeable-button"></design-land-example-viewer-container>
 
-  <h3>Theming</h3>
-  <p>The default color of a button is light gray, but it can be updated to one of the supported colors by using the <code>color</code> property.</p>
-  <p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
-  <p><code>white</code> and <code>theme</code> should be used on a darker background in order to have sufficient contrast for certain button types.</p>
+<h3>Theming</h3>
+<p>The default color of a button is light gray, but it can be updated to one of the supported colors by using the <code>color</code> property.</p>
+<p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
+<p><code>white</code> and <code>theme</code> should be used on a darker background in order to have sufficient contrast for certain button types.</p>
 
-  <h3>Status Indicators</h3>
-  <p>Buttons with status indicators can be used to distinguish what type of action it performs and its importance compared to other buttons in the same context.</p>
+<h3>Status Indicators</h3>
+<p>Buttons with status indicators can be used to distinguish what type of action it performs and its importance compared to other buttons in the same context.</p>
 
-  <p>Supported statuses: <code>warn | danger | success</code></p>
+<p>Supported statuses: <code>warn | danger | success</code></p>
 
-  <design-land-example-viewer-container example="statusable-button"></design-land-example-viewer-container>
+<design-land-example-viewer-container example="statusable-button"></design-land-example-viewer-container>
 
-  <h3>Accessibility</h3>
-  <p>Daffodil uses native <code>&lt;a&gt;</code> and <code>&lt;button&gt;</code> HTML elements to ensure an accessible experience by default. The <code>&lt;button&gt;</code> element should be used when a clickable action is performed within the same page. The <code>&lt;a&gt;</code> element should be used to navigate users to a new page or to a different target on the same page.</p>
+<h3>Accessibility</h3>
+<p>Daffodil uses native <code>&lt;a&gt;</code> and <code>&lt;button&gt;</code> HTML elements to ensure an accessible experience by default. The <code>&lt;button&gt;</code> element should be used when a clickable action is performed within the same page. The <code>&lt;a&gt;</code> element should be used to navigate users to a new page or to a different target on the same page.</p>
 
-  <p>Buttons and links containing only icons (<code>&lt;daff-icon-button&gt;</code>) need to be given meaningful labels using <code>aria-label</code> or <code>aria-labelledby</code>.</p>
-</daff-article>
+<p>Buttons and links containing only icons (<code>&lt;daff-icon-button&gt;</code>) need to be given meaningful labels using <code>aria-label</code> or <code>aria-labelledby</code>.</p>

--- a/apps/design-land/src/app/callout/callout.component.html
+++ b/apps/design-land/src/app/callout/callout.component.html
@@ -1,53 +1,51 @@
-<daff-article>
-  <h1 daffArticleTitle>Callout</h1>
-  <p daffArticleLead>Callout is a versatile component that can be used to easily highlight a piece of content.</p>
+<h1 daffArticleTitle>Callout</h1>
+<p daffArticleLead>Callout is a versatile component that can be used to easily highlight a piece of content.</p>
 
-  <h2>Overview</h2>
-  <p>Callouts can be used multiple times on a page. It's a flexible and extensible component that includes pre-styled content containers. It can be used alongside a product list to highlight a set of products, quickly lay out an accordion, showcase a set of features, etc.</p>
+<h2>Overview</h2>
+<p>Callouts can be used multiple times on a page. It's a flexible and extensible component that includes pre-styled content containers. It can be used alongside a product list to highlight a set of products, quickly lay out an accordion, showcase a set of features, etc.</p>
 
-  <h2>Supported Content Types</h2>
-  <p>A <code>&lt;daff-callout&gt;</code> supports transclusion of any content and includes stylized <code>icon</code>, <code>tagline</code>, <code>title</code>, <code>subtitle</code>, and <code>body</code> content containers.</p>
+<h2>Supported Content Types</h2>
+<p>A <code>&lt;daff-callout&gt;</code> supports transclusion of any content and includes stylized <code>icon</code>, <code>tagline</code>, <code>title</code>, <code>subtitle</code>, and <code>body</code> content containers.</p>
 
-  <h3>Icon</h3>
-  <p><code>[daffCalloutIcon]</code> is intended for visual or branding reinforcement. It should not be used for actionable icons.</p>
+<h3>Icon</h3>
+<p><code>[daffCalloutIcon]</code> is intended for visual or branding reinforcement. It should not be used for actionable icons.</p>
 
-  <h3>Tagline</h3>
-  <p>Callout taglines are used by adding <code>[daffCalloutTagline]</code> to a <code>&lt;p&gt;</code> tag. It's intended to supplement the title by providing a short, memorable description.</p>
+<h3>Tagline</h3>
+<p>Callout taglines are used by adding <code>[daffCalloutTagline]</code> to a <code>&lt;p&gt;</code> tag. It's intended to supplement the title by providing a short, memorable description.</p>
 
-  <h3>Title</h3>
-  <p>Callout titles are used by adding <code>[daffCalloutTitle]</code> to a <code>&lt;h*&gt;</code> tag.</p>
+<h3>Title</h3>
+<p>Callout titles are used by adding <code>[daffCalloutTitle]</code> to a <code>&lt;h*&gt;</code> tag.</p>
 
-  <h3>Subtitle</h3>
-  <p>Callout subtitles are used by adding <code>[daffCalloutSubtitle]</code> to a <code>&lt;p&gt;</code> tag.</p>
+<h3>Subtitle</h3>
+<p>Callout subtitles are used by adding <code>[daffCalloutSubtitle]</code> to a <code>&lt;p&gt;</code> tag.</p>
 
-  <h3>Body</h3>
-  <p><code>[daffCalloutBody]</code> is a wrapper container that can be used to place all additional components and content within a <code>&lt;daff-callout&gt;</code> and should only be used once. The body container allows for a ton of control and customization because it's not affected by any of callout's properties and only serves as a wrapping and spacing container.</p>
+<h3>Body</h3>
+<p><code>[daffCalloutBody]</code> is a wrapper container that can be used to place all additional components and content within a <code>&lt;daff-callout&gt;</code> and should only be used once. The body container allows for a ton of control and customization because it's not affected by any of callout's properties and only serves as a wrapping and spacing container.</p>
 
-  <h2>Theming</h2>
-  <p>The default background color of a callout is light gray, but it can be updated to one of the supported colors by using the <code>color</code> property.</p>
-  <p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
+<h2>Theming</h2>
+<p>The default background color of a callout is light gray, but it can be updated to one of the supported colors by using the <code>color</code> property.</p>
+<p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
 
-  <design-land-example-viewer-container example="callout-theming"></design-land-example-viewer-container>
+<design-land-example-viewer-container example="callout-theming"></design-land-example-viewer-container>
 
-  <h2>Text Alignment</h2>
-  <p>Align callout-specific text with the <code>textAlignment</code> property. <code>textAlignment</code> will not cascade the alignment styles down to <code>[daffCalloutBody]</code> or any additional components or elements that are placed inside of a callout. <code>textAlignment</code> is set to <code>left</code> by default.</p>
-  <p>Supported alignments: <code>left | center | right</code></p>
-  <design-land-example-viewer-container example="callout-text-alignment"></design-land-example-viewer-container>
+<h2>Text Alignment</h2>
+<p>Align callout-specific text with the <code>textAlignment</code> property. <code>textAlignment</code> will not cascade the alignment styles down to <code>[daffCalloutBody]</code> or any additional components or elements that are placed inside of a callout. <code>textAlignment</code> is set to <code>left</code> by default.</p>
+<p>Supported alignments: <code>left | center | right</code></p>
+<design-land-example-viewer-container example="callout-text-alignment"></design-land-example-viewer-container>
 
-  <h2 id="compact-callouts">Compact Callouts</h2>
-  <p>Callouts are available in a <code>compact</code> mode, which decreases the overall padding of the callout container to suit UIs that require less negative space. To enable the mode, set the <code>compact</code> property on <code>&lt;daff-callout&gt;</code>.</p>
+<h2 id="compact-callouts">Compact Callouts</h2>
+<p>Callouts are available in a <code>compact</code> mode, which decreases the overall padding of the callout container to suit UIs that require less negative space. To enable the mode, set the <code>compact</code> property on <code>&lt;daff-callout&gt;</code>.</p>
 
-  <design-land-example-viewer-container example="compact-callout"></design-land-example-viewer-container>
+<design-land-example-viewer-container example="compact-callout"></design-land-example-viewer-container>
 
-  <h2>Gridded Callouts</h2>
-  <p>Callouts are flexible enough to support grids within them.</p>
+<h2>Gridded Callouts</h2>
+<p>Callouts are flexible enough to support grids within them.</p>
 
-  <h3>Callout with Two Columns</h3>
-  <design-land-example-viewer-container example="callout-with-grid"></design-land-example-viewer-container>
+<h3>Callout with Two Columns</h3>
+<design-land-example-viewer-container example="callout-with-grid"></design-land-example-viewer-container>
 
-  <h2>Layout</h2>
-  <p>The <code>layout</code> property is deprecated and replaced by the <code>textAlignable</code> property.</p>
+<h2>Layout</h2>
+<p>The <code>layout</code> property is deprecated and replaced by the <code>textAlignable</code> property.</p>
 
-  <h2>Size</h2>
-  <p>The <code>size</code> property is deprecated and replaced by the <code>compact</code> property.</p>
-</daff-article>
+<h2>Size</h2>
+<p>The <code>size</code> property is deprecated and replaced by the <code>compact</code> property.</p>

--- a/apps/design-land/src/app/card/card.component.html
+++ b/apps/design-land/src/app/card/card.component.html
@@ -1,58 +1,56 @@
-<daff-article>
-	<h1 daffArticleTitle>Card</h1>
-	<p daffArticleLead>Cards are versatile content containers that contain content and actions to convey information about a single subject.</p>
+<h1 daffArticleTitle>Card</h1>
+<p daffArticleLead>Cards are versatile content containers that contain content and actions to convey information about a single subject.</p>
 
-	<h2>Overview</h2>
-	<p>There are three types of cards: default (filled), raised, and stroked. Cards can contain anything from images, blocks of text, lists, accordions, and other components.</p>
+<h2>Overview</h2>
+<p>There are three types of cards: default (filled), raised, and stroked. Cards can contain anything from images, blocks of text, lists, accordions, and other components.</p>
 
-	<h2>Basic Card</h2>
-	<p>The example below is a default, filled card that includes all of a card's pre-styled elements and a fixed width. Cards naturally do not have a fixed width, so they'll be 100% wide by default. The width is changeable with custom CSS.</p>
-	<design-land-example-viewer-container example="basic-card"></design-land-example-viewer-container>
+<h2>Basic Card</h2>
+<p>The example below is a default, filled card that includes all of a card's pre-styled elements and a fixed width. Cards naturally do not have a fixed width, so they'll be 100% wide by default. The width is changeable with custom CSS.</p>
+<design-land-example-viewer-container example="basic-card"></design-land-example-viewer-container>
 
-	<h2>Supported Content Types</h2>
-	<p>A card supports a wide variety of content and includes minimally pre-styled <code>image</code>, <code>icon</code>, <code>tagline</code>, <code>title</code>, <code>content</code>, and <code>actions</code> content containers.</p>
+<h2>Supported Content Types</h2>
+<p>A card supports a wide variety of content and includes minimally pre-styled <code>image</code>, <code>icon</code>, <code>tagline</code>, <code>title</code>, <code>content</code>, and <code>actions</code> content containers.</p>
 
-	<h3>Image</h3>
-	<p>Image can be added to a card by using the <code>daffCardImage</code> attribute. It stretches the image to a card's defined width and ensures that its border radius is flush with a card.</p>
+<h3>Image</h3>
+<p>Image can be added to a card by using the <code>daffCardImage</code> attribute. It stretches the image to a card's defined width and ensures that its border radius is flush with a card.</p>
 
-	<h3>Icon</h3>
-	<p>Icon can be added to a card by using the <code>daffCardIcon</code> attribute. It's intended for visual or branding reinforcement and should not be used for actionable icons.</p>
+<h3>Icon</h3>
+<p>Icon can be added to a card by using the <code>daffCardIcon</code> attribute. It's intended for visual or branding reinforcement and should not be used for actionable icons.</p>
 
-	<h3>Tagline</h3>
-	<p>Tagline can be added to a card by using the <code>daffCardTagline</code> attribute. It's intended to supplement the title by providing a short, memorable description.</p>
+<h3>Tagline</h3>
+<p>Tagline can be added to a card by using the <code>daffCardTagline</code> attribute. It's intended to supplement the title by providing a short, memorable description.</p>
 
-	<h3>Title</h3>
-	<p>Title can be added to a card by using the <code>daffCardTitle</code> attribute.</p>
+<h3>Title</h3>
+<p>Title can be added to a card by using the <code>daffCardTitle</code> attribute.</p>
 
-	<h3>Content</h3>
-	<p>Content can be added to a card by using the <code>daffCardContent</code> attribute and should only be used once. It's a wrapper container that can be used to place all additional components and text content within a card. The content container allows for a ton of control and customization because it's not affected by any of card's properties and only serves as a wrapping and spacing container.</p>
+<h3>Content</h3>
+<p>Content can be added to a card by using the <code>daffCardContent</code> attribute and should only be used once. It's a wrapper container that can be used to place all additional components and text content within a card. The content container allows for a ton of control and customization because it's not affected by any of card's properties and only serves as a wrapping and spacing container.</p>
 
-	<h3>Actions</h3>
-	<p>Buttons can be added to a card by using the <code>daffCardActions</code> attribute. This container will always be positioned at the bottom of a card.</p>
+<h3>Actions</h3>
+<p>Buttons can be added to a card by using the <code>daffCardActions</code> attribute. This container will always be positioned at the bottom of a card.</p>
 
-	<h2>Properties</h2>
+<h2>Properties</h2>
 
-	<h3>Orientation</h3>
-	<p>Orientation dictates how a card's content is stacked — <code>vertical</code> or <code>horizontal</code>. Cards are oriented vertically by default. The orientation of a card can be defined or updated by using the <code>orientation</code> property. Horizontal cards will stack vertically on smaller screens due to size constraints.</p>
+<h3>Orientation</h3>
+<p>Orientation dictates how a card's content is stacked — <code>vertical</code> or <code>horizontal</code>. Cards are oriented vertically by default. The orientation of a card can be defined or updated by using the <code>orientation</code> property. Horizontal cards will stack vertically on smaller screens due to size constraints.</p>
 
-	<design-land-example-viewer-container example="card-orientation"></design-land-example-viewer-container>
+<design-land-example-viewer-container example="card-orientation"></design-land-example-viewer-container>
 
-	<h2>Linkable Card</h2>
-	<p>Cards can be linkable by adding the component selector to the <code>&lt;a&gt;</code> tag. All card types are linkable.</p>
-	<design-land-example-viewer-container example="linkable-card"></design-land-example-viewer-container>
+<h2>Linkable Card</h2>
+<p>Cards can be linkable by adding the component selector to the <code>&lt;a&gt;</code> tag. All card types are linkable.</p>
+<design-land-example-viewer-container example="linkable-card"></design-land-example-viewer-container>
 
-	<h2>Raised Card</h2>
-	<p>A raised card adds elevation to the default card.</p>
-	<design-land-example-viewer-container example="raised-card"></design-land-example-viewer-container>
+<h2>Raised Card</h2>
+<p>A raised card adds elevation to the default card.</p>
+<design-land-example-viewer-container example="raised-card"></design-land-example-viewer-container>
 
-	<h2>Stroked Card</h2>
-	<p>A stroked card adds a border to the default card.</p>
-	<design-land-example-viewer-container example="stroked-card"></design-land-example-viewer-container>
+<h2>Stroked Card</h2>
+<p>A stroked card adds a border to the default card.</p>
+<design-land-example-viewer-container example="stroked-card"></design-land-example-viewer-container>
 
-	<h3>Theming</h3>
-  <p>Cards will use the base color of your application to display the default background and/or border color. A card's colors can be defined by using the <code>color</code> property.</p>
+<h3>Theming</h3>
+<p>Cards will use the base color of your application to display the default background and/or border color. A card's colors can be defined by using the <code>color</code> property.</p>
 
-  <p>Supported colors: <code>primary | secondary | tertiary | white | black | theme | theme-contrast</code></p>
+<p>Supported colors: <code>primary | secondary | tertiary | white | black | theme | theme-contrast</code></p>
 
-	<design-land-example-viewer-container example="card-theming"></design-land-example-viewer-container>
-</daff-article>
+<design-land-example-viewer-container example="card-theming"></design-land-example-viewer-container>

--- a/apps/design-land/src/app/container/container.component.html
+++ b/apps/design-land/src/app/container/container.component.html
@@ -1,49 +1,46 @@
-<daff-article>
-  <h1>Container</h1>
-  <p daffArticleLead>Container is a basic structural element that can be used to restrict content to a specific width. Containers are not responsible for providing padding or margin.</p>
+<h1 daffArticleTitle>Container</h1>
+<p daffArticleLead>Container is a basic structural element that can be used to restrict content to a specific width. Containers are not responsible for providing padding or margin.</p>
 
-  <h2>Size</h2>
-  <p>The size of a container can be defined by using the <code>size</code> property. There is no default size set.</p>
-  <p>Supported sizes: <code>xs | sm | md | lg | xl</code></p>
+<h2>Size</h2>
+<p>The size of a container can be defined by using the <code>size</code> property. There is no default size set.</p>
+<p>Supported sizes: <code>xs | sm | md | lg | xl</code></p>
 
-  <table>
-    <thead>
-      <tr>
-        <th>Size</th>
-        <th>Syntax</th>
-        <th>Max width</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Extra small</td>
-        <td>xs</td>
-        <td>640px</td>
-      </tr>
-      <tr>
-        <td>Small</td>
-        <td>sm</td>
-        <td>800px</td>
-      </tr>
-      <tr>
-        <td>Medium</td>
-        <td>md</td>
-        <td>1040px</td>
-      </tr>
-      <tr>
-        <td>Large</td>
-        <td>lg</td>
-        <td>1340px</td>
-      </tr>
-      <tr>
-        <td>Extra large</td>
-        <td>xl</td>
-        <td>1920px</td>
-      </tr>
-    </tbody>
-  </table>
+<table>
+  <thead>
+    <tr>
+      <th>Size</th>
+      <th>Syntax</th>
+      <th>Max width</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Extra small</td>
+      <td>xs</td>
+      <td>640px</td>
+    </tr>
+    <tr>
+      <td>Small</td>
+      <td>sm</td>
+      <td>800px</td>
+    </tr>
+    <tr>
+      <td>Medium</td>
+      <td>md</td>
+      <td>1040px</td>
+    </tr>
+    <tr>
+      <td>Large</td>
+      <td>lg</td>
+      <td>1340px</td>
+    </tr>
+    <tr>
+      <td>Extra large</td>
+      <td>xl</td>
+      <td>1920px</td>
+    </tr>
+  </tbody>
+</table>
 
-  <h2>Usage</h2>
-  <design-land-example-viewer-container example="container-sizes"></design-land-example-viewer-container>
-  
-</daff-article>
+<h2>Usage</h2>
+<design-land-example-viewer-container example="container-sizes"></design-land-example-viewer-container>

--- a/apps/design-land/src/app/core/article-encapsulated/article-encapsulated.component.ts
+++ b/apps/design-land/src/app/core/article-encapsulated/article-encapsulated.component.ts
@@ -1,0 +1,26 @@
+import {
+  Component,
+  ElementRef,
+  Renderer2,
+} from '@angular/core';
+
+import { daffArticleEncapsulatedMixin } from '@daffodil/design';
+
+/**
+ * An _elementRef and an instance of renderer2 are needed for the link set mixins
+ */
+class DesignLandArticleEncapsulatedBase {
+  constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
+}
+
+const _designLandArticleEncapsulatedBase = daffArticleEncapsulatedMixin((DesignLandArticleEncapsulatedBase));
+
+@Component({
+  selector: 'design-land-article-encapsulated',
+  template: '<ng-content></ng-content>',
+})
+export class DesignLandArticleEncapsulatedComponent extends _designLandArticleEncapsulatedBase {
+  constructor(private elementRef: ElementRef, private renderer: Renderer2) {
+    super(elementRef, renderer);
+  }
+}

--- a/apps/design-land/src/app/core/article-encapsulated/article-encapsulated.module.ts
+++ b/apps/design-land/src/app/core/article-encapsulated/article-encapsulated.module.ts
@@ -1,0 +1,17 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { DesignLandArticleEncapsulatedComponent } from './article-encapsulated.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+  declarations: [
+    DesignLandArticleEncapsulatedComponent,
+  ],
+  exports: [
+    DesignLandArticleEncapsulatedComponent,
+  ],
+})
+export class DesignLandArticleEncapsulatedModule { }

--- a/apps/design-land/src/app/foundations/color/color.component.html
+++ b/apps/design-land/src/app/foundations/color/color.component.html
@@ -1,147 +1,145 @@
-<daff-article>
-	<h1 daffArticleTitle>Color</h1>
-	<p daffArticleLead>Color is used to help us distinguish and create consistent experiences across products.</p>
+<h1 daffArticleTitle>Color</h1>
+<p daffArticleLead>Color is used to help us distinguish and create consistent experiences across products.</p>
 
-	<h3>Accessibility Considerations and Guarantees</h3>
-	<p>We are committed to complying with the <a href="https://www.w3.org/TR/WCAG/" target="_blank">Web Content Accessibility Guidelines (WCAG) 2.1</a>. The component kit is built with the guidelines in mind. If you choose to identify your own color palettes outside of Daffodil's colors, please make sure to choose primary, secondary, tertiary, and extended colors that will pass the guidelines. Ensure there is sufficient color contrast between elements so that people who are visually impaired can see and use your products.</p>
+<h3>Accessibility Considerations and Guarantees</h3>
+<p>We are committed to complying with the <a href="https://www.w3.org/TR/WCAG/" target="_blank">Web Content Accessibility Guidelines (WCAG) 2.1</a>. The component kit is built with the guidelines in mind. If you choose to identify your own color palettes outside of Daffodil's colors, please make sure to choose primary, secondary, tertiary, and extended colors that will pass the guidelines. Ensure there is sufficient color contrast between elements so that people who are visually impaired can see and use your products.</p>
 
-	<h5>The following contrast considerations are of interest:</h5>
-	<p>To verify contrast ratios, we recommend using this <a href="contrast-ratio.com">contrast ratio calculator</a>.</p>
+<h5>The following contrast considerations are of interest:</h5>
+<p>To verify contrast ratios, we recommend using this <a href="contrast-ratio.com">contrast ratio calculator</a>.</p>
 
-	<table>
-		<thead>
-			<tr>
-				<th>Element type</th>
-				<th>Contrast ratio</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td>Normal Text</td>
-				<td>
-					4.5:1 (AA)<br>
-					7:1 (AAA)
-				</td>
-			</tr>
-			<tr>
-				<td>Large Text</td>
-				<td>
-					3:1 (AA)<br>
-					4.5:1 (AAA)
-				</td>
-			</tr>
-		</tbody>
-	</table>
+<table>
+	<thead>
+		<tr>
+			<th>Element type</th>
+			<th>Contrast ratio</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Normal Text</td>
+			<td>
+				4.5:1 (AA)<br>
+				7:1 (AAA)
+			</td>
+		</tr>
+		<tr>
+			<td>Large Text</td>
+			<td>
+				3:1 (AA)<br>
+				4.5:1 (AAA)
+			</td>
+		</tr>
+	</tbody>
+</table>
 
-	<h6>Normal Text</h6>
-	<p>Normal text must have a contrast ratio of at least 4.5:1 to pass AA guidelines and 7:1 to pass AAA guidelines. This is accurate only if your font is <strong>at least 16px with Regular weight or heavier.</strong></p>
+<h6>Normal Text</h6>
+<p>Normal text must have a contrast ratio of at least 4.5:1 to pass AA guidelines and 7:1 to pass AAA guidelines. This is accurate only if your font is <strong>at least 16px with Regular weight or heavier.</strong></p>
 
-	<h6>Large Text</h6>
-	<p>Large text must have a contrast ratio of at least 3:1 to pass AA guidelines and 4.5:1 to pass AAA guidelines. This is accurate only if your font is <strong>at least 18.66px with Bold weight or 24px.</strong></p>
- 
-	<h6>As a result, we've ensured that in the palettes that we provide, the following are enforced:</h6>
-	<ul>
-		<li>"70" (e.g. 80 - 10) palette steps apart guarantees at least a 7:1 ratio</li>
-		<li>"60" (e.g. 70 - 10) palette steps apart guarantees at least a 4.5:1 ratio</li>
-	</ul>
+<h6>Large Text</h6>
+<p>Large text must have a contrast ratio of at least 3:1 to pass AA guidelines and 4.5:1 to pass AAA guidelines. This is accurate only if your font is <strong>at least 18.66px with Bold weight or 24px.</strong></p>
 
-	<p>Note, there may be smaller increments that allow for the contrast ratios to be met (e.g. "20/70" passes a 4.5:1 ratio), but this is not consistently reliable across and within palettes, so please use this at your discretion.</p>
+<h6>As a result, we've ensured that in the palettes that we provide, the following are enforced:</h6>
+<ul>
+	<li>"70" (e.g. 80 - 10) palette steps apart guarantees at least a 7:1 ratio</li>
+	<li>"60" (e.g. 70 - 10) palette steps apart guarantees at least a 4.5:1 ratio</li>
+</ul>
 
-	<h3>Color palettes</h3>
-	<div class="dl-color__grid">
-			<div class="dl-color__palette primary">
-			<div style="background-color: #f1f3fc;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#f1f3fc</span></div>
-			<div style="background-color: #e4e7fa;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#e4e7fa</span></div>
-			<div style="background-color: #bec7f7;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#bec7f7</span></div>
-			<div style="background-color: #95a6f7;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#95a6f7</span></div>
-			<div style="background-color: #6e89fa;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#6e89fa</span></div>
-			<div class="dl-color__default" style="background-color: #1f66ff;"><span class="dl-color__hex">60 Blue</span><span class="dl-color__hue">#1f66ff</span></div>
-			<div style="background-color: #174fc9;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#174fc9</span></div>
-			<div style="background-color: #183b93;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#183b93</span></div>
-			<div style="background-color: #132a68;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#132a68</span></div>
-			<div style="background-color: #0d1b45;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#0d1b45</span></div>
-		</div>
+<p>Note, there may be smaller increments that allow for the contrast ratios to be met (e.g. "20/70" passes a 4.5:1 ratio), but this is not consistently reliable across and within palettes, so please use this at your discretion.</p>
 
-		<div class="dl-color__palette secondary">
-			<div style="background-color: #f3f2fc;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#f3f2fc</span></div>
-			<div style="background-color: #e7e6fa;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#e7e6fa</span></div>
-			<div style="background-color: #c7c4f7;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#c7c4f7</span></div>
-			<div style="background-color: #a7a1f7;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#a7a1f7</span></div>
-			<div style="background-color: #8e84fa;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#8e84fa</span></div>
-			<div class="dl-color__default" style="background-color: #6a57ff;"><span class="dl-color__hex">60 Purple</span><span class="dl-color__hue">#6a57ff</span></div>
-			<div style="background-color: #4d2df3;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#4d2df3</span></div>
-			<div style="background-color: #391dbe;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#391dbe</span></div>
-			<div style="background-color: #281885;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#281885</span></div>
-			<div style="background-color: #191057;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#191057</span></div>
-		</div>
-
-		<div class="dl-color__palette tertiary">
-			<div style="background-color: #d6fcea;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#d6fcea</span></div>
-			<div style="background-color: #9dfbd3;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#9dfbd3</span></div>
-			<div style="background-color: #51e1ae;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#51e1ae</span></div>
-			<div style="background-color: #37c193;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#37c193</span></div>
-			<div style="background-color: #1fa67c;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#1fa67c</span></div>
-			<div class="dl-color__default" style="background-color: #00835f;"><span class="dl-color__hex">60 Turquoise</span><span class="dl-color__hue">#00835f</span></div>
-			<div style="background-color: #0f654a;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#0f654a</span></div>
-			<div style="background-color: #104b37;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#104b37</span></div>
-			<div style="background-color: #0d3426;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#0d3426</span></div>
-			<div style="background-color: #082218;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#082218</span></div>
-		</div>
+<h3>Color palettes</h3>
+<div class="dl-color__grid">
+		<div class="dl-color__palette primary">
+		<div style="background-color: #f1f3fc;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#f1f3fc</span></div>
+		<div style="background-color: #e4e7fa;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#e4e7fa</span></div>
+		<div style="background-color: #bec7f7;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#bec7f7</span></div>
+		<div style="background-color: #95a6f7;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#95a6f7</span></div>
+		<div style="background-color: #6e89fa;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#6e89fa</span></div>
+		<div class="dl-color__default" style="background-color: #1f66ff;"><span class="dl-color__hex">60 Blue</span><span class="dl-color__hue">#1f66ff</span></div>
+		<div style="background-color: #174fc9;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#174fc9</span></div>
+		<div style="background-color: #183b93;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#183b93</span></div>
+		<div style="background-color: #132a68;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#132a68</span></div>
+		<div style="background-color: #0d1b45;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#0d1b45</span></div>
 	</div>
 
-	<h3>Decorative palettes</h3>
-	<p>The decorative palettes consists of colors that should be reserved for indicators, avatars, and data visualization. These colors should be used sparingly. The yellow palette is important to the Daffodil brand and should not be used for warning indicators.</p>
-	<div class="dl-color__decorative-grid">
-		<div class="dl-color__palette brand-yellow">
-			<div style="background-color: #fffaeb;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#fffaeb</span></div>
-			<div style="background-color: #fff1c2;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#fff1c2</span></div>
-			<div style="background-color: #ffe799;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#ffe799</span></div>
-			<div style="background-color: #ffde70;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#ffde70</span></div>
-			<div style="background-color: #ffd447;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#ffd447</span></div>
-			<div class="dl-color__default" style="background-color: #ffc810;"><span class="dl-color__hex">60 Yellow</span><span class="dl-color__hue">#ffc810</span></div>
-			<div style="background-color: #f5bc00;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#f5bc00</span></div>
-			<div style="background-color: #cc9c00;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#cc9c00</span></div>
-			<div style="background-color: #a37d00;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#a37d00</span></div>
-			<div style="background-color: #7a5e00;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#7a5e00</span></div>
-		</div>
-
-		<div class="dl-color__palette bronze">
-			<div style="background-color: #fbf2ec;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#fbf2ec</span></div>
-			<div style="background-color: #f7e1d3;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#f7e1d3</span></div>
-			<div style="background-color: #f2c093;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#f2c093</span></div>
-			<div style="background-color: #e49d40;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#e49d40</span></div>
-			<div style="background-color: #d2801a;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#d2801a</span></div>
-			<div class="dl-color__default" style="background-color: #b36200;"><span class="dl-color__hex">60 Bronze</span><span class="dl-color__hue">#b36200</span></div>
-			<div style="background-color: #955400;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#955400</span></div>
-			<div style="background-color: #704000;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#704000</span></div>
-			<div style="background-color: #462900;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#462900</span></div>
-			<div style="background-color: #1a0f00;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#1a0f00</span></div>
-		</div>
-
-		<div class="dl-color__palette red-palette">
-			<div style="background-color: #fcf1f1;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#fcf1f1</span></div>
-			<div style="background-color: #fae0e0;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#fae0e0</span></div>
-			<div style="background-color: #f8babb;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#f8babb</span></div>
-			<div style="background-color: #f88d8f;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#f88d8f</span></div>
-			<div style="background-color: #fb5d61;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#fb5d61</span></div>
-			<div class="dl-color__default" style="background-color: #ec0019;"><span class="dl-color__hex">60 Red</span><span class="dl-color__hue">#ec0019</span></div>
-			<div style="background-color: #b30e19;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#b30e19</span></div>
-			<div style="background-color: #871016;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#860f0f</span></div>
-			<div style="background-color: #5e0c10;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#5e0c10</span></div>
-			<div style="background-color: #3f0809;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#400808</span></div>
-		</div>
-
-		<div class="dl-color__palette green">
-			<div style="background-color: #dafcde;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#dafcde</span></div>
-			<div style="background-color: #a9fbb5;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#a9fbb5</span></div>
-			<div style="background-color: #4ee56e;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#4ee56e</span></div>
-			<div style="background-color: #35c457;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#35c457</span></div>
-			<div style="background-color: #1da943;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#1da943</span></div>
-			<div class="dl-color__default" style="background-color: #00872f;"><span class="dl-color__hex">60 Green</span><span class="dl-color__hue">#00872f</span></div>
-			<div style="background-color: #0e6726;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#0e6726</span></div>
-			<div style="background-color: #0f4c1e;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#0f4c1e</span></div>
-			<div style="background-color: #0c3515;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#0c3515</span></div>
-			<div style="background-color: #07230d;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#07230d</span></div>
-		</div>
+	<div class="dl-color__palette secondary">
+		<div style="background-color: #f3f2fc;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#f3f2fc</span></div>
+		<div style="background-color: #e7e6fa;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#e7e6fa</span></div>
+		<div style="background-color: #c7c4f7;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#c7c4f7</span></div>
+		<div style="background-color: #a7a1f7;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#a7a1f7</span></div>
+		<div style="background-color: #8e84fa;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#8e84fa</span></div>
+		<div class="dl-color__default" style="background-color: #6a57ff;"><span class="dl-color__hex">60 Purple</span><span class="dl-color__hue">#6a57ff</span></div>
+		<div style="background-color: #4d2df3;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#4d2df3</span></div>
+		<div style="background-color: #391dbe;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#391dbe</span></div>
+		<div style="background-color: #281885;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#281885</span></div>
+		<div style="background-color: #191057;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#191057</span></div>
 	</div>
-</daff-article>
+
+	<div class="dl-color__palette tertiary">
+		<div style="background-color: #d6fcea;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#d6fcea</span></div>
+		<div style="background-color: #9dfbd3;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#9dfbd3</span></div>
+		<div style="background-color: #51e1ae;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#51e1ae</span></div>
+		<div style="background-color: #37c193;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#37c193</span></div>
+		<div style="background-color: #1fa67c;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#1fa67c</span></div>
+		<div class="dl-color__default" style="background-color: #00835f;"><span class="dl-color__hex">60 Turquoise</span><span class="dl-color__hue">#00835f</span></div>
+		<div style="background-color: #0f654a;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#0f654a</span></div>
+		<div style="background-color: #104b37;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#104b37</span></div>
+		<div style="background-color: #0d3426;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#0d3426</span></div>
+		<div style="background-color: #082218;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#082218</span></div>
+	</div>
+</div>
+
+<h3>Decorative palettes</h3>
+<p>The decorative palettes consists of colors that should be reserved for indicators, avatars, and data visualization. These colors should be used sparingly. The yellow palette is important to the Daffodil brand and should not be used for warning indicators.</p>
+<div class="dl-color__decorative-grid">
+	<div class="dl-color__palette brand-yellow">
+		<div style="background-color: #fffaeb;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#fffaeb</span></div>
+		<div style="background-color: #fff1c2;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#fff1c2</span></div>
+		<div style="background-color: #ffe799;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#ffe799</span></div>
+		<div style="background-color: #ffde70;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#ffde70</span></div>
+		<div style="background-color: #ffd447;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#ffd447</span></div>
+		<div class="dl-color__default" style="background-color: #ffc810;"><span class="dl-color__hex">60 Yellow</span><span class="dl-color__hue">#ffc810</span></div>
+		<div style="background-color: #f5bc00;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#f5bc00</span></div>
+		<div style="background-color: #cc9c00;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#cc9c00</span></div>
+		<div style="background-color: #a37d00;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#a37d00</span></div>
+		<div style="background-color: #7a5e00;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#7a5e00</span></div>
+	</div>
+
+	<div class="dl-color__palette bronze">
+		<div style="background-color: #fbf2ec;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#fbf2ec</span></div>
+		<div style="background-color: #f7e1d3;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#f7e1d3</span></div>
+		<div style="background-color: #f2c093;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#f2c093</span></div>
+		<div style="background-color: #e49d40;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#e49d40</span></div>
+		<div style="background-color: #d2801a;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#d2801a</span></div>
+		<div class="dl-color__default" style="background-color: #b36200;"><span class="dl-color__hex">60 Bronze</span><span class="dl-color__hue">#b36200</span></div>
+		<div style="background-color: #955400;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#955400</span></div>
+		<div style="background-color: #704000;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#704000</span></div>
+		<div style="background-color: #462900;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#462900</span></div>
+		<div style="background-color: #1a0f00;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#1a0f00</span></div>
+	</div>
+
+	<div class="dl-color__palette red-palette">
+		<div style="background-color: #fcf1f1;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#fcf1f1</span></div>
+		<div style="background-color: #fae0e0;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#fae0e0</span></div>
+		<div style="background-color: #f8babb;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#f8babb</span></div>
+		<div style="background-color: #f88d8f;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#f88d8f</span></div>
+		<div style="background-color: #fb5d61;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#fb5d61</span></div>
+		<div class="dl-color__default" style="background-color: #ec0019;"><span class="dl-color__hex">60 Red</span><span class="dl-color__hue">#ec0019</span></div>
+		<div style="background-color: #b30e19;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#b30e19</span></div>
+		<div style="background-color: #871016;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#860f0f</span></div>
+		<div style="background-color: #5e0c10;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#5e0c10</span></div>
+		<div style="background-color: #3f0809;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#400808</span></div>
+	</div>
+
+	<div class="dl-color__palette green">
+		<div style="background-color: #dafcde;"><span class="dl-color__hex">10</span><span class="dl-color__hue">#dafcde</span></div>
+		<div style="background-color: #a9fbb5;"><span class="dl-color__hex">20</span><span class="dl-color__hue">#a9fbb5</span></div>
+		<div style="background-color: #4ee56e;"><span class="dl-color__hex">30</span><span class="dl-color__hue">#4ee56e</span></div>
+		<div style="background-color: #35c457;"><span class="dl-color__hex">40</span><span class="dl-color__hue">#35c457</span></div>
+		<div style="background-color: #1da943;"><span class="dl-color__hex">50</span><span class="dl-color__hue">#1da943</span></div>
+		<div class="dl-color__default" style="background-color: #00872f;"><span class="dl-color__hex">60 Green</span><span class="dl-color__hue">#00872f</span></div>
+		<div style="background-color: #0e6726;"><span class="dl-color__hex">70</span><span class="dl-color__hue">#0e6726</span></div>
+		<div style="background-color: #0f4c1e;"><span class="dl-color__hex">80</span><span class="dl-color__hue">#0f4c1e</span></div>
+		<div style="background-color: #0c3515;"><span class="dl-color__hex">90</span><span class="dl-color__hue">#0c3515</span></div>
+		<div style="background-color: #07230d;"><span class="dl-color__hex">100</span><span class="dl-color__hue">#07230d</span></div>
+	</div>
+</div>

--- a/apps/design-land/src/app/foundations/variables/variables.component.html
+++ b/apps/design-land/src/app/foundations/variables/variables.component.html
@@ -1,57 +1,55 @@
-<daff-article>
-	<h1 daffArticleTitle>Variables</h1>
-	<p daffArticleLead>Daffodil's CSS custom properties can be used for fast and easy design and development. We provide common, functional CSS variables that can be used to quickly style elements without the need to create theme files.</p>
+<h1 daffArticleTitle>Variables</h1>
+<p daffArticleLead>Daffodil's CSS custom properties can be used for fast and easy design and development. We provide common, functional CSS variables that can be used to quickly style elements without the need to create theme files.</p>
 
-	<h2>CSS Custom Properties</h2>
-	<p>Our custom properties are prefixed with <code>daff-</code> to avoid conflicts with third party variables.</p>
-	<table>
-		<thead>
-			<tr>
-				<th>Variable</th>
-				<th>Description</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td>--daff-theme-rgb</td>
-				<td>The theme's base color in RGB</td>
-			</tr>
-			<tr>
-				<td>--daff-theme-contrast-rgb</td>
-				<td>The theme's base contrast color in RGB</td>
-			</tr>
-			<tr>
-				<td>--daff-theme</td>
-				<td>The theme's base color</td>
-			</tr>
-			<tr>
-				<td>--daff-theme-contrast</td>
-				<td>The theme's base contrast color</td>
-			</tr>
-			<tr>
-				<td>--daff-theme-primary</td>
-				<td>The theme's primary color</td>
-			</tr>
-			<tr>
-				<td>--daff-theme-secondary</td>
-				<td>The theme's secondary color</td>
-			</tr>
-			<tr>
-				<td>--daff-theme-tertiary</td>
-				<td>The theme's tertiary color</td>
-			</tr>
-			<tr>
-				<td>--daff-theme-warn</td>
-				<td>The theme's warning color</td>
-			</tr>
-			<tr>
-				<td>--daff-theme-success</td>
-				<td>The theme's success color</td>
-			</tr>
-			<tr>
-				<td>--daff-theme-danger</td>
-				<td>The theme's danger color</td>
-			</tr>
-		</tbody>
-	</table>
-</daff-article>
+<h2>CSS Custom Properties</h2>
+<p>Our custom properties are prefixed with <code>daff-</code> to avoid conflicts with third party variables.</p>
+<table>
+	<thead>
+		<tr>
+			<th>Variable</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>--daff-theme-rgb</td>
+			<td>The theme's base color in RGB</td>
+		</tr>
+		<tr>
+			<td>--daff-theme-contrast-rgb</td>
+			<td>The theme's base contrast color in RGB</td>
+		</tr>
+		<tr>
+			<td>--daff-theme</td>
+			<td>The theme's base color</td>
+		</tr>
+		<tr>
+			<td>--daff-theme-contrast</td>
+			<td>The theme's base contrast color</td>
+		</tr>
+		<tr>
+			<td>--daff-theme-primary</td>
+			<td>The theme's primary color</td>
+		</tr>
+		<tr>
+			<td>--daff-theme-secondary</td>
+			<td>The theme's secondary color</td>
+		</tr>
+		<tr>
+			<td>--daff-theme-tertiary</td>
+			<td>The theme's tertiary color</td>
+		</tr>
+		<tr>
+			<td>--daff-theme-warn</td>
+			<td>The theme's warning color</td>
+		</tr>
+		<tr>
+			<td>--daff-theme-success</td>
+			<td>The theme's success color</td>
+		</tr>
+		<tr>
+			<td>--daff-theme-danger</td>
+			<td>The theme's danger color</td>
+		</tr>
+	</tbody>
+</table>

--- a/apps/design-land/src/app/hero/hero.component.html
+++ b/apps/design-land/src/app/hero/hero.component.html
@@ -1,54 +1,52 @@
-<daff-article>
-  <h1>Hero</h1>
-  <p daffArticleLead>Hero is a top level container that is large and captivating. It should only be used once as the first container on any given page.</p>
+<h1 daffArticleTitle>Hero</h1>
+<p daffArticleLead>Hero is a top level container that is large and captivating. It should only be used once as the first container on any given page.</p>
 
-  <h2>Overview</h2>
-  <p>Heros are the first thing users see on a page and are designed to catch their attention. It's a flexible and extensible component that includes pre-styled content containers.</p>
+<h2>Overview</h2>
+<p>Heros are the first thing users see on a page and are designed to catch their attention. It's a flexible and extensible component that includes pre-styled content containers.</p>
 
-  <h2>Supported Content Types</h2>
-  <p>A <code>&lt;daff-hero&gt;</code> supports transclusion of any content and includes stylized <code>icon</code>, <code>tagline</code>, <code>title</code>, <code>subtitle</code>, and <code>body</code> content containers.</p>
+<h2>Supported Content Types</h2>
+<p>A <code>&lt;daff-hero&gt;</code> supports transclusion of any content and includes stylized <code>icon</code>, <code>tagline</code>, <code>title</code>, <code>subtitle</code>, and <code>body</code> content containers.</p>
 
-  <h3>Icon</h3>
-  <p><code>[daffHeroIcon]</code> is intended for visual or branding reinforcement. It should not be used for actionable icons.</p>
+<h3>Icon</h3>
+<p><code>[daffHeroIcon]</code> is intended for visual or branding reinforcement. It should not be used for actionable icons.</p>
 
-  <h3>Tagline</h3>
-  <p>Hero taglines are used by adding <code>[daffHeroTagline]</code> to a <code>&lt;p&gt;</code> tag. It's intended to supplement the title by providing a short, memorable description.</p>
+<h3>Tagline</h3>
+<p>Hero taglines are used by adding <code>[daffHeroTagline]</code> to a <code>&lt;p&gt;</code> tag. It's intended to supplement the title by providing a short, memorable description.</p>
 
-  <h3>Title</h3>
-  <p>Hero titles are used by adding <code>[daffHeroTitle]</code> to a <code>&lt;h1&gt;</code> tag.</p>
+<h3>Title</h3>
+<p>Hero titles are used by adding <code>[daffHeroTitle]</code> to a <code>&lt;h1&gt;</code> tag.</p>
 
-  <h3>Subtitle</h3>
-  <p>Hero subtitles are used by adding <code>[daffHeroSubtitle]</code> to a <code>&lt;h2&gt;</code> tag.</p>
+<h3>Subtitle</h3>
+<p>Hero subtitles are used by adding <code>[daffHeroSubtitle]</code> to a <code>&lt;h2&gt;</code> tag.</p>
 
-  <h3>Body</h3>
-  <p><code>[daffHeroBody]</code> is a wrapper container that can be used to place all additional components and content within a <code>&lt;daff-hero&gt;</code> and should only be used once. The body container allows for a ton of control and customization because it's not affected by any of hero's properties and only serves as a wrapping and spacing container.</p>
+<h3>Body</h3>
+<p><code>[daffHeroBody]</code> is a wrapper container that can be used to place all additional components and content within a <code>&lt;daff-hero&gt;</code> and should only be used once. The body container allows for a ton of control and customization because it's not affected by any of hero's properties and only serves as a wrapping and spacing container.</p>
 
-  <h2>Theming</h2>
-  <p>The default background color of a hero is light gray, but it can be updated to one of the supported colors by using the <code>color</code> property.</p>
-  <p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
+<h2>Theming</h2>
+<p>The default background color of a hero is light gray, but it can be updated to one of the supported colors by using the <code>color</code> property.</p>
+<p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
 
-  <design-land-example-viewer-container example="hero-theming"></design-land-example-viewer-container>
+<design-land-example-viewer-container example="hero-theming"></design-land-example-viewer-container>
 
-  <h2>Text Alignment</h2>
-  <p>Align hero-specific text with the <code>textAlignment</code> property. <code>textAlignment</code> will not cascade the alignment styles down to <code>[daffHeroBody]</code> or any additional components or elements that are placed inside of a hero. <code>textAlignment</code> is set to <code>left</code> by default.</p>
-  <p>Supported alignments: <code>left | center | right</code></p>
-  
-  <design-land-example-viewer-container example="hero-text-alignment"></design-land-example-viewer-container>
+<h2>Text Alignment</h2>
+<p>Align hero-specific text with the <code>textAlignment</code> property. <code>textAlignment</code> will not cascade the alignment styles down to <code>[daffHeroBody]</code> or any additional components or elements that are placed inside of a hero. <code>textAlignment</code> is set to <code>left</code> by default.</p>
+<p>Supported alignments: <code>left | center | right</code></p>
 
-  <h2>Compact Heroes</h2>
-  <p>Heroes are available in a <code>compact</code> mode, which decreases the overall padding of the hero container to suit UIs that require less negative space. To enable the mode, set the <code>compact</code> property on <code>&lt;daff-hero&gt;</code>.</p>
+<design-land-example-viewer-container example="hero-text-alignment"></design-land-example-viewer-container>
 
-  <design-land-example-viewer-container example="compact-hero"></design-land-example-viewer-container>
+<h2>Compact Heroes</h2>
+<p>Heroes are available in a <code>compact</code> mode, which decreases the overall padding of the hero container to suit UIs that require less negative space. To enable the mode, set the <code>compact</code> property on <code>&lt;daff-hero&gt;</code>.</p>
 
-  <h2>Gridded Heroes</h2>
-  <p>Heros are flexible enough to support grids within them.</p>
+<design-land-example-viewer-container example="compact-hero"></design-land-example-viewer-container>
 
-  <h3>Hero with Two Columns</h3>
-  <design-land-example-viewer-container example="hero-with-grid"></design-land-example-viewer-container>
+<h2>Gridded Heroes</h2>
+<p>Heros are flexible enough to support grids within them.</p>
 
-  <h2>Size</h2>
-  <p>The <code>size</code> property will be deprecated in v1.0.0. <code>compact</code> will be replaced by the <code>DaffCompactable</code> interface.</p>
+<h3>Hero with Two Columns</h3>
+<design-land-example-viewer-container example="hero-with-grid"></design-land-example-viewer-container>
 
-  <h2>Layout</h2>
-  <p>The <code>layout</code> property will be deprecated in v1.0.0</p>
-</daff-article>
+<h2>Size</h2>
+<p>The <code>size</code> property will be deprecated in v1.0.0. <code>compact</code> will be replaced by the <code>DaffCompactable</code> interface.</p>
+
+<h2>Layout</h2>
+<p>The <code>layout</code> property will be deprecated in v1.0.0</p>

--- a/apps/design-land/src/app/list/list.component.html
+++ b/apps/design-land/src/app/list/list.component.html
@@ -1,28 +1,26 @@
-<daff-article>
-  <h1>List</h1>
-  <p><code>DaffListComponent</code> is a flexible component that can be used to display a series of content. It can be modified to support a range of content types.</p>
+<h1 daffArticleTitle>List</h1>
+<p daffArticleLead> List is a flexible component that can be used to display a series of content. It can be modified to support a range of content types.</p>
 
-  <h4>Basic Lists</h4>
-  <p>A <code>&lt;daff-list&gt;</code> consists of multiple <code>&lt;daff-list-item&gt;s</code>.</p>
-  <design-land-example-viewer-container example="basic-list"></design-land-example-viewer-container>
+<h2>Basic Lists</h2>
+<p>A <code>&lt;daff-list&gt;</code> consists of multiple <code>&lt;daff-list-item&gt;s</code>.</p>
+<design-land-example-viewer-container example="basic-list"></design-land-example-viewer-container>
 
-  <h4>Navigation Lists</h4>
-  <p>Use <code>&lt;daff-nav-list&gt;</code> for navigation lists. <code>&lt;mat-list-item&gt;</code>should be added to an anchor tag directly.</p>
-  <design-land-example-viewer-container example="nav-list"></design-land-example-viewer-container>
+<h2>Navigation Lists</h2>
+<p>Use <code>&lt;daff-nav-list&gt;</code> for navigation lists. <code>&lt;mat-list-item&gt;</code>should be added to an anchor tag directly.</p>
+<design-land-example-viewer-container example="nav-list"></design-land-example-viewer-container>
 
-  <h4>Multi-line Lists</h4>
-  <p>For lists that have multiple lines per item, wrap each line appropriately with a heading or paragraph tag.</p>
-  <design-land-example-viewer-container example="multiline-list"></design-land-example-viewer-container>
+<h2>Multi-line Lists</h2>
+<p>For lists that have multiple lines per item, wrap each line appropriately with a heading or paragraph tag.</p>
+<design-land-example-viewer-container example="multiline-list"></design-land-example-viewer-container>
 
-  <h4>List with Icons</h4>
-  <p>To add an icon to a list item, use the <code>&lt;golfPrefix&gt;</code> or <code>&lt;golfSuffix&gt;</code> attributes for the appropriate placements.</p>
-  <design-land-example-viewer-container example="icon-list"></design-land-example-viewer-container>
+<h2>List with Icons</h2>
+<p>To add an icon to a list item, use the <code>&lt;golfPrefix&gt;</code> or <code>&lt;golfSuffix&gt;</code> attributes for the appropriate placements.</p>
+<design-land-example-viewer-container example="icon-list"></design-land-example-viewer-container>
 
-  <h4>Deprecation Notice</h4>
-  <p>The <code>mode</code> property will be deprecated in v1.0.0.</p>
-  <ul>
-    <li><code>mode="navigation"</code> is replaced with <code>&lt;daff-nav-list&gt;</code>.</li>
-    <li><code>mode="link"</code> is replaced with <code>&lt;daff-nav-list&gt;</code>.</li>
-    <li><code>mode="multiline"</code> is completely deprecated. Multi-line lists will be a natural result of adding multiple lines to a <code>&lt;daff-list-item&gt;</code>.</li>
-  </ul>
-</daff-article>
+<h2>Deprecation Notice</h2>
+<p>The <code>mode</code> property will be deprecated in v1.0.0.</p>
+<ul>
+  <li><code>mode="navigation"</code> is replaced with <code>&lt;daff-nav-list&gt;</code>.</li>
+  <li><code>mode="link"</code> is replaced with <code>&lt;daff-nav-list&gt;</code>.</li>
+  <li><code>mode="multiline"</code> is completely deprecated. Multi-line lists will be a natural result of adding multiple lines to a <code>&lt;daff-list-item&gt;</code>.</li>
+</ul>

--- a/apps/design-land/src/app/loading-icon/loading-icon.component.html
+++ b/apps/design-land/src/app/loading-icon/loading-icon.component.html
@@ -1,37 +1,34 @@
-<daff-article>
-  <h1 daffArticleTitle>Loading Icon</h1>
-  <p daffArticleLead>
-    The loading icon is used as an indicator of an event in progress.
-  </p>
+<h1 daffArticleTitle>Loading Icon</h1>
+<p daffArticleLead>
+  The loading icon is used as an indicator of an event in progress.
+</p>
 
-  <h2>About</h2>
-  <p>
-    This loading icon can be used to indicate that an event is ocurring and is still in progress.
-    The color and size of the loading icon can be customized to suit the needs of your project.
-  </p>
+<h2>About</h2>
+<p>
+  This loading icon can be used to indicate that an event is ocurring and is still in progress.
+  The color and size of the loading icon can be customized to suit the needs of your project.
+</p>
 
-  <h3>Diameter</h3>
-  <p>
-    The diameter of a loading icon can be defined by using the <code>diameter</code> property. By default, the diameter is set to <code>60</code>.
-  </p>
-  <design-land-example-viewer-container example="loading-icon-diameter"></design-land-example-viewer-container>
+<h3>Diameter</h3>
+<p>
+  The diameter of a loading icon can be defined by using the <code>diameter</code> property. By default, the diameter is set to <code>60</code>.
+</p>
+<design-land-example-viewer-container example="loading-icon-diameter"></design-land-example-viewer-container>
 
-  <h3>Theming</h3>
-  <p>
-    The loading icon color is defined by using the <code>color</code> property. By default, the color is set to 
-    <code>primary</code>. This can be changed to one of the supported colors.
-  </p>
-  <p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
-  <design-land-example-viewer-container example="loading-icon-color"></design-land-example-viewer-container>
+<h3>Theming</h3>
+<p>
+  The loading icon color is defined by using the <code>color</code> property. By default, the color is set to 
+  <code>primary</code>. This can be changed to one of the supported colors.
+</p>
+<p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
+<design-land-example-viewer-container example="loading-icon-color"></design-land-example-viewer-container>
 
-  <h3>Accessibility</h3>
-  <p>
-    Loading icons should be given meaningful labels by using <code>aria-label</code> or <code>aria-labelledby</code>.
-    Additionally, if a loading icon is used to indicate a process in progress, using
-    <a href="https://www.w3.org/TR/wai-aria-1.0/states_and_properties#aria-live" target="_blank"><code>aria-live</code></a> 
-    and
-    <a href="https://www.w3.org/TR/wai-aria-1.0/states_and_properties#aria-busy" target="_blank"><code>aria-busy</code></a>
-    should be strongly considered.
-  </p>
-
-</daff-article>
+<h3>Accessibility</h3>
+<p>
+  Loading icons should be given meaningful labels by using <code>aria-label</code> or <code>aria-labelledby</code>.
+  Additionally, if a loading icon is used to indicate a process in progress, using
+  <a href="https://www.w3.org/TR/wai-aria-1.0/states_and_properties#aria-live" target="_blank"><code>aria-live</code></a> 
+  and
+  <a href="https://www.w3.org/TR/wai-aria-1.0/states_and_properties#aria-busy" target="_blank"><code>aria-busy</code></a>
+  should be strongly considered.
+</p>

--- a/apps/design-land/src/app/media-gallery/media-gallery.component.html
+++ b/apps/design-land/src/app/media-gallery/media-gallery.component.html
@@ -1,19 +1,17 @@
-<daff-article>
-	<h1 daffArticleTitle>Media Gallery</h1>
-	<p daffArticleLead><code>&lt;daff-media-gallery&gt;</code> is used to display a group of <code>[daffThumbnail]</code>s in a gallery format. Media galleries are useful to showcase multiple images related to a single product or topic.</p>
+<h1 daffArticleTitle>Media Gallery</h1>
+<p daffArticleLead>Media gallery is used to display a group of thumbnails in a gallery format. Media galleries are useful to showcase multiple images related to a single product or topic.</p>
 
-	<h2>Thumbnail</h2>
-	<p><code>[daffThumbnail]</code>should be used as a directive with <code>&lt;daff-image&gt;</code>. (View <a href="/image">Image Documentation</a>)</p>
-	<p>It should never be used as a standalone component. The first thumbnail is selected by default and dynamically rendered as the primary image by utilizing the <code>&lt;daff-media-renderer&gt;</code> component. The selected thumbnail can be controlled by the enduser, and the position of the list of thumbnails is dependent on the screen size.</p>
+<h2>Thumbnail</h2>
+<p><code>[daffThumbnail]</code>should be used as a directive with <code>&lt;daff-image&gt;</code>. (View <a href="/image">Image Documentation</a>)</p>
+<p>It should never be used as a standalone component. The first thumbnail is selected by default and dynamically rendered as the primary image by utilizing the <code>&lt;daff-media-renderer&gt;</code> component. The selected thumbnail can be controlled by the enduser, and the position of the list of thumbnails is dependent on the screen size.</p>
 
-	<design-land-example-viewer-container example="basic-media-gallery"></design-land-example-viewer-container>
+<design-land-example-viewer-container example="basic-media-gallery"></design-land-example-viewer-container>
 
-	<h2>Image Aspect Ratio</h2>
-	<p>It's recommended to utilize the same aspect ratio for all images in the same media gallery. Otherwise, the height and width of the media gallery may change with every different aspect ratio presented by the selected thumbnail as show in the example.</p>
+<h2>Image Aspect Ratio</h2>
+<p>It's recommended to utilize the same aspect ratio for all images in the same media gallery. Otherwise, the height and width of the media gallery may change with every different aspect ratio presented by the selected thumbnail as show in the example.</p>
 
-	<p>The thumbnail dimension is set to <code>80x80</code> pixels, so the recommended aspect ratio is <code>1:1</code>. However, it is not required since the thumbnail will horizontally and vertically center align images within a thumbnail.</p>
-	<design-land-example-viewer-container example="mismatched-sizes-media-gallery"></design-land-example-viewer-container>
+<p>The thumbnail dimension is set to <code>80x80</code> pixels, so the recommended aspect ratio is <code>1:1</code>. However, it is not required since the thumbnail will horizontally and vertically center align images within a thumbnail.</p>
+<design-land-example-viewer-container example="mismatched-sizes-media-gallery"></design-land-example-viewer-container>
 
-	<h2>Accessibility</h2>
-	<p>Accessibility considerations for media gallery is handled by the <code>DaffImageComponent</code>. The <code>alt</code> attribute must be defined in <code>&lt;daff-image&gt;</code>. It specifies an alternate text for an image. An error will appear if it's not defined. This is important because it allows screen readers to describe what's in the image for visually impaired people. (View <a href="/image">Image Documentation</a>)</p>
-</daff-article>
+<h2>Accessibility</h2>
+<p>Accessibility considerations for media gallery is handled by the <code>DaffImageComponent</code>. The <code>alt</code> attribute must be defined in <code>&lt;daff-image&gt;</code>. It specifies an alternate text for an image. An error will appear if it's not defined. This is important because it allows screen readers to describe what's in the image for visually impaired people. (View <a href="/image">Image Documentation</a>)</p>

--- a/apps/design-land/src/app/modal/modal.component.html
+++ b/apps/design-land/src/app/modal/modal.component.html
@@ -1,22 +1,17 @@
-<daff-article>
-	<h1 daffArticleTitle>Modal</h1>
-	<p daffArticleLead>The <code>DaffModalComponent</code> is a dynamically rendered element that floats about the rest of
-		a page's content. It can be especially useful for interstitials that require additional user feedback.</p>
+<h1 daffArticleTitle>Modal</h1>
+<p daffArticleLead>Modal is a dynamically rendered element that floats about the rest of a page's content. It can be especially useful for interstitials that require additional user feedback.</p>
 
-	<h3>Supported Content Types</h3>
-	<p>These components and directives help to structure the content in your modal.</p>
-	<p>The <code>DaffModalComponent</code> optionally transcludes:</p>
-	<ul>
-		<li><code>daff-modal-header</code>: component that places the <code>&lt;daffModalTitle&gt;</code> with styles to
-			handle the placement of an optional actionable icon.</li>
-		<li><code>daffModalTitle</code>: directive for modal title that can be applied to a heading element
-			(<code>&lt;h2&gt;</code>, &lt;h3&gt;, etc.)</li>
-		<li><code>daff-modal-content</code>: scrollable component to place the primary content in modal.</li>
-		<li><code>daff-modal-actions</code>: component to help place actionable components like buttons or links.</li>
-	</ul>
+<h2>Supported Content Types</h2>
+<p>These components and directives help to structure the content in your modal.</p>
+<p>The <code>DaffModalComponent</code> optionally transcludes:</p>
+<ul>
+	<li><code>daff-modal-header</code>: component that places the <code>&lt;daffModalTitle&gt;</code> with styles to
+		handle the placement of an optional actionable icon.</li>
+	<li><code>daffModalTitle</code>: directive for modal title that can be applied to a heading element
+		(<code>&lt;h2&gt;</code>, &lt;h3&gt;, etc.)</li>
+	<li><code>daff-modal-content</code>: scrollable component to place the primary content in modal.</li>
+	<li><code>daff-modal-actions</code>: component to help place actionable components like buttons or links.</li>
+</ul>
 
-	<h3>Usage</h3>
-
-	<design-land-example-viewer-container example="basic-modal"></design-land-example-viewer-container>
-
-</daff-article>
+<h2>Usage</h2>
+<design-land-example-viewer-container example="basic-modal"></design-land-example-viewer-container>

--- a/apps/design-land/src/app/navbar/navbar.component.html
+++ b/apps/design-land/src/app/navbar/navbar.component.html
@@ -1,29 +1,37 @@
-<daff-article>
-  <h1 daffArticleTitle>Navbar</h1>
-  <p daffArticleLead>Navbar is a flexible and extensible, horizontally stacked component intended for major blocks of navigation links.</p>
+<h1 daffArticleTitle>Navbar</h1>
+<p daffArticleLead>Navbar is a flexible and extensible, horizontally stacked component intended for major blocks of navigation links.</p>
 
-  <h2>Overview</h2>
-  <p>The navbar contains minimal layout styles, allowing the content within it to be fluid and customizable. It utilizes the <code>flex</code> display and is customizable with all the flexbox properties. It's required to be used with the native HTML <code>&lt;nav&gt;</code> element to ensure an accessible experience by default.</p>
+<h2>Overview</h2>
+<p>The navbar contains minimal layout styles, allowing the content within it to be fluid and customizable. It utilizes the <code>flex</code> display and is customizable with all the flexbox properties. It's required to be used with the native HTML <code>&lt;nav&gt;</code> element to ensure an accessible experience by default.</p>
 
-  <h2>Basic Navbar</h2>
+<h2>Basic Navbar</h2>
+<design-land-article-encapsulated>
   <design-land-example-viewer-container example="basic-navbar"></design-land-example-viewer-container>
+</design-land-article-encapsulated>
 
-  <h2>Theming</h2>
-  <p>The default background color of a navbar is light gray, but it can be updated to one of the supported colors by using the <code>color</code> property.</p>
-  <p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
+<h2>Theming</h2>
+<p>The default background color of a navbar is light gray, but it can be updated to one of the supported colors by using the <code>color</code> property.</p>
+<p>Supported colors: <code>primary | secondary | tertiary | black | white | theme | theme-contrast</code></p>
+
+<design-land-article-encapsulated>
   <design-land-example-viewer-container example="navbar-theming"></design-land-example-viewer-container>
+</design-land-article-encapsulated>
 
-  <h2>Contained Navbar</h2>
-  <p>A navbar can be contained to a specific width by using <code>&lt;daff-container&gt;</code>. <a routerLink="/container">(View Container Documentation)</a> The layout styles for the navbar will be passed down to the container by utilizing the <code>daffManageContainerLayoutMixin</code>.</p>
+<h2>Contained Navbar</h2>
+<p>A navbar can be contained to a specific width by using <code>&lt;daff-container&gt;</code>. <a routerLink="/container">(View Container Documentation)</a> The layout styles for the navbar will be passed down to the container by utilizing the <code>daffManageContainerLayoutMixin</code>.</p>
+<design-land-article-encapsulated>
   <design-land-example-viewer-container example="contained-navbar"></design-land-example-viewer-container>
+</design-land-article-encapsulated>
 
-  <h2>Raised Navbar</h2>
-  <p>The raised property adds elevation to a navbar. To enable it, set the <code>raised</code> property on <code>&lt;nav daff-navbar&gt;</code>.</p>
+<h2>Raised Navbar</h2>
+<p>The raised property adds elevation to a navbar. To enable it, set the <code>raised</code> property on <code>&lt;nav daff-navbar&gt;</code>.</p>
+<design-land-article-encapsulated>
   <design-land-example-viewer-container example="raised-navbar"></design-land-example-viewer-container>
+</design-land-article-encapsulated>
 
-  <h2>Accessibility</h2>
-  <p>Daffodil enforces the usage of the native <code>&lt;nav&gt;</code> HTML element to ensure an accessible experience by default. If more than one navbar is used, every navbar should be given a meaningful label by using the <code>aria-lablledby</code> attribute.</p>
-  <h3>Example</h3>
+<h2>Accessibility</h2>
+<p>Daffodil enforces the usage of the native <code>&lt;nav&gt;</code> HTML element to ensure an accessible experience by default. If more than one navbar is used, every navbar should be given a meaningful label by using the <code>aria-lablledby</code> attribute.</p>
+<h3>Example</h3>
 <pre>
 <code>
 &lt;nav daff-navbar aria-labelledby="main-navigation"&gt;
@@ -37,4 +45,3 @@
 &lt;/footer&gt;
 </code>
 </pre>
-</daff-article>

--- a/apps/design-land/src/app/navbar/navbar.module.ts
+++ b/apps/design-land/src/app/navbar/navbar.module.ts
@@ -5,9 +5,9 @@ import { RouterModule } from '@angular/router';
 import {
   DaffArticleModule,
   DaffNavbarModule,
-  DaffButtonModule,
 } from '@daffodil/design';
 
+import { DesignLandArticleEncapsulatedModule } from '../core/article-encapsulated/article-encapsulated.module';
 import { DesignLandExampleViewerModule } from '../core/code-preview/container/example-viewer.module';
 import { DesignLandNavbarRoutingModule } from './navbar-routing.module';
 import { DesignLandNavbarComponent } from './navbar.component';
@@ -24,9 +24,9 @@ import { DesignLandNavbarComponent } from './navbar.component';
     DesignLandNavbarRoutingModule,
     DesignLandExampleViewerModule,
 
-    DaffArticleModule,
     DaffNavbarModule,
-    DaffButtonModule,
+    DaffArticleModule,
+    DesignLandArticleEncapsulatedModule,
   ],
 })
 export class DesignLandNavbarModule { }

--- a/apps/design-land/src/app/paginator/paginator.component.html
+++ b/apps/design-land/src/app/paginator/paginator.component.html
@@ -1,15 +1,17 @@
-<h1>Daff Paginator</h1>
+	<h1 daffArticleTitle>Paginator</h1>
 
-<daff-paginator color="primary" aria-label="Primary" [numberOfPages]="numberOfPages" [currentPage]="primaryCurrentPage" (notifyPageChange)="onPageChange($event)"></daff-paginator>
+	<design-land-article-encapsulated>
+	<daff-paginator color="primary" aria-label="Primary" [numberOfPages]="numberOfPages" [currentPage]="primaryCurrentPage" (notifyPageChange)="onPageChange($event)"></daff-paginator>
 
-<daff-paginator color="secondary" aria-label="Secondary" [numberOfPages]="numberOfPages" [currentPage]="secondaryCurrentPage" (notifyPageChange)="onPageChange1($event)"></daff-paginator>
+	<daff-paginator color="secondary" aria-label="Secondary" [numberOfPages]="numberOfPages" [currentPage]="secondaryCurrentPage" (notifyPageChange)="onPageChange1($event)"></daff-paginator>
 
-<daff-paginator color="tertiary" aria-label="Tertiary" [numberOfPages]="numberOfPages" [currentPage]="tertiaryCurrentPage" (notifyPageChange)="onPageChange2($event)"></daff-paginator>
+	<daff-paginator color="tertiary" aria-label="Tertiary" [numberOfPages]="numberOfPages" [currentPage]="tertiaryCurrentPage" (notifyPageChange)="onPageChange2($event)"></daff-paginator>
 
-<daff-paginator color="theme" aria-label="Theme" [numberOfPages]="numberOfPages" [currentPage]="themeCurrentPage" (notifyPageChange)="onPageChange3($event)"></daff-paginator>
+	<daff-paginator color="theme" aria-label="Theme" [numberOfPages]="numberOfPages" [currentPage]="themeCurrentPage" (notifyPageChange)="onPageChange3($event)"></daff-paginator>
 
-<daff-paginator color="theme-contrast" aria-label="Theme Contrast" [numberOfPages]="numberOfPages" [currentPage]="themeContrastCurrentPage" (notifyPageChange)="onPageChange4($event)"></daff-paginator>
+	<daff-paginator color="theme-contrast" aria-label="Theme Contrast" [numberOfPages]="numberOfPages" [currentPage]="themeContrastCurrentPage" (notifyPageChange)="onPageChange4($event)"></daff-paginator>
 
-<daff-paginator color="black" aria-label="Black" [numberOfPages]="numberOfPages" [currentPage]="blackCurrentPage" (notifyPageChange)="onPageChange5($event)"></daff-paginator>
+	<daff-paginator color="black" aria-label="Black" [numberOfPages]="numberOfPages" [currentPage]="blackCurrentPage" (notifyPageChange)="onPageChange5($event)"></daff-paginator>
 
-<daff-paginator color="white" aria-label="White" [numberOfPages]="numberOfPages" [currentPage]="whiteCurrentPage" (notifyPageChange)="onPageChange6($event)"></daff-paginator>
+	<daff-paginator color="white" aria-label="White" [numberOfPages]="numberOfPages" [currentPage]="whiteCurrentPage" (notifyPageChange)="onPageChange6($event)"></daff-paginator>
+</design-land-article-encapsulated>

--- a/apps/design-land/src/app/paginator/paginator.module.ts
+++ b/apps/design-land/src/app/paginator/paginator.module.ts
@@ -1,8 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { DaffPaginatorModule } from '@daffodil/design';
+import {
+  DaffArticleModule,
+  DaffPaginatorModule,
+} from '@daffodil/design';
 
+import { DesignLandArticleEncapsulatedModule } from '../core/article-encapsulated/article-encapsulated.module';
 import { DesignLandPaginatorRoutingModule } from './paginator-routing.module';
 import { DesignLandPaginatorComponent } from './paginator.component';
 
@@ -12,8 +16,12 @@ import { DesignLandPaginatorComponent } from './paginator.component';
   ],
   imports: [
     CommonModule,
+
     DaffPaginatorModule,
+    DaffArticleModule,
+
     DesignLandPaginatorRoutingModule,
+    DesignLandArticleEncapsulatedModule,
   ],
 })
 export class DesignLandPaginatorModule { }

--- a/apps/design-land/src/app/quantity-field/quantity-field.component.html
+++ b/apps/design-land/src/app/quantity-field/quantity-field.component.html
@@ -1,20 +1,17 @@
-<daff-article>
-  <h1>Quantity Field</h1>
-  <p>DaffQuantityFieldComponent is a form control element that switches between a native select and input element. The maximum number accepted in a quantity select by default is 10. It will switch to a quantity input if 10+ is selected.</p>
+<h1 daffArticleTitle>Quantity Field</h1>
+<p daffArticleLead>DaffQuantityFieldComponent is a form control element that switches between a native select and input element. The maximum number accepted in a quantity select by default is 10. It will switch to a quantity input if 10+ is selected.</p>
 
-  <h2>Usage</h2>
-  <h3>Basic</h3>
-    <design-land-example-viewer-container example="basic-quantity-field"></design-land-example-viewer-container>
+<h2>Usage</h2>
+<h3>Basic</h3>
+<design-land-example-viewer-container example="basic-quantity-field"></design-land-example-viewer-container>
 
-  <h3>Disabled</h3>
-  <design-land-example-viewer-container example="disabled-quantity-field"></design-land-example-viewer-container>
+<h3>Disabled</h3>
+<design-land-example-viewer-container example="disabled-quantity-field"></design-land-example-viewer-container>
 
-  <h3>Custom Select Max Value (15)</h3>
-  <p>The value at which the field will switch to using an input is configurable.</p>
-  <design-land-example-viewer-container example="select-max-quantity-field"></design-land-example-viewer-container>
+<h3>Custom Select Max Value (15)</h3>
+<p>The value at which the field will switch to using an input is configurable.</p>
+<design-land-example-viewer-container example="select-max-quantity-field"></design-land-example-viewer-container>
 
-  <h3>Custom Range Limits (5 - 50)</h3>
-  <p>The absolute minimum and maximum values can be specified.</p>
-  <design-land-example-viewer-container example="custom-range-quantity-field"></design-land-example-viewer-container>
-
-</daff-article>
+<h3>Custom Range Limits (5 - 50)</h3>
+<p>The absolute minimum and maximum values can be specified.</p>
+<design-land-example-viewer-container example="custom-range-quantity-field"></design-land-example-viewer-container>

--- a/apps/design-land/src/app/sidebar/sidebar.component.html
+++ b/apps/design-land/src/app/sidebar/sidebar.component.html
@@ -1,20 +1,22 @@
-<daff-form-field>
-  <select daff-native-select [(ngModel)]="mode">
-    <option value="push">Push (push)</option>
-    <option value="side">Side (side)</option>
-    <option value="over">Over (over)</option>
-    <option value="fixed">Fixed (fixed)</option>
-  </select>
-</daff-form-field>
-
-<button daff-button (click)="open = !open">{{ open ? "Close" : "Open" }}</button>
-
-<daff-sidebar-viewport [mode]="mode" [opened]="open">
-    <daff-sidebar>
-      <a daff-link-set-item routerLink="accordion">Accordion</a><br>
-      <a daff-link-set-item routerLink="article">Article</a><br>
-    </daff-sidebar>
-    <p>Some Content</p>
-</daff-sidebar-viewport>
-<h1>Outside Focus   </h1>
-<input>    <input>     
+<design-land-article-encapsulated>
+  <daff-form-field>
+    <select daff-native-select [(ngModel)]="mode">
+      <option value="push">Push (push)</option>
+      <option value="side">Side (side)</option>
+      <option value="over">Over (over)</option>
+      <option value="fixed">Fixed (fixed)</option>
+    </select>
+  </daff-form-field>
+  
+  <button daff-button (click)="open = !open">{{ open ? "Close" : "Open" }}</button>
+  
+  <daff-sidebar-viewport [mode]="mode" [opened]="open">
+      <daff-sidebar>
+        <a daff-link-set-item routerLink="accordion">Accordion</a><br>
+        <a daff-link-set-item routerLink="article">Article</a><br>
+      </daff-sidebar>
+      <p>Some Content</p>
+  </daff-sidebar-viewport>
+  <h1>Outside Focus   </h1>
+  <input>    <input>     
+</design-land-article-encapsulated>

--- a/apps/design-land/src/app/sidebar/sidebar.module.ts
+++ b/apps/design-land/src/app/sidebar/sidebar.module.ts
@@ -7,21 +7,27 @@ import {
   DaffButtonModule,
   DaffNativeSelectModule,
   DaffFormFieldModule,
+  DaffArticleModule,
 } from '@daffodil/design';
 
+import { DesignLandArticleEncapsulatedModule } from '../core/article-encapsulated/article-encapsulated.module';
 import { DesignLandSidebarRoutingModule } from './sidebar-routing.module';
 import { DesignLandSidebarComponent } from './sidebar.component';
 
 @NgModule({
-  declarations: [DesignLandSidebarComponent],
+  declarations: [
+    DesignLandSidebarComponent,
+  ],
   imports: [
     CommonModule,
     FormsModule,
+    DaffArticleModule,
     DaffNativeSelectModule,
     DaffFormFieldModule,
     DaffButtonModule,
     DaffSidebarModule,
     DesignLandSidebarRoutingModule,
+    DesignLandArticleEncapsulatedModule,
   ],
 })
 export class DesignLandSidebarModule { }

--- a/apps/design-land/src/app/typography/typography.component.html
+++ b/apps/design-land/src/app/typography/typography.component.html
@@ -1,91 +1,89 @@
-<daff-article>
-	<h1 daffArticleTitle>Typography</h1>
-	<p daffArticleLead>We use typography to establish hierarchy, organize information, and guide our users through a product or experience.</p>
+<h1 daffArticleTitle>Typography</h1>
+<p daffArticleLead>We use typography to establish hierarchy, organize information, and guide our users through a product or experience.</p>
 
-	<h2>Type scale</h2>
-	<p>The Design Land typopgrahic scale is designed with visual distinctions to help our users better understand content and UI. Text sizes, styles, and layouts were selected to maintain logical hierarchies and drive consistency throughout an application.</p>
+<h2>Type scale</h2>
+<p>The Design Land typopgrahic scale is designed with visual distinctions to help our users better understand content and UI. Text sizes, styles, and layouts were selected to maintain logical hierarchies and drive consistency throughout an application.</p>
 
-	<h3>8px system</h3>
-	<p>Our type scale is based on an 8px system, where the type is largely divisible by 8. For smaller sizes, the system allows for the scale to be divisble by 4.</p>
-	<p>Font sizes are smaller on mobile and scaled up at the <code>tablet</code> breakpoint.</p>
+<h3>8px system</h3>
+<p>Our type scale is based on an 8px system, where the type is largely divisible by 8. For smaller sizes, the system allows for the scale to be divisble by 4.</p>
+<p>Font sizes are smaller on mobile and scaled up at the <code>tablet</code> breakpoint.</p>
 
-	<div class="dl-typography__typescale-card">
-		<div class="dl-typography__desktop-subheading">56/64px — Headline Extra Large</div>
-		<div class="dl-typography__mobile-subheading">40/44px — Headline Extra Large</div>
-		<div class="dl-typography__headline-xl">
-			Build the next generation of ecommerce stores with Daffodil.
-		</div>
+<div class="dl-typography__typescale-card">
+	<div class="dl-typography__desktop-subheading">56/64px — Headline Extra Large</div>
+	<div class="dl-typography__mobile-subheading">40/44px — Headline Extra Large</div>
+	<div class="dl-typography__headline-xl">
+		Build the next generation of ecommerce stores with Daffodil.
 	</div>
+</div>
 
-	<div class="dl-typography__typescale-card">
-		<div class="dl-typography__desktop-subheading">48/56px — Headline Large</div>
-		<div class="dl-typography__mobile-subheading">32/36px — Headline Large</div>
-		<div class="dl-typography__headline-lg">
-			Build the next generation of ecommerce stores with Daffodil.
-		</div>
+<div class="dl-typography__typescale-card">
+	<div class="dl-typography__desktop-subheading">48/56px — Headline Large</div>
+	<div class="dl-typography__mobile-subheading">32/36px — Headline Large</div>
+	<div class="dl-typography__headline-lg">
+		Build the next generation of ecommerce stores with Daffodil.
 	</div>
+</div>
 
-	<div class="dl-typography__typescale-card">
-		<div class="dl-typography__desktop-subheading">32/40px — Headline Medium</div>
-		<div class="dl-typography__mobile-subheading">24/28px — Headline Medium</div>
-		<div class="dl-typography__headline-md">
-			Build the next generation of ecommerce stores with Daffodil.
-		</div>
+<div class="dl-typography__typescale-card">
+	<div class="dl-typography__desktop-subheading">32/40px — Headline Medium</div>
+	<div class="dl-typography__mobile-subheading">24/28px — Headline Medium</div>
+	<div class="dl-typography__headline-md">
+		Build the next generation of ecommerce stores with Daffodil.
 	</div>
+</div>
 
-	<div class="dl-typography__typescale-card">
-		<div class="dl-typography__desktop-subheading">24/32px — Headline Small</div>
-		<div class="dl-typography__mobile-subheading">20/24px — Headline Small</div>
-		<div class="dl-typography__headline-sm">
-			Build the next generation of ecommerce stores with Daffodil.
-		</div>
+<div class="dl-typography__typescale-card">
+	<div class="dl-typography__desktop-subheading">24/32px — Headline Small</div>
+	<div class="dl-typography__mobile-subheading">20/24px — Headline Small</div>
+	<div class="dl-typography__headline-sm">
+		Build the next generation of ecommerce stores with Daffodil.
 	</div>
+</div>
 
-	<div class="dl-typography__typescale-card">
-		<div class="dl-typography__desktop-subheading">24/32px — Body Large</div>
-		<div class="dl-typography__mobile-subheading">24/32px — Body Large</div>
-		<div class="dl-typography__body-lg">
-			Build the next generation of ecommerce stores with Daffodil.
-		</div>
+<div class="dl-typography__typescale-card">
+	<div class="dl-typography__desktop-subheading">24/32px — Body Large</div>
+	<div class="dl-typography__mobile-subheading">24/32px — Body Large</div>
+	<div class="dl-typography__body-lg">
+		Build the next generation of ecommerce stores with Daffodil.
 	</div>
+</div>
 
-	<div class="dl-typography__typescale-card">
-		<div class="dl-typography__desktop-subheading">20/28px — Body Medium</div>
-		<div class="dl-typography__mobile-subheading">20/28px — Body Medium</div>
-		<div class="dl-typography__body-md">
-			Build the next generation of ecommerce stores with Daffodil.
-		</div>
+<div class="dl-typography__typescale-card">
+	<div class="dl-typography__desktop-subheading">20/28px — Body Medium</div>
+	<div class="dl-typography__mobile-subheading">20/28px — Body Medium</div>
+	<div class="dl-typography__body-md">
+		Build the next generation of ecommerce stores with Daffodil.
 	</div>
+</div>
 
-	<div class="dl-typography__typescale-card">
-		<div class="dl-typography__desktop-subheading">16/24px — Body Small</div>
-		<div class="dl-typography__mobile-subheading">16/24px — Body Small</div>
-		<div class="dl-typography__body-sm">
-			Build the next generation of ecommerce stores with Daffodil.
-		</div>
+<div class="dl-typography__typescale-card">
+	<div class="dl-typography__desktop-subheading">16/24px — Body Small</div>
+	<div class="dl-typography__mobile-subheading">16/24px — Body Small</div>
+	<div class="dl-typography__body-sm">
+		Build the next generation of ecommerce stores with Daffodil.
 	</div>
+</div>
 
-	<div class="dl-typography__typescale-card">
-		<div class="dl-typography__desktop-subheading">14/20px — Body Extra Small</div>
-		<div class="dl-typography__mobile-subheading">14/20px — Body Extra Small</div>
-		<div class="dl-typography__body-xs">
-			Build the next generation of ecommerce stores with Daffodil.
-		</div>
+<div class="dl-typography__typescale-card">
+	<div class="dl-typography__desktop-subheading">14/20px — Body Extra Small</div>
+	<div class="dl-typography__mobile-subheading">14/20px — Body Extra Small</div>
+	<div class="dl-typography__body-xs">
+		Build the next generation of ecommerce stores with Daffodil.
 	</div>
+</div>
 
-	<div class="dl-typography__typescale-card">
-		<div class="dl-typography__desktop-subheading">14/16px — Subheading</div>
-		<div class="dl-typography__mobile-subheading">14/16px — Subheading</div>
-		<div class="dl-typography__body-subheading">
-			Build the next generation of ecommerce stores with Daffodil.
-		</div>
+<div class="dl-typography__typescale-card">
+	<div class="dl-typography__desktop-subheading">14/16px — Subheading</div>
+	<div class="dl-typography__mobile-subheading">14/16px — Subheading</div>
+	<div class="dl-typography__body-subheading">
+		Build the next generation of ecommerce stores with Daffodil.
 	</div>
+</div>
 
-	<div class="dl-typography__typescale-card">
-		<div class="dl-typography__desktop-subheading">12/16px — Caption</div>
-		<div class="dl-typography__mobile-subheading">12/16px — Caption</div>
-		<div class="dl-typography__body-caption">
-			Build the next generation of ecommerce stores with Daffodil.
-		</div>
+<div class="dl-typography__typescale-card">
+	<div class="dl-typography__desktop-subheading">12/16px — Caption</div>
+	<div class="dl-typography__mobile-subheading">12/16px — Caption</div>
+	<div class="dl-typography__body-caption">
+		Build the next generation of ecommerce stores with Daffodil.
 	</div>
-</daff-article>
+</div>

--- a/libs/design/src/atoms/button/button.component.ts
+++ b/libs/design/src/atoms/button/button.component.ts
@@ -9,6 +9,7 @@ import {
   Renderer2,
 } from '@angular/core';
 
+import { daffArticleEncapsulatedMixin } from '../../core/article-encapsulated/public_api';
 import {
   daffColorMixin,
   DaffColorable,
@@ -47,7 +48,7 @@ class DaffButtonBase{
   constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
 }
 
-const _daffButtonBase = daffPrefixableMixin(daffSuffixableMixin(daffColorMixin(daffStatusMixin(daffSizeMixin<DaffButtonSize>(DaffButtonBase, 'md')))));
+const _daffButtonBase = daffArticleEncapsulatedMixin(daffPrefixableMixin(daffSuffixableMixin(daffColorMixin(daffStatusMixin(daffSizeMixin<DaffButtonSize>(DaffButtonBase, 'md'))))));
 
 export type DaffButtonType = 'daff-button' | 'daff-stroked-button' | 'daff-raised-button' | 'daff-icon-button' | 'daff-underline-button' | undefined;
 

--- a/libs/design/src/core/article-encapsulated/article-encapsulated-mixin.ts
+++ b/libs/design/src/core/article-encapsulated/article-encapsulated-mixin.ts
@@ -1,0 +1,24 @@
+import {
+  ElementRef,
+  Renderer2,
+} from '@angular/core';
+
+import { Constructor } from '../constructor/constructor';
+
+export interface HasElementRef {
+	_elementRef: ElementRef;
+	_renderer: Renderer2;
+}
+
+/**
+ * A mixin for giving a component the ability to prevent article styles from cascading down.
+ */
+export function
+daffArticleEncapsulatedMixin<T extends Constructor<HasElementRef>>(Base: T) {
+  return class extends Base {
+    constructor(...args: any[]) {
+      super(...args);
+      this._renderer.addClass(this._elementRef.nativeElement, `daff-ae`);
+    }
+  };
+}

--- a/libs/design/src/core/article-encapsulated/article-encapsulated.spec.ts
+++ b/libs/design/src/core/article-encapsulated/article-encapsulated.spec.ts
@@ -1,0 +1,35 @@
+import { ElementRef } from '@angular/core';
+
+import {
+  daffArticleEncapsulatedMixin,
+  HasElementRef,
+} from './article-encapsulated-mixin';
+
+class TestingClass implements HasElementRef {
+  element: HTMLElement = document.createElement('div');
+
+  _elementRef = new ElementRef<HTMLElement>(this.element);
+  _renderer: any = {
+    addClass: (el: HTMLElement, className: string) => {
+      el.classList.add(className);
+    },
+    removeClass: (el: HTMLElement, className: string) => {
+      el.classList.remove(className);
+    },
+  };
+}
+
+describe('daffArticleEncapsulatedMixin', () => {
+  let instance;
+  let manageContainerLayoutClass;
+
+  beforeEach(() => {
+    manageContainerLayoutClass = daffArticleEncapsulatedMixin(TestingClass);
+    instance = new manageContainerLayoutClass();
+  });
+
+
+  it('should set a namespaced manage container layout class', () => {
+    expect(instance.element.classList).toContain('daff-ae');
+  });
+});

--- a/libs/design/src/core/article-encapsulated/public_api.ts
+++ b/libs/design/src/core/article-encapsulated/public_api.ts
@@ -1,0 +1,1 @@
+export { daffArticleEncapsulatedMixin } from './article-encapsulated-mixin';

--- a/libs/design/src/core/public_api.ts
+++ b/libs/design/src/core/public_api.ts
@@ -9,3 +9,4 @@ export * from './mutable/mutable';
 export * from './text-alignable/text-alignable';
 export * from './compactable/public_api';
 export * from './manage-container-layout/public_api';
+export * from './article-encapsulated/public_api';

--- a/libs/design/src/molecules/accordion/accordion/accordion.component.ts
+++ b/libs/design/src/molecules/accordion/accordion/accordion.component.ts
@@ -1,7 +1,20 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
+  Renderer2,
 } from '@angular/core';
+
+import { daffArticleEncapsulatedMixin } from '../../../core/article-encapsulated/public_api';
+
+/**
+ * An _elementRef and an instance of renderer2 are needed for the link set mixins
+ */
+class DaffAccordionBase {
+  constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
+}
+
+const _daffAccordionBase = daffArticleEncapsulatedMixin((DaffAccordionBase));
 
 @Component({
   selector: 'daff-accordion',
@@ -10,6 +23,8 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 
-export class DaffAccordionComponent {
-
+export class DaffAccordionComponent extends _daffAccordionBase {
+  constructor(private elementRef: ElementRef, private renderer: Renderer2) {
+    super(elementRef, renderer);
+  }
 }

--- a/libs/design/src/molecules/article/article/article-theme.scss
+++ b/libs/design/src/molecules/article/article/article-theme.scss
@@ -1,3 +1,5 @@
+@import './stops-article-cascade';
+
 @mixin daff-article-theme($theme) {
 	$primary: map-get($theme, primary);
 	$secondary: map-get($theme, secondary);
@@ -16,22 +18,15 @@
 			color: daff-illuminate($base-contrast, $gray, 3);
 		}
 
-		a {
+		@include stopsArticleCascade(a) {
 			color: daff-color($primary);
 		}
 
-		> {
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				color: $text-color;
-			}
+		@include stopsArticleCascade(h1, h2, h3, h4, h5, h6) {
+			color: $text-color;
 		}
 
-		> p {
+		@include stopsArticleCascade(p) {
 			color: $text-color;
 		}
 

--- a/libs/design/src/molecules/article/article/article.component.scss
+++ b/libs/design/src/molecules/article/article/article.component.scss
@@ -1,66 +1,61 @@
 @import 'daff-util';
+@import './stops-article-cascade';
 
 .daff-article {
 	display: block;
 
-	> {
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6 {
-			margin-bottom: 0.5rem;
-		}
+	@include stopsArticleCascade(a) {
+		font-weight: 600;
+		text-decoration: none;
 
-		h2,
-		h3,
-		h4,
-		h5,
-		h6 {
-			margin-top: 2rem;
-		}
-
-		h1 {
-			@include headline-lg();
-		}
-
-		h2 {
-			font-size: 2rem;
-			line-height: 2.5rem;
-		}
-
-		h3 {
-			font-size: 1.5rem;
-			line-height: 2rem;
-		}
-
-		h4 {
-			font-size: 1.25rem;
-			line-height: 1.5rem;
-		}
-
-		h5 {
-			font-size: 1.125rem;
-			line-height: 1.5rem;
-		}
-
-		h6 {
-			font-size: 1rem;
-			line-height: 1.5rem;
-		}
-
-		p {
-			margin: 0 0 1rem;
-		}
-
-		strong {
-			@include embolden();
+		&:hover {
+			text-decoration: underline;
 		}
 	}
 
-	a {
-		font-weight: 500;
+	@include stopsArticleCascade(h1, h2, h3, h4, h5, h6) {
+		margin-bottom: 0.5rem;
+	}
+
+	@include stopsArticleCascade(h2, h3, h4, h5, h6) {
+		margin-top: 2rem;
+	}
+
+	@include stopsArticleCascade(h1) {
+		@include headline-lg();
+	}
+
+	@include stopsArticleCascade(h2) {
+		font-size: 2rem;
+		line-height: 2.5rem;
+	}
+
+	@include stopsArticleCascade(h3) {
+		font-size: 1.5rem;
+		line-height: 2rem;
+	}
+
+	@include stopsArticleCascade(h4) {
+		font-size: 1.25rem;
+		line-height: 1.5rem;
+	}
+
+	@include stopsArticleCascade(h5) {
+		font-size: 1.125rem;
+		line-height: 1.5rem;
+	}
+
+	@include stopsArticleCascade(h6) {
+		font-size: 1rem;
+		line-height: 1.5rem;
+	}
+
+	@include stopsArticleCascade(p) {
+		margin: 0 0 1rem;
+	}
+
+	strong {
+		@include embolden();
 	}
 
 	pre {
@@ -142,7 +137,7 @@
 		}
 
 		td {
-			padding: 8px 16px;
+			padding: 0.5rem 1rem;
 			vertical-align: top;
 			box-sizing: border-box;
 		}

--- a/libs/design/src/molecules/article/article/stops-article-cascade.scss
+++ b/libs/design/src/molecules/article/article/stops-article-cascade.scss
@@ -1,0 +1,7 @@
+@mixin stopsArticleCascade($selector...) {
+	#{$selector} {
+		&:not(.daff-ae *, .daff-ae) {
+			@content;
+		}
+	}
+}

--- a/libs/design/src/molecules/callout/callout/callout.component.ts
+++ b/libs/design/src/molecules/callout/callout/callout.component.ts
@@ -8,7 +8,7 @@ import {
   Renderer2,
 } from '@angular/core';
 
-
+import { daffArticleEncapsulatedMixin } from '../../../core/article-encapsulated/public_api';
 import {
   DaffColorable,
   daffColorMixin,
@@ -44,7 +44,7 @@ class DaffCalloutBase {
   constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
 }
 
-const _daffCalloutBase = daffManageContainerLayoutMixin(daffColorMixin(daffCompactableMixin(daffTextAlignmentMixin(DaffCalloutBase, 'left'))));
+const _daffCalloutBase = daffArticleEncapsulatedMixin(daffManageContainerLayoutMixin(daffColorMixin(daffCompactableMixin(daffTextAlignmentMixin(DaffCalloutBase, 'left')))));
 
 /**
  * @inheritdoc

--- a/libs/design/src/molecules/card/card/card.component.ts
+++ b/libs/design/src/molecules/card/card/card.component.ts
@@ -9,6 +9,7 @@ import {
   OnInit,
 } from '@angular/core';
 
+import { daffArticleEncapsulatedMixin } from '../../../core/article-encapsulated/public_api';
 import {
   DaffColorable,
   daffColorMixin,
@@ -37,7 +38,7 @@ class DaffCardBase {
   constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
 }
 
-const _daffCardBase = daffColorMixin(DaffCardBase);
+const _daffCardBase = daffArticleEncapsulatedMixin(daffColorMixin(DaffCardBase));
 
 /**
  * @inheritdoc

--- a/libs/design/src/molecules/hero/hero/hero.component.ts
+++ b/libs/design/src/molecules/hero/hero/hero.component.ts
@@ -8,7 +8,7 @@ import {
   Renderer2,
 } from '@angular/core';
 
-
+import { daffArticleEncapsulatedMixin } from '../../../core/article-encapsulated/public_api';
 import {
   daffColorMixin,
   DaffColorable,
@@ -39,13 +39,13 @@ export enum DaffHeroSizeEnum {
 }
 
 /**
- * An _elementRef and an instance of renderer2 are needed for the Colorable mixin
+ * An _elementRef and an instance of renderer2 are needed for the hero mixins
  */
 class DaffHeroBase {
   constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
 }
 
-const _daffHeroBase = daffManageContainerLayoutMixin(daffColorMixin(daffCompactableMixin(daffTextAlignmentMixin(DaffHeroBase, 'left'))));
+const _daffHeroBase = daffArticleEncapsulatedMixin(daffManageContainerLayoutMixin(daffColorMixin(daffCompactableMixin(daffTextAlignmentMixin(DaffHeroBase, 'left')))));
 
 /**
  * @inheritdoc

--- a/libs/design/src/molecules/link-set/link-set/link-set.component.ts
+++ b/libs/design/src/molecules/link-set/link-set/link-set.component.ts
@@ -2,9 +2,21 @@ import {
   Component,
   HostBinding,
   ViewEncapsulation,
-  Input,
   ChangeDetectionStrategy,
+  ElementRef,
+  Renderer2,
 } from '@angular/core';
+
+import { daffArticleEncapsulatedMixin } from '../../../core/article-encapsulated/public_api';
+
+/**
+ * An _elementRef and an instance of renderer2 are needed for the link set mixins
+ */
+class DaffLinkSetBase {
+  constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
+}
+
+const _daffLinkSetBase = daffArticleEncapsulatedMixin((DaffLinkSetBase));
 
 /**
  * DaffLinkSetComponent is a component for displaying a two or more links.
@@ -16,10 +28,14 @@ import {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DaffLinkSetComponent {
+export class DaffLinkSetComponent extends _daffLinkSetBase {
 
   /**
    * @docs-private
    */
   @HostBinding('class.daff-link-set') class = true;
+
+  constructor(private elementRef: ElementRef, private renderer: Renderer2) {
+    super(elementRef, renderer);
+  }
 }

--- a/libs/design/src/molecules/list/list/list.component.ts
+++ b/libs/design/src/molecules/list/list/list.component.ts
@@ -5,7 +5,10 @@ import {
   Input,
   HostBinding,
   ElementRef,
+  Renderer2,
 } from '@angular/core';
+
+import { daffArticleEncapsulatedMixin } from '../../../core/article-encapsulated/public_api';
 
 /**
  * @deprecated
@@ -25,6 +28,15 @@ enum DaffListTypeEnum {
   Nav = 'daff-nav-list'
 }
 
+/**
+ * An _elementRef and an instance of renderer2 are needed for the list mixins
+ */
+class DaffListBase {
+  constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
+}
+
+const _daffListBase = daffArticleEncapsulatedMixin((DaffListBase));
+
 @Component({
   selector:
     'daff-list' + ',' +
@@ -35,7 +47,7 @@ enum DaffListTypeEnum {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 
-export class DaffListComponent {
+export class DaffListComponent extends _daffListBase {
   /**
    * @deprecated
    * */
@@ -79,7 +91,9 @@ export class DaffListComponent {
     return this._getHostElement().localName;
   }
 
-  constructor(private elementRef: ElementRef) {}
+  constructor(private elementRef: ElementRef, private renderer: Renderer2) {
+    super(elementRef, renderer);
+  }
 
   /**
    * @docs-private

--- a/libs/design/src/molecules/media-gallery/media-gallery.component.ts
+++ b/libs/design/src/molecules/media-gallery/media-gallery.component.ts
@@ -5,13 +5,25 @@ import {
   Input,
   OnInit,
   OnDestroy,
+  ElementRef,
+  Renderer2,
 } from '@angular/core';
 
+import { daffArticleEncapsulatedMixin } from '../../core/article-encapsulated/public_api';
 import { DaffMediaGalleryRegistration } from './media-gallery-registration.interface';
 import { DAFF_MEDIA_GALLERY_TOKEN } from './media-gallery-token';
 import { DaffMediaGalleryRegistry } from './registry/media-gallery.registry';
 
 let uniqueGalleryId = 0;
+
+/**
+ * An _elementRef and an instance of renderer2 are needed for the link set mixins
+ */
+class DaffMediaGalleryBase {
+  constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
+}
+
+const _daffMediaGalleryBase = daffArticleEncapsulatedMixin((DaffMediaGalleryBase));
 
 @Component({
   selector: 'daff-media-gallery',
@@ -23,7 +35,7 @@ let uniqueGalleryId = 0;
     { provide: DAFF_MEDIA_GALLERY_TOKEN, useExisting: DaffMediaGalleryComponent },
   ],
 })
-export class DaffMediaGalleryComponent implements DaffMediaGalleryRegistration, OnInit, OnDestroy {
+export class DaffMediaGalleryComponent extends _daffMediaGalleryBase implements DaffMediaGalleryRegistration, OnInit, OnDestroy {
 	/**
 	 * Adds a class for styling the media gallery
 	 */
@@ -34,8 +46,13 @@ export class DaffMediaGalleryComponent implements DaffMediaGalleryRegistration, 
 	 */
 	@Input() name = `${uniqueGalleryId}`;
 
-	constructor(private registry: DaffMediaGalleryRegistry) {
-	  uniqueGalleryId++;
+	constructor(
+		private elementRef: ElementRef,
+		private renderer: Renderer2,
+		private registry: DaffMediaGalleryRegistry,
+	) {
+	  	super(elementRef, renderer);
+	  	uniqueGalleryId++;
 	}
 
 	ngOnInit() {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Article styles cascade down to design components that are nested inside a `<daff-article>` 
Fixes: N/A


## What is the new behavior?
1. Create `daffArticleEncapsulatedMixin`. Extending the mixin in a component will prevent article styles from cascading down into a component's styles.
2. Implement `daffArticleEncapsulatedMixin`
```
Components that implement the mixin:
Button
Card
Hero
Accordion
Callout
Card
Hero
LinkSet
List
MediaGallery

Components that **do not** implement the mixin:
Article - DNI - i'm me
Backdrop - DNI - irrelevant
Image - DNI - irrelevant
Form - DNI - does not require solo usage
Loading Icon - DNI - irrelevant
Progress Indicator - DNI - irrelevant
Feature - ignored, deprecated
Image Gallery - ignored, deprecated
ImageList - ignored, deprecated
Modal - DNI - irrelevant
Navbar - DNI - low probability of solo usage
Paginator - DNI - low probability of solo usage
QtyDropdown - ignored, deprecated
Sidebar - DNI - low probability of solo usage
```
3. `DesignLandArticleEncapsulatedComponent`'s purpose is to extend this mixin to components that typically have low probability of usage, but is needed for the sake of docs UI.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information