### PR TITLE
feat(cart): reset order errors when cart is successfully mutated

### DIFF
--- a/libs/cart/state/src/reducers/action-types.type.ts
+++ b/libs/cart/state/src/reducers/action-types.type.ts
@@ -3,6 +3,7 @@ import {
   DaffCartAddress,
   DaffCartCoupon,
   DaffCartItemInput,
+  DaffCartOrderResult,
   DaffCartPaymentMethod,
   DaffCartShippingRate,
 } from '@daffodil/cart';
@@ -18,6 +19,7 @@ import {
   DaffCartPaymentMethodsActions,
   DaffCartCouponActions,
   DaffCartAddressActions,
+  DaffCartOrderActions,
 } from '../actions/public_api';
 import { DaffStatefulCartItem } from '../models/public_api';
 
@@ -28,7 +30,8 @@ export type ActionTypes<
   W extends DaffCartAddress = DaffCartAddress,
   X extends DaffCartShippingRate = DaffCartShippingRate,
   Y extends DaffCartPaymentMethod = DaffCartPaymentMethod,
-  Z extends DaffCartCoupon = DaffCartCoupon
+  Z extends DaffCartCoupon = DaffCartCoupon,
+  TOrderResult extends DaffCartOrderResult = DaffCartOrderResult,
 > = DaffCartActions<T>
 | DaffCartItemActions<V, U, T>
 | DaffCartBillingAddressActions<W, T>
@@ -38,4 +41,5 @@ export type ActionTypes<
 | DaffCartShippingInformationActions<X, T>
 | DaffCartPaymentActions<Y, T, W>
 | DaffCartPaymentMethodsActions<Y>
+| DaffCartOrderActions<TOrderResult>
 | DaffCartCouponActions<T, Z>;

--- a/libs/cart/state/src/reducers/cart-order/cart-order.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order.reducer.spec.ts
@@ -4,6 +4,32 @@ import {
   DaffCartPlaceOrderSuccess,
   DaffCartPlaceOrderFailure,
   daffCartOrderInitialState as initialState,
+  DaffCartActionTypes,
+  DaffCartClearSuccess,
+  DaffCartCreateSuccess,
+  DaffAddToCartSuccess,
+  DaffCartBillingAddressActionTypes,
+  DaffCartBillingAddressUpdateSuccess,
+  DaffCartShippingAddressUpdateSuccess,
+  DaffCartShippingAddressActionTypes,
+  DaffCartAddressActionTypes,
+  DaffCartAddressUpdateSuccess,
+  DaffCartCouponApplySuccess,
+  DaffCartCouponActionTypes,
+  DaffCartCouponRemoveSuccess,
+  DaffCartCouponRemoveAllSuccess,
+  DaffCartItemUpdateSuccess,
+  DaffCartItemActionTypes,
+  DaffCartItemAddSuccess,
+  DaffCartItemDeleteSuccess,
+  DaffCartItemDeleteOutOfStockSuccess,
+  DaffCartPaymentRemoveSuccess,
+  DaffCartPaymentActionTypes,
+  DaffCartPaymentUpdateSuccess,
+  DaffCartPaymentUpdateWithBillingSuccess,
+  DaffCartShippingInformationUpdateSuccess,
+  DaffCartShippingInformationActionTypes,
+  DaffCartShippingInformationDeleteSuccess,
 } from '@daffodil/cart/state';
 import {
   DaffState,
@@ -94,6 +120,402 @@ describe('Cart | Reducer | CartOrder', () => {
 
     it('should add an error to state', () => {
       expect(result.errors.length).toEqual(2);
+    });
+  });
+
+  describe('when CartClearSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartClearSuccess>{
+        type: DaffCartActionTypes.CartClearSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartCreateSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartCreateSuccess>{
+        type: DaffCartActionTypes.CartCreateSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when AddToCartSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffAddToCartSuccess>{
+        type: DaffCartActionTypes.AddToCartSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartBillingAddressUpdateSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartBillingAddressUpdateSuccess>{
+        type: DaffCartBillingAddressActionTypes.CartBillingAddressUpdateSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartShippingAddressUpdateSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartShippingAddressUpdateSuccess>{
+        type: DaffCartShippingAddressActionTypes.CartShippingAddressUpdateSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartAddressUpdateSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartAddressUpdateSuccess>{
+        type: DaffCartAddressActionTypes.CartAddressUpdateSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartCouponApplySuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartCouponApplySuccess>{
+        type: DaffCartCouponActionTypes.CartCouponApplySuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartCouponRemoveSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartCouponRemoveSuccess>{
+        type: DaffCartCouponActionTypes.CartCouponRemoveSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartCouponRemoveAllSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartCouponRemoveAllSuccess>{
+        type: DaffCartCouponActionTypes.CartCouponRemoveAllSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartItemUpdateSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartItemUpdateSuccess>{
+        type: DaffCartItemActionTypes.CartItemUpdateSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartItemAddSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartItemAddSuccess>{
+        type: DaffCartItemActionTypes.CartItemAddSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartItemDeleteSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartItemDeleteSuccess>{
+        type: DaffCartItemActionTypes.CartItemDeleteSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartItemDeleteOutOfStockSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartItemDeleteOutOfStockSuccess>{
+        type: DaffCartItemActionTypes.CartItemDeleteOutOfStockSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartPaymentRemoveSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartPaymentRemoveSuccess>{
+        type: DaffCartPaymentActionTypes.CartPaymentRemoveSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartPaymentUpdateSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartPaymentUpdateSuccess>{
+        type: DaffCartPaymentActionTypes.CartPaymentUpdateSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartPaymentUpdateWithBillingSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartPaymentUpdateWithBillingSuccess>{
+        type: DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartShippingInformationUpdateSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartShippingInformationUpdateSuccess>{
+        type: DaffCartShippingInformationActionTypes.CartShippingInformationUpdateSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when CartShippingInformationDeleteSuccessAction is triggered', () => {
+    let result;
+    let state: DaffCartOrderReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: DaffState.Resolving,
+      };
+
+      const action = <DaffCartShippingInformationDeleteSuccess>{
+        type: DaffCartShippingInformationActionTypes.CartShippingInformationDeleteSuccessAction,
+      };
+
+      result = reducer(state, action);
+    });
+
+    it('should reset the errors in state', () => {
+      expect(result.errors).toEqual([]);
     });
   });
 });

--- a/libs/cart/state/src/reducers/cart-order/cart-order.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order.reducer.ts
@@ -1,17 +1,43 @@
-import { DaffCartOrderResult } from '@daffodil/cart';
+import {
+  DaffCart,
+  DaffCartAddress,
+  DaffCartCoupon,
+  DaffCartItemInput,
+  DaffCartOrderResult,
+  DaffCartPaymentMethod,
+  DaffCartShippingRate,
+} from '@daffodil/cart';
 import { DaffState } from '@daffodil/core/state';
 import { DaffLoadingState } from '@daffodil/core/state';
 
+import { DaffStatefulCartItem } from '../..';
 import {
-  DaffCartOrderActions,
+  DaffCartActionTypes,
+  DaffCartAddressActionTypes,
+  DaffCartBillingAddressActionTypes,
+  DaffCartCouponActionTypes,
+  DaffCartItemActionTypes,
   DaffCartOrderActionTypes,
+  DaffCartPaymentActionTypes,
+  DaffCartShippingAddressActionTypes,
+  DaffCartShippingInformationActionTypes,
 } from '../../actions/public_api';
+import { ActionTypes } from '../action-types.type';
 import { daffCartOrderInitialState } from './cart-order-initial-state';
 import { DaffCartOrderReducerState } from './cart-order-state.interface';
 
 export function daffCartOrderReducer<T extends DaffCartOrderResult = DaffCartOrderResult>(
   state = daffCartOrderInitialState,
-  action: DaffCartOrderActions<T>,
+  action: ActionTypes<
+  DaffCart,
+  DaffStatefulCartItem,
+  DaffCartItemInput,
+  DaffCartAddress,
+  DaffCartShippingRate,
+  DaffCartPaymentMethod,
+  DaffCartCoupon,
+  T
+  >,
 ): DaffCartOrderReducerState<T> {
   switch (action.type) {
     case DaffCartOrderActionTypes.CartPlaceOrderAction:
@@ -36,6 +62,29 @@ export function daffCartOrderReducer<T extends DaffCartOrderResult = DaffCartOrd
           ...state.errors,
           action.payload,
         ],
+      };
+
+    case DaffCartActionTypes.CartClearSuccessAction:
+    case DaffCartActionTypes.CartCreateSuccessAction:
+    case DaffCartActionTypes.AddToCartSuccessAction:
+    case DaffCartBillingAddressActionTypes.CartBillingAddressUpdateSuccessAction:
+    case DaffCartShippingAddressActionTypes.CartShippingAddressUpdateSuccessAction:
+    case DaffCartAddressActionTypes.CartAddressUpdateSuccessAction:
+    case DaffCartCouponActionTypes.CartCouponApplySuccessAction:
+    case DaffCartCouponActionTypes.CartCouponRemoveSuccessAction:
+    case DaffCartCouponActionTypes.CartCouponRemoveAllSuccessAction:
+    case DaffCartItemActionTypes.CartItemUpdateSuccessAction:
+    case DaffCartItemActionTypes.CartItemAddSuccessAction:
+    case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
+    case DaffCartItemActionTypes.CartItemDeleteOutOfStockSuccessAction:
+    case DaffCartPaymentActionTypes.CartPaymentRemoveSuccessAction:
+    case DaffCartPaymentActionTypes.CartPaymentUpdateSuccessAction:
+    case DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingSuccessAction:
+    case DaffCartShippingInformationActionTypes.CartShippingInformationUpdateSuccessAction:
+    case DaffCartShippingInformationActionTypes.CartShippingInformationDeleteSuccessAction:
+      return {
+        ...state,
+        errors: [],
       };
 
     default:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Cart order errors will persist until a successful place order


## What is the new behavior?
Cart order errors will be reset on any successful cart mutation

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information