### PR TITLE
feat(demo): prevent lib imports on demo

### DIFF
--- a/apps/demo/.eslintrc.js
+++ b/apps/demo/.eslintrc.js
@@ -41,6 +41,12 @@ module.exports = {
             style: 'camelCase'
           }
         ],
+        'no-restricted-imports': ['error', {
+          'patterns': [{
+            'group': ['libs/*'],
+            'message': 'Usage of private modules not allowed. Did you mean to import from @daffodil/*?'
+          }],
+        }],
       }
     },
     {


### PR DESCRIPTION
Add a eslint rule to prevent demo app from importing from the libs group, preferring @daffodil/*

resolves #286

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The demo app allowed imports from the lib/* group

Fixes: #286 


## What is the new behavior?
The demo app (when linted) will show an error when attempts to lib imports are made

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Example

* Add import from a lib/* group

![image](https://user-images.githubusercontent.com/16000608/193523553-48f0001b-f601-4f63-a586-b6e3c46dfbc2.png)

* Run `npm run lint` on demo project context

* Observe linting error being shown

![image](https://user-images.githubusercontent.com/16000608/193524032-e1ab6510-c805-4c5e-be33-d464d36d5437.png)

