### PR TITLE
feat(cart): set recoverable on OOS error in Magento get call

### DIFF
--- a/libs/cart/driver/magento/src/cart.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart.service.spec.ts
@@ -14,6 +14,7 @@ import {
   DaffCartItem,
 } from '@daffodil/cart';
 import {
+  DaffCartDriverErrorCodes,
   DaffCartItemDriver,
   DaffCartNotFoundError,
   DaffProductOutOfStockError,
@@ -156,6 +157,35 @@ describe('@daffodil/cart/driver/magento | DaffMagentoCartService', () => {
         service.get(cartId).subscribe(result => {
           expect(result.errors).toContain(jasmine.any(DaffCartNotFoundError));
           expect(result.errors).toContain(jasmine.any(DaffProductOutOfStockError));
+          done();
+        });
+
+        const op = controller.expectOne(addTypenameToDocument(getCart([])));
+
+        op.flush({
+          errors: [new GraphQLError(
+            'Can\'t find a cart with that ID.',
+            null,
+            null,
+            null,
+            null,
+            null,
+            { category: 'graphql-no-such-entity' },
+          ), new GraphQLError(
+            'Some of the products are out of stock.',
+            null,
+            null,
+            null,
+            null,
+            null,
+            { category: 'graphql-no-such-entity' },
+          )],
+        });
+      });
+
+      it('should should set out of stock errors as recoverable', done => {
+        service.get(cartId).subscribe(result => {
+          expect(result.errors.find(error => error.code === DaffCartDriverErrorCodes.PRODUCT_OUT_OF_STOCK).recoverable).toBeTrue();
           done();
         });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

OOS errors are not set as recoverable in the magento driver


## What is the new behavior?
they are

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information