### PR TITLE
feat(cart,demo): use DaffDriverResponse for get call and handle partial success

### DIFF
--- a/apps/demo/src/app/cart/routing-resolvers/effects/cart-resolver.effects.spec.ts
+++ b/apps/demo/src/app/cart/routing-resolvers/effects/cart-resolver.effects.spec.ts
@@ -93,7 +93,10 @@ describe('CartResolverEffects', () => {
       describe('and service call to cartService.get is successful', () => {
 
         beforeEach(() => {
-          spyOn(driver, 'get').and.returnValue(of(stubCart));
+          spyOn(driver, 'get').and.returnValue(of({
+            response: stubCart,
+            errors: [],
+          }));
         });
 
         it('should dispatch a ResolveCartSuccess action', () => {

--- a/apps/demo/src/app/cart/routing-resolvers/effects/cart-resolver.effects.ts
+++ b/apps/demo/src/app/cart/routing-resolvers/effects/cart-resolver.effects.ts
@@ -70,7 +70,7 @@ export class CartResolverEffects {
 
 	private getCartHandler(): Observable<Action> {
 	  return this.driver.get(this.cartStorage.getCartId()).pipe(
-	    map(resp => new ResolveCartSuccess(resp)),
+	    map(resp => new ResolveCartSuccess(resp.response)),
 	    catchError(error => of(new ResolveCartFailure(null))),
 	  );
 	}

--- a/libs/cart/driver/in-memory/src/drivers/cart/cart.service.spec.ts
+++ b/libs/cart/driver/in-memory/src/drivers/cart/cart.service.spec.ts
@@ -12,7 +12,7 @@ import { DaffCartFactory } from '@daffodil/cart/testing';
 
 import { DaffInMemoryCartService } from './cart.service';
 
-describe('Driver | In Memory | Cart | CartService', () => {
+describe('@daffodil/cart/driver/in-memory | DaffInMemoryCartService', () => {
   let cartService: DaffInMemoryCartService;
   let httpMock: HttpTestingController;
   let cartFactory: DaffCartFactory;
@@ -47,9 +47,9 @@ describe('Driver | In Memory | Cart | CartService', () => {
   });
 
   describe('get | getting a cart', () => {
-    it('should send a get request and return cart', done => {
-      cartService.get(cartId).subscribe(cart => {
-        expect(cart).toEqual(mockCart);
+    it('should send a get request and return the cart in the response', done => {
+      cartService.get(cartId).subscribe(({ response }) => {
+        expect(response).toEqual(mockCart);
         done();
       });
 

--- a/libs/cart/driver/in-memory/src/drivers/cart/cart.service.ts
+++ b/libs/cart/driver/in-memory/src/drivers/cart/cart.service.ts
@@ -14,6 +14,7 @@ import {
   DaffCartServiceInterface,
   DaffCartNotFoundError,
 } from '@daffodil/cart/driver';
+import { DaffDriverResponse } from '@daffodil/driver';
 
 /**
  * @inheritdoc
@@ -21,7 +22,7 @@ import {
 @Injectable({
   providedIn: 'root',
 })
-export class DaffInMemoryCartService implements DaffCartServiceInterface<DaffCart> {
+export class DaffInMemoryCartService implements DaffCartServiceInterface {
   /**
    * The URL with which the driver makes calls to the backend.
    */
@@ -29,10 +30,13 @@ export class DaffInMemoryCartService implements DaffCartServiceInterface<DaffCar
 
   constructor(private http: HttpClient) {}
 
-  get(cartId: DaffCart['id']): Observable<DaffCart> {
+  get(cartId: DaffCart['id']): Observable<DaffDriverResponse<DaffCart>> {
     return this.http.get<DaffCart>(`${this.url}/${cartId}`).pipe(
       catchError((error: Error) => throwError(new DaffCartNotFoundError(error.message))),
-      map(result => result),
+      map(result => ({
+        response: result,
+        errors: [],
+      })),
     );
   }
 

--- a/libs/cart/driver/magento/src/errors/transform.ts
+++ b/libs/cart/driver/magento/src/errors/transform.ts
@@ -1,23 +1,32 @@
 import { ApolloError } from '@apollo/client/core';
+import { GraphQLError } from 'graphql';
 
 import { DaffCartCoupon } from '@daffodil/cart';
 import {
   DaffCartDriverErrorMap,
   DaffInvalidCouponCodeError,
 } from '@daffodil/cart/driver';
-import { daffTransformMagentoError } from '@daffodil/driver/magento';
+import { DaffError } from '@daffodil/core';
+import {
+  daffTransformMagentoError,
+  daffMagentoTransformGraphQlError,
+} from '@daffodil/driver/magento';
 
 import {
   DaffCartMagentoErrorMap,
   DaffCartMagentoErrorMessageRegexMap,
 } from './map';
 
-
-function transformMagentoCartGraphQlError(error: ApolloError, requestPayload?: unknown): Error {
+/**
+ * Transforms a single GraphQL error.
+ * Optionally accepts a request payload which can be used in certain cases
+ * to add supplemental info to the error.
+ */
+export function transformMagentoCartGraphQlError(error: GraphQLError, requestPayload?: unknown): DaffError {
   // TODO: readdress this when we move to eslint
   // eslint-disable-next-line
   for (const code in DaffCartMagentoErrorMessageRegexMap) {
-    const matchIndex = error.graphQLErrors[0].message.search(DaffCartMagentoErrorMessageRegexMap[code]);
+    const matchIndex = error.message.search(DaffCartMagentoErrorMessageRegexMap[code]);
 
     if (matchIndex > -1 && DaffCartDriverErrorMap[code]) {
       const errObj = new DaffCartDriverErrorMap[code](error.message);
@@ -30,12 +39,16 @@ function transformMagentoCartGraphQlError(error: ApolloError, requestPayload?: u
     }
   }
 
-  return daffTransformMagentoError(error, DaffCartMagentoErrorMap);
+  return daffMagentoTransformGraphQlError(error, DaffCartMagentoErrorMap);
 };
 
+/**
+ * Transforms only the first GraphQL error with the cart magento error transformer,
+ * otherwise falls back to a standard Magento error transform.
+ */
 export function transformCartMagentoError(error, requestPayload?: unknown) {
   if (error.graphQLErrors?.length) {
-    return transformMagentoCartGraphQlError(error, requestPayload);
+    return transformMagentoCartGraphQlError((<ApolloError>error).graphQLErrors[0], requestPayload);
   } else {
     return daffTransformMagentoError(error, DaffCartMagentoErrorMap);
   }

--- a/libs/cart/driver/src/interfaces/cart-service.interface.ts
+++ b/libs/cart/driver/src/interfaces/cart-service.interface.ts
@@ -2,6 +2,7 @@ import { InjectionToken } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { DaffCart } from '@daffodil/cart';
+import { DaffDriverResponse } from '@daffodil/driver';
 
 /**
  * The interface responsible for managing a customer's cart.
@@ -10,7 +11,7 @@ export interface DaffCartServiceInterface<T extends DaffCart = DaffCart> {
 	/**
 	 * Retrieve a cart
 	 */
-  get(id: T['id']): Observable<T>;
+  get(id: T['id']): Observable<DaffDriverResponse<T>>;
 
   /**
    * Creates a cart.

--- a/libs/cart/driver/testing/src/drivers/cart/cart.service.spec.ts
+++ b/libs/cart/driver/testing/src/drivers/cart/cart.service.spec.ts
@@ -6,7 +6,7 @@ import { DaffCartFactory } from '@daffodil/cart/testing';
 
 import { DaffTestingCartService } from './cart.service';
 
-describe('Driver | Testing | Cart | CartService', () => {
+describe('@daffodil/cart/driver/testing | DaffTestingCartService', () => {
   let service: DaffTestingCartService;
   let cartFactory: DaffCartFactory;
 

--- a/libs/cart/driver/testing/src/drivers/cart/cart.service.ts
+++ b/libs/cart/driver/testing/src/drivers/cart/cart.service.ts
@@ -7,6 +7,7 @@ import {
 import { DaffCart } from '@daffodil/cart';
 import { DaffCartServiceInterface } from '@daffodil/cart/driver';
 import { DaffCartFactory } from '@daffodil/cart/testing';
+import { DaffDriverResponse } from '@daffodil/driver';
 
 /**
  * @inheritdoc
@@ -19,8 +20,11 @@ export class DaffTestingCartService implements DaffCartServiceInterface {
     private cartFactory: DaffCartFactory,
   ) {}
 
-  get(id: DaffCart['id']): Observable<DaffCart> {
-    return of(this.cartFactory.create());
+  get(id: DaffCart['id']): Observable<DaffDriverResponse<DaffCart>> {
+    return of({
+      response: this.cartFactory.create(),
+      errors: [],
+    });
   }
 
   addToCart(productId: string, qty: number): Observable<DaffCart> {

--- a/libs/cart/routing/src/resolvers/cart-resolver.service.spec.ts
+++ b/libs/cart/routing/src/resolvers/cart-resolver.service.spec.ts
@@ -101,10 +101,10 @@ describe('DaffCartResolver', () => {
 
       it('should resolve with a DaffCartLoadFailure action', () => {
         cartResolver.resolve().subscribe((resolvedValue) => {
-          expect(resolvedValue).toEqual(new DaffCartLoadFailure(null));
+          expect(resolvedValue).toEqual(new DaffCartLoadFailure([]));
         });
 
-        store.dispatch(new DaffCartLoadFailure(null));
+        store.dispatch(new DaffCartLoadFailure([]));
       });
 
       it('should redirect to the provided DaffCartResolverRedirectUrl', () => {
@@ -112,7 +112,7 @@ describe('DaffCartResolver', () => {
           expect(router.navigateByUrl).toHaveBeenCalledWith(stubUrl);
         });
 
-        store.dispatch(new DaffCartLoadFailure(null));
+        store.dispatch(new DaffCartLoadFailure([]));
       });
     });
 

--- a/libs/cart/state/src/actions/cart.actions.ts
+++ b/libs/cart/state/src/actions/cart.actions.ts
@@ -11,6 +11,7 @@ export enum DaffCartActionTypes {
   CartStorageFailureAction = '[DaffCart] Cart Storage Failure Action',
   CartLoadAction = '[DaffCart] Cart Load Action',
   CartLoadSuccessAction = '[DaffCart] Cart Load Success Action',
+  CartLoadPartialSuccessAction = '[DaffCart] Cart Load Partial Success Action',
   CartLoadFailureAction = '[DaffCart] Cart Load Failure Action',
   CartCreateAction = '[DaffCart] Cart Create Action',
   CartCreateSuccessAction = '[DaffCart] Cart Create Success Action',
@@ -23,6 +24,7 @@ export enum DaffCartActionTypes {
   CartClearFailureAction = '[DaffCart] Cart Reset Failure Action',
   ResolveCartAction = '[DaffCart] Resolve Cart Action',
   ResolveCartSuccessAction = '[DaffCart] Resolve Cart Success Action',
+  ResolveCartPartialSuccessAction = '[DaffCart] Resolve Cart Partial Success Action',
   ResolveCartServerSideAction = '[DaffCart] Resolve Cart Server Side Action',
   ResolveCartFailureAction = '[DaffCart] Resolve Cart Failure Action',
 }
@@ -53,12 +55,24 @@ export class DaffCartLoadSuccess<T extends DaffCart = DaffCart> implements Actio
 }
 
 /**
+ * An action that indicates a user's cart is loaded but recoverable errors occurred.
+ * There should be enough data to render the cart
+ * but the user should probably be shown error messages as well.
+ * A common example is some cart items being out of stock.
+ */
+export class DaffCartLoadPartialSuccess<T extends DaffCart = DaffCart> implements Action {
+  readonly type = DaffCartActionTypes.CartLoadPartialSuccessAction;
+
+  constructor(public payload: T, public errors: DaffStateError[]) {}
+}
+
+/**
  * Indicates the failed load of the cart.
  */
 export class DaffCartLoadFailure implements Action {
   readonly type = DaffCartActionTypes.CartLoadFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -150,12 +164,24 @@ export class DaffResolveCartSuccess<T extends DaffCart = DaffCart> implements Ac
 }
 
 /**
+ * An action that indicates a user's cart is resolved but recoverable errors occurred.
+ * There should be enough data to render the cart
+ * but the user should probably be shown error messages as well.
+ * A common example is some cart items being out of stock.
+ */
+export class DaffResolveCartPartialSuccess<T extends DaffCart = DaffCart> implements Action {
+  readonly type = DaffCartActionTypes.ResolveCartPartialSuccessAction;
+
+  constructor(public payload: T, public errors: DaffStateError[]) {}
+}
+
+/**
  * An action that indicates that a cart failed to resolve.
  */
 export class DaffResolveCartFailure implements Action {
   readonly type = DaffCartActionTypes.ResolveCartFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -175,6 +201,7 @@ export type DaffCartActions<T extends DaffCart = DaffCart> =
   | DaffCartStorageFailure
   | DaffCartLoad
   | DaffCartLoadSuccess<T>
+  | DaffCartLoadPartialSuccess<T>
   | DaffCartLoadFailure
   | DaffCartCreate
   | DaffCartCreateSuccess<T>
@@ -187,5 +214,6 @@ export type DaffCartActions<T extends DaffCart = DaffCart> =
   | DaffCartClearFailure
   | DaffResolveCart
   | DaffResolveCartSuccess<T>
+  | DaffResolveCartPartialSuccess<T>
   | DaffResolveCartServerSide
   | DaffResolveCartFailure;

--- a/libs/cart/state/src/effects/cart.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart.effects.spec.ts
@@ -16,6 +16,7 @@ import {
 import {
   DaffCartServiceInterface,
   DaffCartDriver,
+  DaffProductOutOfStockError,
 } from '@daffodil/cart/driver';
 import { DaffTestingCartDriverModule } from '@daffodil/cart/driver/testing';
 import {
@@ -33,6 +34,7 @@ import {
   DaffCartCreateFailure,
   DaffCartStorageFailure,
   DaffResolveCartSuccess,
+  DaffCartLoadPartialSuccess,
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import { DaffStorageServiceError } from '@daffodil/core';
@@ -43,7 +45,7 @@ import {
 
 import { DaffCartEffects } from './cart.effects';
 
-describe('Daffodil | Cart | CartEffects', () => {
+describe('@daffodil/cart/state | DaffCartEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCartEffects<DaffCart>;
 
@@ -54,10 +56,10 @@ describe('Daffodil | Cart | CartEffects', () => {
   let driver: DaffCartServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverGetSpy: jasmine.Spy;
-  let driverCreateSpy: jasmine.Spy;
-  let driverClearSpy: jasmine.Spy;
-  let driverAddToCartSpy: jasmine.Spy;
+  let driverGetSpy: jasmine.Spy<DaffCartServiceInterface['get']>;
+  let driverCreateSpy: jasmine.Spy<DaffCartServiceInterface['create']>;
+  let driverClearSpy: jasmine.Spy<DaffCartServiceInterface['clear']>;
+  let driverAddToCartSpy: jasmine.Spy<DaffCartServiceInterface['addToCart']>;
   let getCartIdSpy: jasmine.Spy;
   let setCartIdSpy: jasmine.Spy;
 
@@ -103,7 +105,10 @@ describe('Daffodil | Cart | CartEffects', () => {
 
     describe('and the call to CartService is successful', () => {
       beforeEach(() => {
-        driverGetSpy.and.returnValue(of(mockCart));
+        driverGetSpy.and.returnValue(of({
+          response: mockCart,
+          errors: [],
+        }));
         const cartLoadSuccessAction = new DaffCartLoadSuccess(mockCart);
         actions$ = hot('--a', { a: cartLoadAction });
         expected = cold('--b', { b: cartLoadSuccessAction });
@@ -114,12 +119,32 @@ describe('Daffodil | Cart | CartEffects', () => {
       });
     });
 
+    describe('and the call to CartService is partially successful', () => {
+      let oosError: DaffProductOutOfStockError;
+
+      beforeEach(() => {
+        oosError = new DaffProductOutOfStockError('Some of the cart items are out of stock');
+        oosError.recoverable = true;
+        driverGetSpy.and.returnValue(of({
+          response: mockCart,
+          errors: [oosError],
+        }));
+        const cartLoadPartialSuccessAction = new DaffCartLoadPartialSuccess(mockCart, [daffTransformErrorToStateError(oosError)]);
+        actions$ = hot('--a', { a: cartLoadAction });
+        expected = cold('--b', { b: cartLoadPartialSuccessAction });
+      });
+
+      it('should dispatch a DaffCartLoadPartialSuccess action', () => {
+        expect(effects.get$).toBeObservable(expected);
+      });
+    });
+
     describe('and the call to CartService fails', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to load cart' };
         const response = cold('#', {}, error);
         driverGetSpy.and.returnValue(response);
-        const cartLoadFailureAction = new DaffCartLoadFailure(error);
+        const cartLoadFailureAction = new DaffCartLoadFailure([error]);
         actions$ = hot('--a', { a: cartLoadAction });
         expected = cold('--b', { b: cartLoadFailureAction });
       });

--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -818,7 +818,7 @@ describe('DaffCartFacade', () => {
     it('should contain an error upon a failed cart load', () => {
       const error: DaffStateError = { code: 'error code', message: 'error message' };
       const expected = cold('a', { a: [error]});
-      facade.dispatch(new DaffCartLoadFailure(error));
+      facade.dispatch(new DaffCartLoadFailure([error]));
       expect(facade.cartErrors$).toBeObservable(expected);
     });
   });

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -18,6 +18,8 @@ import {
   DaffCartItemUpdateFailure,
   DaffCartCreateSuccess,
   DaffCartItemDeleteOutOfStockSuccess,
+  DaffCartLoadPartialSuccess,
+  DaffResolveCartPartialSuccess,
 } from '@daffodil/cart/state';
 import { DaffStatefulCartItemFactory } from '@daffodil/cart/state/testing';
 import {
@@ -382,6 +384,93 @@ describe('Cart | Cart Item Entities Reducer', () => {
       const resolveCartSuccess = new DaffResolveCartSuccess(cart);
 
       result = daffCartItemEntitiesReducer(initialState, resolveCartSuccess);
+    });
+
+    it('sets expected number of cartItems on state', () => {
+      expect(result.ids.length).toEqual(cartItems.length);
+    });
+
+    it('sets expected cart item on state', () => {
+      expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
+    });
+
+    it('should reset the cart item errors', () => {
+      expect(result.entities[cartItems[0].id].errors).toEqual([]);
+    });
+  });
+
+  describe('when DeleteOutOfStockSuccessAction is triggered', () => {
+
+    let cart: DaffCart;
+    let cartItems: DaffStatefulCartItem[];
+    let result;
+
+    beforeEach(() => {
+      cartItems = statefulCartItemFactory.createMany(2);
+      cart = new DaffCartFactory().create({
+        items: cartItems,
+      });
+      const deleteOutOfStockSuccess = new DaffCartItemDeleteOutOfStockSuccess(cart);
+
+      result = daffCartItemEntitiesReducer(initialState, deleteOutOfStockSuccess);
+    });
+
+    it('sets expected number of cartItems on state', () => {
+      expect(result.ids.length).toEqual(cartItems.length);
+    });
+
+    it('sets expected cart item on state', () => {
+      expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
+    });
+
+    it('should reset the cart item errors', () => {
+      expect(result.entities[cartItems[0].id].errors).toEqual([]);
+    });
+  });
+
+  describe('when ResolveCartPartialSuccessAction is triggered', () => {
+
+    let cart: DaffCart;
+    let cartItems: DaffStatefulCartItem[];
+    let result;
+
+    beforeEach(() => {
+      cartItems = statefulCartItemFactory.createMany(2);
+      cart = new DaffCartFactory().create({
+        items: cartItems,
+      });
+      const resolveCartPartialSuccess = new DaffResolveCartPartialSuccess(cart, []);
+
+      result = daffCartItemEntitiesReducer(initialState, resolveCartPartialSuccess);
+    });
+
+    it('sets expected number of cartItems on state', () => {
+      expect(result.ids.length).toEqual(cartItems.length);
+    });
+
+    it('sets expected cart item on state', () => {
+      expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
+    });
+
+    it('should reset the cart item errors', () => {
+      expect(result.entities[cartItems[0].id].errors).toEqual([]);
+    });
+  });
+
+  describe('when CartLoadPartialSuccessAction is triggered', () => {
+
+    let cart: DaffCart;
+    let cartItems: DaffStatefulCartItem[];
+    let result;
+
+    beforeEach(() => {
+      cartItems = statefulCartItemFactory.createMany(2);
+      cart = new DaffCartFactory().create({
+        items: cartItems,
+      });
+      const cartLoadPartialSuccess = new DaffCartLoadPartialSuccess(cart, []);
+
+      result = daffCartItemEntitiesReducer(initialState, cartLoadPartialSuccess);
     });
 
     it('sets expected number of cartItems on state', () => {

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -399,35 +399,6 @@ describe('Cart | Cart Item Entities Reducer', () => {
     });
   });
 
-  describe('when DeleteOutOfStockSuccessAction is triggered', () => {
-
-    let cart: DaffCart;
-    let cartItems: DaffStatefulCartItem[];
-    let result;
-
-    beforeEach(() => {
-      cartItems = statefulCartItemFactory.createMany(2);
-      cart = new DaffCartFactory().create({
-        items: cartItems,
-      });
-      const deleteOutOfStockSuccess = new DaffCartItemDeleteOutOfStockSuccess(cart);
-
-      result = daffCartItemEntitiesReducer(initialState, deleteOutOfStockSuccess);
-    });
-
-    it('sets expected number of cartItems on state', () => {
-      expect(result.ids.length).toEqual(cartItems.length);
-    });
-
-    it('sets expected cart item on state', () => {
-      expect(result.entities[cartItems[0].id]).toEqual(cartItems[0]);
-    });
-
-    it('should reset the cart item errors', () => {
-      expect(result.entities[cartItems[0].id].errors).toEqual([]);
-    });
-  });
-
   describe('when ResolveCartPartialSuccessAction is triggered', () => {
 
     let cart: DaffCart;

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -71,6 +71,8 @@ export function daffCartItemEntitiesReducer<
     case DaffCartItemActionTypes.CartItemDeleteOutOfStockSuccessAction:
     case DaffCartActionTypes.CartLoadSuccessAction:
     case DaffCartActionTypes.ResolveCartSuccessAction:
+    case DaffCartActionTypes.CartLoadPartialSuccessAction:
+    case DaffCartActionTypes.ResolveCartPartialSuccessAction:
     case DaffCartActionTypes.CartClearSuccessAction:
       return adapter.setAll(<T[]><unknown>action.payload.items.map(item => ({
         ...item,

--- a/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
@@ -77,7 +77,7 @@ describe('Cart | Reducer | cartResolveReducer', () => {
         resolved: DaffCartResolveState.Resolving,
       };
 
-      const cartResolveFailure = new DaffResolveCartFailure(error);
+      const cartResolveFailure = new DaffResolveCartFailure([error]);
 
       result = reducer(state, cartResolveFailure);
     });

--- a/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
@@ -21,6 +21,7 @@ import {
   DaffResolveCartSuccess,
   DaffResolveCartFailure,
   DaffResolveCartServerSide,
+  DaffResolveCartPartialSuccess,
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import { DaffStorageServiceError } from '@daffodil/core';
@@ -30,9 +31,10 @@ import {
   daffTransformErrorToStateError,
 } from '@daffodil/core/state';
 
+import { DaffCartLoadPartialSuccess } from '../../actions/public_api';
 import { cartReducer } from './cart.reducer';
 
-describe('Cart | Reducer | Cart', () => {
+describe('@daffodil/cart/state | cartReducer', () => {
   let cartFactory: DaffCartFactory;
   let error: DaffStateError;
   let cart: DaffCart;
@@ -108,6 +110,42 @@ describe('Cart | Reducer | Cart', () => {
     });
   });
 
+  describe('when CartLoadPartialSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartReducerState<DaffCart>;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: {
+          ...initialState.loading,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
+        },
+        errors: {
+          ...initialState.errors,
+          [DaffCartOperationType.Cart]: [{ code: 'first error code', message: 'first error message' }],
+        },
+      };
+
+      const cartListLoadSuccess = new DaffCartLoadPartialSuccess(cart, [error]);
+
+      result = cartReducer(state, cartListLoadSuccess);
+    });
+
+    it('should set cart from action.payload', () => {
+      expect(result.cart).toEqual(cart);
+    });
+
+    it('should indicate that the cart is not loading', () => {
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
+    });
+
+    it('should add an error to the cart section of state.errors', () => {
+      expect(result.errors[DaffCartOperationType.Cart].length).toEqual(2);
+      expect(result.errors[DaffCartOperationType.Cart]).toContain(error);
+    });
+  });
+
   describe('when ResolveCartSuccessAction is triggered', () => {
     let result;
     let state: DaffCartReducerState<DaffCart>;
@@ -139,6 +177,42 @@ describe('Cart | Reducer | Cart', () => {
     });
   });
 
+  describe('when ResolveCartPartialSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartReducerState<DaffCart>;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: {
+          ...initialState.loading,
+          [DaffCartOperationType.Cart]: DaffState.Resolving,
+        },
+        errors: {
+          ...initialState.errors,
+          [DaffCartOperationType.Cart]: [{ code: 'first error code', message: 'first error message' }],
+        },
+      };
+
+      const cartListLoadSuccess = new DaffResolveCartPartialSuccess(cart, [error]);
+
+      result = cartReducer(state, cartListLoadSuccess);
+    });
+
+    it('should set cart from action.payload', () => {
+      expect(result.cart).toEqual(cart);
+    });
+
+    it('should indicate that the cart is not loading', () => {
+      expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Complete);
+    });
+
+    it('should add an error to the cart section of state.errors', () => {
+      expect(result.errors[DaffCartOperationType.Cart].length).toEqual(2);
+      expect(result.errors[DaffCartOperationType.Cart]).toContain(error);
+    });
+  });
+
   describe('when CartLoadFailureAction is triggered', () => {
     let result;
     let state: DaffCartReducerState<DaffCart>;
@@ -156,7 +230,7 @@ describe('Cart | Reducer | Cart', () => {
         },
       };
 
-      const cartListLoadFailure = new DaffCartLoadFailure(error);
+      const cartListLoadFailure = new DaffCartLoadFailure([error]);
 
       result = cartReducer(state, cartListLoadFailure);
     });
@@ -187,7 +261,7 @@ describe('Cart | Reducer | Cart', () => {
         },
       };
 
-      const cartListLoadFailure = new DaffResolveCartFailure(error);
+      const cartListLoadFailure = new DaffResolveCartFailure([error]);
 
       result = cartReducer(state, cartListLoadFailure);
     });
@@ -198,6 +272,7 @@ describe('Cart | Reducer | Cart', () => {
 
     it('should add an error to the cart section of state.errors', () => {
       expect(result.errors[DaffCartOperationType.Cart].length).toEqual(2);
+      expect(result.errors[DaffCartOperationType.Cart]).toContain(error);
     });
   });
 

--- a/libs/cart/state/src/reducers/cart/cart.reducer.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.ts
@@ -60,17 +60,35 @@ export function cartReducer<T extends DaffCart>(
         },
         ...setLoading(state.loading, DaffState.Complete),
       };
-    case DaffCartActionTypes.CartLoadFailureAction:
     case DaffCartActionTypes.CartClearFailureAction:
     case DaffCartActionTypes.AddToCartFailureAction:
     case DaffCartActionTypes.CartCreateFailureAction:
     case DaffCartActionTypes.CartStorageFailureAction:
-    case DaffCartActionTypes.ResolveCartFailureAction:
     case DaffCartActionTypes.ResolveCartServerSideAction:
       return {
         ...state,
         ...addError(state.errors, action.payload),
         ...setLoading(state.loading, DaffState.Complete),
+      };
+
+    case DaffCartActionTypes.CartLoadFailureAction:
+    case DaffCartActionTypes.ResolveCartFailureAction:
+      return {
+        ...state,
+        ...addError(state.errors, ...action.payload),
+        ...setLoading(state.loading, DaffState.Stable),
+      };
+
+    case DaffCartActionTypes.ResolveCartPartialSuccessAction:
+    case DaffCartActionTypes.CartLoadPartialSuccessAction:
+      return {
+        ...state,
+        cart: {
+          ...state.cart,
+          ...action.payload,
+        },
+        ...addError(state.errors, ...action.errors),
+        ...setLoading(state.loading, DaffState.Stable),
       };
 
     default:

--- a/libs/cart/state/src/reducers/errors/error-state-helpers.ts
+++ b/libs/cart/state/src/reducers/errors/error-state-helpers.ts
@@ -4,10 +4,10 @@ import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartErrors } from './cart-errors.type';
 
 export const initializeErrorAdder = (errorSpace: DaffCartOperationType) =>
-  (errors: DaffCartErrors, error: DaffStateError) => ({
+  (errors: DaffCartErrors, ...errorsToAdd: DaffStateError[]) => ({
     errors: {
       ...errors,
-      [errorSpace]: errors[errorSpace].concat(new Array(error)),
+      [errorSpace]: errors[errorSpace].concat(errorsToAdd),
     },
   });
 

--- a/libs/cart/state/src/selectors/cart/cart.selector.spec.ts
+++ b/libs/cart/state/src/selectors/cart/cart.selector.spec.ts
@@ -243,7 +243,7 @@ describe('Cart | Selector | Cart', () => {
     it('should be failed after cart resolution failure', () => {
       const selector = store.pipe(select(selectCartResolved));
       const expected = cold('a', { a: DaffCartResolveState.Failed });
-      store.dispatch(new DaffResolveCartFailure(error));
+      store.dispatch(new DaffResolveCartFailure([error]));
 
       expect(selector).toBeObservable(expected);
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The cart get call will only either error or succeed.


## What is the new behavior?
The cart get call can return errors or a response or both. This new case is handled by a somewhat ugly effect.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
`DaffCartServiceInterface#get` now has a return type of `Observable<DaffDriverResponse<T>>`. Implementations should update this method accordingly. Consuming code should be modified to handle the larger type as well as the edge case of a partial success.

## Other information