### PR TITLE
refactor(design): remove unnecessary daff-util imports

### DIFF
--- a/libs/design/hero/examples/src/compact-hero/compact-hero.component.scss
+++ b/libs/design/hero/examples/src/compact-hero/compact-hero.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 .daff-compact-hero {
 	&__icon {
 		display: flex;

--- a/libs/design/hero/examples/src/hero-text-alignment/hero-text-alignment.component.scss
+++ b/libs/design/hero/examples/src/hero-text-alignment/hero-text-alignment.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 .daff-hero-text-alignment {
 	&__icon {
 		display: flex;

--- a/libs/design/hero/examples/src/hero-theming/hero-theming.component.scss
+++ b/libs/design/hero/examples/src/hero-theming/hero-theming.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 .daff-hero-theming {
 	&__icon {
 		display: flex;

--- a/libs/design/src/atoms/form/form-field/form-field/form-field.component.scss
+++ b/libs/design/src/atoms/form/form-field/form-field/form-field.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 .daff-form-field {
 	display: block;
 	position: relative;

--- a/libs/design/src/atoms/form/input/input.component.scss
+++ b/libs/design/src/atoms/form/input/input.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 :host {
 	border: none;
 	border-radius: 4px;

--- a/libs/design/src/atoms/form/select/select/select.component.scss
+++ b/libs/design/src/atoms/form/select/select/select.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 .daff-native-select {
 	appearance: none;
 	background: transparent;

--- a/libs/design/src/atoms/image/image.component.scss
+++ b/libs/design/src/atoms/image/image.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 :host {
 	display: inline-block;
 	border-radius: inherit;

--- a/libs/design/src/molecules/modal/modal-actions/modal-actions.component.scss
+++ b/libs/design/src/molecules/modal/modal-actions/modal-actions.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 :host {
 	display: block;
 	padding-top: 24px;

--- a/libs/design/src/molecules/modal/modal-content/modal-content.component.scss
+++ b/libs/design/src/molecules/modal/modal-content/modal-content.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 :host {
 	display: block;
 	margin: 0 -24px;

--- a/libs/design/src/molecules/navbar/navbar.component.scss
+++ b/libs/design/src/molecules/navbar/navbar.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 :host {
 	display: flex;
 	align-items: center;

--- a/libs/design/src/molecules/sidebar/sidebar/sidebar.component.scss
+++ b/libs/design/src/molecules/sidebar/sidebar/sidebar.component.scss
@@ -1,5 +1,3 @@
-@import 'daff-util';
-
 :host {
 	display: block;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Style files are importing `daff-util` even though styles are not dependent on it.

Part of: #2063 

## What is the new behavior?
Remove `daff-util` imports in style files that don't require it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information