### PR TITLE
fix(reviews): magento query not cacheable

### DIFF
--- a/libs/reviews/driver/magento/src/queries/get-product-reviews.ts
+++ b/libs/reviews/driver/magento/src/queries/get-product-reviews.ts
@@ -4,8 +4,10 @@ import { magentoProductPageInfoFragment } from '@daffodil/product/driver/magento
 
 import { magentoProductReviewFragment } from './fragments/public_api';
 
+export const MAGENTO_REVIEWS_LIST_QUERY_NAME = 'MagentoProductReviews';
+
 export const getProductReviews = gql`
-  query MagentoProductReviews($id: String!, $pageSize: Int, $currentPage: Int) {
+  query ${MAGENTO_REVIEWS_LIST_QUERY_NAME}($id: String!, $pageSize: Int, $currentPage: Int) {
     products(filter: {
       sku: {
         eq: $id

--- a/libs/reviews/driver/magento/src/queries/public_api.ts
+++ b/libs/reviews/driver/magento/src/queries/public_api.ts
@@ -1,3 +1,3 @@
 export * from './fragments/public_api';
 
-export { getProductReviews } from './get-product-reviews';
+export * from './get-product-reviews';

--- a/libs/reviews/driver/magento/src/reviews-driver.module.ts
+++ b/libs/reviews/driver/magento/src/reviews-driver.module.ts
@@ -4,13 +4,17 @@ import {
   ModuleWithProviders,
 } from '@angular/core';
 
+import { DAFF_MAGENTO_CACHEABLE_OPERATIONS } from '@daffodil/driver/magento';
 import {
   daffProvideProductMagentoExtraProductPreviewFragments,
   daffProvideProductMagentoExtraProductPreviewTransforms,
 } from '@daffodil/product/driver/magento';
 import { DaffReviewsDriver } from '@daffodil/reviews/driver';
 
-import { magentoReviewedProductFragment } from './queries/public_api';
+import {
+  magentoReviewedProductFragment,
+  MAGENTO_REVIEWS_LIST_QUERY_NAME,
+} from './queries/public_api';
 import { DaffReviewsMagentoService } from './reviews.service';
 import { magentoReviewedProductTransform } from './transforms/public_api';
 
@@ -34,6 +38,11 @@ export class DaffReviewsMagentoDriverModule {
         ...daffProvideProductMagentoExtraProductPreviewTransforms(
           magentoReviewedProductTransform,
         ),
+        {
+          provide: DAFF_MAGENTO_CACHEABLE_OPERATIONS,
+          useValue: MAGENTO_REVIEWS_LIST_QUERY_NAME,
+          multi: true,
+        },
       ],
     };
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
The reviews Magento driver makes a cacheable query.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information