### PR TITLE
feat(design): update icon button sizes to meet wcag touch target requirements

### DIFF
--- a/libs/design/src/atoms/button/button.component.scss
+++ b/libs/design/src/atoms/button/button.component.scss
@@ -84,16 +84,16 @@
 
 	&.daff-md {
 		font-size: $normal-font-size;
-		line-height: 2.5rem;
-		height: 2.5rem;
-		width: 2.5rem;
+		line-height: 3rem;
+		height: 3rem;
+		width: 3rem;
 	}
 
 	&.daff-lg {
 		font-size: $medium-font-size;
-		line-height: 3rem;
-		height: 3rem;
-		width: 3rem;
+		line-height: 3.5rem;
+		height: 3.5rem;
+		width: 3.5rem;
 	}
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The icon button's default size does not meet WCAG's minimum touch target requirement.

Fixes: N/A


## What is the new behavior?
The icon button's default size (`md`) meets the minimum touch target requirement of 44pxx44px.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information