### PR TITLE
feat(customer): don't store contextual entity errors in global state

### DIFF
--- a/libs/customer/state/src/reducers/address/reducer.spec.ts
+++ b/libs/customer/state/src/reducers/address/reducer.spec.ts
@@ -271,11 +271,6 @@ describe('@daffodil/customer/state | daffCustomerAddressReducer', () => {
       result = reducer(state, customerUpdateFailureAction);
     });
 
-    it('stores the errors in state', () => {
-      expect(result.daffErrors).toContain(mockError);
-      expect(result.daffErrors.length).toEqual(1);
-    });
-
     it('sets loading to stable', () => {
       expect(result.daffState).toEqual(DaffState.Stable);
     });
@@ -348,11 +343,6 @@ describe('@daffodil/customer/state | daffCustomerAddressReducer', () => {
       result = reducer(state, customerDeleteFailureAction);
     });
 
-    it('stores the errors in state', () => {
-      expect(result.daffErrors).toContain(mockError);
-      expect(result.daffErrors.length).toEqual(1);
-    });
-
     it('sets loading to stable', () => {
       expect(result.daffState).toEqual(DaffState.Stable);
     });
@@ -423,11 +413,6 @@ describe('@daffodil/customer/state | daffCustomerAddressReducer', () => {
       const customerAddFailureAction = new DaffCustomerAddressAddFailure(mockError, 'id');
 
       result = reducer(state, customerAddFailureAction);
-    });
-
-    it('stores the errors in state', () => {
-      expect(result.daffErrors).toContain(mockError);
-      expect(result.daffErrors.length).toEqual(1);
     });
 
     it('sets loading to stable', () => {

--- a/libs/customer/state/src/reducers/address/reducer.ts
+++ b/libs/customer/state/src/reducers/address/reducer.ts
@@ -36,13 +36,13 @@ export const daffCustomerAddressReducer = <T extends DaffCustomerAddress = DaffC
     case action.type === DaffCustomerAddressActionTypes.AddressUpdateSuccessAction:
     case action.type === DaffCustomerAddressActionTypes.AddressAddSuccessAction:
     case action.type === DaffCustomerAddressActionTypes.AddressDeleteSuccessAction:
+    case action.type === DaffCustomerAddressActionTypes.AddressUpdateFailureAction:
+    case action.type === DaffCustomerAddressActionTypes.AddressAddFailureAction:
+    case action.type === DaffCustomerAddressActionTypes.AddressDeleteFailureAction:
       return daffCompleteOperation(state);
 
     case action.type === DaffCustomerAddressActionTypes.AddressListFailureAction:
     case action.type === DaffCustomerAddressActionTypes.AddressLoadFailureAction:
-    case action.type === DaffCustomerAddressActionTypes.AddressUpdateFailureAction:
-    case action.type === DaffCustomerAddressActionTypes.AddressAddFailureAction:
-    case action.type === DaffCustomerAddressActionTypes.AddressDeleteFailureAction:
       return daffOperationFailed([(<DaffCustomerAddressLoadFailure>action).payload], state);
 
     default:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

address update, add, and delete errors are stored in global state


## What is the new behavior?

address update, add, and delete errors are stored in entity state only

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information