### PR TITLE
perf(demo): lazy load demo checkout module

### DIFF
--- a/apps/demo/src/app/app-routing.module.ts
+++ b/apps/demo/src/app/app-routing.module.ts
@@ -33,7 +33,7 @@ export const appRoutes: Routes = [
       },
       {
         path: 'checkout',
-        loadChildren: () => import('./checkout/checkout.module').then(m => m.CheckoutModule)
+        loadChildren: () => import('./checkout/checkout.module').then(m => m.CheckoutModule),
       },
       { path: '404', component: NotFoundComponent },
     ],

--- a/apps/demo/src/app/app-routing.module.ts
+++ b/apps/demo/src/app/app-routing.module.ts
@@ -33,13 +33,7 @@ export const appRoutes: Routes = [
       },
       {
         path: 'checkout',
-        children: [
-          { path: '', component: CheckoutViewComponent },
-          { path: 'thank-you', component: ThankYouViewComponent },
-        ],
-        resolve: {
-          cartItem: EmptyCartResolver,
-        },
+        loadChildren: () => import('./checkout/checkout.module').then(m => m.CheckoutModule)
       },
       { path: '404', component: NotFoundComponent },
     ],

--- a/apps/demo/src/app/app.module.ts
+++ b/apps/demo/src/app/app.module.ts
@@ -12,7 +12,6 @@ import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { DemoCartRootModule } from './cart/cart-root.module';
-import { CheckoutModule } from './checkout/checkout.module';
 import { TemplateModule } from './core/template/template/template.module';
 import { DemoDriverMap } from './drivers/map';
 import { NotFoundModule } from './misc/not-found/not-found.module';
@@ -44,7 +43,6 @@ import { ThankYouModule } from './thank-you/thank-you.module';
     DemoRoutingComponentModule,
     DemoCartRootModule,
     ProductModule,
-    CheckoutModule,
     ThankYouModule,
     TemplateModule,
     NotFoundModule,

--- a/apps/demo/src/app/checkout/checkout-routing.module.ts
+++ b/apps/demo/src/app/checkout/checkout-routing.module.ts
@@ -1,0 +1,33 @@
+import { NgModule } from '@angular/core';
+import {
+  RouterModule,
+  Routes,
+} from '@angular/router';
+import { EmptyCartResolver } from '../cart/routing-resolvers/resolvers/empty-cart-resolver.service';
+
+import { ThankYouViewComponent } from '../thank-you/pages/thank-you-view.component';
+import { CheckoutViewComponent } from './pages/checkout-view/checkout-view.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    children: [
+      { path: '', component: CheckoutViewComponent },
+      { path: 'thank-you', component: ThankYouViewComponent },
+    ],
+    resolve: {
+      cartItem: EmptyCartResolver,
+    },
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes),
+  ],
+  exports: [
+    RouterModule,
+  ],
+})
+export class CheckoutRoutingModule { }

--- a/apps/demo/src/app/checkout/checkout-routing.module.ts
+++ b/apps/demo/src/app/checkout/checkout-routing.module.ts
@@ -3,8 +3,8 @@ import {
   RouterModule,
   Routes,
 } from '@angular/router';
-import { EmptyCartResolver } from '../cart/routing-resolvers/resolvers/empty-cart-resolver.service';
 
+import { EmptyCartResolver } from '../cart/routing-resolvers/resolvers/empty-cart-resolver.service';
 import { ThankYouViewComponent } from '../thank-you/pages/thank-you-view.component';
 import { CheckoutViewComponent } from './pages/checkout-view/checkout-view.component';
 
@@ -19,7 +19,7 @@ const routes: Routes = [
     resolve: {
       cartItem: EmptyCartResolver,
     },
-  }
+  },
 ];
 
 @NgModule({

--- a/apps/demo/src/app/checkout/checkout.module.ts
+++ b/apps/demo/src/app/checkout/checkout.module.ts
@@ -10,6 +10,7 @@ import {
 } from '@daffodil/design';
 
 import { CartSummaryWrapperModule } from '../cart/components/cart-summary-wrapper/cart-summary-wrapper.module';
+import { CheckoutRoutingModule } from './checkout-routing.module';
 import { DemoCheckoutStateModule } from './checkout-state.module';
 import { PaymentModule } from './components/payment/payment/payment.module';
 import { PlaceOrderModule } from './components/place-order/place-order.module';
@@ -30,6 +31,7 @@ import { CheckoutViewComponent } from './pages/checkout-view/checkout-view.compo
 
     DaffAccordionModule,
     DaffContainerModule,
+    CheckoutRoutingModule
   ],
   declarations: [
     CheckoutViewComponent,

--- a/apps/demo/src/app/checkout/checkout.module.ts
+++ b/apps/demo/src/app/checkout/checkout.module.ts
@@ -28,10 +28,9 @@ import { CheckoutViewComponent } from './pages/checkout-view/checkout-view.compo
     ShippingModule,
     PaymentModule,
     PlaceOrderModule,
-
     DaffAccordionModule,
     DaffContainerModule,
-    CheckoutRoutingModule
+    CheckoutRoutingModule,
   ],
   declarations: [
     CheckoutViewComponent,


### PR DESCRIPTION
Change demo checkout module to be lazy-loaded to improve initial page load

resolves The demo's checkout module should be lazy-loaded. #201

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The demo checkout module is not being lazy loaded #201


## What is the new behavior?

The demo checkout module **is now**  being lazy loaded

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information