### PR TITLE
chore: enable eslint in vscode by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,5 +38,6 @@
         "typescript",
         "typescriptreact",
         "html"
-    ]
+    ],
+    "eslint.format.enable": true
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
I keep having to click to allow eslint in Codespaces. This annoys me greatly.

Fixes: N/A


## What is the new behavior?
This is enabled by default.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```