### PR TITLE
fix(design): add exports for external usage

### DIFF
--- a/libs/design/package.json
+++ b/libs/design/package.json
@@ -38,5 +38,19 @@
   },
   "devDependencies": {
     "@daffodil/core": "0.0.0-PLACEHOLDER"
+  },
+  "exports": {
+    "./scss/daff-global": {
+      "sass": "./scss/daff-global.scss"
+    },
+    "./scss/theme": {
+      "sass": "./scss/theme.scss"
+    },
+    "./scss/daff-util": {
+      "sass": "./scss/daff-util.scss"
+    },
+    "./scss/daff-typography": {
+      "sass": "./scss/daff-typography.scss"
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
If you try to run a sample app with just `@daffodil/design` themes you will get an error that says:

```bash
Unable to import `@daffodil/design/scss/daff-theme`
```

Fixes: N/A


## What is the new behavior?
By adding these keys, [as described here](https://github.com/ng-packagr/ng-packagr/blob/main/docs/copy-assets.md#exporting-styles) we now specify the expected exports of our package.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information