### PR TITLE
fix(contact,newsletter): correct dependency listings

### DIFF
--- a/libs/contact/package.json
+++ b/libs/contact/package.json
@@ -20,9 +20,18 @@
     "@daffodil/core": "0.0.0-PLACEHOLDER"
   },
   "peerDependencies": {
-    "@daffodil/driver": "0.0.0-PLACEHOLDER",
-    "@daffodil/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
-    "@angular/core": "0.0.0-PLACEHOLDER"
+    "@angular/core": "0.0.0-PLACEHOLDER",
+    "@daffodil/core": "0.0.0-PLACEHOLDER",
+    "rxjs": "0.0.0-PLACEHOLDER"
+  },
+  "optionalDependencies": {
+    "@angular/platform-browser": "0.0.0-PLACEHOLDER",
+    "@angular/router": "0.0.0-PLACEHOLDER",
+    "@daffodil/driver": "0.0.0-PLACEHOLDER",
+    "@faker-js/faker": "0.0.0-PLACEHOLDER",
+    "@ngrx/effects": "0.0.0-PLACEHOLDER",
+    "@ngrx/store": "0.0.0-PLACEHOLDER",
+    "angular-in-memory-web-api": "0.0.0-PLACEHOLDER"
   }
 }

--- a/libs/newsletter/package.json
+++ b/libs/newsletter/package.json
@@ -5,13 +5,15 @@
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@daffodil/core": "0.0.0-PLACEHOLDER",
-    "@ngrx/effects": "0.0.0-PLACEHOLDER",
-    "@ngrx/store": "0.0.0-PLACEHOLDER",
-    "rxjs": "0.0.0-PLACEHOLDER",
-    "@daffodil/driver": "0.0.0-PLACEHOLDER"
+    "rxjs": "0.0.0-PLACEHOLDER"
   },
   "optionalDependencies": {
+    "@angular/platform-browser": "0.0.0-PLACEHOLDER",
+    "@angular/router": "0.0.0-PLACEHOLDER",
+    "@daffodil/driver": "0.0.0-PLACEHOLDER",
     "@faker-js/faker": "0.0.0-PLACEHOLDER",
+    "@ngrx/effects": "0.0.0-PLACEHOLDER",
+    "@ngrx/store": "0.0.0-PLACEHOLDER",
     "angular-in-memory-web-api": "0.0.0-PLACEHOLDER"
   },
   "repository": {


### PR DESCRIPTION
Many of the current dependencies of these packages are missing, and users would not be notified by npm of that fact. In addition, several dependencies are incorrectly listed as peers, causing unnecessary installation if you don't happen to use the associated entry point of the package.