### PR TITLE
fix(design): remove tilde from cdk and modern normalize module imports

### DIFF
--- a/libs/design/scss/global.scss
+++ b/libs/design/scss/global.scss
@@ -12,8 +12,8 @@
 // ```
 
 @use 'typography' as t;
-@use '~@angular/cdk/overlay-prebuilt';
-@use '~modern-normalize/modern-normalize';
+@use '@angular/cdk/overlay-prebuilt';
+@use 'modern-normalize/modern-normalize';
 @forward './theming/theme-css-variables';
 
 body,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, we import `scss` files with a `~`. This is unnecessary.

Fixes: N/A


## What is the new behavior?
We no longer use the `~` in imports.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

This may be breaking for some users depending on old library versions, but this very unlikely.

## Other information