### PR TITLE
 feat(contact): strengthen contact driver types

### DIFF
--- a/libs/contact/driver/hubspot/src/config/contact-config.interface.ts
+++ b/libs/contact/driver/hubspot/src/config/contact-config.interface.ts
@@ -2,6 +2,9 @@ import { InjectionToken } from '@angular/core';
 
 import { DaffHubspotConfig } from '@daffodil/driver/hubspot';
 
+/**
+ * The injection token that holds the configuration of the DaffContact feature.
+ */
 export const DaffContactConfigToken = new InjectionToken<DaffHubspotConfig>(
   'DaffContactConfig',
 );

--- a/libs/contact/driver/hubspot/src/contact.service.spec.ts
+++ b/libs/contact/driver/hubspot/src/contact.service.spec.ts
@@ -5,28 +5,33 @@ import {
 } from 'jasmine-marbles';
 import { Observable } from 'rxjs';
 
-import { DaffContactDriver } from '@daffodil/contact/driver';
+import { HubspotResponse } from '@daffodil/driver/hubspot/models/hubspot-response';
 
 import { DaffContactHubspotService } from './contact.service';
 import { DAFF_CONTACT_HUBSPOT_FORMS_TOKEN } from './token/hubspot-forms.token';
 
+const stubHubspotResponse: HubspotResponse = { inlineMessage: '123', errors: []};
+
 describe('DaffContactHubspotService', () => {
-  let contactService;
+  let contactService: DaffContactHubspotService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        { provide: DaffContactDriver, useClass: DaffContactHubspotService },
+        {
+          provide: DaffContactHubspotService,
+          useClass: DaffContactHubspotService,
+        },
         {
           provide: DAFF_CONTACT_HUBSPOT_FORMS_TOKEN,
           useValue: {
-            submit: (): Observable<any> => hot('--a', { a: { test: '123' }}),
+            submit: (): Observable<any> => hot('--a', { a: stubHubspotResponse }),
           },
         },
       ],
     });
 
-    contactService = TestBed.inject(DaffContactDriver);
+    contactService = TestBed.inject(DaffContactHubspotService);
   });
 
   it('should be created', () => {
@@ -34,9 +39,9 @@ describe('DaffContactHubspotService', () => {
   });
 
   describe('when sending', () => {
-    it('should return an observable of HubspotResponse', () => {
+    it('should return an observable of DaffContactResponse', () => {
       const payload = { email: 'email@email.edu' };
-      const expected = cold('--b', { b: { test: '123' }});
+      const expected = cold('--b', { b: { message: '123' }});
       expect(contactService.send(payload)).toBeObservable(expected);
     });
   });

--- a/libs/contact/driver/hubspot/src/contact.service.ts
+++ b/libs/contact/driver/hubspot/src/contact.service.ts
@@ -3,9 +3,13 @@ import {
   Injectable,
 } from '@angular/core';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
-import { DaffContactUnion } from '@daffodil/contact';
-import { DaffContactServiceInterface } from '@daffodil/contact/driver';
+import {
+  DaffContactRequest,
+  DaffContactResponse,
+  DaffContactServiceInterface,
+} from '@daffodil/contact/driver';
 import { DaffHubspotFormsService } from '@daffodil/driver/hubspot';
 
 import { DAFF_CONTACT_HUBSPOT_FORMS_TOKEN } from './token/hubspot-forms.token';
@@ -14,11 +18,10 @@ import { DAFF_CONTACT_HUBSPOT_FORMS_TOKEN } from './token/hubspot-forms.token';
  * @inheritdoc
  */
 @Injectable()
-export class DaffContactHubspotService
-implements DaffContactServiceInterface<DaffContactUnion, any> {
+export class DaffContactHubspotService implements DaffContactServiceInterface {
   constructor(@Inject(DAFF_CONTACT_HUBSPOT_FORMS_TOKEN) private hubspotService: DaffHubspotFormsService) {}
 
-  send(payload: DaffContactUnion): Observable<any> {
-    return this.hubspotService.submit(payload);
+  send(payload: DaffContactRequest): Observable<DaffContactResponse> {
+    return this.hubspotService.submit(payload).pipe(map((r) => ({ message: r.inlineMessage })));
   }
 }

--- a/libs/contact/driver/hubspot/src/token/hubspot-forms.token.ts
+++ b/libs/contact/driver/hubspot/src/token/hubspot-forms.token.ts
@@ -13,10 +13,16 @@ import {
 } from '@daffodil/driver/hubspot';
 
 import { DaffContactConfigToken } from '../config/contact-config.interface';
+import { DaffContactHubSpotDriverModule } from '../hubspot-driver.module';
 
+/**
+ * The InjectionToken that holds the Hubspot Forms Service
+ * used by the ContactDriver to send submissions to Hubspot.
+ */
 export const DAFF_CONTACT_HUBSPOT_FORMS_TOKEN = new InjectionToken<DaffHubspotFormsService>('DAFF_CONTACT_HUBSPOT_FORMS_TOKEN',
   {
-    providedIn: 'root', factory: () => daffHubspotFormsServiceFactory(
+    providedIn: DaffContactHubSpotDriverModule,
+    factory: () => daffHubspotFormsServiceFactory(
       inject(HttpClient),
       inject(DOCUMENT),
       inject(Router),

--- a/libs/contact/driver/in-memory/src/contact.service.ts
+++ b/libs/contact/driver/in-memory/src/contact.service.ts
@@ -1,9 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
 
-import { DaffContactUnion } from '@daffodil/contact';
-import { DaffContactServiceInterface } from '@daffodil/contact/driver';
+import {
+  DaffContactServiceInterface,
+  DaffContactResponse,
+} from '@daffodil/contact/driver';
 
 /**
  * @inheritdoc
@@ -11,12 +12,12 @@ import { DaffContactServiceInterface } from '@daffodil/contact/driver';
 @Injectable({
   providedIn: 'root',
 })
-export class DaffInMemoryContactService implements DaffContactServiceInterface<DaffContactUnion, DaffContactUnion>{
+export class DaffInMemoryContactService implements DaffContactServiceInterface {
 
   url = '/api/contact';
   constructor(private http: HttpClient) {}
 
-  send(payload: DaffContactUnion): Observable<DaffContactUnion> {
-    return this.http.post<DaffContactUnion>(this.url, payload);
+  send(payload) {
+    return this.http.post<DaffContactResponse>(this.url, payload);
   }
 }

--- a/libs/contact/driver/in-memory/src/in-memory-backend/contact-in-memory-backend.service.spec.ts
+++ b/libs/contact/driver/in-memory/src/in-memory-backend/contact-in-memory-backend.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
 
-import { DaffContactUnion } from '@daffodil/contact';
+import { DaffContactRequest } from '@daffodil/contact/driver';
 
 import { DaffInMemoryBackendContactService } from './contact-in-memory-backend.service';
 
@@ -26,25 +25,24 @@ describe('DaffContactInMemoryBackend', () => {
     });
 
     it('should intialize empty on createDb', () => {
-      expect(result.forums).toEqual([]);
+      expect(result.submissions).toEqual([]);
     });
 
     it('should validate that its not empty', () => {
-      const forumSubmission: DaffContactUnion = undefined;
-      expect(contactTestingService.post(forumSubmission)).toEqual(Error('Payload is undefined'));
+      const submission: DaffContactRequest = undefined;
+      expect(contactTestingService.post(submission)).toEqual(Error('Payload is undefined'));
     });
 
     it('should validate that it doesnt already exist', () => {
-
-      const forumSubmission: DaffContactUnion = { email: 'test@test.com' };
+      const forumSubmission: DaffContactRequest = { email: 'test@test.com' };
       contactTestingService.post(forumSubmission);
       expect(contactTestingService.post(forumSubmission)).toEqual(Error('Already contains submission'));
     });
 
     it('should be able to submit a valid form', () => {
-      const forumSubmission: DaffContactUnion = { email: 'new@test.com' };
+      const forumSubmission: DaffContactRequest = { email: 'new@test.com' };
       contactTestingService.post(forumSubmission).subscribe((resp) => {
-        expect(resp).toEqual(forumSubmission);
+        expect(resp).toEqual({ message: 'Success!' });
       });
     });
   });

--- a/libs/contact/driver/in-memory/src/in-memory-backend/contact-in-memory-backend.service.ts
+++ b/libs/contact/driver/in-memory/src/in-memory-backend/contact-in-memory-backend.service.ts
@@ -4,15 +4,19 @@ import {
   RequestInfoUtilities,
   ParsedRequestUrl,
 } from 'angular-in-memory-web-api';
-import { of } from 'rxjs';
+import {
+  Observable,
+  of,
+} from 'rxjs';
 
-import { DaffContactUnion } from '@daffodil/contact';
+import { DaffContactRequest } from '@daffodil/contact/driver';
+import { DaffContactResponse } from '@daffodil/contact/driver';
 
 @Injectable({
   providedIn: 'root',
 })
 export class DaffInMemoryBackendContactService implements InMemoryDbService {
-  forums: DaffContactUnion[] = [];
+  submissions: DaffContactRequest[] = [];
 
   parseRequestUrl(url: string, utils: RequestInfoUtilities): ParsedRequestUrl {
     return utils.parseRequestUrl(url);
@@ -20,19 +24,20 @@ export class DaffInMemoryBackendContactService implements InMemoryDbService {
 
   createDb(): any {
     return {
-      forums: this.forums,
+      submissions: this.submissions,
     };
   }
-  //validate that its not empty
-  //validate that it doesn't already exist
-  post(reqInfo: any): any {
+
+  post(reqInfo: { body: DaffContactRequest }): Observable<DaffContactResponse> | Error {
+    //validate that its not empty
     if(reqInfo === undefined){
       return Error('Payload is undefined');
-    } else if(this.forums.indexOf(reqInfo.body) !== -1){
+      //validate that it doesn't already exist
+    } else if(this.submissions.indexOf(reqInfo.body) !== -1){
       return Error('Already contains submission');
     } else{
-      this.forums.push(reqInfo.body);
-      return of(reqInfo);
+      this.submissions.push(reqInfo.body);
+      return of({ message: 'Success!' });
     }
   }
 }

--- a/libs/contact/driver/src/interfaces/contact-service.interface.ts
+++ b/libs/contact/driver/src/interfaces/contact-service.interface.ts
@@ -1,7 +1,20 @@
 import { InjectionToken } from '@angular/core';
-import { Observable } from 'rxjs';
+import {
+  Observable,
+  of,
+} from 'rxjs';
 
-export const DaffContactDriver = new InjectionToken<DaffContactServiceInterface<any, any>>('DaffContactDriver');
-export interface DaffContactServiceInterface<T, V> {
-  send(payload: T): Observable<V>;
+import { DaffContactRequest } from '../model/contact-request';
+import { DaffContactResponse } from '../model/contact-response';
+
+/**
+ * The injection token that holds the reference to the DaffContactDriver.
+ */
+export const DaffContactDriver = new InjectionToken<DaffContactServiceInterface>('DaffContactDriver');
+
+/**
+ * The interface that a contact driver must implement.
+ */
+export interface DaffContactServiceInterface<T extends DaffContactRequest = DaffContactRequest> {
+  send(payload: T): Observable<DaffContactResponse>;
 }

--- a/libs/contact/driver/src/model/contact-request.ts
+++ b/libs/contact/driver/src/model/contact-request.ts
@@ -1,0 +1,16 @@
+import { DaffContactUnion } from '@daffodil/contact';
+
+/**
+ * A weak type, specifying the fields that drivers are be guaranteed to act upon.
+ */
+export interface DaffContactBlueprintRequest {
+  name?: string;
+  email: string;
+  phone?: string;
+  message?: string;
+}
+
+/**
+ * The type used by the DaffContactDriver to send requests to implementing services.
+ */
+export type DaffContactRequest = DaffContactBlueprintRequest | DaffContactUnion;

--- a/libs/contact/driver/src/model/contact-response.ts
+++ b/libs/contact/driver/src/model/contact-response.ts
@@ -1,0 +1,9 @@
+/**
+ * The response object to a successful contact form submission.
+ */
+export interface DaffContactResponse {
+  /**
+   * The message provided by a successful form submission.
+   */
+  message: string;
+}

--- a/libs/contact/driver/src/public_api.ts
+++ b/libs/contact/driver/src/public_api.ts
@@ -1,1 +1,3 @@
 export * from './interfaces/contact-service.interface';
+export { DaffContactRequest } from './model/contact-request';
+export { DaffContactResponse } from './model/contact-response';

--- a/libs/contact/driver/testing/src/contact.service.ts
+++ b/libs/contact/driver/testing/src/contact.service.ts
@@ -1,12 +1,15 @@
 import { Injectable } from '@angular/core';
 import {
-  of,
   Observable,
+  of,
 } from 'rxjs';
 import { delay } from 'rxjs/operators';
 
-import { DaffContactUnion } from '@daffodil/contact';
-import { DaffContactServiceInterface } from '@daffodil/contact/driver';
+import {
+  DaffContactRequest,
+  DaffContactResponse,
+  DaffContactServiceInterface,
+} from '@daffodil/contact/driver';
 
 /**
  * @inheritdoc
@@ -14,8 +17,8 @@ import { DaffContactServiceInterface } from '@daffodil/contact/driver';
 @Injectable({
   providedIn: 'root',
 })
-export class DaffTestingContactService implements DaffContactServiceInterface<DaffContactUnion, any>{
-  send(payload: DaffContactUnion): Observable<any>{
-    return of('Success').pipe(delay(10));
+export class DaffTestingContactService implements DaffContactServiceInterface {
+  send(payload: DaffContactRequest): Observable<DaffContactResponse> {
+    return of({ message: 'success' }).pipe(delay(10));
   }
 }

--- a/libs/contact/integration-tests/drivers/hubspot.spec.ts
+++ b/libs/contact/integration-tests/drivers/hubspot.spec.ts
@@ -4,14 +4,20 @@ import {
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { of } from 'rxjs';
 
-import { DaffContactDriver } from '@daffodil/contact/driver';
+import {
+  DaffContactDriver,
+  DaffContactServiceInterface,
+} from '@daffodil/contact/driver';
 import { DaffContactHubSpotDriverModule } from '@daffodil/contact/driver/hubspot';
+import { HubspotResponse } from '@daffodil/driver/hubspot/models/hubspot-response';
+
+const stubHubspotResponse: HubspotResponse = { inlineMessage: 'Success!', errors: []};
 
 describe('DaffContactHubspotDriver', () => {
-  let contactService;
+  let contactService: DaffContactServiceInterface;
   let httpMock: HttpTestingController;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -37,9 +43,9 @@ describe('DaffContactHubspotDriver', () => {
 
   describe('when sending', () => {
     it('should send a submission', () => {
-      const forumSubmission = { email: 'test@email.com' };
-      contactService.send(forumSubmission).subscribe((resp) => {
-        expect(resp).toEqual(forumSubmission);
+      const submission = { email: 'test@email.com' };
+      contactService.send(submission).subscribe((resp) => {
+        expect(resp).toEqual({ message: 'Success!' });
       });
       const req = httpMock.expectOne(
         'https://api.hsforms.com/submissions/v3/integration/submit/123123/123123',
@@ -48,7 +54,7 @@ describe('DaffContactHubspotDriver', () => {
         fields: [Object({ name: 'email', value: 'test@email.com' })],
         context: Object({ hutk: null, pageUri: '/', pageName: jasmine.any(String) }),
       }));
-      req.flush(forumSubmission);
+      req.flush(stubHubspotResponse);
       httpMock.verify();
     });
 

--- a/libs/contact/state/src/actions/contact.actions.ts
+++ b/libs/contact/state/src/actions/contact.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@ngrx/store';
 
+import { DaffContactRequest } from '@daffodil/contact/driver';
 import { DaffStateError } from '@daffodil/core/state';
 
 export enum DaffContactActionTypes {
@@ -11,13 +12,13 @@ export enum DaffContactActionTypes {
   ContactResetAction = '[Daff-Contact] Contact Reset Action',
 }
 
-export class DaffContactSubmit<T> implements Action {
+export class DaffContactSubmit<T extends DaffContactRequest = DaffContactRequest> implements Action {
   readonly type = DaffContactActionTypes.ContactSubmitAction;
 
   constructor(public payload: T) {}
 }
 
-export class DaffContactRetry<T> implements Action {
+export class DaffContactRetry<T extends DaffContactRequest = DaffContactRequest> implements Action {
   readonly type = DaffContactActionTypes.ContactRetryAction;
 
   constructor(public payload: T) {}
@@ -37,7 +38,7 @@ export class DaffContactReset implements Action {
   readonly type = DaffContactActionTypes.ContactResetAction;
 }
 
-export type DaffContactActions<T> =
+export type DaffContactActions<T extends DaffContactRequest> =
 	| DaffContactSubmit<T>
 	| DaffContactRetry<T>
 	| DaffContactFailedSubmit

--- a/libs/contact/state/src/effects/contact.effects.spec.ts
+++ b/libs/contact/state/src/effects/contact.effects.spec.ts
@@ -1,15 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { Actions } from '@ngrx/effects';
 import { provideMockActions } from '@ngrx/effects/testing';
 import {
   hot,
   cold,
 } from 'jasmine-marbles';
-import {
-  Observable,
-  of,
-} from 'rxjs';
+import { of } from 'rxjs';
 
-import { DaffContactUnion } from '@daffodil/contact';
 import { DaffContactDriver } from '@daffodil/contact/driver';
 import { DaffContactTestingDriverModule } from '@daffodil/contact/driver/testing';
 import {
@@ -23,8 +20,8 @@ import {
 import { DaffContactEffects } from './contact.effects';
 
 describe('DaffContactEffects', () => {
-  let actions$: Observable<any>;
-  let effects: DaffContactEffects<DaffContactUnion, any>;
+  let actions$: Actions;
+  let effects: DaffContactEffects;
   const mockForm = { firstName: 'John', lastName: 'Doe' };
   let daffContactDriver;
 

--- a/libs/contact/state/src/effects/contact.effects.ts
+++ b/libs/contact/state/src/effects/contact.effects.ts
@@ -23,6 +23,7 @@ import { DAFF_CONTACT_ERROR_MATCHER } from '@daffodil/contact';
 import {
   DaffContactServiceInterface,
   DaffContactDriver,
+  DaffContactRequest,
 } from '@daffodil/contact/driver';
 import { DaffError } from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
@@ -37,11 +38,11 @@ import {
 } from '../actions/contact.actions';
 
 @Injectable()
-export class DaffContactEffects<T, V> {
+export class DaffContactEffects {
   constructor(
     private actions$: Actions,
     @Inject(DaffContactDriver)
-    private driver: DaffContactServiceInterface<T, V>,
+    private driver: DaffContactServiceInterface,
     @Inject(DAFF_CONTACT_ERROR_MATCHER) private errorMatcher: ErrorTransformer,
   ) {}
 
@@ -55,8 +56,8 @@ export class DaffContactEffects<T, V> {
 	    switchMap(
 	      (
 	        action:
-          | DaffContactSubmit<T>
-          | DaffContactRetry<T>
+          | DaffContactSubmit
+          | DaffContactRetry
           | DaffContactCancel,
 	      ) => {
 	        if (action instanceof DaffContactCancel) {
@@ -69,9 +70,9 @@ export class DaffContactEffects<T, V> {
 	  ),
   );
 
-  private submitContact(contact: T): Observable<Action> {
+  private submitContact(contact: DaffContactRequest): Observable<Action> {
 	  return this.driver.send(contact).pipe(
-	    map((resp: V) => new DaffContactSuccessSubmit()),
+	    map(() => new DaffContactSuccessSubmit()),
 	    catchError((error: DaffError) => of(new DaffContactFailedSubmit([this.errorMatcher(error)]))),
 	  );
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


    
Previously, the `DaffContactServiceInterface` was extremely weak in both request and response.
    
This hardens the type, ironing down the possible send arguments and eliminating the genericity of the response type.
    
BREAKING CHANGE: The contact driver type changed, if you're providing an implementation, please see the new `DaffContactServiceInterface`. If you had a use-case for a generic response type, I would love to hear your feedback.


Note for @griest024 this has two other diffs that are nice and this pr should be rebase merged.