### PR TITLE
fix(cart): magento driver not passing street2 value

### DIFF
--- a/libs/cart/driver/magento/src/transforms/inputs/cart-address.service.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/inputs/cart-address.service.spec.ts
@@ -1,15 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 
+import { DaffCartAddress } from '@daffodil/cart';
+import { MagentoCartAddressInput } from '@daffodil/cart/driver/magento';
 import { DaffCartAddressFactory } from '@daffodil/cart/testing';
 
 import { DaffMagentoCartAddressInputTransformer } from './cart-address.service';
 
-describe('Driver | Magento | Cart | Transformer | MagentoCartAddress', () => {
+describe('@daffodil/cart/driver/magento | DaffMagentoCartAddressInputTransformer', () => {
   let service: DaffMagentoCartAddressInputTransformer;
 
   let daffCartAddressFactory: DaffCartAddressFactory;
 
-  let mockDaffCartAddress;
+  let mockDaffCartAddress: DaffCartAddress;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -30,19 +32,22 @@ describe('Driver | Magento | Cart | Transformer | MagentoCartAddress', () => {
   });
 
   describe('transform | transforming a cart address', () => {
-    let transformedCartAddress;
-    let street;
-    let city;
-    let firstname;
-    let region;
+    let transformedCartAddress: MagentoCartAddressInput;
+    let street: string;
+    let street2: string;
+    let city: string;
+    let firstname: string;
+    let region: string;
 
     beforeEach(() => {
       street = 'street';
+      street2 = 'street2';
       city = 'city';
       firstname = 'firstname';
       region = 'region';
 
       mockDaffCartAddress.street = street;
+      mockDaffCartAddress.street2 = street2;
       mockDaffCartAddress.city = city;
       mockDaffCartAddress.firstname = firstname;
       mockDaffCartAddress.region = region;
@@ -51,7 +56,7 @@ describe('Driver | Magento | Cart | Transformer | MagentoCartAddress', () => {
     });
 
     it('should return an object with the correct values', () => {
-      expect(transformedCartAddress.street).toEqual([street]);
+      expect(transformedCartAddress.street).toEqual([street, street2]);
       expect(transformedCartAddress.city).toEqual(city);
       expect(transformedCartAddress.firstname).toEqual(firstname);
       expect(transformedCartAddress.region).toEqual(region);

--- a/libs/cart/driver/magento/src/transforms/inputs/cart-address.service.ts
+++ b/libs/cart/driver/magento/src/transforms/inputs/cart-address.service.ts
@@ -9,6 +9,11 @@ import { MagentoCartAddressInput } from '../../models/requests/cart-address';
 })
 export class DaffMagentoCartAddressInputTransformer {
   transform(cartAddress: Partial<DaffCartAddress>): MagentoCartAddressInput {
+    const street = [cartAddress.street];
+    if (cartAddress.street2) {
+      street.push(cartAddress.street2);
+    }
+
     return {
       city: cartAddress.city,
       country_code: cartAddress.country,
@@ -17,7 +22,7 @@ export class DaffMagentoCartAddressInputTransformer {
       postcode: cartAddress.postcode,
       region: cartAddress.region,
       save_in_address_book: false,
-      street: [cartAddress.street],
+      street,
       telephone: cartAddress.telephone,
     };
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The magento driver is not sending the `street2` field for the address input

## What is the new behavior?
The `street2` value is included if it is specified

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information