### PR TITLE
feat(core,driver): return generic error as a fallback

### DIFF
--- a/libs/auth/driver/magento/src/errors/transform.spec.ts
+++ b/libs/auth/driver/magento/src/errors/transform.spec.ts
@@ -5,7 +5,7 @@ import { DaffUnauthorizedError } from '@daffodil/auth';
 import { MagentoAuthGraphQlErrorCode } from './codes';
 import { transformMagentoAuthError } from './transform';
 
-describe('Transforming Magento GraphQlErrors into DaffAuthErrors', () => {
+describe('@daffodil/auth/driver/magento | transformMagentoAuthError', () => {
   const unhandledGraphQlError = {
     message: 'A error we dont handle',
     extensions: {},
@@ -37,36 +37,5 @@ describe('Transforming Magento GraphQlErrors into DaffAuthErrors', () => {
     const result = transformMagentoAuthError(error);
 
     expect(result).toEqual(jasmine.any(DaffUnauthorizedError));
-  });
-
-  it('should not handle a graphql error if the first error is not a handled type', () => {
-    const error = new ApolloError({
-      graphQLErrors: [unhandledGraphQlError, handledGraphQlError],
-    });
-    expect(transformMagentoAuthError(error)).toEqual(error);
-  });
-
-  it('should not crash if the extension is not defined', () => {
-    const error = new ApolloError({
-      graphQLErrors: [{ ...unhandledGraphQlError, extensions: {}}],
-    });
-    expect(transformMagentoAuthError(error)).toEqual(error);
-  });
-
-  it('should not touch the error if there is no mapping', () => {
-    const error = new ApolloError({
-      graphQLErrors: [
-        {
-          ...unhandledGraphQlError,
-          extensions: { category: 'an-unmanaged-error' },
-        },
-      ],
-    });
-    expect(transformMagentoAuthError(error)).toEqual(error);
-  });
-
-  it('should not touch errors that are not GraphQl errors', () => {
-    const error = new Error('an error');
-    expect(transformMagentoAuthError(error)).toEqual(error);
   });
 });

--- a/libs/core/src/errors/error-map.ts
+++ b/libs/core/src/errors/error-map.ts
@@ -1,8 +1,9 @@
 import { Constructable } from '../constructable/constructable';
+import { DaffError } from './error.interface';
 
 /**
- * A type for a dictionary of error codes to errors.
+ * A type for a dictionary of error codes to Daffodil errors.
  */
 export interface DaffErrorCodeMap {
-	[x: string]: Constructable<Error>;
+	[x: string]: Constructable<DaffError>;
 }

--- a/libs/core/src/errors/is-error.spec.ts
+++ b/libs/core/src/errors/is-error.spec.ts
@@ -1,0 +1,38 @@
+import { DaffError } from './error.interface';
+import { DaffInheritableError } from './inheritable-error';
+import { daffIsError } from './is-error';
+
+class MockError extends DaffInheritableError implements DaffError {
+  code = 'MockError';
+}
+
+describe('@daffodil/core | daffIsError', () => {
+  let daffError: MockError;
+  let notDaffError: Error;
+  let result: boolean;
+
+  beforeEach(() => {
+    daffError = new MockError('A Daffodil error');
+    notDaffError = new Error('Not a Daffodil error');
+  });
+
+  describe('when the error is a daffodil error', () => {
+    beforeEach(() => {
+      result = daffIsError(daffError);
+    });
+
+    it('should return true', () => {
+      expect(result).toBeTrue();
+    });
+  });
+
+  describe('when the error is not a daffodil error', () => {
+    beforeEach(() => {
+      result = daffIsError(notDaffError);
+    });
+
+    it('should return false', () => {
+      expect(result).toBeFalse();
+    });
+  });
+});

--- a/libs/core/src/errors/is-error.ts
+++ b/libs/core/src/errors/is-error.ts
@@ -1,0 +1,8 @@
+import { DaffError } from './error.interface';
+import { DaffInheritableError } from './inheritable-error';
+
+/**
+ * Checks if the passed object is a {@link DaffError}
+ */
+export const daffIsError = (error: any): boolean =>
+  error instanceof DaffInheritableError || !!(<DaffError>error).code;

--- a/libs/core/src/errors/public_api.ts
+++ b/libs/core/src/errors/public_api.ts
@@ -1,3 +1,4 @@
 export { DaffErrorCodeMap } from './error-map';
 export { DaffError } from './error.interface';
 export { DaffInheritableError } from './inheritable-error';
+export { daffIsError } from './is-error';

--- a/libs/core/state/src/errors/transform-error-to-state-error.spec.ts
+++ b/libs/core/state/src/errors/transform-error-to-state-error.spec.ts
@@ -1,9 +1,12 @@
-import { DaffError } from '@daffodil/core';
+import {
+  DaffError,
+  DaffInheritableError,
+} from '@daffodil/core';
 import { DaffStateError } from '@daffodil/core/state';
 
 import { daffTransformErrorToStateError } from './transform-error-to-state-error';
 
-class TestError extends Error implements DaffError {
+class TestError extends DaffInheritableError implements DaffError {
   constructor(public code: string, public message: string) {
     super(message);
   }

--- a/libs/driver/magento/src/errors/error.class.ts
+++ b/libs/driver/magento/src/errors/error.class.ts
@@ -1,0 +1,17 @@
+import {
+  DaffError,
+  DaffInheritableError,
+} from '@daffodil/core';
+
+export const DAFF_DRIVER_MAGENTO_ERROR_CODE = 'DAFF_DRIVER_MAGENTO_ERROR';
+
+/**
+ * A very general error thrown when a more specific error type cannot be determined.
+ */
+export class DaffDriverMagentoError extends DaffInheritableError implements DaffError {
+	public readonly code: string = DAFF_DRIVER_MAGENTO_ERROR_CODE;
+
+	constructor(message?: string) {
+	  super(message);
+	}
+}

--- a/libs/driver/magento/src/errors/public_api.ts
+++ b/libs/driver/magento/src/errors/public_api.ts
@@ -1,1 +1,6 @@
 export { daffTransformMagentoError } from './transform';
+export { daffMagentoTransformGraphQlError } from './transform-graphql';
+export {
+  DAFF_DRIVER_MAGENTO_ERROR_CODE,
+  DaffDriverMagentoError,
+} from './error.class';

--- a/libs/driver/magento/src/errors/transform-graphql.ts
+++ b/libs/driver/magento/src/errors/transform-graphql.ts
@@ -11,9 +11,7 @@ export function daffMagentoTransformGraphQlError<T extends DaffErrorCodeMap>(
   error: GraphQLError,
   map: T,
 ): DaffError {
-
   const ErrorClass = map[error.extensions.category] || DaffDriverMagentoError;
-  console.log(ErrorClass);
 
   return new ErrorClass(error.message) ;
 };

--- a/libs/driver/magento/src/errors/transform-graphql.ts
+++ b/libs/driver/magento/src/errors/transform-graphql.ts
@@ -1,0 +1,19 @@
+import { GraphQLError } from 'graphql';
+
+import {
+  DaffError,
+  DaffErrorCodeMap,
+} from '@daffodil/core';
+
+import { DaffDriverMagentoError } from './error.class';
+
+export function daffMagentoTransformGraphQlError<T extends DaffErrorCodeMap>(
+  error: GraphQLError,
+  map: T,
+): DaffError {
+
+  const ErrorClass = map[error.extensions.category] || DaffDriverMagentoError;
+  console.log(ErrorClass);
+
+  return new ErrorClass(error.message) ;
+};

--- a/libs/driver/magento/src/errors/transform.spec.ts
+++ b/libs/driver/magento/src/errors/transform.spec.ts
@@ -53,6 +53,20 @@ describe('Driver | Magento | Errors | daffTransformMagentoError', () => {
     };
   });
 
+  describe('if the passed error is a Daffodil error', () => {
+    let daffError: MockError;
+    let result: DaffError;
+
+    beforeEach(() => {
+      daffError = new MockError('A Daffodil error');
+      result = daffTransformMagentoError(daffError, map);
+    });
+
+    it('should return the passed error', () => {
+      expect(result).toEqual(daffError);
+    });
+  });
+
   it('should be able to process graphql errors and return the relevant error if a mapping exists', () => {
     const error = new ApolloError({
       graphQLErrors: [handledGraphQlError],

--- a/libs/driver/magento/src/errors/transform.ts
+++ b/libs/driver/magento/src/errors/transform.ts
@@ -1,26 +1,20 @@
-import { ApolloError } from '@apollo/client/core';
+import {
+  DaffError,
+  DaffErrorCodeMap,
+} from '@daffodil/core';
 
-import { DaffErrorCodeMap } from '@daffodil/core';
-
-function transformGraphQlError<T extends DaffErrorCodeMap>(
-  error: ApolloError,
-  map: T,
-): Error {
-  if (!error.graphQLErrors.length) {
-    return error;
-  }
-  const lookup = map[error.graphQLErrors[0].extensions.category];
-  return lookup ? new lookup(error.message) : error;
-};
+import { DaffDriverMagentoError } from './error.class';
+import { daffMagentoTransformGraphQlError } from './transform-graphql';
 
 /**
  * Transforms the passed error according to the lookup in the passed map.
  */
-export function daffTransformMagentoError<T extends DaffErrorCodeMap>(error: any, map: T): Error {
+// TODO: return array of errors
+export function daffTransformMagentoError<T extends DaffErrorCodeMap>(error: any, map: T): DaffError {
   // TODO: handle network errors
   if (error.graphQLErrors) {
-    return transformGraphQlError<T>(error, map);
+    return error.graphQLErrors.map(err => daffMagentoTransformGraphQlError<T>(err, map))[0];
   } else {
-    return error;
+    return new DaffDriverMagentoError(error.message);
   }
 };

--- a/libs/driver/magento/src/errors/transform.ts
+++ b/libs/driver/magento/src/errors/transform.ts
@@ -1,6 +1,7 @@
 import {
   DaffError,
   DaffErrorCodeMap,
+  daffIsError,
 } from '@daffodil/core';
 
 import { DaffDriverMagentoError } from './error.class';
@@ -14,6 +15,8 @@ export function daffTransformMagentoError<T extends DaffErrorCodeMap>(error: any
   // TODO: handle network errors
   if (error.graphQLErrors) {
     return error.graphQLErrors.map(err => daffMagentoTransformGraphQlError<T>(err, map))[0];
+  } else if (daffIsError(error)) {
+    return error;
   } else {
     return new DaffDriverMagentoError(error.message);
   }

--- a/libs/geography/driver/magento/src/geography.service.spec.ts
+++ b/libs/geography/driver/magento/src/geography.service.spec.ts
@@ -9,7 +9,10 @@ import {
 import { GraphQLError } from 'graphql';
 import { catchError } from 'rxjs/operators';
 
-import { schema } from '@daffodil/driver/magento';
+import {
+  DaffDriverMagentoError,
+  schema,
+} from '@daffodil/driver/magento';
 import {
   DaffCountry,
   DaffSubdivision,
@@ -226,11 +229,10 @@ describe('Driver | Magento | Geography | GeographyService', () => {
     });
 
     describe('when the call to the Magento API is unsuccessful', () => {
-      it('should throw an Error with a GraphQLError', done => {
+      it('should throw a general Magento driver error', done => {
         service.list().pipe(
           catchError(err => {
-            expect(err).toEqual(jasmine.any(Error));
-            expect(err.graphQLErrors[0]).toEqual(jasmine.any(GraphQLError));
+            expect(err).toEqual(jasmine.any(DaffDriverMagentoError));
             done();
             return [];
           }),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The daffodil error transform can return any `Error`


## What is the new behavior?
The transform's return type is constrained to `DaffError`
The transform now accepts an array of errors to transform. This is necessary to accomodate multiple errors occuring for a single driver call.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
needed for #1950 