### PR TITLE
feat(design-land): add highlight.js a11y themes to dark and light mode

### DIFF
--- a/apps/design-land/src/scss/styles.scss
+++ b/apps/design-land/src/scss/styles.scss
@@ -8,14 +8,15 @@
 @import 'daff-theme';
 
 @import "theme";
-@import 'highlight.js/styles/github.css';
 
 .daff-theme-light {
+  @import 'highlight.js/scss/a11y-light.scss';
   @include daff-theme($theme);
   background: #ffffff;
 }
 
 .daff-theme-dark {
+  @import 'highlight.js/scss/a11y-dark.scss';
   @include daff-theme($theme-dark);
   background: #1a1a1a;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current highlight.js theme in design-land is not accessible in dark mode.

Fixes: #1399 


## What is the new behavior?
Update light mode to use `a11y-light` and dark mode to use `a11y-dark`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information