### PR TITLE
fix(auth): do not crash when token is inaccessible

### DIFF
--- a/libs/auth/driver/magento/src/apollo-bearer-token-link-generator.spec.ts
+++ b/libs/auth/driver/magento/src/apollo-bearer-token-link-generator.spec.ts
@@ -1,4 +1,8 @@
-import { TestBed } from '@angular/core/testing';
+import { Inject } from '@angular/core';
+import {
+  inject,
+  TestBed,
+} from '@angular/core/testing';
 import {
   DocumentNode,
   gql,
@@ -12,6 +16,10 @@ import {
 } from 'apollo-angular/testing';
 
 import { DaffAuthStorageService } from '@daffodil/auth';
+import {
+  DaffPersistenceServiceToken,
+  DaffServerErrorStorageService,
+} from '@daffodil/core';
 
 import { MagentoAuthApolloBearerTokenLinkGenerator } from './apollo-bearer-token-link-generator';
 
@@ -74,6 +82,20 @@ describe('@daffodil/auth/driver/magento | MagentoAuthApolloBearerTokenLinkGenera
       });
 
       it('should not set the authorization header', () => {
+        apollo.query({ query }).subscribe();
+        operation = controller.expectOne(query).operation;
+        service.getLink().request(operation, <NextLink><unknown>jasmine.createSpy);
+
+        expect(operation.getContext().headers?.authorization).toBeUndefined();
+      });
+    });
+
+    describe('when getting the token fails due to a storage error', () => {
+      beforeEach(() => {
+        daffAuthStorageService.getAuthToken.and.throwError('Some sort of error');
+      });
+
+      it('should not crash', () => {
         apollo.query({ query }).subscribe();
         operation = controller.expectOne(query).operation;
         service.getLink().request(operation, <NextLink><unknown>jasmine.createSpy);

--- a/libs/auth/driver/magento/src/apollo-bearer-token-link-generator.ts
+++ b/libs/auth/driver/magento/src/apollo-bearer-token-link-generator.ts
@@ -19,7 +19,12 @@ export class MagentoAuthApolloBearerTokenLinkGenerator implements DaffApolloLink
 
   getLink(): ApolloLink {
     return new ApolloLink((operation, forward) => {
-      const token = this.storage.getAuthToken();
+      let token = null;
+
+      try {
+        token = this.storage.getAuthToken();
+      } catch(e){}
+
       if (token) {
         operation.setContext({
           headers: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Since this token is attached to all further Graphql queries, queries that failed to handle the storage service error will crash unexpectedly.

Fixes: N/A


## What is the new behavior?
As a result, I've surpressed the error to a "no token" state.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
