### PR TITLE
feat(category): apply category filters from query params

### DIFF
--- a/libs/category/testing/src/factories/filters/type/equal.spec.ts
+++ b/libs/category/testing/src/factories/filters/type/equal.spec.ts
@@ -7,7 +7,7 @@ import {
 
 import { DaffCategoryFilterEqualFactory } from './equal';
 
-describe('Category | Testing | Factories | DaffCategoryFilterEqualFactory', () => {
+describe('@daffodil/category/testing | DaffCategoryFilterEqualFactory', () => {
 
   let factory: DaffCategoryFilterEqualFactory;
 
@@ -32,7 +32,10 @@ describe('Category | Testing | Factories | DaffCategoryFilterEqualFactory', () =
     it('should return a category filter of type equal', () => {
       expect(result.type).toEqual(DaffCategoryFilterType.Equal);
       expect(result.options).toBeDefined();
-      expect(Object.keys(result.options).length).toEqual(0);
+    });
+
+    it('should create options', () => {
+      expect(Object.keys(result.options).length).toBeGreaterThan(0);
     });
   });
 });

--- a/libs/category/testing/src/factories/filters/type/equal.ts
+++ b/libs/category/testing/src/factories/filters/type/equal.ts
@@ -3,15 +3,27 @@ import * as faker from '@faker-js/faker/locale/en_US';
 
 import {
   DaffCategoryFilterEqual,
+  DaffCategoryFilterEqualOption,
+  daffCategoryFilterEqualOptionArrayToDict,
   DaffCategoryFilterType,
 } from '@daffodil/category';
 import { DaffModelFactory } from '@daffodil/core/testing';
+
+import { DaffCategoryFilterEqualOptionFactory } from './equal/public_api';
 
 export class MockCategoryEqualFilter implements DaffCategoryFilterEqual {
   type: DaffCategoryFilterType.Equal = DaffCategoryFilterType.Equal;
   label = faker.commerce.productMaterial();
   name = faker.datatype.uuid();
-  options = {};
+  options = daffCategoryFilterEqualOptionArrayToDict(this.createOptions());
+
+  constructor(
+    private optionFactory: DaffCategoryFilterEqualOptionFactory,
+  ) {}
+
+  protected createOptions(): DaffCategoryFilterEqualOption[] {
+    return this.optionFactory.createMany(faker.datatype.number({ min: 3, max: 5 }));
+  }
 }
 
 /**
@@ -21,8 +33,10 @@ export class MockCategoryEqualFilter implements DaffCategoryFilterEqual {
   providedIn: 'root',
 })
 export class DaffCategoryFilterEqualFactory extends DaffModelFactory<DaffCategoryFilterEqual>{
-  constructor(){
-    super(MockCategoryEqualFilter);
+  constructor(
+    optionFactory: DaffCategoryFilterEqualOptionFactory,
+  ) {
+    super(MockCategoryEqualFilter, optionFactory);
   }
 }
 

--- a/libs/category/testing/src/factories/filters/type/range-numeric/pair.ts
+++ b/libs/category/testing/src/factories/filters/type/range-numeric/pair.ts
@@ -11,8 +11,20 @@ import { DaffCategoryFilterRangeNumericOptionFactory } from './option';
 
 export class MockDaffCategoryFilterRangeNumericPair implements DaffCategoryFilterRangePair<number> {
   applied: true = true;
-  max: DaffCategoryFilterRangeOption<number>;
-  min: DaffCategoryFilterRangeOption<number>;
+  max: DaffCategoryFilterRangeOption<number> = this.createMaxOption();
+  min: DaffCategoryFilterRangeOption<number> = this.createMinOption();
+
+  constructor(
+    private optionFactory: DaffCategoryFilterRangeNumericOptionFactory,
+  ) {}
+
+  protected createMinOption(): DaffCategoryFilterRangeOption<number> {
+    return this.optionFactory.create({ value: faker.datatype.number({ min: 0, max: 100 }) });
+  }
+
+  protected createMaxOption(): DaffCategoryFilterRangeOption<number> {
+    return this.optionFactory.create({ value: faker.datatype.number({ min: 100, max: 1000 }) });
+  }
 }
 
 /**
@@ -22,17 +34,10 @@ export class MockDaffCategoryFilterRangeNumericPair implements DaffCategoryFilte
   providedIn: 'root',
 })
 export class DaffCategoryFilterRangeNumericPairFactory extends DaffModelFactory<DaffCategoryFilterRangePair<number>>{
-  constructor(private option: DaffCategoryFilterRangeNumericOptionFactory){
-    super(MockDaffCategoryFilterRangeNumericPair);
-  }
-
-  create(partial: Partial<DaffCategoryFilterRangePair<number>> = {}) {
-    return {
-      ...new this.type(),
-      min: this.option.create({ value: faker.datatype.number({ min: 0, max: 100 }) }),
-      max: this.option.create({ value: faker.datatype.number({ min: 100, max: 1000 }) }),
-      ...partial,
-    };
+  constructor(
+    optionFactory: DaffCategoryFilterRangeNumericOptionFactory,
+  ) {
+    super(MockDaffCategoryFilterRangeNumericPair, optionFactory);
   }
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- adds an effect for applying category filters from query params
  - only param, value pairs that actually correspond to unapplied filter options are applied
- also improves some filter factories to create options

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information