### PR TITLE
style(daffio): prevent libs imports

### DIFF
--- a/apps/daffio/.eslintrc.js
+++ b/apps/daffio/.eslintrc.js
@@ -45,6 +45,12 @@ module.exports = {
             style: 'camelCase'
           }
         ],
+        'no-restricted-imports': ['error', {
+          'patterns': [{
+            'group': ['libs/*'],
+            'message': 'Usage of private modules not allowed. Did you mean to import from @daffodil/*?'
+          }],
+        }],
       }
     },
     {


### PR DESCRIPTION
We have seen, time and time again, that we make mistakes when importing package imports into the apps in the mono-repo.

It's been three years. Time to end the madness.

Touches: https://github.com/graycoreio/daffodil/issues/286
https://github.com/graycoreio/daffodil/commit/ef415fd63ed9de06db9416d6fe848f892a2ae6c5#diff-0652517437cf57376cc1ca6259e7a0d704fe791e61a0f5592212f866cd9c82e2R13