### PR TITLE
feat(cart): add errors to cart item entity

### DIFF
--- a/libs/cart/state/src/facades/cart/cart-facade.interface.ts
+++ b/libs/cart/state/src/facades/cart/cart-facade.interface.ts
@@ -277,4 +277,8 @@ export interface DaffCartFacadeInterface<
    * Zero by default.
    */
 	getCartItemTotalDiscount(itemId: U['id']): Observable<number>;
+  /**
+   * Gets the specified item's errors.
+   */
+	getCartItemErrors(itemId: U['id']): Observable<DaffStateError[]>;
 }

--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -77,6 +77,7 @@ import {
 import { DaffState } from '@daffodil/core/state';
 import { DaffStateError } from '@daffodil/core/state';
 
+import { DaffCartItemUpdateFailure } from '../../actions/public_api';
 import { DaffCartFacade } from './cart.facade';
 
 describe('DaffCartFacade', () => {
@@ -1697,6 +1698,27 @@ describe('DaffCartFacade', () => {
       const expected = cold('a', { a: cart.items[0].discounts.reduce((acc, { amount }) => acc + amount, 0) });
       facade.dispatch(new DaffCartLoadSuccess(cart));
       expect(facade.getCartItemTotalDiscount(cart.items[0].id)).toBeObservable(expected);
+    });
+  });
+
+  describe('getCartItemErrors', () => {
+    let error: DaffStateError;
+
+    beforeEach(() => {
+      error = {
+        code: 'code',
+        message: 'message',
+      };
+    });
+
+    it('should be the cart item\'s sum of all discounts', () => {
+      const cart = cartFactory.create({
+        items: statefulCartItemFactory.createMany(2),
+      });
+      const expected = cold('a', { a: [error]});
+      facade.dispatch(new DaffCartLoadSuccess(cart));
+      facade.dispatch(new DaffCartItemUpdateFailure(error, cart.items[0].id));
+      expect(facade.getCartItemErrors(cart.items[0].id)).toBeObservable(expected);
     });
   });
 });

--- a/libs/cart/state/src/facades/cart/cart.facade.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.ts
@@ -145,6 +145,7 @@ export class DaffCartFacade<
   private _selectCartItemRowTotal: DaffCartMemoizedSelectors<T, V, U>['selectCartItemRowTotal'];
   private _selectCartItemDiscounts: DaffCartMemoizedSelectors<T, V, U>['selectCartItemDiscounts'];
   private _selectCartItemTotalDiscount: DaffCartMemoizedSelectors<T, V, U>['selectCartItemTotalDiscount'];
+  private _selectCartItemErrors: DaffCartMemoizedSelectors<T, V, U>['selectCartItemErrors'];
 
   constructor(
     private store: Store<DaffCartStateRootSlice<T, V, U>>,
@@ -248,6 +249,7 @@ export class DaffCartFacade<
       selectCartItemQuantity,
       selectCartItemDiscounts,
       selectCartItemTotalDiscount,
+      selectCartItemErrors,
     } = getDaffCartSelectors<T, V, U>();
     this._selectCartItemConfiguredAttributes = selectCartItemConfiguredAttributes;
     this._selectCartItemCompositeOptions = selectCartItemCompositeOptions;
@@ -258,6 +260,7 @@ export class DaffCartFacade<
     this._selectCartItemRowTotal = selectCartItemRowTotal;
     this._selectCartItemDiscounts = selectCartItemDiscounts;
     this._selectCartItemTotalDiscount = selectCartItemTotalDiscount;
+    this._selectCartItemErrors = selectCartItemErrors;
 
     this.cart$ = this.store.pipe(select(selectCartValue));
 
@@ -387,6 +390,10 @@ export class DaffCartFacade<
   getCartItemTotalDiscount(itemId: U['id']): Observable<number> {
     return this.store.pipe(select(this._selectCartItemTotalDiscount(itemId)));
   }
+
+  getCartItemErrors(itemId: U['id']): Observable<DaffStateError[]> {
+    return this.store.pipe(select(this._selectCartItemErrors(itemId)));
+  };
 
   dispatch(action: Action) {
     this.store.dispatch(action);

--- a/libs/cart/state/src/models/stateful-cart-item.ts
+++ b/libs/cart/state/src/models/stateful-cart-item.ts
@@ -1,4 +1,5 @@
 import { DaffCartItem } from '@daffodil/cart';
+import { DaffStateError } from '@daffodil/core/state';
 
 /**
  * The state of the cart item is intended to enhance the client side UX like indicating when a cart
@@ -8,6 +9,10 @@ import { DaffCartItem } from '@daffodil/cart';
  */
 export interface DaffStatefulCartItem extends DaffCartItem {
 	daffState: DaffCartItemStateEnum;
+  /**
+   * Errors specific to the cart item.
+   */
+  errors: DaffStateError[];
 }
 
 export enum DaffCartItemStateEnum {

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -29,12 +29,17 @@ import { daffCartItemEntitiesAdapter } from './cart-item-entities-reducer-adapte
 import { daffCartItemEntitiesReducer } from './cart-item-entities.reducer';
 
 describe('Cart | Cart Item Entities Reducer', () => {
-
+  let error: DaffStateError;
   let statefulCartItemFactory: DaffStatefulCartItemFactory;
   const initialState = daffCartItemEntitiesAdapter().getInitialState();
 
   beforeEach(() => {
     statefulCartItemFactory = new DaffStatefulCartItemFactory();
+
+    error = {
+      code: 'code',
+      message: 'message',
+    };
   });
 
   describe('when an unknown action is triggered', () => {
@@ -148,6 +153,10 @@ describe('Cart | Cart Item Entities Reducer', () => {
     it('sets expected statefulCartItem on state', () => {
       expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
     });
+
+    it('should reset the cart item\'s errors', () => {
+      expect(result.entities[cartItems[0].id].errors).toEqual([]);
+    });
   });
 
   describe('when CartItemLoadSuccessAction is triggered', () => {
@@ -165,6 +174,10 @@ describe('Cart | Cart Item Entities Reducer', () => {
     it('sets expected statefulCartItem on state', () => {
       expect(result.entities[statefulCartItem.id]).toEqual(statefulCartItem);
     });
+
+    it('should reset the cart item\'s errors', () => {
+      expect(result.entities[statefulCartItem.id].errors).toEqual([]);
+    });
   });
 
   describe('when CartItemUpdateSuccessAction is triggered', () => {
@@ -174,7 +187,9 @@ describe('Cart | Cart Item Entities Reducer', () => {
     let result;
 
     beforeEach(() => {
-      cartItems = statefulCartItemFactory.createMany(2);
+      cartItems = statefulCartItemFactory.createMany(2, {
+        errors: [error],
+      });
       cart = new DaffCartFactory().create({
         items: cartItems,
       });
@@ -194,6 +209,10 @@ describe('Cart | Cart Item Entities Reducer', () => {
     it('sets the state of the updated cart item to Updated', () => {
       expect(result.entities[cartItems[0].id].daffState).toEqual(DaffCartItemStateEnum.Updated);
     });
+
+    it('should reset the cart item\'s errors', () => {
+      expect(result.entities[cartItems[0].id].errors).toEqual([]);
+    });
   });
 
   describe('when CartItemAddSuccessAction is triggered with a new cart item', () => {
@@ -203,7 +222,9 @@ describe('Cart | Cart Item Entities Reducer', () => {
     let result;
 
     beforeEach(() => {
-      statefulCartItem = statefulCartItemFactory.create();
+      statefulCartItem = statefulCartItemFactory.create({
+        errors: [error],
+      });
       cart = new DaffCartFactory().create({
         items: [statefulCartItem],
       });
@@ -223,6 +244,10 @@ describe('Cart | Cart Item Entities Reducer', () => {
     it('sets the new cart item\'s state to New', () => {
       expect(result.entities[statefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.New);
     });
+
+    it('should reset the cart item\'s errors', () => {
+      expect(result.entities[statefulCartItem.id].errors).toEqual([]);
+    });
   });
 
   describe('when CartItemAddSuccessAction is triggered with an existing cart item', () => {
@@ -232,7 +257,9 @@ describe('Cart | Cart Item Entities Reducer', () => {
     let result;
 
     beforeEach(() => {
-      statefulCartItem = statefulCartItemFactory.create();
+      statefulCartItem = statefulCartItemFactory.create({
+        errors: [error],
+      });
       cart = new DaffCartFactory().create({
         items: [statefulCartItem],
       });
@@ -254,6 +281,10 @@ describe('Cart | Cart Item Entities Reducer', () => {
 
     it('sets the cart item\'s state to Updated', () => {
       expect(result.entities[statefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.Updated);
+    });
+
+    it('should reset the cart item\'s errors', () => {
+      expect(result.entities[statefulCartItem.id].errors).toEqual([]);
     });
   });
 
@@ -305,6 +336,10 @@ describe('Cart | Cart Item Entities Reducer', () => {
     it('sets expected cart item on state', () => {
       expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
     });
+
+    it('should reset the cart item errors', () => {
+      expect(result.entities[cartItems[0].id].errors).toEqual([]);
+    });
   });
 
   describe('when ResolveCartSuccessAction is triggered', () => {
@@ -329,6 +364,10 @@ describe('Cart | Cart Item Entities Reducer', () => {
 
     it('sets expected cart item on state', () => {
       expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
+    });
+
+    it('should reset the cart item errors', () => {
+      expect(result.entities[cartItems[0].id].errors).toEqual([]);
     });
   });
 
@@ -427,7 +466,6 @@ describe('Cart | Cart Item Entities Reducer', () => {
   });
 
   describe('when CartItemLoadFailureAction is triggered', () => {
-    let error: DaffStateError;
     let statefulCartItem: DaffStatefulCartItem;
     let result;
 
@@ -449,7 +487,6 @@ describe('Cart | Cart Item Entities Reducer', () => {
   });
 
   describe('when CartItemDeleteFailureAction is triggered', () => {
-    let error: DaffStateError;
     let statefulCartItem: DaffStatefulCartItem;
     let result;
 
@@ -471,7 +508,6 @@ describe('Cart | Cart Item Entities Reducer', () => {
   });
 
   describe('when CartItemUpdateFailureAction is triggered', () => {
-    let error: DaffStateError;
     let statefulCartItem: DaffStatefulCartItem;
     let result;
 
@@ -489,6 +525,10 @@ describe('Cart | Cart Item Entities Reducer', () => {
 
     it('should reset daffState on the cart item', () => {
       expect(result.entities[statefulCartItem.id].daffState).toEqual(DaffCartItemStateEnum.Error);
+    });
+
+    it('should add the error to the cart item\'s errors', () => {
+      expect(result.entities[statefulCartItem.id].errors).toContain(error);
     });
   });
 

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -41,11 +41,13 @@ export function daffCartItemEntitiesReducer<
       return adapter.setAll(action.payload.map(item => ({
         ...item,
         daffState: getDaffState(state.entities[item.id]) || DaffCartItemStateEnum.Default,
+        errors: [],
       })), state);
     case DaffCartItemActionTypes.CartItemLoadSuccessAction:
       return adapter.upsertOne({
         ...action.payload,
         daffState: getDaffState(state.entities[action.payload.id]) || DaffCartItemStateEnum.Default,
+        errors: [],
       }, state);
     case DaffCartItemActionTypes.CartItemAddSuccessAction:
       return adapter.setAll(
@@ -63,6 +65,7 @@ export function daffCartItemEntitiesReducer<
       return adapter.upsertOne({
         ...state.entities[action.itemId],
         daffState: DaffCartItemStateEnum.Error,
+        errors: state.entities[action.itemId]?.errors.concat(action.payload) || [],
       }, state);
     case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
     case DaffCartActionTypes.CartLoadSuccessAction:
@@ -99,9 +102,9 @@ function updateAddedCartItemState<T extends DaffStatefulCartItem>(oldCartItems: 
     const oldItem = oldCartItems[newItem.id];
     switch(true) {
       case !oldItem:
-        return { ...newItem, daffState: DaffCartItemStateEnum.New };
+        return { ...newItem, daffState: DaffCartItemStateEnum.New, errors: []};
       case oldItem?.qty !== newItem.qty:
-        return { ...newItem, daffState: DaffCartItemStateEnum.Updated };
+        return { ...newItem, daffState: DaffCartItemStateEnum.Updated, errors: []};
       default:
         return newItem;
     }
@@ -110,6 +113,6 @@ function updateAddedCartItemState<T extends DaffStatefulCartItem>(oldCartItems: 
 
 function updateMutatedCartItemState<T extends DaffStatefulCartItem>(responseItems: T[], stateItems: Dictionary<T>, itemId: T['id']): T[] {
   return responseItems.map(item => item.id === itemId ?
-    { ...item, daffState: DaffCartItemStateEnum.Updated } :
+    { ...item, daffState: DaffCartItemStateEnum.Updated, errors: []} :
     { ...item, daffState: getDaffState(stateItems[item.id]) || DaffCartItemStateEnum.Default });
 }

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -65,7 +65,7 @@ export function daffCartItemEntitiesReducer<
       return adapter.upsertOne({
         ...state.entities[action.itemId],
         daffState: DaffCartItemStateEnum.Error,
-        errors: state.entities[action.itemId]?.errors?.concat(action.payload) || [],
+        errors: state.entities[action.itemId]?.errors?.concat(action.payload) || [action.payload],
       }, state);
     case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
     case DaffCartActionTypes.CartLoadSuccessAction:

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -65,7 +65,7 @@ export function daffCartItemEntitiesReducer<
       return adapter.upsertOne({
         ...state.entities[action.itemId],
         daffState: DaffCartItemStateEnum.Error,
-        errors: state.entities[action.itemId]?.errors.concat(action.payload) || [],
+        errors: state.entities[action.itemId]?.errors?.concat(action.payload) || [],
       }, state);
     case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
     case DaffCartActionTypes.CartLoadSuccessAction:

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
@@ -114,10 +114,6 @@ describe('Cart | Reducer | Cart Item', () => {
     it('should indicate that the cart is not loading', () => {
       expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Complete);
     });
-
-    it('should add an error to the item section of state.errors', () => {
-      expect(result.errors[DaffCartOperationType.Item].length).toEqual(2);
-    });
   });
 
   describe('when CartItemDeleteSuccessAction is triggered', () => {

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
@@ -84,6 +84,12 @@ export function cartItemReducer<T extends DaffCart>(
         ...setLoading(state.loading, DaffState.Complete),
       };
 
+    case DaffCartItemActionTypes.CartItemUpdateFailureAction:
+      return {
+        ...state,
+        ...setLoading(state.loading, DaffState.Complete),
+      };
+
     default:
       return state;
   }

--- a/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.ts
+++ b/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.ts
@@ -17,6 +17,7 @@ import {
   DaffCartItemDiscount,
 } from '@daffodil/cart';
 import { daffAdd } from '@daffodil/core';
+import { DaffStateError } from '@daffodil/core/state';
 
 import {
   DaffCartItemStateEnum,
@@ -74,6 +75,10 @@ export interface DaffCartItemEntitiesMemoizedSelectors<
    * Zero by default.
    */
 	selectCartItemTotalDiscount: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, number>;
+  /**
+   * Selects the specified item's errors.
+   */
+	selectCartItemErrors: (id: U['id']) => MemoizedSelector<DaffCartStateRootSlice<T, V, U>, DaffStateError[]>;
 }
 
 const createCartItemEntitiesSelectors = <
@@ -210,6 +215,11 @@ const createCartItemEntitiesSelectors = <
     (discounts: U['discounts']) => discounts?.reduce((acc, { amount }) => daffAdd(acc, amount), 0) || 0,
   )).memoized;
 
+  const selectCartItemErrors = defaultMemoize((itemId: U['id']) => createSelector(
+    selectCartItem(itemId),
+    (cartItem: U) => cartItem?.errors || [],
+  )).memoized;
+
   return {
     selectCartItemEntitiesState,
     selectCartItemIds,
@@ -228,6 +238,7 @@ const createCartItemEntitiesSelectors = <
     selectCartItemQuantity,
     selectCartItemDiscounts,
     selectCartItemTotalDiscount,
+    selectCartItemErrors,
   };
 };
 

--- a/libs/cart/state/testing/src/factories/stateful-cart-item.factory.spec.ts
+++ b/libs/cart/state/testing/src/factories/stateful-cart-item.factory.spec.ts
@@ -41,6 +41,7 @@ describe('Cart | State | Testing | Factories | StatefulCartItemFactory', () => {
       expect(result.row_total).not.toBeNull();
       expect(result.in_stock).not.toBeNull();
       expect(result.daffState).not.toBeNull();
+      expect(result.errors).not.toBeNull();
     });
   });
 });

--- a/libs/cart/state/testing/src/factories/stateful-cart-item.factory.ts
+++ b/libs/cart/state/testing/src/factories/stateful-cart-item.factory.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
 
 import {
   DaffStatefulCartItem,
@@ -9,6 +10,7 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class DaffMockStatefulCartItem extends DaffMockCartItem implements DaffStatefulCartItem {
 	daffState = DaffCartItemStateEnum.Default;
+  errors = [];
 }
 
 @Injectable({

--- a/libs/cart/state/testing/src/factories/stateful-composite-cart-item.factory.ts
+++ b/libs/cart/state/testing/src/factories/stateful-composite-cart-item.factory.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
 
 import {
   DaffCartItemStateEnum,
@@ -9,6 +10,7 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class DaffMockStatefulCompositeCartItem extends DaffMockCompositeCartItem implements DaffStatefulCompositeCartItem {
 	daffState: DaffCartItemStateEnum.Default;
+  errors = [];
 }
 
 @Injectable({

--- a/libs/cart/state/testing/src/factories/stateful-composite-cart-item.spec.ts
+++ b/libs/cart/state/testing/src/factories/stateful-composite-cart-item.spec.ts
@@ -44,6 +44,7 @@ describe('Cart | State | Testing | Factories | StatefulCompositeCartItemFactory'
       expect(result.options[0].option_label).not.toBeNull();
       expect(result.options[0].value_label).not.toBeNull();
       expect(result.daffState).not.toBeNull();
+      expect(result.errors).not.toBeNull();
     });
   });
 });

--- a/libs/cart/state/testing/src/factories/stateful-configurable-cart-item.factory.ts
+++ b/libs/cart/state/testing/src/factories/stateful-configurable-cart-item.factory.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import * as faker from 'faker/locale/en_US';
 
 import {
   DaffCartItemStateEnum,
@@ -9,6 +10,7 @@ import { DaffModelFactory } from '@daffodil/core/testing';
 
 export class DaffMockStatefulConfigurableCartItem extends DaffMockConfigurableCartItem implements DaffStatefulConfigurableCartItem {
 	daffState: DaffCartItemStateEnum.Default;
+  errors = [];
 }
 
 @Injectable({

--- a/libs/cart/state/testing/src/factories/stateful-configurable-cart-item.spec.ts
+++ b/libs/cart/state/testing/src/factories/stateful-configurable-cart-item.spec.ts
@@ -42,6 +42,7 @@ describe('Cart | State | Testing | Factories | StatefulConfigurableCartItemFacto
       expect(result.attributes[0].attribute_label).not.toBeNull();
       expect(result.attributes[0].value_label).not.toBeNull();
       expect(result.daffState).not.toBeNull();
+      expect(result.errors).not.toBeNull();
     });
   });
 });

--- a/libs/cart/state/testing/src/mock-cart-facade.ts
+++ b/libs/cart/state/testing/src/mock-cart-facade.ts
@@ -151,5 +151,9 @@ export class MockDaffCartFacade implements DaffCartFacadeInterface {
 	  return new BehaviorSubject(0);
 	}
 
+	getCartItemErrors(itemId: DaffCartItem['id']): BehaviorSubject<DaffStateError[]> {
+	  return new BehaviorSubject([]);
+	}
+
 	dispatch(action: Action) {};
 }


### PR DESCRIPTION
this only handles cart item update errors

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- cart items don't have specific errors
- cart item update errors are stored in the generic cart item error state

## What is the new behavior?
- cart item entities have their own specific errors
- cart item update errors are not stored in the generic cart item error state

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information