### PR TITLE
feat(external-router): allow for additional data to be stored on daff…

### DIFF
--- a/libs/external-router/routing/src/guard/existence.guard.spec.ts
+++ b/libs/external-router/routing/src/guard/existence.guard.spec.ts
@@ -99,7 +99,7 @@ describe('@daffodil/external-router/routing | DaffExternalRouterExistenceGuard',
       ).subscribe();
 
       expect(router.config).toEqual([
-        <DaffRouteWithDataPath>{ path: '/some-resolved/path/with/file-endings.html', component: FakeComponent, data: { daffExternalRouteType: STUB_RESOLVABLE_TYPE }} ,
+        <DaffRouteWithDataPath>{ path: '/some-resolved/path/with/file-endings.html', component: FakeComponent, daffExternalRouteType: STUB_RESOLVABLE_TYPE , data: {}} ,
         { path: '**', redirectTo: '/' },
       ]);
     });
@@ -198,7 +198,7 @@ describe('@daffodil/external-router/routing | DaffExternalRouterExistenceGuard',
       ).subscribe();
 
       expect(router.config).toEqual([
-        <DaffRouteWithDataPath>{ path: 'some-path', component: FakeComponent, data: { daffExternalRouteType: STUB_RESOLVABLE_TYPE }},
+        <DaffRouteWithDataPath>{ path: 'some-path', component: FakeComponent, daffExternalRouteType: STUB_RESOLVABLE_TYPE, data: {}},
         { path: '**', redirectTo: '/' },
       ]);
     });
@@ -253,7 +253,7 @@ describe('@daffodil/external-router/routing | DaffExternalRouterExistenceGuard',
       ).subscribe();
 
       expect(router.config).toEqual([
-        <DaffRouteWithDataPath>{ path: 'some-path.html', component: FakeComponent, data: { daffExternalRouteType: STUB_RESOLVABLE_TYPE }},
+        <DaffRouteWithDataPath>{ path: 'some-path.html', component: FakeComponent, daffExternalRouteType: STUB_RESOLVABLE_TYPE, data: { }},
         { path: '**', redirectTo: '/' },
       ]);
     });

--- a/libs/external-router/src/model/resolvable-route.ts
+++ b/libs/external-router/src/model/resolvable-route.ts
@@ -1,5 +1,6 @@
 import { DaffIdentifiable } from '@daffodil/core';
 
+import { DaffRouteData } from './route-data';
 import { DaffExternalRouteType } from './route-type';
 
 /**
@@ -21,9 +22,22 @@ export interface DaffExternallyResolvableUrl extends DaffIdentifiable {
    * Should not contain URL fragments, query parameters, or leading slashes.
    */
   url: string;
+
+  /**
+   * The type of the route
+   *
+   * @see {@link DaffExternalRouteType}
+   */
   type: DaffExternalRouteType;
+
   /**
    * The HTTP status code for the resolvable route.
    */
   code: number;
+
+  /**
+   * Additional route data. Note that this is not guaranteed to come from
+   * the driver, its only available when the driver makes it available.
+   */
+  data?: DaffRouteData;
 }

--- a/libs/external-router/src/model/route-data.ts
+++ b/libs/external-router/src/model/route-data.ts
@@ -1,0 +1,8 @@
+/**
+ * Data associated with a route.
+ */
+export interface DaffRouteData {
+  canonical_url?: string;
+  meta_description?: string;
+  title?: string;
+}

--- a/libs/external-router/src/model/route-info.ts
+++ b/libs/external-router/src/model/route-info.ts
@@ -1,12 +1,10 @@
-import { Route } from '@angular/router';
-
 import { DaffExternalRouterInsertionStrategy } from './insertion-strategy.type';
-import { DaffRouteWithDataPath } from './route-with-data-path';
+import { DaffRouteWithType } from './route-with-type';
 
 /**
  * An object containing the info needed to insert a route into a configuration.
  */
 export interface DaffRouteInfo {
-  route: DaffRouteWithDataPath;
+  route: DaffRouteWithType;
   insertionStrategy?: DaffExternalRouterInsertionStrategy;
 }

--- a/libs/external-router/src/model/route-with-seo-data.ts
+++ b/libs/external-router/src/model/route-with-seo-data.ts
@@ -1,0 +1,14 @@
+import { Route } from '@angular/router';
+
+import { DaffRouteData } from './route-data';
+
+/**
+ * A type that describes the special data that Daffodil will store for SEO purposes on
+ * an external resolved route.
+ *
+ * {@link daffDataPathUrlMatcher}
+ * {@link daffInsertDataPathStrategy}
+ */
+export type DaffRouteWithSeoData = Route & {
+  data: DaffRouteData;
+};

--- a/libs/external-router/src/model/route-with-type.ts
+++ b/libs/external-router/src/model/route-with-type.ts
@@ -1,9 +1,6 @@
-import {
-  Data,
-  Route,
-} from '@angular/router';
+import { Route } from '@angular/router';
 
-import { DaffRouteData } from './route-data';
+import { DaffExternalRouteType } from './route-type';
 
 /**
  * A type that describes the special data that Daffodil will look for when attempting
@@ -12,8 +9,6 @@ import { DaffRouteData } from './route-data';
  * {@link daffDataPathUrlMatcher}
  * {@link daffInsertDataPathStrategy}
  */
-export type DaffRouteWithDataPath = Route & {
-  data?: {
-    daffPaths?: Record<string, DaffRouteData | Data>;
-  };
+export type DaffRouteWithType = Route & {
+  daffExternalRouteType: DaffExternalRouteType;
 };

--- a/libs/external-router/src/public_api.ts
+++ b/libs/external-router/src/public_api.ts
@@ -21,3 +21,5 @@ export { daffDataPathUrlMatcher } from './router/url-matcher/data-path-matcher';
 
 export { DaffExternalRouterNoWildcardError } from './errors/no-wildcard';
 export { DaffExternalRouterUnknownRouteTypeError } from './errors/unknown-type';
+
+export { daffExtractDaffPathData } from './util/extract-daff-path-data';

--- a/libs/external-router/src/router/router.service.spec.ts
+++ b/libs/external-router/src/router/router.service.spec.ts
@@ -95,7 +95,7 @@ describe('@daffodil/external-router | DaffExternalRouter', () => {
     service.add({ url: 'some-path', type: 'type-a', id: 'id', code: 200 });
 
     expect(router.config).toEqual([
-      <DaffRouteWithDataPath>{ path: 'some-path', redirectTo: '/', data: { daffExternalRouteType: 'type-a' }},
+      <DaffRouteWithDataPath>{ path: 'some-path', redirectTo: '/', daffExternalRouteType: 'type-a', data: { }},
       { path: '**', redirectTo: 'somewhere-else' },
     ]);
   });

--- a/libs/external-router/src/router/strategies/insert-data-path.spec.ts
+++ b/libs/external-router/src/router/strategies/insert-data-path.spec.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { DaffRouteWithDataPath } from '../../model/route-with-data-path';
+import { DaffRouteWithType } from '../../model/route-with-type';
 import { daffInsertDataPathStrategy } from './insert-data-path';
 
 describe('@daffodil/external-router | daffInsertDataPathOnRouteMatchingType', () => {
@@ -33,15 +33,15 @@ describe('@daffodil/external-router | daffInsertDataPathOnRouteMatchingType', ()
     expect(daffInsertDataPathStrategy(externalRoute, routes)).toEqual([]);
   });
 
-  it('should insert an entry into the route matching the associated `daffRouteType`', () => {
+  it('should insert an entry into the route matching the associated `daffExternalRouteType`', () => {
     const type = 'CATEGORY';
 
     const PATH = 'some-wild-path.html';
 
-    const externalRoute: DaffRouteWithDataPath = {
+    const externalRoute: DaffRouteWithType = {
       path: PATH,
+      daffExternalRouteType: type,
       data: {
-        daffExternalRouteType: type,
       },
     };
 
@@ -50,7 +50,110 @@ describe('@daffodil/external-router | daffInsertDataPathOnRouteMatchingType', ()
     ];
 
     expect(daffInsertDataPathStrategy(externalRoute, routes)).toEqual([
-      { children: [{}], data: { daffExternalRouteType: type, daffPaths: { [PATH]: PATH }}},
+      { children: [{}], data: { daffExternalRouteType: type, daffPaths: { [PATH]: {}}}},
     ]);
+  });
+
+  describe('inserting an entry that matches', () => {
+    it('should assign data to the associated daffPath', () => {
+      const type = 'CATEGORY';
+
+      const PATH = 'some-wild-path.html';
+
+      const externalRoute: DaffRouteWithType = {
+        path: PATH,
+        daffExternalRouteType: type,
+        data: {
+        },
+      };
+
+      const routes = [
+        { children: [{}], data: { daffExternalRouteType: type }},
+      ];
+
+      expect(daffInsertDataPathStrategy(externalRoute, routes)).toEqual([
+        { children: [{}], data: { daffExternalRouteType: type, daffPaths: { [PATH]: {}}}},
+      ]);
+    });
+
+    it('should replace data when reinserting existing data to an existing daffPath', () => {
+      const type = 'CATEGORY';
+
+      const PATH = 'some-wild-path.html';
+
+      const externalRoute: DaffRouteWithType = {
+        path: PATH,
+        daffExternalRouteType: type,
+        data: {
+          some_key: 'test1',
+          some_other_key: 'some_other_key',
+        },
+      };
+
+      const externalRoute2: DaffRouteWithType = {
+        path: PATH,
+        daffExternalRouteType: type,
+        data: {
+          some_key: 'some_key',
+          some_third_key: 'some_third_key',
+        },
+      };
+
+      const routes = [
+        { children: [{}], data: { daffExternalRouteType: type }},
+      ];
+      let result = daffInsertDataPathStrategy(externalRoute, routes);
+      result = daffInsertDataPathStrategy(externalRoute2, result);
+
+      expect(result).toEqual([
+        { children: [{}], data: { daffExternalRouteType: type, daffPaths: { [PATH]: {
+          some_key: 'some_key',
+          some_third_key: 'some_third_key',
+        }}}},
+      ]);
+    });
+
+    it('should insert multiple different entries on the same type with a different path', () => {
+      const type = 'CATEGORY';
+
+      const PATH = 'some-wild-path.html';
+
+      const externalRoute: DaffRouteWithType = {
+        path: PATH,
+        daffExternalRouteType: type,
+        data: {
+          some_key: 'test1',
+          some_other_key: 'some_other_key',
+        },
+      };
+      const PATH_2 = 'some-other-path.html';
+      const externalRoute2: DaffRouteWithType = {
+        path: PATH_2,
+        daffExternalRouteType: type,
+        data: {
+          some_key: 'test2',
+          some_other_key: 'some_other_key',
+        },
+      };
+
+      const routes = [
+        { children: [{}], data: { daffExternalRouteType: type }},
+      ];
+      let result = daffInsertDataPathStrategy(externalRoute, routes);
+      result = daffInsertDataPathStrategy(externalRoute2, result);
+
+      expect(result).toEqual([
+        { children: [{}], data: { daffExternalRouteType: type, daffPaths: {
+          [PATH]: {
+            some_key: 'test1',
+            some_other_key: 'some_other_key',
+          },
+          [PATH_2]: {
+            some_key: 'test2',
+            some_other_key: 'some_other_key',
+          },
+        }}},
+      ]);
+    });
   });
 });

--- a/libs/external-router/src/router/url-matcher/data-path-matcher.spec.ts
+++ b/libs/external-router/src/router/url-matcher/data-path-matcher.spec.ts
@@ -46,7 +46,7 @@ describe('@daffodil/external-router | daffPathUrlMatcher', () => {
         path: '',
         data: {
           daffPaths: {
-            [path]: path,
+            [path]: {},
           },
         },
       };

--- a/libs/external-router/src/transform/resolved-route-to-route.spec.ts
+++ b/libs/external-router/src/transform/resolved-route-to-route.spec.ts
@@ -26,8 +26,9 @@ describe('@daffodil/external-router | daffTransformResolvedRouteToRoute', () => 
     ).toEqual({
       route: {
         path: 'some-url',
-        data: { daffExternalRouteType: 'some-type' },
+        daffExternalRouteType: 'some-type',
         redirectTo: '/',
+        data: {},
       },
       insertionStrategy,
     });

--- a/libs/external-router/src/transform/resolved-route-to-route.ts
+++ b/libs/external-router/src/transform/resolved-route-to-route.ts
@@ -22,10 +22,10 @@ export const daffTransformResolvedRouteToRoute = (
   return {
     route: {
       path: resolvedRoute.url,
+      daffExternalRouteType: resolvedRoute.type,
       ...routeType.route,
       data: {
-        daffExternalRouteType: resolvedRoute.type,
-        ...routeType.route.data,
+        ...resolvedRoute.data,
       },
     },
     insertionStrategy: routeType.insertionStrategy,

--- a/libs/external-router/src/util/extract-daff-path-data.ts
+++ b/libs/external-router/src/util/extract-daff-path-data.ts
@@ -1,0 +1,13 @@
+import {
+  ActivatedRouteSnapshot,
+  Data,
+} from '@angular/router';
+
+/**
+ * Extracts a key from DaffPath data based upon the currently activated
+ * RouteSnapshot.
+ */
+export const daffExtractDaffPathData = <T extends Data = Data>(snapshot: ActivatedRouteSnapshot, key: keyof T): unknown => {
+  const pathFromRoot = snapshot.pathFromRoot[snapshot.pathFromRoot.length - 1].url.map((seg) => seg.path).join('/');
+  return snapshot.data?.daffPaths?.[pathFromRoot]?.[key] ?? null;
+};


### PR DESCRIPTION
…Paths in externally routed Routes.

BREAKING CHANGE: previously, the value of an individual daffPath key was a string. This was nonsensical, so we broke it.