### PR TITLE
feat(external-router): add a new Magento v2.4.3 driver

### DIFF
--- a/libs/external-router/driver/magento/2.4.3/ng-package.json
+++ b/libs/external-router/driver/magento/2.4.3/ng-package.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../../dist/external-router/driver/magento/2.4.3",
+  "deleteDestPath": false,
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/external-router/driver/magento/2.4.3/package.json
+++ b/libs/external-router/driver/magento/2.4.3/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@daffodil/external-router/driver/magento/2.4.3"
+}

--- a/libs/external-router/driver/magento/2.4.3/src/graphql/queries/resolve.ts
+++ b/libs/external-router/driver/magento/2.4.3/src/graphql/queries/resolve.ts
@@ -1,0 +1,31 @@
+import { gql } from 'apollo-angular';
+
+export const DAFF_MAGENTO_RESOLVE_URL_QUERY_NAME = 'MagentoResolveUrlv243';
+
+/**
+ * This query retrieves a URL resolution from Magento and informs you about
+ * what type of route the URL is.
+ */
+export const MagentoResolveUrlv243 = gql`
+	query ${DAFF_MAGENTO_RESOLVE_URL_QUERY_NAME}($url: String!) {
+		route(url: $url) {
+			relative_url
+			redirect_code
+			type
+			... on CategoryInterface {
+				uid
+				name
+				meta_description
+				meta_title
+				canonical_url
+			}
+			... on ProductInterface {
+				uid
+				name
+				meta_description
+				meta_title
+				canonical_url
+			}
+		}
+	}
+`;

--- a/libs/external-router/driver/magento/2.4.3/src/index.ts
+++ b/libs/external-router/driver/magento/2.4.3/src/index.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/libs/external-router/driver/magento/2.4.3/src/magento.module.ts
+++ b/libs/external-router/driver/magento/2.4.3/src/magento.module.ts
@@ -1,0 +1,54 @@
+import { CommonModule } from '@angular/common';
+import {
+  NgModule,
+  ModuleWithProviders,
+} from '@angular/core';
+
+import { DAFF_MAGENTO_CACHEABLE_OPERATIONS } from '@daffodil/driver/magento';
+import { DaffExternalRouterDriver } from '@daffodil/external-router/driver';
+
+import { DAFF_MAGENTO_RESOLVE_URL_QUERY_NAME } from './graphql/queries/resolve';
+import { DaffExternalRouterMagentoDriver } from './magento.service';
+
+/**
+ * The module used to configure the {@link DaffExternalRouterDriver} for usage with Magento.
+ *
+ * ```ts
+ * @NgModule({
+ *   declarations: [],
+ *   imports: [
+ *     ...
+ *     DaffExternalRouterDriverMagentoModule.forRoot()
+ *   ],
+ * })
+ * export class AppModule{}
+ * ```
+ *
+ * Note that this package depends upon ApolloClient, as the Magento driver uses GraphQl to make it's API calls.
+ */
+@NgModule({
+  declarations: [],
+  imports: [CommonModule],
+})
+export class DaffExternalRouterDriverMagentoModule {
+
+  /**
+   * Configures the package for the root injector.
+   */
+  static forRoot(): ModuleWithProviders<DaffExternalRouterDriverMagentoModule> {
+    return {
+      ngModule: DaffExternalRouterDriverMagentoModule,
+      providers: [
+        {
+          provide: DaffExternalRouterDriver,
+          useExisting: DaffExternalRouterMagentoDriver,
+        },
+        {
+          provide: DAFF_MAGENTO_CACHEABLE_OPERATIONS,
+          useValue: DAFF_MAGENTO_RESOLVE_URL_QUERY_NAME,
+          multi: true,
+        },
+      ],
+    };
+  }
+}

--- a/libs/external-router/driver/magento/2.4.3/src/magento.service.spec.ts
+++ b/libs/external-router/driver/magento/2.4.3/src/magento.service.spec.ts
@@ -1,0 +1,104 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ApolloTestingController,
+  ApolloTestingModule,
+} from 'apollo-angular/testing';
+import { TestScheduler } from 'rxjs/testing';
+
+import { ID } from '@daffodil/core';
+import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
+import {
+  MagentoUrlRewriteEntityTypeEnum,
+  MagentoRouteResponse,
+} from '@daffodil/external-router/driver/magento';
+
+import { MagentoResolveUrlv243 } from './graphql/queries/resolve';
+import { DaffExternalRouterDriverMagentoModule } from './magento.module';
+import { DaffExternalRouterMagentoDriver } from './magento.service';
+
+describe('@daffodil/external-router/driver/magento/2.4.3 | DaffExternalRouterMagentoDriver', () => {
+  let service: DaffExternalRouterMagentoDriver;
+  let controller: ApolloTestingController;
+  let scheduler: TestScheduler;
+  let id: ID;
+  let responseUrl: string;
+  let requestUrl: string;
+  let resolution: MagentoRouteResponse;
+  let resolvableUrl: DaffExternallyResolvableUrl;
+
+  const setupTest = () => {
+    TestBed.configureTestingModule({
+      imports: [
+        DaffExternalRouterDriverMagentoModule.forRoot(),
+        ApolloTestingModule,
+      ],
+    });
+    service = TestBed.inject(DaffExternalRouterMagentoDriver);
+    controller = TestBed.inject(ApolloTestingController);
+
+    scheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+
+    responseUrl = 'url';
+    requestUrl = `/${responseUrl}`;
+    id = 'id';
+    resolution = {
+      route: {
+        relative_url: responseUrl,
+        type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
+        redirect_code: 0,
+        uid: id,
+      },
+    };
+
+    resolvableUrl = {
+      id,
+      url: responseUrl,
+      type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
+      code: 200,
+    };
+  };
+
+  it('should be created', () => {
+    setupTest();
+    expect(service).toBeTruthy();
+  });
+
+  describe('resolve', () => {
+    it('should return a resolvable url when using the v2.4.3 query', done => {
+      setupTest();
+
+      service.resolve(requestUrl).subscribe(result => {
+        console.log(result);
+        expect(result.type).toEqual(MagentoUrlRewriteEntityTypeEnum.PRODUCT);
+        done();
+      });
+
+      const op = controller.expectOne(MagentoResolveUrlv243);
+
+      op.flush({
+        data: resolution,
+      });
+    });
+  });
+
+  describe('the driver returning null', () => {
+    it('should return a DaffExternallyResolvableUrl with a code of 404', done => {
+      setupTest();
+
+      service.resolve(requestUrl).subscribe(result => {
+        expect(result.code).toEqual(404);
+        done();
+      });
+
+      const op = controller.expectOne(MagentoResolveUrlv243);
+
+      op.flush({
+        data: {
+          route: null,
+        },
+      });
+    });
+  });
+});

--- a/libs/external-router/driver/magento/2.4.3/src/magento.service.ts
+++ b/libs/external-router/driver/magento/2.4.3/src/magento.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { Apollo } from 'apollo-angular';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+
+import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
+import { DaffExternalRouterDriverInterface } from '@daffodil/external-router/driver';
+import { MagentoRouteResponse } from '@daffodil/external-router/driver/magento';
+
+import { MagentoResolveUrlv243 } from './graphql/queries/resolve';
+import { transformResolutionToResolvableUrlv243 } from './transforms/resolution-to-resolvable-url';
+
+
+/**
+ * The DaffExternalRouterMagentoDriver is responsible for translating an
+ * arbitrary URI into a DaffExternallyResolvableUrl with Magento environments.
+ *
+ * @inheritdoc
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffExternalRouterMagentoDriver
+implements DaffExternalRouterDriverInterface {
+  constructor(
+    private apollo: Apollo,
+  ) {}
+
+  resolve(url: string): Observable<DaffExternallyResolvableUrl> {
+    return this.apollo
+      .query<MagentoRouteResponse>({
+      query: MagentoResolveUrlv243,
+      variables: {
+        url,
+      },
+    })
+      .pipe(map(response => transformResolutionToResolvableUrlv243(response.data.route)));
+  }
+}

--- a/libs/external-router/driver/magento/2.4.3/src/public_api.ts
+++ b/libs/external-router/driver/magento/2.4.3/src/public_api.ts
@@ -1,0 +1,6 @@
+/*
+ * Public API Surface of @daffodil/external-router/driver/magento/2.4.3
+ */
+
+export { DaffExternalRouterMagentoDriver } from './magento.service';
+export { DaffExternalRouterDriverMagentoModule } from './magento.module';

--- a/libs/external-router/driver/magento/2.4.3/src/transforms/resolution-to-resolvable-url.spec.ts
+++ b/libs/external-router/driver/magento/2.4.3/src/transforms/resolution-to-resolvable-url.spec.ts
@@ -1,0 +1,134 @@
+import { ID } from '@daffodil/core';
+import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
+import { DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION } from '@daffodil/external-router/driver';
+import {
+  MagentoRoute,
+  MagentoUrlRewriteEntityTypeEnum,
+} from '@daffodil/external-router/driver/magento';
+
+import { transformResolutionToResolvableUrlv243 } from './resolution-to-resolvable-url';
+
+describe('@daffodil/external-router/driver/magento | transformResolutionToResolvableUrlv243', () => {
+  let id: ID;
+  let url: string;
+  let route: MagentoRoute;
+  let resolvableUrl: DaffExternallyResolvableUrl;
+
+  beforeEach(() => {
+    id = 'id';
+    url = 'url';
+    route = {
+      relative_url: `/${url}?query=param#fragment`,
+      type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
+      redirect_code: 0,
+      uid: id,
+    };
+    resolvableUrl = {
+      id,
+      url,
+      type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
+      code: 200,
+    };
+  });
+
+  it('should return a resolvable url with the correct values', () => {
+    const result = transformResolutionToResolvableUrlv243(route);
+    expect(result.type).toEqual(MagentoUrlRewriteEntityTypeEnum.PRODUCT);
+    expect(result.url).toEqual(url);
+    expect(result.id).toEqual(id);
+    expect(result.code).toEqual(200);
+  });
+
+  it('should return transform some additional data from the route', () => {
+    const routeWithSeoData = {
+      relative_url: `/${url}?query=param#fragment`,
+      type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
+      redirect_code: 0,
+      name: 'Test Name',
+      meta_title: 'Test Title',
+      meta_description: 'Test Description',
+      canonical_url: 'test-url.html',
+      uid: id,
+    };
+
+    const expected: DaffExternallyResolvableUrl = {
+      url,
+      type: routeWithSeoData.type,
+      id: routeWithSeoData.uid,
+      code: 200,
+      data: {
+        canonical_url: routeWithSeoData.canonical_url,
+        meta_description: routeWithSeoData.meta_description,
+        title: routeWithSeoData.meta_title,
+      },
+    };
+
+    expect(
+      transformResolutionToResolvableUrlv243(routeWithSeoData),
+    ).toEqual(expected);
+  });
+
+  it('should return name is meta_title is falsy', () => {
+    const routeWithSeoData = {
+      relative_url: `/${url}?query=param#fragment`,
+      type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
+      redirect_code: 0,
+      name: 'Test Name',
+      meta_title: null,
+      meta_description: 'Test Description',
+      canonical_url: 'test-url.html',
+      uid: id,
+    };
+
+    const expected: DaffExternallyResolvableUrl = {
+      url,
+      type: routeWithSeoData.type,
+      id: routeWithSeoData.uid,
+      code: 200,
+      data: {
+        canonical_url: routeWithSeoData.canonical_url,
+        meta_description: routeWithSeoData.meta_description,
+        title: routeWithSeoData.name,
+      },
+    };
+
+    expect(
+      transformResolutionToResolvableUrlv243(routeWithSeoData),
+    ).toEqual(expected);
+  });
+
+  it('should return an empty title if meta_title and name are falsy', () => {
+    const routeWithSeoData = {
+      relative_url: `/${url}?query=param#fragment`,
+      type: MagentoUrlRewriteEntityTypeEnum.PRODUCT,
+      redirect_code: 0,
+      name: null,
+      meta_title: null,
+      meta_description: 'Test Description',
+      canonical_url: 'test-url.html',
+      uid: id,
+    };
+
+    const expected: DaffExternallyResolvableUrl = {
+      url,
+      type: routeWithSeoData.type,
+      id: routeWithSeoData.uid,
+      code: 200,
+      data: {
+        canonical_url: routeWithSeoData.canonical_url,
+        meta_description: routeWithSeoData.meta_description,
+        title: '',
+      },
+    };
+
+    expect(
+      transformResolutionToResolvableUrlv243(routeWithSeoData),
+    ).toEqual(expected);
+  });
+
+  it('should transform null routes to the not found response', () => {
+    expect(
+      transformResolutionToResolvableUrlv243(null),
+    ).toEqual(DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION);
+  });
+});

--- a/libs/external-router/driver/magento/2.4.3/src/transforms/resolution-to-resolvable-url.ts
+++ b/libs/external-router/driver/magento/2.4.3/src/transforms/resolution-to-resolvable-url.ts
@@ -1,0 +1,25 @@
+import {
+  daffUriTruncateLeadingSlash,
+  daffUriTruncateQueryFragment,
+} from '@daffodil/core/routing';
+import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
+import { DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION } from '@daffodil/external-router/driver';
+import {
+  magentoTransformRedirectToHttpCode,
+  MagentoRoute,
+} from '@daffodil/external-router/driver/magento';
+
+
+export const transformResolutionToResolvableUrlv243 = (
+  resolution: MagentoRoute,
+): DaffExternallyResolvableUrl => (resolution ? {
+  id: resolution.uid,
+  url: daffUriTruncateLeadingSlash(daffUriTruncateQueryFragment(resolution.relative_url)),
+  type: resolution.type,
+  code: magentoTransformRedirectToHttpCode(resolution.redirect_code),
+  data: {
+    canonical_url: resolution.canonical_url,
+    title: resolution.meta_title ?? resolution.name ?? '',
+    meta_description: resolution.meta_description,
+  },
+} : DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION);

--- a/libs/external-router/driver/magento/src/model/public_api.ts
+++ b/libs/external-router/driver/magento/src/model/public_api.ts
@@ -1,3 +1,5 @@
 export { MagentoUrlResolver } from './url-resolver';
 export { MagentoUrlRewriteEntityTypeEnum } from './resolution-types';
 export { MagentoUrlResolverResponse } from './url-resolver-response';
+export { MagentoRoute } from './route';
+export { MagentoRouteResponse } from './route-response';

--- a/libs/external-router/driver/magento/src/model/route-response.ts
+++ b/libs/external-router/driver/magento/src/model/route-response.ts
@@ -1,0 +1,5 @@
+import { MagentoRoute } from './route';
+
+export interface MagentoRouteResponse {
+  route: MagentoRoute;
+}

--- a/libs/external-router/driver/magento/src/model/route.ts
+++ b/libs/external-router/driver/magento/src/model/route.ts
@@ -1,0 +1,41 @@
+export interface MagentoRoute {
+  /**
+   * The relative path for the route.
+   */
+  relative_url: string;
+
+  /**
+   * The type of route, typically PRODUCT, CATEGORY or CMS_PAGE
+   */
+  type: string;
+
+  /**
+   * The HTTP code for the page.
+   */
+  redirect_code: number;
+
+  /**
+   * In v2.4.3 this became the standard field across types
+   */
+  uid?: string;
+
+  /**
+   * The canonical url of the route.
+   */
+  canonical_url?: string;
+
+  /**
+   * The meta description of the route
+   */
+  meta_description?: string;
+
+  /**
+   * The name of the route
+   */
+  name?: string;
+
+  /**
+   * The title of the route
+   */
+  meta_title?: string;
+}


### PR DESCRIPTION
Note, this uses the new `route` query to retrieve some additional data about the route in question.
