### PR TITLE
fix(contact, newsletter): allow hubspot drivers to be used together

### DIFF
--- a/libs/contact/driver/hubspot/src/contact.service.spec.ts
+++ b/libs/contact/driver/hubspot/src/contact.service.spec.ts
@@ -6,9 +6,9 @@ import {
 import { Observable } from 'rxjs';
 
 import { DaffContactDriver } from '@daffodil/contact/driver';
-import { DaffHubspotFormsService } from '@daffodil/driver/hubspot';
 
 import { DaffContactHubspotService } from './contact.service';
+import { DAFF_CONTACT_HUBSPOT_FORMS_TOKEN } from './token/hubspot-forms.token';
 
 describe('DaffContactHubspotService', () => {
   let contactService;
@@ -18,7 +18,7 @@ describe('DaffContactHubspotService', () => {
       providers: [
         { provide: DaffContactDriver, useClass: DaffContactHubspotService },
         {
-          provide: DaffHubspotFormsService,
+          provide: DAFF_CONTACT_HUBSPOT_FORMS_TOKEN,
           useValue: {
             submit: (): Observable<any> => hot('--a', { a: { test: '123' }}),
           },

--- a/libs/contact/driver/hubspot/src/contact.service.ts
+++ b/libs/contact/driver/hubspot/src/contact.service.ts
@@ -1,9 +1,14 @@
-import { Injectable } from '@angular/core';
+import {
+  Inject,
+  Injectable,
+} from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { DaffContactUnion } from '@daffodil/contact';
 import { DaffContactServiceInterface } from '@daffodil/contact/driver';
 import { DaffHubspotFormsService } from '@daffodil/driver/hubspot';
+
+import { DAFF_CONTACT_HUBSPOT_FORMS_TOKEN } from './token/hubspot-forms.token';
 
 /**
  * @inheritdoc
@@ -11,7 +16,7 @@ import { DaffHubspotFormsService } from '@daffodil/driver/hubspot';
 @Injectable()
 export class DaffContactHubspotService
 implements DaffContactServiceInterface<DaffContactUnion, any> {
-  constructor(private hubspotService: DaffHubspotFormsService) {}
+  constructor(@Inject(DAFF_CONTACT_HUBSPOT_FORMS_TOKEN) private hubspotService: DaffHubspotFormsService) {}
 
   send(payload: DaffContactUnion): Observable<any> {
     return this.hubspotService.submit(payload);

--- a/libs/contact/driver/hubspot/src/hubspot-driver.module.ts
+++ b/libs/contact/driver/hubspot/src/hubspot-driver.module.ts
@@ -1,21 +1,11 @@
-import {
-  CommonModule,
-  DOCUMENT,
-} from '@angular/common';
-import { HttpClient } from '@angular/common/http';
+import { CommonModule } from '@angular/common';
 import {
   NgModule,
   ModuleWithProviders,
 } from '@angular/core';
-import { Title } from '@angular/platform-browser';
-import { Router } from '@angular/router';
 
 import { DaffContactDriver } from '@daffodil/contact/driver';
-import {
-  DaffHubspotFormsService,
-  daffHubspotFormsServiceFactory,
-  DaffHubspotConfig,
-} from '@daffodil/driver/hubspot';
+import { DaffHubspotConfig } from '@daffodil/driver/hubspot';
 
 import { DaffContactConfigToken } from './config/contact-config.interface';
 import { DaffContactHubspotService } from './contact.service';
@@ -32,11 +22,6 @@ export class DaffContactHubSpotDriverModule {
       providers: [
         { provide: DaffContactDriver, useClass: DaffContactHubspotService },
         { provide: DaffContactConfigToken, useValue: config },
-        {
-          provide: DaffHubspotFormsService,
-          useFactory: daffHubspotFormsServiceFactory,
-          deps: [HttpClient, DOCUMENT, Router, Title, DaffContactConfigToken],
-        },
       ],
     };
   }

--- a/libs/contact/driver/hubspot/src/token/hubspot-forms.token.ts
+++ b/libs/contact/driver/hubspot/src/token/hubspot-forms.token.ts
@@ -1,0 +1,26 @@
+import { DOCUMENT } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import {
+  inject,
+  InjectionToken,
+} from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+
+import {
+  DaffHubspotFormsService,
+  daffHubspotFormsServiceFactory,
+} from '@daffodil/driver/hubspot';
+
+import { DaffContactConfigToken } from '../config/contact-config.interface';
+
+export const DAFF_CONTACT_HUBSPOT_FORMS_TOKEN = new InjectionToken<DaffHubspotFormsService>('DAFF_CONTACT_HUBSPOT_FORMS_TOKEN',
+  {
+    providedIn: 'root', factory: () => daffHubspotFormsServiceFactory(
+      inject(HttpClient),
+      inject(DOCUMENT),
+      inject(Router),
+      inject(Title),
+      inject(DaffContactConfigToken),
+    ),
+  });

--- a/libs/newsletter/driver/hubspot/src/hubspot-driver.module.ts
+++ b/libs/newsletter/driver/hubspot/src/hubspot-driver.module.ts
@@ -1,20 +1,10 @@
-import {
-  CommonModule,
-  DOCUMENT,
-} from '@angular/common';
-import { HttpClient } from '@angular/common/http';
+import { CommonModule } from '@angular/common';
 import {
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
-import { Title } from '@angular/platform-browser';
-import { Router } from '@angular/router';
 
-import {
-  DaffHubspotConfig,
-  DaffHubspotFormsService,
-  daffHubspotFormsServiceFactory,
-} from '@daffodil/driver/hubspot';
+import { DaffHubspotConfig } from '@daffodil/driver/hubspot';
 import { DaffNewsletterDriver } from '@daffodil/newsletter/driver';
 
 import { DaffNewsletterConfigToken } from './config/newsletter-config.interface';
@@ -37,17 +27,6 @@ export class DaffNewsletterHubSpotDriverModule {
         {
           provide: DaffNewsletterConfigToken,
           useValue: config,
-        },
-        {
-          provide: DaffHubspotFormsService,
-          useFactory: daffHubspotFormsServiceFactory,
-          deps: [
-            HttpClient,
-            DOCUMENT,
-            Router,
-            Title,
-            DaffNewsletterConfigToken,
-          ],
         },
       ],
     };

--- a/libs/newsletter/driver/hubspot/src/newsletter.service.spec.ts
+++ b/libs/newsletter/driver/hubspot/src/newsletter.service.spec.ts
@@ -5,9 +5,8 @@ import {
 } from 'jasmine-marbles';
 import { Observable } from 'rxjs';
 
-import { DaffHubspotFormsService } from '@daffodil/driver/hubspot';
-
 import { DaffNewsletterHubspotService } from './newsletter.service';
+import { DAFF_NEWSLETTER_HUBSPOT_FORMS_TOKEN } from './token/hubspot-forms.token';
 
 describe('DaffNewsletterHubspotService', () => {
   let newsletterService;
@@ -17,7 +16,7 @@ describe('DaffNewsletterHubspotService', () => {
       providers: [
         DaffNewsletterHubspotService,
         {
-          provide: DaffHubspotFormsService,
+          provide: DAFF_NEWSLETTER_HUBSPOT_FORMS_TOKEN,
           useValue: {
             submit: (): Observable<any> => hot('--a', { a: { test: '123' }}),
           },

--- a/libs/newsletter/driver/hubspot/src/newsletter.service.ts
+++ b/libs/newsletter/driver/hubspot/src/newsletter.service.ts
@@ -1,14 +1,19 @@
-import { Injectable } from '@angular/core';
+import {
+  Inject,
+  Injectable,
+} from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { DaffHubspotFormsService } from '@daffodil/driver/hubspot';
 import { DaffNewsletterUnion } from '@daffodil/newsletter';
 import { DaffNewsletterServiceInterface } from '@daffodil/newsletter/driver';
 
+import { DAFF_NEWSLETTER_HUBSPOT_FORMS_TOKEN } from './token/hubspot-forms.token';
+
 @Injectable()
 export class DaffNewsletterHubspotService implements DaffNewsletterServiceInterface<DaffNewsletterUnion, any> {
 
-  constructor(private hubspotService: DaffHubspotFormsService) {}
+  constructor(@Inject(DAFF_NEWSLETTER_HUBSPOT_FORMS_TOKEN) private hubspotService: DaffHubspotFormsService) {}
 
   send(payload: DaffNewsletterUnion): Observable<any> {
     return this.hubspotService.submit(payload);

--- a/libs/newsletter/driver/hubspot/src/token/hubspot-forms.token.ts
+++ b/libs/newsletter/driver/hubspot/src/token/hubspot-forms.token.ts
@@ -1,0 +1,26 @@
+import { DOCUMENT } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import {
+  inject,
+  InjectionToken,
+} from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+
+import {
+  DaffHubspotFormsService,
+  daffHubspotFormsServiceFactory,
+} from '@daffodil/driver/hubspot';
+
+import { DaffNewsletterConfigToken } from '../config/newsletter-config.interface';
+
+export const DAFF_NEWSLETTER_HUBSPOT_FORMS_TOKEN = new InjectionToken<DaffHubspotFormsService>('DAFF_NEWSLETTER_HUBSPOT_FORMS_TOKEN',
+  {
+    providedIn: 'root', factory: () => daffHubspotFormsServiceFactory(
+      inject(HttpClient),
+      inject(DOCUMENT),
+      inject(Router),
+      inject(Title),
+      inject(DaffNewsletterConfigToken),
+    ),
+  });


### PR DESCRIPTION
Previously, if you tried to use the two Daff*HubspotDriverModules in the same injection heirarchy, whichever one was imported last would win. This would mean rather unexpected behaviors for users. This makes the two imports distinct.