### PR TITLE
fix(category,product): magento driver setting wrong collection count

### DIFF
--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.ts
@@ -14,7 +14,13 @@ export class DaffMagentoCategoryPageConfigTransformerService {
     const aggregatesWithoutCategories = categoryResponse.aggregates.filter(aggregate => aggregate.attribute_code !== 'category_id');
 
     return {
-      ...magentoProductCollectionMetadataTransform(aggregatesWithoutCategories, categoryResponse.page_info, categoryResponse.sort_fields, categoryResponse.products),
+      ...magentoProductCollectionMetadataTransform(
+        aggregatesWithoutCategories,
+        categoryResponse.page_info,
+        categoryResponse.sort_fields,
+        categoryResponse.products,
+        categoryResponse.total_count,
+      ),
       id: categoryResponse.category.uid,
     };
   }

--- a/libs/product/driver/magento/src/transforms/collection-metadata.spec.ts
+++ b/libs/product/driver/magento/src/transforms/collection-metadata.spec.ts
@@ -44,9 +44,9 @@ describe('@daffodil/product/driver/magento | magentoProductCollectionMetadataTra
     sortFields = sortFieldsFactory.create();
     aggregates = [];
     products = productFactory.createMany(3);
-    count = products.length;
+    count = 54;
 
-    result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products);
+    result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products, count);
   });
 
   it('should transform page info', () => {
@@ -70,14 +70,14 @@ describe('@daffodil/product/driver/magento | magentoProductCollectionMetadataTra
     });
 
     it('should complete successfully', () => {
-      expect(magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products)).toBeTruthy();
+      expect(magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products, count)).toBeTruthy();
     });
   });
 
   describe('when the aggregate is a select', () => {
     beforeEach(() => {
       aggregates = selectAggregateFactory.createMany(1);
-      result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products);
+      result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products, count);
     });
 
     it('should return a DaffProductCollectionMetadata with an equal filter type', () => {
@@ -88,7 +88,7 @@ describe('@daffodil/product/driver/magento | magentoProductCollectionMetadataTra
   describe('when the aggregate is a price', () => {
     beforeEach(() => {
       aggregates = priceAggregateFactory.createMany(1);
-      result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products);
+      result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products, count);
     });
 
     it('should return a DaffProductCollectionMetadata with a range filter type', () => {
@@ -101,7 +101,7 @@ describe('@daffodil/product/driver/magento | magentoProductCollectionMetadataTra
 
     beforeEach(() => {
       sortDirection = DaffSortDirectionEnum.Descending;
-      result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products, undefined, sortDirection);
+      result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products, count, undefined, sortDirection);
     });
 
     it('should set that value', () => {
@@ -111,7 +111,7 @@ describe('@daffodil/product/driver/magento | magentoProductCollectionMetadataTra
 
   describe('when the applied sort option is not passed', () => {
     beforeEach(() => {
-      result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products, undefined);
+      result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products, count, undefined);
     });
 
     it('should set that value to the default sort option', () => {
@@ -124,7 +124,7 @@ describe('@daffodil/product/driver/magento | magentoProductCollectionMetadataTra
 
     beforeEach(() => {
       sortOption = 'option';
-      result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products, sortOption);
+      result = magentoProductCollectionMetadataTransform(aggregates, pageInfo, sortFields, products, count, sortOption);
     });
 
     it('should set that value', () => {

--- a/libs/product/driver/magento/src/transforms/collection-metadata.ts
+++ b/libs/product/driver/magento/src/transforms/collection-metadata.ts
@@ -20,11 +20,12 @@ export const magentoProductCollectionMetadataTransform = (
   pageInfo: MagentoProductPageInfo,
   sortFields: MagentoProductSortFields,
   products: MagentoProduct[],
+  count: number,
   appliedSortOption?: string,
   appliedSortDirection?: DaffSortDirectionEnum,
 ): DaffProductCollectionMetadata => ({
   ids: products.map(({ sku }) => sku),
-  count: products.length,
+  count,
   pageSize: pageInfo.page_size,
   currentPage: pageInfo.current_page,
   totalPages: pageInfo.total_pages,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The product magento driver was setting the collection count to the number of products on the current page, not the total count.

## What is the new behavior?
The product magento driver uses the actual count field from the platform.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information