### PR TITLE
feat(order): use Magento `region_code` for `region`

### DIFF
--- a/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
+++ b/libs/order/driver/magento/2.4.1/src/helpers/test-data.service.ts
@@ -342,7 +342,7 @@ export class MagentoOrderTestDataFactory {
       telephone: mockDaffOrderAddress.telephone,
       street: [mockDaffOrderAddress.street, mockDaffOrderAddress.street2],
       city: mockDaffOrderAddress.city,
-      region_id: mockDaffOrderAddress.region,
+      region_code: mockDaffOrderAddress.region,
       region: mockDaffOrderAddress.region,
       country_code: mockDaffOrderAddress.country,
       postcode: mockDaffOrderAddress.postcode,

--- a/libs/order/driver/magento/2.4.1/src/models/responses/order-address.ts
+++ b/libs/order/driver/magento/2.4.1/src/models/responses/order-address.ts
@@ -10,7 +10,7 @@ export interface MagentoOrderAddress {
   postcode: string;
   prefix: string;
   region: string;
-  region_id: string;
+  region_code: string;
   street: string[];
   suffix: string;
   telephone: string;

--- a/libs/order/driver/magento/2.4.1/src/queries/fragments/order-address.ts
+++ b/libs/order/driver/magento/2.4.1/src/queries/fragments/order-address.ts
@@ -13,7 +13,7 @@ export const orderAddressFragment = gql`
     postcode
     prefix
     region
-    region_id
+    region_code
     street
     suffix
     telephone

--- a/libs/order/driver/magento/2.4.1/src/transforms/responses/order.ts
+++ b/libs/order/driver/magento/2.4.1/src/transforms/responses/order.ts
@@ -169,7 +169,7 @@ function transformAddress(address: MagentoOrderAddress, order: MagentoOrder): Da
     street: address.street[0],
     street2: address.street[1],
     city: address.city,
-    region: address.region_id,
+    region: address.region_code,
     country: address.country_code,
     postcode: address.postcode,
   };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`region_id` is used for `region`, which is an unhelpful number


## What is the new behavior?

`region_code` is used for `region`, which is the two letter state code

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information