### PR TITLE
fix(tools): release script ignoring dep versions from root dev deps

### DIFF
--- a/tools/release/version/leaf-version.ts
+++ b/tools/release/version/leaf-version.ts
@@ -1,60 +1,60 @@
-import { series, src, dest } from 'gulp';
 import * as fs from 'fs';
-import * as util from 'util';
+import {
+  series,
+  src,
+  dest,
+} from 'gulp';
 import * as through2 from 'through2';
+import * as util from 'util';
 
 import { RELEASE_CONFIG } from '../config';
 
-type PackageJson = {
+interface PackageJson {
   name: string;
   version: string;
   devDependencies: {
-    [key: string] : string,
-  },
+    [key: string]: string;
+  };
   optionalDependencies: {
-    [key: string] : string,
-  },
+    [key: string]: string;
+  };
   peerDependencies: {
-    [key: string] : string,
-  },
+    [key: string]: string;
+  };
   dependencies: {
-    [key: string] : string,
-  }
-};
-
-const readFile = util.promisify(fs.readFile);
-
-const updateObjectFromObject = (a : any, b : any) : typeof a => {
-  return { 
-    ...a, 
-    ...Object.keys(b).filter((k) => k in a).reduce((obj, key) => {
-      obj[key] = b[key]; 
-      return obj;
-    }, {})
+    [key: string]: string;
   };
 }
 
-const getRootPackage = () : Promise<PackageJson> => {
-  return readFile(RELEASE_CONFIG.ROOT_PACKAGE, { encoding: 'utf8'}).then(d => JSON.parse(d));
-}
+const readFile = util.promisify(fs.readFile);
+
+const updateObjectFromObject = (a: any, b: any): typeof a => ({
+  ...a,
+  ...Object.keys(b).filter((k) => k in a).reduce((obj, key) => {
+    obj[key] = b[key];
+    return obj;
+  }, {}),
+});
+
+const getRootPackage = (): Promise<PackageJson> => readFile(RELEASE_CONFIG.ROOT_PACKAGE, { encoding: 'utf8' }).then(d => JSON.parse(d));
 
 const updateLeafPackageVersions = async (): Promise<any> => {
   const rootPackage = await getRootPackage();
-  await new Promise(resolve => 
+  await new Promise(resolve =>
     src(RELEASE_CONFIG.DIST + '/*/package.json')
-    .pipe(
-      through2.obj(function(file, _, cb) {
-        if (file.isBuffer()) {
-          let data = JSON.parse(file.contents.toString()) as PackageJson;
-          data = transfomLeafPackage(data, rootPackage);
-          file.contents = Buffer.from(JSON.stringify(data, null, 2));
-        }
-        cb(null, file);
-      })
-    )
-    .pipe(dest(RELEASE_CONFIG.DIST))
-    .on('end', resolve));
-}
+      .pipe(
+        through2.obj((file, _, cb) => {
+          if (file.isBuffer()) {
+            let data = <PackageJson>JSON.parse(file.contents.toString());
+            data = transfomLeafPackage(data, rootPackage);
+            file.contents = Buffer.from(JSON.stringify(data, null, 2));
+          }
+          cb(null, file);
+        }),
+      )
+      .pipe(dest(RELEASE_CONFIG.DIST))
+      .on('end', resolve));
+};
 
 /**
  * We don't distribute the dev dependencies of the libraries, so we remove them.
@@ -62,40 +62,52 @@ const updateLeafPackageVersions = async (): Promise<any> => {
 const deleteDevDependencies = (packageObject: PackageJson) => {
   delete packageObject.devDependencies;
   return packageObject;
-}
+};
 
 /**
  * Set the versions in the @daffodil packages with the package values from root.
- * We follow a uniform and consistent versioning process, so all packages 
+ * We follow a uniform and consistent versioning process, so all packages
  * will always be held at the same version.
  */
 const updatePackageVersion = (lib: PackageJson, rootPackage: PackageJson) => {
   lib.version = rootPackage.version;
   return lib;
-}
+};
 
 /**
  * For the library dependencies, set their dependency values from the root.
  */
 const updateDependenciesFromRoot = (lib: PackageJson, rootPackage: PackageJson) => {
+  // we want to check all deps for versions
+  const rootDeps = {
+    ...rootPackage.dependencies,
+    ...rootPackage.devDependencies,
+    ...rootPackage.optionalDependencies,
+    ...rootPackage.peerDependencies,
+  };
   if(lib.peerDependencies){
-    lib.peerDependencies = updateObjectFromObject(lib.peerDependencies, rootPackage.dependencies);
+    lib.peerDependencies = updateObjectFromObject(lib.peerDependencies, rootDeps);
   }
   if(lib.optionalDependencies){
-    lib.optionalDependencies = updateObjectFromObject(lib.optionalDependencies, rootPackage.dependencies);
+    lib.optionalDependencies = updateObjectFromObject(lib.optionalDependencies, rootDeps);
   }
   return lib;
-}
+};
 
+const createDaffodilDependenciesObject = (dependencies: Record<string, string>, version: string) => Object.keys(dependencies).filter((k) => k.includes('@daffodil'))
+  .reduce((obj, key) => {
+    obj[key] = version;
+    return obj;
+  }, {});
 
 /**
- * For the Daffodil package dependencies, peer changes are treated specially 
+ * For the Daffodil package dependencies, peer changes are treated specially
  * during framework version updates. This is inconsistent with typical semver
- * practices, but necessary for the framework as a whole to remain consistently 
+ * practices, but necessary for the framework as a whole to remain consistently
  * versioned.
  * See: https://github.com/semver/semver/issues/502
- * 
- * As a few sample cases: 
+ *
+ * As a few sample cases:
  * 1. We're releasing v8.1.1, the set value would be 8.1.1
  * 2. We're releasing v2.6.4, the set value would be 2.6.4
  * 3. We're releasing v2.9.4, the set value would be 2.9.4
@@ -103,37 +115,29 @@ const updateDependenciesFromRoot = (lib: PackageJson, rootPackage: PackageJson) 
  * 5. We're releasing 1.1.0-alpha.1, the set value would be 1.1.0-alpha.1
  */
 const updateDaffodilPeerDependenciesFromNewVersion = (lib: PackageJson, rootPackage: PackageJson)  => {
-	if(!lib.peerDependencies) {
-		return lib;
-	}
+  if(!lib.peerDependencies) {
+    return lib;
+  }
   lib.peerDependencies = updateObjectFromObject(lib.peerDependencies, createDaffodilDependenciesObject(lib.peerDependencies, rootPackage.version));
   return lib;
-}
+};
 
 const updateDaffodilOptionalDependenciesFromNewVersion = (lib: PackageJson, rootPackage: PackageJson)  => {
   if(!lib.optionalDependencies) {
-		return lib;
-	}
-	lib.optionalDependencies = updateObjectFromObject(lib.optionalDependencies, createDaffodilDependenciesObject(lib.optionalDependencies, rootPackage.version));
+    return lib;
+  }
+  lib.optionalDependencies = updateObjectFromObject(lib.optionalDependencies, createDaffodilDependenciesObject(lib.optionalDependencies, rootPackage.version));
   return lib;
-}
-
-const createDaffodilDependenciesObject = (dependencies: Object, version: string) => {
-	return Object.keys(dependencies).filter((k) => k.includes("@daffodil"))
-  .reduce((obj, key) => {
-    obj[key] = version; 
-    return obj;
-  }, {});
-}
+};
 
 const validateNoRemainingPlaceholders = (lib: PackageJson) => {
-  if(JSON.stringify(lib).includes("0.0.0-PLACEHOLDER")){
-    throw `Placeholder found in distributable package ${lib.name} after transformation`;
+  if(JSON.stringify(lib).includes('0.0.0-PLACEHOLDER')) {
+    throw new Error(`Placeholder found in distributable package ${lib.name} after transformation`);
   };
   return lib;
-}
+};
 
-const transfomLeafPackage = (lib: PackageJson, rootPackage: PackageJson) => {
+function transfomLeafPackage(lib: PackageJson, rootPackage: PackageJson) {
   lib = deleteDevDependencies(lib);
   lib = updatePackageVersion(lib, rootPackage);
   lib = updateDependenciesFromRoot(lib, rootPackage);
@@ -141,8 +145,8 @@ const transfomLeafPackage = (lib: PackageJson, rootPackage: PackageJson) => {
   lib = updateDaffodilOptionalDependenciesFromNewVersion(lib, rootPackage);
   lib = validateNoRemainingPlaceholders(lib);
   return lib;
-}
+};
 
 export const leafVersion = series(
-  updateLeafPackageVersions, 
+  updateLeafPackageVersions,
 );


### PR DESCRIPTION
also fixes linting errors

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Updating the leaf package dependency versions during release only pulls dependency versions from the root `package.json`'s `dependencies` field.


## What is the new behavior?
Updating the leaf package dependency versions during release checks all root dependency fields.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information