### PR TITLE
feat(auth): dispatch auth complete when storing auth token

### DIFF
--- a/libs/auth/state/src/effects/register.effects.ts
+++ b/libs/auth/state/src/effects/register.effects.ts
@@ -37,6 +37,7 @@ import {
   DaffAuthRegister,
   DaffAuthRegisterSuccess,
   DaffAuthRegisterFailure,
+  DaffAuthComplete,
 } from '../actions/public_api';
 
 @Injectable()
@@ -57,10 +58,12 @@ export class DaffAuthRegisterEffects<
         () => action.autoLogin,
         defer(() => this.registerDriver.register(action.registration).pipe(
           tap(token => this.storage.setAuthToken(token)),
+          switchMap(() => of(new DaffAuthRegisterSuccess(), new DaffAuthComplete())),
         )),
-        defer(() => this.registerDriver.registerOnly(action.registration)),
+        defer(() => this.registerDriver.registerOnly(action.registration).pipe(
+          map(() => new DaffAuthRegisterSuccess()),
+        )),
       ).pipe(
-        map(() => new DaffAuthRegisterSuccess()),
         catchError((error: DaffError) =>
           of(new DaffAuthRegisterFailure(this.errorMatcher(error))),
         ),

--- a/libs/auth/state/src/effects/reset-password.effects.ts
+++ b/libs/auth/state/src/effects/reset-password.effects.ts
@@ -40,6 +40,7 @@ import {
   DaffSendResetEmail,
   DaffSendResetEmailSuccess,
   DaffSendResetEmailFailure,
+  DaffAuthComplete,
 } from '../actions/public_api';
 
 @Injectable()
@@ -74,10 +75,12 @@ export class DaffAuthResetPasswordEffects<
         () => action.autoLogin,
         defer(() => this.driver.resetPassword(action.info).pipe(
           tap(token => this.storage.setAuthToken(token)),
+          switchMap(() => of(new DaffResetPasswordSuccess(), new DaffAuthComplete())),
         )),
-        defer(() => this.driver.resetPasswordOnly(action.info)),
+        defer(() => this.driver.resetPasswordOnly(action.info).pipe(
+          map(() => new DaffResetPasswordSuccess()),
+        )),
       ).pipe(
-        map(() => new DaffResetPasswordSuccess()),
         catchError((error: DaffError) =>
           of(new DaffResetPasswordFailure(this.errorMatcher(error))),
         ),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
When register and reset password effects automatically log the customer in and store the auth token, they dispatch `DaffAuthComplete`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information