### PR TITLE
fix(seo): `DaffRestoreableMetaService#clear` doesn't work after a `restore`

### DIFF
--- a/libs/seo/src/meta/restoreable.service.spec.ts
+++ b/libs/seo/src/meta/restoreable.service.spec.ts
@@ -73,7 +73,7 @@ describe('@daffodil/seo | DaffRestoreableMetaService', () => {
       });
 
       it('should invoke the meta service with the upserted def', () => {
-        expect(metaServiceSpy.upsert).toHaveBeenCalledOnceWith(def);
+        expect(metaServiceSpy.remove).toHaveBeenCalledOnceWith(def);
       });
     });
   });
@@ -124,6 +124,17 @@ describe('@daffodil/seo | DaffRestoreableMetaService', () => {
       it('should restore the upserted and cleared def', () => {
         expect(metaServiceSpy.upsert.calls.mostRecent().args[0]).toEqual(def);
         expect(metaServiceSpy.upsert).toHaveBeenCalledTimes(2);
+      });
+
+      describe('and then the defs are cleared again', () => {
+        beforeEach(() => {
+          service.clear();
+        });
+
+        it('should clear the restored defs', () => {
+          expect(metaServiceSpy.remove).toHaveBeenCalledTimes(2);
+          expect(metaServiceSpy.remove.calls.mostRecent().args[0]).toEqual(def);
+        });
       });
     });
 

--- a/libs/seo/src/meta/restoreable.service.ts
+++ b/libs/seo/src/meta/restoreable.service.ts
@@ -64,7 +64,7 @@ export class DaffRestoreableMetaService implements DaffSeoRestoreableServiceInte
     this._clearPage();
 
     Object.keys(this._restoreCache).forEach(key => {
-      this.meta.upsert(this._restoreCache[key]);
+      this.upsert(this._restoreCache[key]);
     });
 
     this.emptyRestoreCache();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`DaffRestoreableMetaService#clear` doesn't work after a `restore`


## What is the new behavior?
`DaffRestoreableMetaService#restore` updates the upsert cache, allowing subsequent `clear`s to work

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information