### PR TITLE
feat(core): make the `type` param of `DaffModelFactory` optional

### DIFF
--- a/libs/core/testing/src/factories/factory.spec.ts
+++ b/libs/core/testing/src/factories/factory.spec.ts
@@ -13,23 +13,28 @@ class TestMockModel {
   }
 }
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 class TestFactory extends DaffModelFactory<TestMockModel> {
   constructor() {
     super(TestMockModel, 'field');
   }
 }
 
+@Injectable({
+  providedIn: 'root',
+})
+class TestFactoryNoType extends DaffModelFactory<TestMockModel> {
+  constructor() {
+    super();
+  }
+}
+
 describe('@daffodil/core/testing | DaffModelFactory', () => {
-  let factory: TestFactory;
+  let factory: DaffModelFactory<TestMockModel>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        TestFactory,
-      ],
-    });
-
     factory = TestBed.inject(TestFactory);
   });
 
@@ -56,6 +61,16 @@ describe('@daffodil/core/testing | DaffModelFactory', () => {
 
       it('should preferentially set fields from the partial', () => {
         expect(result.field).toEqual(newField);
+      });
+    });
+
+    describe('when not type was passed', () => {
+      beforeEach(() => {
+        factory = TestBed.inject(TestFactoryNoType);
+      });
+
+      it('should throw an error', () => {
+        expect(() => factory.create()).toThrowError('`type` is required if `create` is not overriden.');
       });
     });
   });

--- a/libs/core/testing/src/factories/factory.ts
+++ b/libs/core/testing/src/factories/factory.ts
@@ -41,13 +41,16 @@ export abstract class DaffModelFactory<T extends Record<string, any>> implements
   _instantiationArgs: ConstructorParameters<Constructable<T>>;
 
   constructor(
-    public type: Constructable<T>,
+    public type?: Constructable<T>,
     ...args: ConstructorParameters<Constructable<T>>
   ) {
     this._instantiationArgs = args;
   }
 
   create(partial = {}): T {
+    if (!this.type) {
+      throw new Error('`type` is required if `create` is not overriden.');
+    }
     return {
       ...new this.type(...this._instantiationArgs),
       ...partial,

--- a/libs/core/testing/src/factories/factory.ts
+++ b/libs/core/testing/src/factories/factory.ts
@@ -11,6 +11,8 @@ import { IDaffModelFactory } from './factory.interface';
  * The mock class is passed as the first constructor arg
  * and any additional args are passed to the mock class constructor.
  *
+ * The constructor args can be omitted if the `create` method is overridden.
+ *
  * The following example demonstrates using this feature to inject
  * a different factory into a mock class.
  *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`DaffModelFactory` requires a type arg.

## What is the new behavior?
`DaffModelFactory` can be instantiated without a type arg, but `create` must be overriden or it will throw.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information