### PR TITLE
feat(product): default filters to `{}` in collection adapter

### DIFF
--- a/libs/product/state/src/reducers/collection/reducer.spec.ts
+++ b/libs/product/state/src/reducers/collection/reducer.spec.ts
@@ -52,10 +52,35 @@ describe('@daffodil/product/state | getProductCollectionStateAdapter', () => {
     it('should reset current page', () => {
       expect(result.currentPage).toEqual(1);
     });
+
+    describe('when null is passed', () => {
+      beforeEach(() => {
+        result = adapter.setFilters(null, initialState);
+      });
+
+      it('should set the filters to an empty object', () => {
+        expect(result.filters).toEqual({});
+      });
+    });
   });
 
   describe('setMetadata', () => {
     let result: DaffProductCollectionReducerState;
+
+    describe('when null filters are passed', () => {
+      beforeEach(() => {
+        productCollectionMetadata = {
+          ...productCollectionMetadata,
+          filters: null,
+        };
+
+        result = adapter.setMetadata(productCollectionMetadata, initialState);
+      });
+
+      it('should set the filters to an empty object', () => {
+        expect(result.filters).toEqual({});
+      });
+    });
 
     describe('when an appliedSortOption is not supplied', () => {
       beforeEach(() => {

--- a/libs/product/state/src/reducers/collection/reducer.ts
+++ b/libs/product/state/src/reducers/collection/reducer.ts
@@ -30,7 +30,7 @@ export class DaffProductCollectionStateAdapter<T extends DaffProductCollectionRe
     return {
       ...state,
       currentPage: 1,
-      filters,
+      filters: filters || {},
     };
   }
 
@@ -40,7 +40,7 @@ export class DaffProductCollectionStateAdapter<T extends DaffProductCollectionRe
   setMetadata(metadata: DaffProductCollectionMetadata, state: T): T {
     return {
       ...super.setMetadata(metadata, state),
-      filters: metadata.filters,
+      filters: metadata.filters || {},
     };
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`selectProductCollectionFilters` can return `null` or `undefined`


## What is the new behavior?
`selectProductCollectionFilters` adheres to the strict typing and only returns truthy values

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information