### PR TITLE
fix(cart): out of stock cart errors persist after successful delete oos

### DIFF
--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
@@ -2,6 +2,7 @@ import {
   DaffCart,
   DaffCartItemInputType,
 } from '@daffodil/cart';
+import { DaffCartDriverErrorCodes } from '@daffodil/cart/driver';
 import {
   DaffCartOperationType,
   DaffCartReducerState,
@@ -249,6 +250,11 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
           ...initialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
+        errors: {
+          ...initialState.errors,
+          [DaffCartOperationType.Item]: [{ code: 'code', message: 'message' }],
+          [DaffCartOperationType.Cart]: [{ code: DaffCartDriverErrorCodes.PRODUCT_OUT_OF_STOCK, message: 'message' }],
+        },
       };
 
       const cartItemRemoveSuccess = new DaffCartItemDeleteOutOfStockSuccess(cart);
@@ -266,6 +272,10 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
     it('should reset the errors in the item section of state.errors to an empty array', () => {
       expect(result.errors[DaffCartOperationType.Item]).toEqual([]);
+    });
+
+    it('should remove out of stock errors from the cart errors', () => {
+      expect(result.errors[DaffCartOperationType.Cart]).not.toContain(jasmine.objectContaining({ code: DaffCartDriverErrorCodes.PRODUCT_OUT_OF_STOCK }));
     });
   });
 

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
@@ -1,4 +1,5 @@
 import { DaffCart } from '@daffodil/cart';
+import { DaffCartDriverErrorCodes } from '@daffodil/cart/driver';
 import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartItemActionTypes } from '../../actions/public_api';
@@ -70,10 +71,25 @@ export function cartItemReducer<T extends DaffCart>(
     case DaffCartItemActionTypes.CartItemUpdateSuccessAction:
     case DaffCartItemActionTypes.CartItemAddSuccessAction:
     case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
-    case DaffCartItemActionTypes.CartItemDeleteOutOfStockSuccessAction:
       return {
         ...state,
         ...resetErrors(state.errors),
+        cart: {
+          ...state.cart,
+          ...action.payload,
+        },
+        ...setLoading(state.loading, DaffState.Complete),
+      };
+
+    case DaffCartItemActionTypes.CartItemDeleteOutOfStockSuccessAction:
+      return {
+        ...state,
+        errors: {
+          ...state.errors,
+          [DaffCartOperationType.Item]: [],
+          // out of stock errors can be in the main cart, remove them here
+          [DaffCartOperationType.Cart]: state.errors[DaffCartOperationType.Cart].filter(({ code }) => code !== DaffCartDriverErrorCodes.PRODUCT_OUT_OF_STOCK),
+        },
         cart: {
           ...state.cart,
           ...action.payload,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After a successful delete OOS cart items, OOS errors will still be in state.


## What is the new behavior?
Successful delete OOS cart items will remove OOS errors from state.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information