### PR TITLE
feat(design): export typography classes for external usage and update usage documentation

### DIFF
--- a/libs/design/package.json
+++ b/libs/design/package.json
@@ -61,6 +61,9 @@
     },
     "./scss/daff-typography": {
       "sass": "./scss/daff-typography.scss"
+    },
+    "./scss/typography/classes": {
+      "sass": "./scss/typography/_classes.scss"
     }
   }
 }

--- a/libs/design/scss/typography/README.md
+++ b/libs/design/scss/typography/README.md
@@ -5,7 +5,7 @@ Daffodil uses typography to establish hierarchy and create clear visual patterns
 To include typography in your project, you can add the following in your Sass file:
 
 ```scss
-@use '@daffodil/design/scss/typography';
+@use '@daffodil/design/scss/utilities';
 ```
 
 ## Type Scale
@@ -46,10 +46,10 @@ The headline mixins are responsive and will adjust at the `tablet` breakpoint.
 
 **Example:**
 ```scss
-@use '@daffodil/design/scss/typography';
+@use '@daffodil/design/scss/utilities';
 
 .title {
-	@include typography.headline-xl;
+	@include utilities.headline-xl;
 }
 ```
 
@@ -64,19 +64,16 @@ The headline mixins are responsive and will adjust at the `tablet` breakpoint.
 
 > `text-truncate` should only be used if the element is `display: block;` or `display: inline-block;`
 
-**Examples:**
-```html
-<div class="title"><span class="embolden">Daffodil</span> is a frontend Ecommerce framework that allows developers to build complex Ecommerce stores.</div>
-```
+You can include the typography utility classes in your project by writing the following in your Sass file:
 
 ```scss
-@use '@daffodil/design/scss/typography';
+@use '@daffodil/design/scss/typography/classes';
+```
 
-.title {
-	span {
-		@include typography.embolden;
-	}
-}
+Otherwise, you can use the mixins in your project by using the following module in your Sass file:
+
+```scss
+@use '@daffodil/design/scss/utilities';
 ```
 
 ## Typography Variables


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
```bash
Unable to import `@daffodil/design/scss/typography`
```

Fixes: N/A


## What is the new behavior?
By adding these keys, [as described here](https://github.com/ng-packagr/ng-packagr/blob/main/docs/copy-assets.md#exporting-styles) we now specify the expected exports of our package.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information