### PR TITLE
feat(core): shallow-compare works with disjoint unions

### DIFF
--- a/libs/core/src/utils/shallow-compare.spec.ts
+++ b/libs/core/src/utils/shallow-compare.spec.ts
@@ -132,4 +132,16 @@ describe('@daffodil/core | shallowCompare', () => {
       expect(result).toBeTrue();
     });
   });
+
+  describe('when the type is a union type', () => {
+    it('should compile without a type error for keys that may or may not be on the type', () => {
+      interface A { a?: string; c: string };
+      interface B { b?: string; c: string };
+      type UserUnion = A | B;
+      const exampleB: () => UserUnion = () => ({ b: '', c: '' });
+      const exampleA: () => UserUnion = () => ({ a: '', c: '' });
+      shallowCompare(exampleB(), exampleA(), ['a','b']);
+      expect(shallowCompare(exampleB(), exampleA(), ['a','b'])).toBe(false);
+    });
+  });
 });

--- a/libs/core/src/utils/shallow-compare.spec.ts
+++ b/libs/core/src/utils/shallow-compare.spec.ts
@@ -140,7 +140,6 @@ describe('@daffodil/core | shallowCompare', () => {
       type UserUnion = A | B;
       const exampleB: () => UserUnion = () => ({ b: '', c: '' });
       const exampleA: () => UserUnion = () => ({ a: '', c: '' });
-      shallowCompare(exampleB(), exampleA(), ['a','b']);
       expect(shallowCompare(exampleB(), exampleA(), ['a','b'])).toBe(false);
     });
   });

--- a/libs/core/src/utils/shallow-compare.ts
+++ b/libs/core/src/utils/shallow-compare.ts
@@ -3,7 +3,7 @@
  * `null` and `undefined` are considered equal for the purposes of the comparison.
  * A strict equality comparison is used for truthy property values.
  */
-export function shallowCompare<T, K extends keyof T = keyof T>(obj1: T, obj2: T, props: K[]): boolean {
+export function shallowCompare<T>(obj1: T, obj2: T, props: (T extends T ? keyof T: never)[]): boolean {
   return !!(obj1 && obj2 && props.reduce(
     (acc, prop) => {
       const p1 = obj1[prop];


### PR DESCRIPTION
Previously, shallow-compare would fail on fields that are disjoint in a union. This allows shallow-compare to handle these fields.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
See the test.

Fixes: N/A


## What is the new behavior?
See the test.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
