### PR TITLE
feat(release): list remaining placeholder deps in leaf version error

### DIFF
--- a/tools/release/version/leaf-version.ts
+++ b/tools/release/version/leaf-version.ts
@@ -12,16 +12,16 @@ import { RELEASE_CONFIG } from '../config';
 interface PackageJson {
   name: string;
   version: string;
-  devDependencies: {
+  devDependencies?: {
     [key: string]: string;
   };
-  optionalDependencies: {
+  optionalDependencies?: {
     [key: string]: string;
   };
-  peerDependencies: {
+  peerDependencies?: {
     [key: string]: string;
   };
-  dependencies: {
+  dependencies?: {
     [key: string]: string;
   };
 }
@@ -131,9 +131,23 @@ const updateDaffodilOptionalDependenciesFromNewVersion = (lib: PackageJson, root
 };
 
 const validateNoRemainingPlaceholders = (lib: PackageJson) => {
-  if(JSON.stringify(lib).includes('0.0.0-PLACEHOLDER')) {
-    throw new Error(`Placeholder found in distributable package ${lib.name} after transformation`);
+  const placeholders = [
+    'devDependencies',
+    'optionalDependencies',
+    'peerDependencies',
+    'dependencies',
+  ].reduce((acc, depType) => {
+    if (lib[depType]) {
+      return acc.concat(Object.keys(lib[depType]).filter(dep => lib[depType][dep] === '0.0.0-PLACEHOLDER'));
+    }
+
+    return acc;
+  }, []);
+
+  if (placeholders.length > 0) {
+    throw new Error(`Placeholder found in distributable package ${lib.name} after transformation; deps: ${placeholders}`);
   };
+
   return lib;
 };
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The leaf version script throws an error for remaining placeholder versions but doesn't tell you for which deps these versions exist.

## What is the new behavior?
The leaf version script now lists the offending deps.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information