### PR TITLE
fix(reviews): collection actions don't change loading state

### DIFF
--- a/libs/reviews/state/src/reducers/product-reviews/reducer.spec.ts
+++ b/libs/reviews/state/src/reducers/product-reviews/reducer.spec.ts
@@ -10,6 +10,9 @@ import {
   DaffReviewsProductListSuccess,
   DaffReviewsProductListFailure,
   DaffProductPageReviewsReducerState,
+  DaffReviewsCollectionChangePageSize,
+  DaffReviewsCollectionChangeCurrentPage,
+  DaffReviewsCollectionChangeSortingOption,
 } from '@daffodil/reviews/state';
 import { DaffProductReviewFactory } from '@daffodil/reviews/testing';
 
@@ -48,6 +51,48 @@ describe('@daffodil/reviews/state | daffProductPageReviewsReducer', () => {
       const productLoadAction: DaffReviewsProductList = new DaffReviewsProductList(productId);
 
       result = daffProductPageReviewsReducer(daffProductReviewsReducerInitialState, productLoadAction);
+    });
+
+    it('sets loading state to true', () => {
+      expect(result.loading).toEqual(true);
+    });
+  });
+
+  describe('when ChangePageSizeAction is triggered', () => {
+    let result: DaffProductPageReviewsReducerState;
+
+    beforeEach(() => {
+      const action = new DaffReviewsCollectionChangePageSize(0);
+
+      result = daffProductPageReviewsReducer(daffProductReviewsReducerInitialState, action);
+    });
+
+    it('sets loading state to true', () => {
+      expect(result.loading).toEqual(true);
+    });
+  });
+
+  describe('when ChangeCurrentPageAction is triggered', () => {
+    let result: DaffProductPageReviewsReducerState;
+
+    beforeEach(() => {
+      const action = new DaffReviewsCollectionChangeCurrentPage(0);
+
+      result = daffProductPageReviewsReducer(daffProductReviewsReducerInitialState, action);
+    });
+
+    it('sets loading state to true', () => {
+      expect(result.loading).toEqual(true);
+    });
+  });
+
+  describe('when ChangeSortingAction is triggered', () => {
+    let result: DaffProductPageReviewsReducerState;
+
+    beforeEach(() => {
+      const action = new DaffReviewsCollectionChangeSortingOption(null);
+
+      result = daffProductPageReviewsReducer(daffProductReviewsReducerInitialState, action);
     });
 
     it('sets loading state to true', () => {

--- a/libs/reviews/state/src/reducers/product-reviews/reducer.ts
+++ b/libs/reviews/state/src/reducers/product-reviews/reducer.ts
@@ -3,6 +3,8 @@ import { DaffProductReview } from '@daffodil/reviews';
 import {
   DaffReviewsProductActionTypes,
   DaffReviewsProductActions,
+  DaffProductReviewsCollectionActionTypes,
+  DaffProductReviewsCollectionActions,
 } from '../../actions/public_api';
 import { DaffProductPageReviewsReducerState } from './state.interface';
 
@@ -21,7 +23,7 @@ export const daffProductReviewsReducerInitialState: DaffProductPageReviewsReduce
  * @param action a product action
  * @returns product state
  */
-export function daffProductPageReviewsReducer<T extends DaffProductReview = DaffProductReview>(state = daffProductReviewsReducerInitialState, action: DaffReviewsProductActions<T>): DaffProductPageReviewsReducerState {
+export function daffProductPageReviewsReducer<T extends DaffProductReview = DaffProductReview>(state = daffProductReviewsReducerInitialState, action: DaffReviewsProductActions<T> | DaffProductReviewsCollectionActions): DaffProductPageReviewsReducerState {
   switch (action.type) {
     case DaffReviewsProductActionTypes.ListAction:
     case DaffProductReviewsCollectionActionTypes.ChangePageSizeAction:

--- a/libs/reviews/state/src/reducers/product-reviews/reducer.ts
+++ b/libs/reviews/state/src/reducers/product-reviews/reducer.ts
@@ -24,6 +24,9 @@ export const daffProductReviewsReducerInitialState: DaffProductPageReviewsReduce
 export function daffProductPageReviewsReducer<T extends DaffProductReview = DaffProductReview>(state = daffProductReviewsReducerInitialState, action: DaffReviewsProductActions<T>): DaffProductPageReviewsReducerState {
   switch (action.type) {
     case DaffReviewsProductActionTypes.ListAction:
+    case DaffProductReviewsCollectionActionTypes.ChangePageSizeAction:
+    case DaffProductReviewsCollectionActionTypes.ChangeCurrentPageAction:
+    case DaffProductReviewsCollectionActionTypes.ChangeSortingAction:
       return { ...state, loading: true };
     case DaffReviewsProductActionTypes.ListSuccessAction:
       return { ...state, loading: false };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
Reviews collection actions now cause reviews page state to be loading.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information