### PR TITLE
feat(cart): fix infinite recurse on subsequent delete OOS calls

### DIFF
--- a/libs/cart/state/src/effects/cart-item.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-item.effects.spec.ts
@@ -5,7 +5,6 @@ import {
   Store,
   StoreModule,
 } from '@ngrx/store';
-import { provideMockStore } from '@ngrx/store/testing';
 import {
   hot,
   cold,

--- a/libs/cart/state/src/effects/cart-item.effects.ts
+++ b/libs/cart/state/src/effects/cart-item.effects.ts
@@ -13,7 +13,6 @@ import {
 } from '@ngrx/store';
 import {
   combineLatest,
-  EMPTY,
   of,
 } from 'rxjs';
 import {
@@ -161,9 +160,10 @@ export class DaffCartItemEffects<
   @Effect()
   removeOutOfStock$ = this.actions$.pipe(
     ofType(DaffCartItemActionTypes.CartItemDeleteOutOfStockAction),
-    switchMap((action: DaffCartItemDeleteOutOfStock) =>
-      this.store.pipe(select(getDaffCartSelectors().selectOutOfStockCartItems)),
-    ),
+    switchMap((action: DaffCartItemDeleteOutOfStock) => this.store.pipe(
+      select(getDaffCartSelectors().selectOutOfStockCartItems),
+      take(1),
+    )),
     switchMap(items => items.length > 0
       ? combineLatest(items.map(item => this.driver.delete(this.storage.getCartId(), item.id))).pipe(
         map(partialCarts => Object.assign({}, ...partialCarts)),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Calling delete OOS can cause an infinite recursion because the cart selector keeps emitting.


## What is the new behavior?
The selector calls are wrapped with `take(1)`, guarding against future emissions.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information