### PR TITLE
feat(seo): pass router URL to `getData`

### DIFF
--- a/libs/seo/state/src/effects/router/page-hook.effects.ts
+++ b/libs/seo/state/src/effects/router/page-hook.effects.ts
@@ -51,7 +51,7 @@ export abstract class DaffSeoPageHookRouterEffects<
       map(event => this.updates.filter(update =>
         event instanceof update.event,
       ).map(({ getData }) =>
-        getData(event, this.activatedRoute),
+        getData(event, this.activatedRoute, this.router.url),
       )),
       tap((data: V[]) => data.forEach(datum => {
         if (datum) {

--- a/libs/seo/state/src/models/update-event-pair.interface.ts
+++ b/libs/seo/state/src/models/update-event-pair.interface.ts
@@ -1,6 +1,7 @@
 import {
   ActivatedRoute,
   Event,
+  Router,
 } from '@angular/router';
 
 import { Constructable } from '@daffodil/core';
@@ -17,5 +18,5 @@ export interface DaffSeoUpdateEventPair<T extends Event = Event, V = unknown> {
   /**
    * A function that gets SEO info from the particular action.
    */
-  getData: (event: T, activatedRoute: ActivatedRoute) => V;
+  getData: (event: T, activatedRoute: ActivatedRoute, url: Router['url']) => V;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`getData` callbacks have no easy way to get router URL (it can be computed from activated route in a convoluted and brittle way)


## What is the new behavior?
`getData` callbacks have an easy way to get router URL

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
having access to the router URL is very useful for getting seo data from externally resolved route data (`route.data.daffPaths[url]`)