### PR TITLE
fix(cart): items removed by delete oos not removed from entity state

### DIFF
--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -314,6 +314,31 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
   });
 
+  describe('when CartItemDeleteOutOfStockSuccessAction is triggered', () => {
+
+    let cart: DaffCart;
+    let cartItems: DaffStatefulCartItem[];
+    let result;
+
+    beforeEach(() => {
+      cartItems = statefulCartItemFactory.createMany(2);
+      cart = new DaffCartFactory().create({
+        items: cartItems,
+      });
+      const cartItemDeleteOutOfStockSuccess = new DaffCartItemDeleteOutOfStockSuccess(cart);
+
+      result = daffCartItemEntitiesReducer(initialState, cartItemDeleteOutOfStockSuccess);
+    });
+
+    it('sets expected number of cartItems on state', () => {
+      expect(result.ids.length).toEqual(cartItems.length);
+    });
+
+    it('sets expected cart item on state', () => {
+      expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
+    });
+  });
+
   describe('when CartLoadSuccessAction is triggered', () => {
 
     let cart: DaffCart;

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -17,6 +17,7 @@ import {
   DaffCartItemDeleteFailure,
   DaffCartItemUpdateFailure,
   DaffCartCreateSuccess,
+  DaffCartItemDeleteOutOfStockSuccess,
 } from '@daffodil/cart/state';
 import { DaffStatefulCartItemFactory } from '@daffodil/cart/state/testing';
 import {

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -68,6 +68,7 @@ export function daffCartItemEntitiesReducer<
         errors: state.entities[action.itemId]?.errors?.concat(action.payload) || [action.payload],
       }, state);
     case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
+    case DaffCartItemActionTypes.CartItemDeleteOutOfStockSuccessAction:
     case DaffCartActionTypes.CartLoadSuccessAction:
     case DaffCartActionTypes.ResolveCartSuccessAction:
     case DaffCartActionTypes.CartClearSuccessAction:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After a successful delete OOS items, there are still OOS items in entity state.


## What is the new behavior?

After a successful delete OOS items, entity state is replaced by the cart items from the repsonse.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information