### PR TITLE
feat(auth): remove auth token from storage when check fails

### DIFF
--- a/libs/auth/state/src/effects/auth.effects.spec.ts
+++ b/libs/auth/state/src/effects/auth.effects.spec.ts
@@ -9,6 +9,7 @@ import {
   of,
 } from 'rxjs';
 
+import { DaffAuthStorageService } from '@daffodil/auth';
 import {
   DaffAuthDriver,
   DaffAuthServiceInterface,
@@ -29,6 +30,7 @@ describe('@daffodil/auth/state | DaffAuthEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffAuthEffects;
 
+  let daffAuthStorageService: DaffAuthStorageService;
   let daffAuthDriver: jasmine.SpyObj<DaffAuthServiceInterface>;
 
   beforeEach(() => {
@@ -46,6 +48,9 @@ describe('@daffodil/auth/state | DaffAuthEffects', () => {
     effects = TestBed.inject(DaffAuthEffects);
 
     daffAuthDriver = TestBed.inject<jasmine.SpyObj<DaffAuthServiceInterface>>(DaffAuthDriver);
+    daffAuthStorageService = TestBed.inject(DaffAuthStorageService);
+
+    spyOn(daffAuthStorageService, 'removeAuthToken');
   });
 
   it('should be created', () => {
@@ -84,6 +89,11 @@ describe('@daffodil/auth/state | DaffAuthEffects', () => {
       it('should notify state that the check failed', () => {
         expect(effects.guardCheck$).toBeObservable(expected);
       });
+
+      it('should remove the auth token from storage', () => {
+        expect(effects.guardCheck$).toBeObservable(expected);
+        expect(daffAuthStorageService.removeAuthToken).toHaveBeenCalledWith();
+      });
     });
   });
 
@@ -119,6 +129,11 @@ describe('@daffodil/auth/state | DaffAuthEffects', () => {
 
       it('should notify state that the check failed', () => {
         expect(effects.check$).toBeObservable(expected);
+      });
+
+      it('should remove the auth token from storage', () => {
+        expect(effects.check$).toBeObservable(expected);
+        expect(daffAuthStorageService.removeAuthToken).toHaveBeenCalledWith();
       });
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When auth checks fail, the token remains in storage

## What is the new behavior?
The auth token is removed from storage when auth checks fail

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information