### PR TITLE
fix(driver): incorrect Magento Breadcrumb type policy key field

### DIFF
--- a/libs/driver/magento/src/graphql/type-policies.ts
+++ b/libs/driver/magento/src/graphql/type-policies.ts
@@ -38,7 +38,7 @@ export const DAFF_MAGENTO_2_4_3_TYPE_POLICIES: TypePolicies = {
   },
   Breadcrumb: {
     // Uses provided fields on the object as the `id`.
-    keyFields: ['category_id'],
+    keyFields: ['category_uid'],
   },
   Cart: {
     keyFields: () => 'Cart',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Magento type policy sets the `Breadcrumb` key field to `category_id`, which is not queried by the driver.


## What is the new behavior?
Magento type policy sets the `Breadcrumb` key field to `category_uid`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information