### PR TITLE
feat(design-land): add theme switch functionality to design land

### DIFF
--- a/apps/design-land/src/app/app.component.html
+++ b/apps/design-land/src/app/app.component.html
@@ -41,6 +41,7 @@
     </daff-link-set>
   </daff-sidebar>
   <div class="design-land__content">
+    <design-land-theme-switch class="design-land__theme-switch"></design-land-theme-switch>
     <daff-article>
       <router-outlet></router-outlet>
     </daff-article>

--- a/apps/design-land/src/app/app.component.scss
+++ b/apps/design-land/src/app/app.component.scss
@@ -1,15 +1,21 @@
 .design-land {
+  &__theme-switch {
+    display: flex;
+    justify-content: right;
+    margin-bottom: 24px;
+  }
+
   &__sidebar {
-    padding: 25px;
+    padding: 24px;
   }
 
   &__content {
-    padding: 25px;
+    padding: 24px 48px 48px;
   }
 }
 
 daff-link-set {
-  margin: 0 0 25px 0;
+  margin: 0 0 24px 0;
 
   &:last-child {
     margin: 0;

--- a/apps/design-land/src/app/app.module.ts
+++ b/apps/design-land/src/app/app.module.ts
@@ -7,11 +7,12 @@ import {
   DaffSidebarModule,
   DaffLinkSetModule,
   DaffArticleModule,
+  DAFF_THEME_INITIALIZER,
 } from '@daffodil/design';
 
 import { DesignLandAppRoutingModule } from './app-routing.module';
 import { DesignLandAppComponent } from './app.component';
-
+import { DesignLandThemeSwitchModule } from './core/theme-switch/theme-switch.module';
 
 @NgModule({
   imports: [
@@ -22,12 +23,16 @@ import { DesignLandAppComponent } from './app.component';
     DaffSidebarModule,
     DaffLinkSetModule,
     DaffArticleModule,
+    DesignLandThemeSwitchModule,
   ],
   declarations: [
     DesignLandAppComponent,
   ],
   bootstrap: [
     DesignLandAppComponent,
+  ],
+  providers: [
+    DAFF_THEME_INITIALIZER,
   ],
 })
 export class AppModule { }

--- a/apps/design-land/src/app/core/code-preview/component/code-preview.component.scss
+++ b/apps/design-land/src/app/core/code-preview/component/code-preview.component.scss
@@ -1,3 +1,6 @@
+@import 'theme';
+@import 'utilities';
+
 :host {
 	border: 1px solid gray;
 	display: block;

--- a/apps/design-land/src/app/core/theme-switch/theme-switch.component.html
+++ b/apps/design-land/src/app/core/theme-switch/theme-switch.component.html
@@ -1,0 +1,3 @@
+<button type="button" daff-icon-button color="theme-contrast" theme-toggle (click)="onButtonClick()" [attr.aria-label]="ariaLabel$ | async">
+  <fa-icon [icon]="icon$ | async"></fa-icon>
+</button>

--- a/apps/design-land/src/app/core/theme-switch/theme-switch.component.spec.ts
+++ b/apps/design-land/src/app/core/theme-switch/theme-switch.component.spec.ts
@@ -1,0 +1,121 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import {
+  FaIconComponent,
+  FontAwesomeModule,
+} from '@fortawesome/angular-fontawesome';
+import {
+  faMoon,
+  faSun,
+} from '@fortawesome/free-solid-svg-icons';
+import { BehaviorSubject } from 'rxjs';
+
+import {
+  DaffTheme,
+  DaffThemingService,
+} from '@daffodil/design';
+
+import {
+  DesignLandThemeSwitchComponent,
+  DL_THEME_SWITCH_TO_DARK_LABEL,
+  DL_THEME_SWITCH_TO_LIGHT_LABEL,
+} from './theme-switch.component';
+
+describe('DesignLandThemeSwitchComponent', () => {
+  let component: DesignLandThemeSwitchComponent;
+  let fixture: ComponentFixture<DesignLandThemeSwitchComponent>;
+
+  let themeService: jasmine.SpyObj<DaffThemingService>;
+  let theme$: BehaviorSubject<DaffTheme>;
+
+  beforeEach(waitForAsync(() => {
+    theme$ = new BehaviorSubject(DaffTheme.Light);
+    themeService = jasmine.createSpyObj(DaffThemingService, ['getTheme', 'switchTheme']);
+    themeService.getTheme.and.returnValue(theme$);
+
+    TestBed.configureTestingModule({
+      imports: [
+        FontAwesomeModule,
+      ],
+      declarations: [
+        DesignLandThemeSwitchComponent,
+      ],
+      providers: [
+        { provide: DaffThemingService, useValue: themeService },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DesignLandThemeSwitchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('the switch label', () => {
+    describe('when the theme is dark', () => {
+      beforeEach(() => {
+        theme$.next(DaffTheme.Dark);
+        fixture.detectChanges();
+      });
+
+      it('should show the switch to light label', () => {
+        const el: HTMLButtonElement = fixture.debugElement.query(By.css('button[theme-toggle]')).nativeElement;
+        expect(el.attributes.getNamedItem('aria-label').value).toEqual(DL_THEME_SWITCH_TO_LIGHT_LABEL);
+      });
+    });
+
+    describe('when the theme is light', () => {
+      beforeEach(() => {
+        theme$.next(DaffTheme.Light);
+        fixture.detectChanges();
+      });
+
+      it('should show the switch to dark label', () => {
+        const el: HTMLButtonElement = fixture.debugElement.query(By.css('button[theme-toggle]')).nativeElement;
+        expect(el.attributes.getNamedItem('aria-label').value).toEqual(DL_THEME_SWITCH_TO_DARK_LABEL);
+      });
+    });
+  });
+
+  describe('the visual indication of the theme switcher', () => {
+    describe('when the theme is dark', () => {
+      beforeEach(() => {
+        theme$.next(DaffTheme.Dark);
+        fixture.detectChanges();
+      });
+
+      it('should show the sun icon', () => {
+        const el: FaIconComponent = fixture.debugElement.query(By.css('fa-icon')).componentInstance;
+        expect(el.icon).toEqual(faSun);
+      });
+    });
+
+    describe('when the theme is light', () => {
+      beforeEach(() => {
+        theme$.next(DaffTheme.Light);
+        fixture.detectChanges();
+      });
+
+      it('should show the moon icon', () => {
+        const el: FaIconComponent = fixture.debugElement.query(By.css('fa-icon')).componentInstance;
+        expect(el.icon).toEqual(faMoon);
+      });
+    });
+  });
+
+  it('should switch the theme when clicked', () => {
+    component.onButtonClick();
+    expect(themeService.switchTheme).toHaveBeenCalledWith();
+  });
+});

--- a/apps/design-land/src/app/core/theme-switch/theme-switch.component.ts
+++ b/apps/design-land/src/app/core/theme-switch/theme-switch.component.ts
@@ -1,0 +1,47 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+} from '@angular/core';
+import {
+  faMoon,
+  faSun,
+  IconDefinition,
+} from '@fortawesome/free-solid-svg-icons';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import {
+  DaffTheme,
+  DaffThemingService,
+} from '@daffodil/design';
+
+export const DL_THEME_SWITCH_TO_LIGHT_LABEL = 'Enable light mode';
+export const DL_THEME_SWITCH_TO_DARK_LABEL = 'Enable dark mode';
+
+@Component({
+  selector: 'design-land-theme-switch',
+  templateUrl: './theme-switch.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DesignLandThemeSwitchComponent implements OnInit {
+  theme$: Observable<DaffTheme>;
+  ariaLabel$: Observable<string>;
+  icon$: Observable<IconDefinition>;
+
+  constructor(private themeService: DaffThemingService) { }
+
+  ngOnInit() {
+    this.theme$ = this.themeService.getTheme();
+    this.ariaLabel$ = this.theme$.pipe(
+      map((theme) => theme === DaffTheme.Light ? DL_THEME_SWITCH_TO_DARK_LABEL : DL_THEME_SWITCH_TO_LIGHT_LABEL),
+    );
+    this.icon$ = this.theme$.pipe(
+      map((theme) => theme === DaffTheme.Light ? faMoon : faSun),
+    );
+  }
+
+  onButtonClick() {
+    this.themeService.switchTheme();
+  }
+}

--- a/apps/design-land/src/app/core/theme-switch/theme-switch.module.ts
+++ b/apps/design-land/src/app/core/theme-switch/theme-switch.module.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+
+import { DaffButtonModule } from '@daffodil/design';
+
+import { DesignLandThemeSwitchComponent } from './theme-switch.component';
+
+@NgModule({
+  declarations: [
+    DesignLandThemeSwitchComponent,
+  ],
+  imports: [
+    CommonModule,
+    FontAwesomeModule,
+    DaffButtonModule,
+  ],
+  exports: [
+    DesignLandThemeSwitchComponent,
+  ],
+})
+export class DesignLandThemeSwitchModule { }

--- a/apps/design-land/src/scss/styles.scss
+++ b/apps/design-land/src/scss/styles.scss
@@ -10,7 +10,15 @@
 @import "theme";
 @import 'highlight.js/styles/github.css';
 
-@include daff-theme($theme);
+.daff-theme-light {
+  @include daff-theme($theme);
+  background: #ffffff;
+}
+
+.daff-theme-dark {
+  @include daff-theme($theme-dark);
+  background: #1a1a1a;
+}
 
 body {
   margin: 0;

--- a/apps/design-land/src/scss/theme.scss
+++ b/apps/design-land/src/scss/theme.scss
@@ -6,6 +6,12 @@ $tertiary: daff-configure-palette($daff-turquoise, 60);
 
 $theme: daff-configure-theme($primary, $secondary, $tertiary, 'light');
 
+$primary-dark: daff-configure-palette($daff-blue, 50);
+$secondary-dark: daff-configure-palette($daff-purple, 50);
+$tertiary-dark: daff-configure-palette($daff-turquoise, 50);
+
+$theme-dark: daff-configure-theme($primary-dark, $secondary-dark, $tertiary-dark, 'dark');
+
 $black: daff-map-deep-get($theme, 'core.black');
 $white: daff-map-deep-get($theme, 'core.white');
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no easy way to switch themes in design land.

Fixes: N/A


## What is the new behavior?
Add theme switch functionality. It allows people to easily toggle between dark and light mode in design land.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information