### PR TITLE
perf(reviews): don't query nested product in magento driver

### DIFF
--- a/libs/reviews/driver/magento/src/models/responses/get-product-reviews.ts
+++ b/libs/reviews/driver/magento/src/models/responses/get-product-reviews.ts
@@ -3,6 +3,7 @@ import { MagentoProductReviews } from './product-reviews';
 export interface MagentoGetProductReviewsResponse {
   products: {
     items?: ({
+      sku: string;
       reviews: MagentoProductReviews;
     } | null)[];
   };

--- a/libs/reviews/driver/magento/src/models/responses/product-review.interface.ts
+++ b/libs/reviews/driver/magento/src/models/responses/product-review.interface.ts
@@ -5,9 +5,6 @@ export interface MagentoProductReview {
   average_rating: number;
   created_at: string;
   nickname: string;
-  product: {
-    sku: string;
-  };
   ratings_breakdown: MagentoProductReviewRating[];
   summary: string;
   text: string;

--- a/libs/reviews/driver/magento/src/models/responses/reviewed-product.interface.ts
+++ b/libs/reviews/driver/magento/src/models/responses/reviewed-product.interface.ts
@@ -1,6 +1,7 @@
 import { MagentoProduct } from '@daffodil/product/driver/magento';
 
 export interface MagentoReviewedProduct extends MagentoProduct {
+  sku: string;
   review_count: number;
   rating_summary: number;
 }

--- a/libs/reviews/driver/magento/src/queries/fragments/review.ts
+++ b/libs/reviews/driver/magento/src/queries/fragments/review.ts
@@ -5,12 +5,9 @@ export const magentoProductReviewFragment = gql`
     average_rating
     created_at
     nickname
-    product {
-      sku
-    }
     ratings_breakdown {
-        name
-        value
+      name
+      value
     }
     summary
     text

--- a/libs/reviews/driver/magento/src/queries/fragments/reviewed-product.ts
+++ b/libs/reviews/driver/magento/src/queries/fragments/reviewed-product.ts
@@ -2,6 +2,7 @@ import { gql } from 'apollo-angular';
 
 export const magentoReviewedProductFragment = gql`
   fragment magentoReviewedProduct on ProductInterface {
+    sku
     review_count
     rating_summary
   }

--- a/libs/reviews/driver/magento/src/reviews.service.spec.ts
+++ b/libs/reviews/driver/magento/src/reviews.service.spec.ts
@@ -60,6 +60,7 @@ describe('@daffodil/reviews/driver/magento | DaffReviewsMagentoService', () => {
     mockGetProductReviewsResponse = {
       products: {
         items: [{
+          sku: productId,
           reviews: mockMagentoReviews,
         }],
       },
@@ -75,7 +76,7 @@ describe('@daffodil/reviews/driver/magento | DaffReviewsMagentoService', () => {
       it('should return the list of Daffodil countries', done => {
         service.list(productId).subscribe((result) => {
           expect(Object.values(result.data)).toEqual(jasmine.arrayContaining(mockMagentoReviews.items.map(e => jasmine.objectContaining({
-            productId: e.product.sku,
+            productId,
           }))));
           done();
         });

--- a/libs/reviews/driver/magento/src/transforms/responses/product-review.ts
+++ b/libs/reviews/driver/magento/src/transforms/responses/product-review.ts
@@ -3,10 +3,11 @@ import { DaffProductReview } from '@daffodil/reviews';
 import { MagentoProductReview } from '../../models/public_api';
 import { magentoProductRatingTransform } from './product-rating';
 
-export const magentoProductReviewTransform = (review: MagentoProductReview): DaffProductReview => ({
-  id: `${review.product.sku}-${review.nickname}`,
+export const magentoProductReviewTransform = (review: MagentoProductReview, productSku: string): DaffProductReview => ({
+  // TODO: use real ID when available
+  id: `${productSku}-${review.nickname}-${review.summary}`,
   overallRating: review.average_rating,
-  productId: review.product.sku,
+  productId: productSku,
   // TODO: investigate timezones issue
   // magento does not give timezone info in the string
   // figure out way to infer it

--- a/libs/reviews/driver/magento/src/transforms/responses/product-reviews.ts
+++ b/libs/reviews/driver/magento/src/transforms/responses/product-reviews.ts
@@ -7,7 +7,7 @@ import { magentoProductReviewCollectionMetadataTransform } from './product-revie
 
 export const magentoProductReviewsTransform = (productReviews: MagentoGetProductReviewsResponse): DaffProductReviews => {
   const reviews = productReviews.products.items?.[0]?.reviews;
-  const data = daffIdentifiableArrayToDict(reviews.items.map(magentoProductReviewTransform) || []);
+  const data = daffIdentifiableArrayToDict(reviews.items.map(review => magentoProductReviewTransform(review, productReviews.products.items?.[0].sku)) || []);
 
   return {
     data,

--- a/libs/reviews/driver/magento/src/validators/get-reviews.spec.ts
+++ b/libs/reviews/driver/magento/src/validators/get-reviews.spec.ts
@@ -19,6 +19,7 @@ describe('@daffodil/reviews/driver/magento | validateGetProductReviewsResponse',
       data: {
         products: {
           items: [{
+            sku: 'sku',
             reviews: reviewsFactory.create(),
           }],
         },

--- a/libs/reviews/driver/magento/testing/src/factories/product-review.factory.spec.ts
+++ b/libs/reviews/driver/magento/testing/src/factories/product-review.factory.spec.ts
@@ -33,7 +33,6 @@ describe('@daffodil/reviews/driver/magento/testing | MagentoProductReviewFactory
       expect(result.ratings_breakdown).toBeDefined();
       expect(result.summary).toBeDefined();
       expect(result.text).toBeDefined();
-      expect(result.product.sku).toBeDefined();
     });
   });
 });

--- a/libs/reviews/driver/magento/testing/src/factories/product-review.factory.ts
+++ b/libs/reviews/driver/magento/testing/src/factories/product-review.factory.ts
@@ -16,9 +16,6 @@ export class MockMagentoProductReview implements MagentoProductReview {
   average_rating = faker.datatype.number({ min: 0, max: 100 });
   created_at = faker.date.past();
   nickname = faker.name.firstName();
-  product = {
-    sku: faker.datatype.uuid(),
-  };
   ratings_breakdown = this.createRatings();
 
   constructor(

--- a/libs/reviews/driver/magento/testing/src/factories/reviewed-product.factory.spec.ts
+++ b/libs/reviews/driver/magento/testing/src/factories/reviewed-product.factory.spec.ts
@@ -27,6 +27,7 @@ describe('@daffodil/reviews/driver/magento/testing | MagentoReviewedProductFacto
     });
 
     it('should return', () => {
+      expect(result.sku).toBeDefined();
       expect(result.rating_summary).toBeDefined();
       expect(result.review_count).toBeDefined();
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: perf
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

fixes: #2263 


## What is the new behavior?
the reviews magento driver only uses fields from the root product

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information