### PR TITLE
perf(product): exclude media gallery requests from products

### DIFF
--- a/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
@@ -67,9 +67,8 @@ describe('DaffMagentoCategoryTransformerService', () => {
             sku: stubCategory.product_ids[0],
             url_key: 'url_key',
             url_suffix: '.html',
-            image: null,
             price_range: null,
-            thumbnail: {
+            image: {
               url: 'url',
               label: 'label',
             },
@@ -93,9 +92,8 @@ describe('DaffMagentoCategoryTransformerService', () => {
           sku: 'a different SKU',
           url_key: 'url_key',
           url_suffix: '.html',
-          image: null,
           price_range: null,
-          thumbnail: {
+          image: {
             url: 'url',
             label: 'label',
           },

--- a/libs/product-composite/driver/magento/testing/src/factories/bundle/bundle.factory.spec.ts
+++ b/libs/product-composite/driver/magento/testing/src/factories/bundle/bundle.factory.spec.ts
@@ -31,8 +31,6 @@ describe('@daffodil/product-composite/driver/magento/testing | MagentoBundledPro
       expect(result.uid).toBeDefined();
       expect(result.image.label).toBeDefined();
       expect(result.image.url).toBeDefined();
-      expect(result.thumbnail.label).toBeDefined();
-      expect(result.thumbnail.url).toBeDefined();
       expect(result.url_key).toBeDefined();
       expect(result.name).toBeDefined();
       expect(result.description).toBeDefined();

--- a/libs/product-configurable/driver/magento/testing/src/factories/configurable/configurable.factory.spec.ts
+++ b/libs/product-configurable/driver/magento/testing/src/factories/configurable/configurable.factory.spec.ts
@@ -34,8 +34,6 @@ describe('@daffodil/product-configurable/testing | Factories | MagentoConfigurab
       expect(result.uid).toBeDefined();
       expect(result.image.label).toBeDefined();
       expect(result.image.url).toBeDefined();
-      expect(result.thumbnail.label).toBeDefined();
-      expect(result.thumbnail.url).toBeDefined();
       expect(result.url_key).toBeDefined();
       expect(result.url_suffix).toBeDefined();
       expect(result.name).toBeDefined();

--- a/libs/product/driver/magento/src/models/magento-product.ts
+++ b/libs/product/driver/magento/src/models/magento-product.ts
@@ -13,10 +13,6 @@ export interface MagentoProduct extends MagentoProductPreview {
   meta_title?: string;
   meta_description?: string;
   canonical_url?: string;
-  image?: {
-    url: string;
-    label: string;
-  };
   media_gallery_entries?: {
     label: string;
     file: string;

--- a/libs/product/driver/magento/src/models/product-preview.interface.ts
+++ b/libs/product/driver/magento/src/models/product-preview.interface.ts
@@ -16,7 +16,7 @@ export interface MagentoProductPreview {
   sku: string;
   url_key: string;
   url_suffix: string;
-  thumbnail: {
+  image: {
     url: string;
     label: string;
   };

--- a/libs/product/driver/magento/src/queries/fragments/product-page.ts
+++ b/libs/product/driver/magento/src/queries/fragments/product-page.ts
@@ -1,0 +1,21 @@
+import { gql } from 'apollo-angular';
+
+import { magentoProductFragment } from './product';
+
+export const magentoProductPageFragment = gql`
+  fragment magentoProductPage on ProductInterface {
+    ...product
+    __typename
+		media_gallery_entries {
+			label
+			file
+			position
+			disabled
+			uid
+		}
+		description {
+			html
+		}
+	}
+  ${magentoProductFragment}
+`;

--- a/libs/product/driver/magento/src/queries/fragments/product-preview.ts
+++ b/libs/product/driver/magento/src/queries/fragments/product-preview.ts
@@ -22,7 +22,7 @@ export const magentoProductPreviewFragment = gql`
 				}
 			}
 		}
-    thumbnail {
+    image {
 			url
 			label
 		}

--- a/libs/product/driver/magento/src/queries/fragments/product.ts
+++ b/libs/product/driver/magento/src/queries/fragments/product.ts
@@ -15,17 +15,7 @@ export const magentoProductFragment = gql`
 			url
 			label
 		}
-		media_gallery_entries {
-			label
-			file
-			position
-			disabled
-			uid
-		}
 		short_description {
-			html
-		}
-		description {
 			html
 		}
 	}

--- a/libs/product/driver/magento/src/queries/fragments/product.ts
+++ b/libs/product/driver/magento/src/queries/fragments/product.ts
@@ -11,10 +11,6 @@ export const magentoProductFragment = gql`
 		meta_description
     canonical_url
     stock_status
-    image {
-			url
-			label
-		}
 		short_description {
 			html
 		}

--- a/libs/product/driver/magento/src/queries/fragments/public_api.ts
+++ b/libs/product/driver/magento/src/queries/fragments/public_api.ts
@@ -1,0 +1,5 @@
+export { magentoProductFragment } from './product';
+export { magentoProductPreviewFragment } from './product-preview';
+export { magentoProductPageFragment } from './product-page';
+export { magentoProductAggregationsFragment } from './product-aggregations';
+export { magentoProductSortFieldsFragment } from './sort-fields';

--- a/libs/product/driver/magento/src/queries/get-all-products.ts
+++ b/libs/product/driver/magento/src/queries/get-all-products.ts
@@ -6,7 +6,7 @@ import {
   daffBuildFragmentDefinition,
 } from '@daffodil/core/graphql';
 
-import { magentoProductFragment } from './fragments/product';
+import { magentoProductPageFragment } from './fragments/public_api';
 
 export const DAFF_MAGENTO_GET_ALL_PRODUCTS_QUERY_NAME = 'MagentoGetAllProducts';
 
@@ -15,7 +15,7 @@ export const getAllProducts = (extraProductFragments: DocumentNode[] = []) => gq
     products(pageSize: $pageSize) {
       total_count
       items {
-        ...product
+        ...magentoProductPage
         ${daffBuildFragmentNameSpread(...extraProductFragments)}
       }
       page_info {
@@ -24,6 +24,6 @@ export const getAllProducts = (extraProductFragments: DocumentNode[] = []) => gq
       }
     }
   }
-  ${magentoProductFragment}
+  ${magentoProductPageFragment}
   ${daffBuildFragmentDefinition(...extraProductFragments)}
 `;

--- a/libs/product/driver/magento/src/queries/get-product-by-url.ts
+++ b/libs/product/driver/magento/src/queries/get-product-by-url.ts
@@ -6,7 +6,7 @@ import {
   daffBuildFragmentDefinition,
 } from '@daffodil/core/graphql';
 
-import { magentoProductFragment } from './fragments/product';
+import { magentoProductPageFragment } from './fragments/public_api';
 
 export const DAFF_MAGENTO_GET_A_PRODUCT_BY_URL_QUERY_NAME = 'MagentoGetAProductByUrl';
 
@@ -18,11 +18,11 @@ export const getProductByUrl = (extraProductFragments: DocumentNode[] = []) => g
       }
     }){
       items {
-        ...product
+        ...magentoProductPage
         ${daffBuildFragmentNameSpread(...extraProductFragments)}
       }
     }
   }
-  ${magentoProductFragment}
+  ${magentoProductPageFragment}
   ${daffBuildFragmentDefinition(...extraProductFragments)}
 `;

--- a/libs/product/driver/magento/src/queries/get-product.ts
+++ b/libs/product/driver/magento/src/queries/get-product.ts
@@ -6,7 +6,7 @@ import {
   daffBuildFragmentDefinition,
 } from '@daffodil/core/graphql';
 
-import { magentoProductFragment } from './fragments/product';
+import { magentoProductPageFragment } from './fragments/public_api';
 
 export const DAFF_MAGENTO_GET_A_PRODUCT_QUERY_NAME = 'MagentoGetAProduct';
 
@@ -18,11 +18,11 @@ export const getProduct = (extraProductFragments: DocumentNode[] = []) => gql`
       }
     }){
       items {
-        ...product
+        ...magentoProductPage
         ${daffBuildFragmentNameSpread(...extraProductFragments)}
       }
     }
   }
-  ${magentoProductFragment}
+  ${magentoProductPageFragment}
   ${daffBuildFragmentDefinition(...extraProductFragments)}
 `;

--- a/libs/product/driver/magento/src/queries/public_api.ts
+++ b/libs/product/driver/magento/src/queries/public_api.ts
@@ -2,7 +2,4 @@ export * from './get-product';
 export * from './get-product-by-url';
 export * from './get-all-products';
 export * from './get-filter-types';
-export { magentoProductFragment } from './fragments/product';
-export { magentoProductPreviewFragment } from './fragments/product-preview';
-export { magentoProductAggregationsFragment } from './fragments/product-aggregations';
-export { magentoProductSortFieldsFragment } from './fragments/sort-fields';
+export * from './fragments/public_api';

--- a/libs/product/driver/magento/src/transforms/product-preview.ts
+++ b/libs/product/driver/magento/src/transforms/product-preview.ts
@@ -45,7 +45,7 @@ export function transformMagentoSimpleProductPreview(product: MagentoProductPrev
     id: product.sku,
     url: `/${product.url_key}${product.url_suffix}`,
     name: product.name,
-    thumbnail: transformThumbnail(product.thumbnail),
+    thumbnail: transformThumbnail(product.image),
     price: getPrice(product),
     discount: getDiscount(product),
     images: transformMediaGalleryEntries(product, mediaUrl),
@@ -53,7 +53,7 @@ export function transformMagentoSimpleProductPreview(product: MagentoProductPrev
   };
 }
 
-function transformThumbnail(image: MagentoProduct['thumbnail']): DaffProductImage {
+function transformThumbnail(image: MagentoProduct['image']): DaffProductImage {
   return {
     url: image.url,
     label: image.label,

--- a/libs/product/driver/magento/src/transforms/simple-product-transformers.spec.ts
+++ b/libs/product/driver/magento/src/transforms/simple-product-transformers.spec.ts
@@ -34,8 +34,8 @@ describe('DaffMagentoSimpleProductTransformerService', () => {
       },
       images: [],
       thumbnail: {
-        url: stubMagentoProduct.thumbnail.url,
-        label: stubMagentoProduct.thumbnail.label,
+        url: stubMagentoProduct.image.url,
+        label: stubMagentoProduct.image.label,
         id: null,
       },
       description: stubMagentoProduct.description.html,

--- a/libs/product/driver/magento/src/transforms/simple-product-transformers.ts
+++ b/libs/product/driver/magento/src/transforms/simple-product-transformers.ts
@@ -28,8 +28,8 @@ export class DaffMagentoSimpleProductTransformers {
     return {
       ...this.productPreviewTransform(product, mediaUrl),
 
-      description: product.description.html,
-      short_description: product.short_description.html,
+      description: product.description?.html,
+      short_description: product.short_description?.html,
       meta_title: product.meta_title,
       meta_description: product.meta_description,
       canonicalUrl: product.canonical_url,

--- a/libs/product/driver/magento/testing/src/factories/core/product-preview.factory.spec.ts
+++ b/libs/product/driver/magento/testing/src/factories/core/product-preview.factory.spec.ts
@@ -29,8 +29,8 @@ describe('@daffodil/product/testing | MagentoProductPreviewFactory', () => {
     it('should return a MagentoProduct with all required fields defined', () => {
       expect(result.__typename).toBeDefined();
       expect(result.uid).toBeDefined();
-      expect(result.thumbnail.label).toBeDefined();
-      expect(result.thumbnail.url).toBeDefined();
+      expect(result.image.label).toBeDefined();
+      expect(result.image.url).toBeDefined();
       expect(result.url_key).toBeDefined();
       expect(result.url_suffix).toBeDefined();
       expect(result.name).toBeDefined();

--- a/libs/product/driver/magento/testing/src/factories/core/product-preview.factory.ts
+++ b/libs/product/driver/magento/testing/src/factories/core/product-preview.factory.ts
@@ -16,7 +16,7 @@ export class MockMagentoProductPreview implements MagentoProductPreview {
   name = faker.random.word();
   sku = faker.random.alphaNumeric(16);
   stock_status = MagentoProductStockStatusEnum.InStock;
-  thumbnail = {
+  image = {
     __typename: 'ProductImage',
     label: faker.random.words(3),
     url: faker.image.imageUrl(),

--- a/libs/product/driver/magento/testing/src/factories/core/product.factory.spec.ts
+++ b/libs/product/driver/magento/testing/src/factories/core/product.factory.spec.ts
@@ -28,22 +28,11 @@ describe('@daffodil/product/testing | MagentoCoreProductFactory', () => {
 
     it('should return a MagentoProduct with all required fields defined', () => {
       expect(result.__typename).toBeDefined();
-      expect(result.uid).toBeDefined();
-      expect(result.image.label).toBeDefined();
-      expect(result.image.url).toBeDefined();
-      expect(result.thumbnail.label).toBeDefined();
-      expect(result.thumbnail.url).toBeDefined();
-      expect(result.url_key).toBeDefined();
-      expect(result.url_suffix).toBeDefined();
       expect(result.canonical_url).toBeDefined();
-      expect(result.name).toBeDefined();
       expect(result.description).toBeDefined();
       expect(result.short_description).toBeDefined();
       expect(result.media_gallery_entries).toBeDefined();
-      expect(result.sku).toBeDefined();
       expect(result.stock_status).toBeDefined();
-      expect(result.price_range.maximum_price.regular_price).toBeDefined();
-      expect(result.price_range.maximum_price.discount).toBeDefined();
     });
   });
 });

--- a/libs/product/driver/magento/testing/src/factories/core/product.factory.ts
+++ b/libs/product/driver/magento/testing/src/factories/core/product.factory.ts
@@ -8,46 +8,17 @@ import {
   MagentoProductStockStatusEnum,
 } from '@daffodil/product/driver/magento';
 
-export class MockMagentoCoreProduct implements MagentoProduct {
+import { MockMagentoProductPreview } from './product-preview.factory';
+
+export class MockMagentoCoreProduct extends MockMagentoProductPreview implements MagentoProduct {
   __typename = MagentoProductTypeEnum.SimpleProduct;
-  uid = faker.datatype.uuid();
-  url_key = faker.random.alphaNumeric(16);
-  url_suffix = '.html';
   canonical_url = faker.internet.url();
-  name = faker.random.word();
   meta_title = faker.random.word();
   meta_description = faker.random.words(3);
-  sku = faker.random.alphaNumeric(16);
   stock_status = MagentoProductStockStatusEnum.InStock;
-  image = {
-    __typename: 'ProductImage',
-    label: faker.random.words(3),
-    url: faker.image.imageUrl(),
-  };
-  thumbnail = {
-    __typename: 'ProductImage',
-    label: faker.random.words(3),
-    url: faker.image.imageUrl(),
-  };
   description = {
     __typename: 'ComplexTextValue',
     html: faker.random.words(5),
-  };
-  price_range = {
-    __typename: 'PriceRange',
-    maximum_price: {
-      __typename: 'ProductPrice',
-      regular_price: {
-        __typename: 'Money',
-        value: faker.datatype.number({ min: 100, max: 1000 }),
-        currency: null,
-      },
-      discount: {
-        __typename: 'ProductDiscount',
-        amount_off: faker.datatype.number({ min: 1, max: 99 }),
-        percent_off: faker.datatype.number({ min: 1, max: 99 }),
-      },
-    },
   };
   short_description = {
     __typename: 'ComplexTextValue',

--- a/libs/product/driver/magento/testing/src/factories/simple/simple.factory.spec.ts
+++ b/libs/product/driver/magento/testing/src/factories/simple/simple.factory.spec.ts
@@ -31,8 +31,6 @@ describe('@daffodil/product/testing | MagentoSimpleProductFactory', () => {
       expect(result.uid).toBeDefined();
       expect(result.image.label).toBeDefined();
       expect(result.image.url).toBeDefined();
-      expect(result.thumbnail.label).toBeDefined();
-      expect(result.thumbnail.url).toBeDefined();
       expect(result.url_key).toBeDefined();
       expect(result.name).toBeDefined();
       expect(result.description).toBeDefined();

--- a/libs/product/src/models/product.ts
+++ b/libs/product/src/models/product.ts
@@ -28,7 +28,7 @@ export interface DaffProduct extends DaffLocatable, DaffIdentifiable, Partial<Da
    */
   name: string;
   /**
-   * A smaller image to concisely visualize the product.
+   * An image to concisely visualize the product.
    */
   thumbnail: DaffProductImage;
   /**


### PR DESCRIPTION
the media gallery is still requested on the product page

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: perf
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

product fragment includes media gallery fields

## What is the new behavior?
only the product page fragment requests media gallery entries

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information