### PR TITLE
feat!: move magento page info from product to driver

### DIFF
--- a/libs/category/driver/magento/src/category.service.spec.ts
+++ b/libs/category/driver/magento/src/category.service.spec.ts
@@ -39,13 +39,14 @@ import {
   DaffFilterRequestEqualFactory,
   DaffFilterRequestRangeNumericFactory,
 } from '@daffodil/core/testing';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
+import { MagentoSearchResultPageInfoFactory } from '@daffodil/driver/magento/testing';
 import {
   MagentoAggregation,
   MagentoProduct,
   MagentoProductFilterTypeField,
   MagentoProductGetFilterTypes,
   MagentoProductGetFilterTypesResponse,
-  MagentoProductPageInfo,
   MagentoProductSortFields,
 } from '@daffodil/product/driver/magento';
 import {
@@ -53,7 +54,6 @@ import {
   MagentoProductAggregationPriceFactory,
   MagentoProductAggregationSelectFactory,
   MagentoProductSortFieldsFactory,
-  MagentoProductPageInfoFactory,
   MagentoSimpleProductFactory,
 } from '@daffodil/product/driver/magento/testing';
 import { DaffProductFactory } from '@daffodil/product/testing';
@@ -77,7 +77,7 @@ describe('@daffodil/category/driver/magento | DaffMagentoCategoryService', () =>
   let selectAggregateFactory: MagentoProductAggregationSelectFactory;
   let magentoFilterTypeFieldFactory: MagentoProductFilterTypeFieldFactory;
   let magentoProductFactory: MagentoSimpleProductFactory;
-  let magentoPageInfoFactory: MagentoProductPageInfoFactory;
+  let magentoPageInfoFactory: MagentoSearchResultPageInfoFactory;
 
   let mockCategoryRequest: DaffCategoryIdRequest;
   let mockCategory: DaffCategory;
@@ -92,7 +92,7 @@ describe('@daffodil/category/driver/magento | DaffMagentoCategoryService', () =>
   let mockMagentoSelectFilterTypeField: MagentoProductFilterTypeField;
   let mockMagentoPriceFilterTypeField: MagentoProductFilterTypeField;
   let mockMagentoProduct: MagentoProduct;
-  let mockMagentoProductPageInfo: MagentoProductPageInfo;
+  let mockMagentoProductPageInfo: MagentoSearchResultPageInfo;
   let mockGetFilterTypesResponse: MagentoProductGetFilterTypesResponse;
   let mockGetCategoryAndProductsResponse: MagentoGetCategoryAndProductsResponse;
   let mockCategoryUrlResolverResponse: MagentoCategoryUrlResolverResponse;
@@ -122,7 +122,7 @@ describe('@daffodil/category/driver/magento | DaffMagentoCategoryService', () =>
     priceAggregateFactory = TestBed.inject(MagentoProductAggregationPriceFactory);
     rangeFilterRequestOptionFactory = TestBed.inject(DaffFilterRangeNumericRequestOptionFactory);
     magentoProductFactory = TestBed.inject(MagentoSimpleProductFactory);
-    magentoPageInfoFactory = TestBed.inject(MagentoProductPageInfoFactory);
+    magentoPageInfoFactory = TestBed.inject(MagentoSearchResultPageInfoFactory);
     magentoFilterTypeFieldFactory = TestBed.inject(MagentoProductFilterTypeFieldFactory);
 
     mockCategory = categoryFactory.create();

--- a/libs/category/driver/magento/src/models/complete-category-response.ts
+++ b/libs/category/driver/magento/src/models/complete-category-response.ts
@@ -1,9 +1,9 @@
 import { DaffSortDirectionEnum } from '@daffodil/core';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 import {
   MagentoAggregation,
   MagentoProduct,
   MagentoProductSortFields,
-  MagentoProductPageInfo,
 } from '@daffodil/product/driver/magento';
 
 import { MagentoCategory } from './category';
@@ -13,7 +13,7 @@ export interface MagentoCompleteCategoryResponse {
   aggregates: MagentoAggregation[];
   products: MagentoProduct[];
   sort_fields: MagentoProductSortFields;
-  page_info: MagentoProductPageInfo;
+  page_info: MagentoSearchResultPageInfo;
   total_count: number;
   appliedSortOption?: string;
   appliedSortDirection?: DaffSortDirectionEnum;

--- a/libs/category/driver/magento/src/models/get-category-and-products.interface.ts
+++ b/libs/category/driver/magento/src/models/get-category-and-products.interface.ts
@@ -1,9 +1,9 @@
 import {
   MagentoAggregation,
-  MagentoProductPageInfo,
   MagentoProduct,
   MagentoProductSortFields,
 } from '@daffodil/product/driver/magento';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 
 import { MagentoCategory } from './category';
 
@@ -11,7 +11,7 @@ export interface MagentoGetCategoryAndProductsResponse {
   categoryList: MagentoCategory[];
   products: {
     items: MagentoProduct[];
-    page_info: MagentoProductPageInfo;
+    page_info: MagentoSearchResultPageInfo;
     total_count: number;
     aggregations: MagentoAggregation[];
     sort_fields: MagentoProductSortFields;

--- a/libs/category/driver/magento/src/models/get-category-and-products.interface.ts
+++ b/libs/category/driver/magento/src/models/get-category-and-products.interface.ts
@@ -1,9 +1,9 @@
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 import {
   MagentoAggregation,
   MagentoProduct,
   MagentoProductSortFields,
 } from '@daffodil/product/driver/magento';
-import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 
 import { MagentoCategory } from './category';
 

--- a/libs/category/driver/magento/src/queries/get-category-and-products.ts
+++ b/libs/category/driver/magento/src/queries/get-category-and-products.ts
@@ -8,11 +8,11 @@ import {
 import {
   magentoProductAggregationsFragment,
   magentoProductFragment,
-  magentoProductPageInfoFragment,
   magentoProductSortFieldsFragment,
 } from '@daffodil/product/driver/magento';
 
 import { magentoCategoryTreeFragment } from './fragments/public_api';
+import { magentoSearchResultPageInfoFragment } from '@daffodil/driver/magento';
 
 export const DAFF_MAGENTO_GET_CATEGORY_AND_PRODUCTS_QUERY_NAME = 'MagentoGetCategoryAndProducts';
 
@@ -30,7 +30,7 @@ query ${DAFF_MAGENTO_GET_CATEGORY_AND_PRODUCTS_QUERY_NAME}($categoryFilters: Cat
       ${daffBuildFragmentNameSpread(...extraProductFragments)}
 		}
 		page_info {
-			...magentoProductPageInfo
+			...magentoSearchResultPageInfo
 		}
 		aggregations {
 			...magentoProductAggregations
@@ -42,7 +42,7 @@ query ${DAFF_MAGENTO_GET_CATEGORY_AND_PRODUCTS_QUERY_NAME}($categoryFilters: Cat
 }
 ${magentoCategoryTreeFragment}
 ${magentoProductFragment}
-${magentoProductPageInfoFragment}
+${magentoSearchResultPageInfoFragment}
 ${magentoProductSortFieldsFragment}
 ${magentoProductAggregationsFragment}
 ${daffBuildFragmentDefinition(...extraProductFragments)}

--- a/libs/category/driver/magento/src/queries/get-category-and-products.ts
+++ b/libs/category/driver/magento/src/queries/get-category-and-products.ts
@@ -5,6 +5,7 @@ import {
   daffBuildFragmentDefinition,
   daffBuildFragmentNameSpread,
 } from '@daffodil/core/graphql';
+import { magentoSearchResultPageInfoFragment } from '@daffodil/driver/magento';
 import {
   magentoProductAggregationsFragment,
   magentoProductFragment,
@@ -12,7 +13,6 @@ import {
 } from '@daffodil/product/driver/magento';
 
 import { magentoCategoryTreeFragment } from './fragments/public_api';
-import { magentoSearchResultPageInfoFragment } from '@daffodil/driver/magento';
 
 export const DAFF_MAGENTO_GET_CATEGORY_AND_PRODUCTS_QUERY_NAME = 'MagentoGetCategoryAndProducts';
 

--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
@@ -16,7 +16,7 @@ import { DaffFilterType } from '@daffodil/core';
 import {
   MagentoAggregation,
   MagentoProduct,
-  MagentoProductPageInfo,
+  MagentoSearchResultPageInfo,
   MagentoProductSortFields,
 } from '@daffodil/product/driver/magento';
 import {
@@ -73,7 +73,7 @@ describe('@daffodil/category/driver/magento | DaffMagentoCategoryPageConfigTrans
     let completeCategoryResponse: MagentoCompleteCategoryResponse;
     let category: MagentoCategory;
     let aggregates: MagentoAggregation[];
-    let page_info: MagentoProductPageInfo;
+    let page_info: MagentoSearchResultPageInfo;
     let sort_fields: MagentoProductSortFields;
     let products: MagentoProduct[];
     let result: DaffCategoryPageMetadata;

--- a/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-page-config-transformer.service.spec.ts
@@ -13,10 +13,10 @@ import {
   DaffCategoryPageMetadataFactory,
 } from '@daffodil/category/testing';
 import { DaffFilterType } from '@daffodil/core';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 import {
   MagentoAggregation,
   MagentoProduct,
-  MagentoSearchResultPageInfo,
   MagentoProductSortFields,
 } from '@daffodil/product/driver/magento';
 import {

--- a/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
@@ -17,7 +17,7 @@ import {
 import {
   DaffMagentoProductsTransformer,
   MagentoAggregation,
-  MagentoProductPageInfo,
+  MagentoSearchResultPageInfo,
   MagentoProductSortFields,
   MAGENTO_PRODUCT_CONFIG_TOKEN,
 } from '@daffodil/product/driver/magento';
@@ -105,7 +105,7 @@ describe('@daffodil/category/driver/magento | DaffMagentoCategoryResponseTransfo
       };
       const aggregates: MagentoAggregation[] = aggregateFactory.createMany(1);
 
-      const page_info: MagentoProductPageInfo = {
+      const page_info: MagentoSearchResultPageInfo = {
         page_size: stubCategoryPageMetadata.pageSize,
         current_page: stubCategoryPageMetadata.currentPage,
         total_pages: stubCategoryPageMetadata.totalPages,

--- a/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-response-transform.service.spec.ts
@@ -14,10 +14,10 @@ import {
   DaffCategoryFactory,
   DaffCategoryPageMetadataFactory,
 } from '@daffodil/category/testing';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 import {
   DaffMagentoProductsTransformer,
   MagentoAggregation,
-  MagentoSearchResultPageInfo,
   MagentoProductSortFields,
   MAGENTO_PRODUCT_CONFIG_TOKEN,
 } from '@daffodil/product/driver/magento';

--- a/libs/driver/magento/src/fragments/page-info.ts
+++ b/libs/driver/magento/src/fragments/page-info.ts
@@ -1,0 +1,9 @@
+import { gql } from 'apollo-angular';
+
+export const magentoSearchResultPageInfoFragment = gql`
+  fragment magentoSearchResultPageInfo on SearchResultPageInfo {
+    page_size
+    current_page
+    total_pages
+  }
+`;

--- a/libs/driver/magento/src/fragments/public_api.ts
+++ b/libs/driver/magento/src/fragments/public_api.ts
@@ -1,0 +1,1 @@
+export { magentoSearchResultPageInfoFragment } from './page-info';

--- a/libs/driver/magento/src/index.ts
+++ b/libs/driver/magento/src/index.ts
@@ -1,5 +1,1 @@
-export { schema } from './schema/schema';
-
-export * from './errors/public_api';
-export * from './models/public_api';
-export * from './graphql/public_api';
+export * from './public_api';

--- a/libs/driver/magento/src/models/responses/page-info.ts
+++ b/libs/driver/magento/src/models/responses/page-info.ts
@@ -1,4 +1,4 @@
-export interface MagentoProductPageInfo {
+export interface MagentoSearchResultPageInfo {
   __typename?: 'SearchResultPageInfo';
   current_page: number;
   page_size: number;

--- a/libs/driver/magento/src/models/responses/public_api.ts
+++ b/libs/driver/magento/src/models/responses/public_api.ts
@@ -1,2 +1,3 @@
 export { MagentoMoney } from './money';
 export { MagentoDiscount } from './discount';
+export { MagentoSearchResultPageInfo } from './page-info';

--- a/libs/driver/magento/src/public_api.ts
+++ b/libs/driver/magento/src/public_api.ts
@@ -1,0 +1,7 @@
+export { schema } from './schema/schema';
+
+export * from './errors/public_api';
+export * from './models/public_api';
+export * from './graphql/public_api';
+export * from './transforms/public_api';
+export * from './fragments/public_api';

--- a/libs/driver/magento/src/transforms/public_api.ts
+++ b/libs/driver/magento/src/transforms/public_api.ts
@@ -1,0 +1,1 @@
+export * from './responses/public_api';

--- a/libs/driver/magento/src/transforms/responses/page-info.ts
+++ b/libs/driver/magento/src/transforms/responses/page-info.ts
@@ -1,0 +1,11 @@
+import { DaffCollectionMetadata } from '@daffodil/core';
+
+import { MagentoSearchResultPageInfo } from '../../models/public_api';
+
+export function magentoPageInfoTransform(pageInfo: MagentoSearchResultPageInfo): Pick<DaffCollectionMetadata, 'pageSize' | 'currentPage' | 'totalPages'> {
+  return {
+    pageSize: pageInfo.page_size,
+    currentPage: pageInfo.current_page,
+    totalPages: pageInfo.total_pages,
+  };
+}

--- a/libs/driver/magento/src/transforms/responses/public_api.ts
+++ b/libs/driver/magento/src/transforms/responses/public_api.ts
@@ -1,0 +1,1 @@
+export { magentoPageInfoTransform } from './page-info';

--- a/libs/driver/magento/testing/src/factories/page-info.factory.spec.ts
+++ b/libs/driver/magento/testing/src/factories/page-info.factory.spec.ts
@@ -1,19 +1,19 @@
 import { TestBed } from '@angular/core/testing';
 
-import { MagentoProductPageInfo } from '@daffodil/product/driver/magento';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 
-import { MagentoProductPageInfoFactory } from './page-info.factory';
+import { MagentoSearchResultPageInfoFactory } from './page-info.factory';
 
-describe('@daffodil/product/driver/magento/testing | MagentoProductPageInfoFactory', () => {
+describe('@daffodil/driver/magento/testing | MagentoSearchResultPageInfoFactory', () => {
 
-  let factory: MagentoProductPageInfoFactory;
+  let factory: MagentoSearchResultPageInfoFactory;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [MagentoProductPageInfoFactory],
+      providers: [MagentoSearchResultPageInfoFactory],
     });
 
-    factory = TestBed.inject(MagentoProductPageInfoFactory);
+    factory = TestBed.inject(MagentoSearchResultPageInfoFactory);
   });
 
   it('should be created', () => {
@@ -22,7 +22,7 @@ describe('@daffodil/product/driver/magento/testing | MagentoProductPageInfoFacto
 
   describe('create', () => {
 
-    let result: MagentoProductPageInfo;
+    let result: MagentoSearchResultPageInfo;
 
     beforeEach(() => {
       result = factory.create();

--- a/libs/driver/magento/testing/src/factories/page-info.factory.ts
+++ b/libs/driver/magento/testing/src/factories/page-info.factory.ts
@@ -2,9 +2,9 @@ import { Injectable } from '@angular/core';
 import * as faker from '@faker-js/faker/locale/en_US';
 
 import { DaffModelFactory } from '@daffodil/core/testing';
-import { MagentoProductPageInfo } from '@daffodil/product/driver/magento';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 
-class MockMagentoProductPageInfo implements MagentoProductPageInfo {
+class MockMagentoSearchResultPageInfo implements MagentoSearchResultPageInfo {
   current_page =  1;
   page_size = faker.datatype.number(100);
   total_pages = faker.datatype.number(100);
@@ -13,8 +13,8 @@ class MockMagentoProductPageInfo implements MagentoProductPageInfo {
 @Injectable({
   providedIn: 'root',
 })
-export class MagentoProductPageInfoFactory extends DaffModelFactory<MagentoProductPageInfo> {
+export class MagentoSearchResultPageInfoFactory extends DaffModelFactory<MagentoSearchResultPageInfo> {
   constructor(){
-    super(MockMagentoProductPageInfo);
+    super(MockMagentoSearchResultPageInfo);
   }
 }

--- a/libs/driver/magento/testing/src/factories/public_api.ts
+++ b/libs/driver/magento/testing/src/factories/public_api.ts
@@ -1,2 +1,3 @@
 export { MagentoMoneyFactory } from './money.factory';
 export { MagentoDiscountFactory } from './discount.factory';
+export { MagentoSearchResultPageInfoFactory } from './page-info.factory';

--- a/libs/product/driver/magento/src/models/public_api.ts
+++ b/libs/product/driver/magento/src/models/public_api.ts
@@ -15,7 +15,6 @@ export {
   MagentoProductSortFields,
   MagentoSortOption,
 } from './sort-fields';
-export { MagentoProductPageInfo } from './page-info';
 export {
   MagentoSortDirectionEnum,
   MagentoSortFieldAction,

--- a/libs/product/driver/magento/src/queries/fragments/page-info.ts
+++ b/libs/product/driver/magento/src/queries/fragments/page-info.ts
@@ -1,9 +1,0 @@
-import { gql } from 'apollo-angular';
-
-export const magentoProductPageInfoFragment = gql`
-  fragment magentoProductPageInfo on SearchResultPageInfo {
-    page_size
-    current_page
-    total_pages
-  }
-`;

--- a/libs/product/driver/magento/src/queries/public_api.ts
+++ b/libs/product/driver/magento/src/queries/public_api.ts
@@ -5,5 +5,4 @@ export * from './get-filter-types';
 export { magentoProductFragment } from './fragments/product';
 export { magentoProductPreviewFragment } from './fragments/product-preview';
 export { magentoProductAggregationsFragment } from './fragments/product-aggregations';
-export { magentoProductPageInfoFragment } from './fragments/page-info';
 export { magentoProductSortFieldsFragment } from './fragments/sort-fields';

--- a/libs/product/driver/magento/src/transforms/collection-metadata.spec.ts
+++ b/libs/product/driver/magento/src/transforms/collection-metadata.spec.ts
@@ -3,31 +3,32 @@ import { TestBed } from '@angular/core/testing';
 import { DaffSortDirectionEnum } from '@daffodil/core';
 import { DaffCollectionMetadata } from '@daffodil/core';
 import { DaffFilterType } from '@daffodil/core';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
+import { MagentoSearchResultPageInfoFactory } from '@daffodil/driver/magento/testing';
 import {
   MagentoProduct,
-  MagentoProductPageInfo,
   MagentoProductSortFields,
 } from '@daffodil/product/driver/magento';
 import { MagentoAggregation } from '@daffodil/product/driver/magento';
 import {
   MagentoProductAggregationSelectFactory,
   MagentoProductAggregationPriceFactory,
-  MagentoProductPageInfoFactory,
   MagentoProductSortFieldsFactory,
   MagentoProductFactory,
 } from '@daffodil/product/driver/magento/testing';
 
 import { magentoProductCollectionMetadataTransform } from './collection-metadata';
 
+
 describe('@daffodil/product/driver/magento | magentoProductCollectionMetadataTransform', () => {
   let priceAggregateFactory: MagentoProductAggregationPriceFactory;
   let selectAggregateFactory: MagentoProductAggregationSelectFactory;
-  let pageInfoFactory: MagentoProductPageInfoFactory;
+  let pageInfoFactory: MagentoSearchResultPageInfoFactory;
   let sortFieldsFactory: MagentoProductSortFieldsFactory;
   let productFactory: MagentoProductFactory;
 
   let aggregates: MagentoAggregation[];
-  let pageInfo: MagentoProductPageInfo;
+  let pageInfo: MagentoSearchResultPageInfo;
   let sortFields: MagentoProductSortFields;
   let count: number;
   let products: MagentoProduct[];
@@ -37,7 +38,7 @@ describe('@daffodil/product/driver/magento | magentoProductCollectionMetadataTra
     productFactory = TestBed.inject(MagentoProductFactory);
     selectAggregateFactory = TestBed.inject(MagentoProductAggregationSelectFactory);
     priceAggregateFactory = TestBed.inject(MagentoProductAggregationPriceFactory);
-    pageInfoFactory = TestBed.inject(MagentoProductPageInfoFactory);
+    pageInfoFactory = TestBed.inject(MagentoSearchResultPageInfoFactory);
     sortFieldsFactory = TestBed.inject(MagentoProductSortFieldsFactory);
 
     pageInfo = pageInfoFactory.create();

--- a/libs/product/driver/magento/src/transforms/collection-metadata.ts
+++ b/libs/product/driver/magento/src/transforms/collection-metadata.ts
@@ -1,11 +1,11 @@
 import { DaffSortDirectionEnum } from '@daffodil/core';
 import { DaffCollectionMetadata } from '@daffodil/core';
 import { daffFilterArrayToDict } from '@daffodil/core';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 
 import {
   MagentoAggregation,
   MagentoProduct,
-  MagentoProductPageInfo,
   MagentoProductSortFields,
 } from '../models/public_api';
 import { magentoProductTransformAggregate } from './aggregate/public_api';
@@ -17,7 +17,7 @@ import { coerceDefaultSortOptionFirst } from './sort-options/sort-default-option
 // TODO: make a single param?
 export const magentoProductCollectionMetadataTransform = (
   aggregates: MagentoAggregation[],
-  pageInfo: MagentoProductPageInfo,
+  pageInfo: MagentoSearchResultPageInfo,
   sortFields: MagentoProductSortFields,
   products: MagentoProduct[],
   count: number,

--- a/libs/product/driver/magento/testing/src/factories/public_api.ts
+++ b/libs/product/driver/magento/testing/src/factories/public_api.ts
@@ -6,5 +6,4 @@ export * from './aggregation/public_api';
 
 export { MagentoProductFilterTypeFieldFactory } from './filter-type-field.factory';
 export { MagentoSimpleProductFactory as MagentoProductFactory } from './simple/simple.factory';
-export { MagentoProductPageInfoFactory } from './page-info.factory';
 export { MagentoProductSortFieldsFactory } from './sort-fields.factory';

--- a/libs/reviews/driver/magento/src/models/responses/product-reviews.ts
+++ b/libs/reviews/driver/magento/src/models/responses/product-reviews.ts
@@ -1,8 +1,8 @@
-import { MagentoProductPageInfo } from '@daffodil/product/driver/magento';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 
 import { MagentoProductReview } from './public_api';
 
 export interface MagentoProductReviews {
   items: MagentoProductReview[];
-  page_info: MagentoProductPageInfo;
+  page_info: MagentoSearchResultPageInfo;
 }

--- a/libs/reviews/driver/magento/src/queries/get-product-reviews.ts
+++ b/libs/reviews/driver/magento/src/queries/get-product-reviews.ts
@@ -1,6 +1,6 @@
 import { gql } from 'apollo-angular';
 
-import { magentoProductPageInfoFragment } from '@daffodil/product/driver/magento';
+import { magentoSearchResultPageInfoFragment } from '@daffodil/driver/magento';
 
 import { magentoProductReviewFragment } from './fragments/public_api';
 
@@ -20,12 +20,12 @@ export const getProductReviews = gql`
             ...magentoProductReview
           }
           page_info {
-            ...magentoProductPageInfo
+            ...magentoSearchResultPageInfo
           }
         }
       }
     }
   }
   ${magentoProductReviewFragment}
-  ${magentoProductPageInfoFragment}
+  ${magentoSearchResultPageInfoFragment}
 `;

--- a/libs/reviews/driver/magento/testing/src/factories/product-reviews.factory.ts
+++ b/libs/reviews/driver/magento/testing/src/factories/product-reviews.factory.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@angular/core';
 import * as faker from '@faker-js/faker/locale/en_US';
 
 import { DaffModelFactory } from '@daffodil/core/testing';
-import { MagentoProductPageInfo } from '@daffodil/product/driver/magento';
-import { MagentoProductPageInfoFactory } from '@daffodil/product/driver/magento/testing';
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
+import { MagentoSearchResultPageInfoFactory } from '@daffodil/driver/magento/testing';
 import {
   MagentoProductReviews,
   MagentoProductReview,
@@ -18,14 +18,14 @@ export class MockMagentoProductReviews implements MagentoProductReviews {
 
   constructor(
     protected reviewFactory: MagentoProductReviewFactory,
-    protected pageInfoFactory: MagentoProductPageInfoFactory,
+    protected pageInfoFactory: MagentoSearchResultPageInfoFactory,
   ) {}
 
   private createReviews(): MagentoProductReview[] {
     return this.reviewFactory.createMany(faker.datatype.number({ min: 3, max: 5 }));
   }
 
-  private createPageInfo(): MagentoProductPageInfo {
+  private createPageInfo(): MagentoSearchResultPageInfo {
     return this.pageInfoFactory.create();
   }
 }
@@ -36,7 +36,7 @@ export class MockMagentoProductReviews implements MagentoProductReviews {
 export class MagentoProductReviewsFactory extends DaffModelFactory<MagentoProductReviews> {
   constructor(
     reviewFactory: MagentoProductReviewFactory,
-    pageInfoFactory: MagentoProductPageInfoFactory,
+    pageInfoFactory: MagentoSearchResultPageInfoFactory,
   ) {
     super(MockMagentoProductReviews, reviewFactory, pageInfoFactory);
   }

--- a/libs/search-product/driver/magento/src/models/get-product-response.interface.ts
+++ b/libs/search-product/driver/magento/src/models/get-product-response.interface.ts
@@ -1,7 +1,7 @@
+import { MagentoSearchResultPageInfo } from '@daffodil/driver/magento';
 import {
   MagentoAggregation,
   MagentoProduct,
-  MagentoProductPageInfo,
   MagentoProductSortFields,
 } from '@daffodil/product/driver/magento';
 
@@ -10,7 +10,7 @@ export interface MagentoSearchForProductsResponse {
   products: {
     __typename?: string;
     items: MagentoProduct[];
-    page_info: MagentoProductPageInfo;
+    page_info: MagentoSearchResultPageInfo;
     aggregations: MagentoAggregation[];
     sort_fields: MagentoProductSortFields;
     total_count: number;

--- a/libs/search-product/driver/magento/src/product-search.service.spec.ts
+++ b/libs/search-product/driver/magento/src/product-search.service.spec.ts
@@ -10,14 +10,17 @@ import { GraphQLError } from 'graphql';
 import { catchError } from 'rxjs/operators';
 
 import { DaffCollectionMetadata } from '@daffodil/core';
-import { schema } from '@daffodil/driver/magento';
+import {
+  MagentoSearchResultPageInfo,
+  schema,
+} from '@daffodil/driver/magento';
+import { MagentoSearchResultPageInfoFactory } from '@daffodil/driver/magento/testing';
 import {
   MagentoAggregation,
   MagentoProduct,
   MagentoProductFilterTypeField,
   MagentoProductGetFilterTypes,
   MagentoProductGetFilterTypesResponse,
-  MagentoProductPageInfo,
   MagentoProductSortFields,
   MagentoSimpleProduct,
 } from '@daffodil/product/driver/magento';
@@ -26,7 +29,6 @@ import {
   MagentoProductAggregationSelectFactory,
   MagentoProductFactory,
   MagentoProductFilterTypeFieldFactory,
-  MagentoProductPageInfoFactory,
   MagentoProductSortFieldsFactory,
   MagentoSimpleProductFactory,
 } from '@daffodil/product/driver/magento/testing';
@@ -46,7 +48,7 @@ describe('@daffodil/search-product/driver/magento | DaffSearchProductMagentoDriv
   let selectAggregateFactory: MagentoProductAggregationSelectFactory;
   let magentoFilterTypeFieldFactory: MagentoProductFilterTypeFieldFactory;
   let magentoProductFactory: MagentoSimpleProductFactory;
-  let magentoPageInfoFactory: MagentoProductPageInfoFactory;
+  let magentoPageInfoFactory: MagentoSearchResultPageInfoFactory;
 
   let mockSimpleProduct: MagentoSimpleProduct;
   let mockSearchProductsResponse: MagentoSearchForProductsResponse;
@@ -56,7 +58,7 @@ describe('@daffodil/search-product/driver/magento | DaffSearchProductMagentoDriv
   let mockMagentoSelectFilterTypeField: MagentoProductFilterTypeField;
   let mockMagentoPriceFilterTypeField: MagentoProductFilterTypeField;
   let mockMagentoProduct: MagentoProduct;
-  let mockMagentoProductPageInfo: MagentoProductPageInfo;
+  let mockMagentoProductPageInfo: MagentoSearchResultPageInfo;
   let mockGetFilterTypesResponse: MagentoProductGetFilterTypesResponse;
 
   beforeEach(() => {
@@ -83,7 +85,7 @@ describe('@daffodil/search-product/driver/magento | DaffSearchProductMagentoDriv
     selectAggregateFactory = TestBed.inject(MagentoProductAggregationSelectFactory);
     priceAggregateFactory = TestBed.inject(MagentoProductAggregationPriceFactory);
     magentoProductFactory = TestBed.inject(MagentoSimpleProductFactory);
-    magentoPageInfoFactory = TestBed.inject(MagentoProductPageInfoFactory);
+    magentoPageInfoFactory = TestBed.inject(MagentoSearchResultPageInfoFactory);
     magentoFilterTypeFieldFactory = TestBed.inject(MagentoProductFilterTypeFieldFactory);
 
     mockSimpleProduct = magentoSimpleProductFactory.create();

--- a/libs/search-product/driver/magento/src/queries/product-search.ts
+++ b/libs/search-product/driver/magento/src/queries/product-search.ts
@@ -5,10 +5,10 @@ import {
   daffBuildFragmentNameSpread,
   daffBuildFragmentDefinition,
 } from '@daffodil/core/graphql';
+import { magentoSearchResultPageInfoFragment } from '@daffodil/driver/magento';
 import {
   magentoProductAggregationsFragment,
   magentoProductFragment,
-  magentoProductPageInfoFragment,
   magentoProductSortFieldsFragment,
 } from '@daffodil/product/driver/magento';
 
@@ -28,7 +28,7 @@ export const productSearch = (extraProductFragments: DocumentNode[] = []) => gql
         ${daffBuildFragmentNameSpread(...extraProductFragments)}
       }
       page_info {
-			...magentoProductPageInfo
+			...magentoSearchResultPageInfo
       }
       aggregations {
         ...magentoProductAggregations
@@ -39,7 +39,7 @@ export const productSearch = (extraProductFragments: DocumentNode[] = []) => gql
 		  total_count
     }
   }
-  ${magentoProductPageInfoFragment}
+  ${magentoSearchResultPageInfoFragment}
   ${magentoProductSortFieldsFragment}
   ${magentoProductAggregationsFragment}
   ${magentoProductFragment}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

page info magento stuff lives in product


## What is the new behavior?
page info stuff has been moved to `@daffodil/driver/magento`

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
`MagentoProductPageInfo` -> `MagentoSearchResultPageInfo`, `magentoProductPageInfoFragment` -> `magentoSearchResultPageInfoFragment`


## Other information