### PR TITLE
fix(product-composite): magento driver tries to sort immutable array

### DIFF
--- a/libs/product-composite/driver/magento/src/transforms/bundled-product-transformers.ts
+++ b/libs/product-composite/driver/magento/src/transforms/bundled-product-transformers.ts
@@ -47,7 +47,7 @@ function transformMagentoBundledProductItem(item: MagentoBundledProductItem): Da
     required: item.required,
     title: item.title,
     input_type: <DaffCompositeProductItemInputEnum>item.type,
-    options: item.options.sort((a, b) => a.position - b.position).map(transformMagentoBundledProductItemOption),
+    options: Array.from(item.options).sort((a, b) => a.position - b.position).map(transformMagentoBundledProductItemOption),
   };
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Magento driver tries to sort an immutable array


## What is the new behavior?
The Magento driver clones the array before sorting it

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I think this is beacuse the response object is in Apollo cache and Apollo tries to prevent mutation