### PR TITLE
feat(design): allow root css variables to be used with or without theme switching

### DIFF
--- a/libs/design/scss/daff-global.scss
+++ b/libs/design/scss/daff-global.scss
@@ -14,6 +14,7 @@
 @use 'typography' as t;
 @use '~@angular/cdk/overlay-prebuilt';
 @use '~modern-normalize/modern-normalize';
+@forward './theming/theme-css-variables';
 
 body,
 html {

--- a/libs/design/scss/theming/_theme-css-variables.scss
+++ b/libs/design/scss/theming/_theme-css-variables.scss
@@ -2,7 +2,7 @@
 @use '../core';
 @use 'theming';
 
-@mixin daff-theme-css-variables($theme) {
+@mixin daff-root($theme) {
 	$base: core.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$primary: map.get($theme, primary);
@@ -12,22 +12,32 @@
 	$white: core.daff-map-deep-get($theme, 'core.white');
 	$black: core.daff-map-deep-get($theme, 'core.black');
 
+	--daff-theme-rgb: #{red($base), green($base), blue($base)};
+	--daff-theme-contrast-rgb: #{red($base-contrast), green($base-contrast),
+		blue($base-contrast)};
+	--daff-theme: #{$base};
+	--daff-theme-contrast: #{$base-contrast};
+	--daff-theme-primary: #{theming.daff-color($primary)};
+	--daff-theme-secondary: #{theming.daff-color($secondary)};
+	--daff-theme-tertiary: #{theming.daff-color($tertiary)};
+	--daff-theme-warn: #{theming.daff-color(theming.$daff-bronze, 60)};
+	--daff-theme-success: #{theming.daff-color(theming.$daff-green, 60)};
+	--daff-theme-danger: #{theming.daff-color(theming.$daff-red, 60)};
+	--daff-theme-white: #{$white};
+	--daff-theme-black: #{$black};
+	--daff-theme-gray: #{theming.daff-color($gray)};
+}
+
+@mixin daff-theme-css-variables($theme, $asRoot: true) {
 	// @docs
 	//
 	// Global theming css variables
-	:root {
-		--daff-theme-rgb: #{red($base), green($base), blue($base)};
-		--daff-theme-contrast-rgb: #{red($base-contrast), green($base-contrast), blue($base-contrast)};
-		--daff-theme: #{$base};
-		--daff-theme-contrast: #{$base-contrast};
-		--daff-theme-primary: #{theming.daff-color($primary)};
-		--daff-theme-secondary: #{theming.daff-color($secondary)};
-		--daff-theme-tertiary: #{theming.daff-color($tertiary)};
-		--daff-theme-warn: #{theming.daff-color(theming.$daff-bronze, 60)};
-		--daff-theme-success: #{theming.daff-color(theming.$daff-green, 60)};
-		--daff-theme-danger: #{theming.daff-color(theming.$daff-red, 60)};
-		--daff-theme-white: #{$white};
-		--daff-theme-black: #{$black};
-		--daff-theme-gray: #{theming.daff-color($gray)};
+	@if ($asRoot) {
+		:root {
+			@include daff-root($theme);
+		}
+		else {
+			@include daff-root($theme);
+		}
 	}
-};
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The css theme variables are not showing up at the root.

Part of: #2063 

## What is the new behavior?
css theme variables is usable at the root. The variables can also be accessed with or without the theme switching functionality.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information