### PR TITLE
feat(auth): remove auth token from storage on logout

### DIFF
--- a/libs/auth/state/src/effects/login.effects.spec.ts
+++ b/libs/auth/state/src/effects/login.effects.spec.ts
@@ -86,6 +86,7 @@ describe('@daffodil/auth/state | DaffAuthLoginEffects', () => {
     mockRegistration = registrationFactory.create();
     mockAuth = authFactory.create();
     setAuthTokenSpy = spyOn(daffAuthStorageService, 'setAuthToken');
+    spyOn(daffAuthStorageService, 'removeAuthToken');
 
     token = mockAuth.token;
     email = mockRegistration.email;
@@ -179,6 +180,11 @@ describe('@daffodil/auth/state | DaffAuthLoginEffects', () => {
 
       it('should notify state that the logout succeeded', () => {
         expect(effects.logout$).toBeObservable(expected);
+      });
+
+      it('should remove the auth token from storage', () => {
+        expect(effects.logout$).toBeObservable(expected);
+        expect(daffAuthStorageService.removeAuthToken).toHaveBeenCalledWith();
       });
     });
 

--- a/libs/auth/state/src/effects/login.effects.ts
+++ b/libs/auth/state/src/effects/login.effects.ts
@@ -75,6 +75,9 @@ export class DaffAuthLoginEffects<
     switchMap((action: DaffAuthLogout) =>
       this.loginDriver.logout().pipe(
         map(() => new DaffAuthLogoutSuccess()),
+        tap(() => {
+          this.storage.removeAuthToken();
+        }),
         catchError((error: DaffError) =>
           of(new DaffAuthLogoutFailure(this.errorMatcher(error))),
         ),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The auth token persists in storage when a logout succeeds

## What is the new behavior?
The auth token is removed from storage upon a successful logout

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information