### PR TITLE
feat(category)!: remove nested products query in Magento driver

### DIFF
--- a/libs/category/driver/magento/src/models/category.ts
+++ b/libs/category/driver/magento/src/models/category.ts
@@ -1,5 +1,3 @@
-import { MagentoProduct } from '@daffodil/product/driver/magento';
-
 export interface MagentoCategory {
   __typename?: string;
   uid: string;
@@ -13,9 +11,6 @@ export interface MagentoCategory {
   breadcrumbs?: MagentoBreadcrumb[];
   level?: number;
   children_count?: number;
-  products?: {
-    items?: MagentoProduct[];
-  };
   children?: MagentoCategory[];
 }
 

--- a/libs/category/driver/magento/src/queries/fragments/category-tree.ts
+++ b/libs/category/driver/magento/src/queries/fragments/category-tree.ts
@@ -17,11 +17,6 @@ export const magentoCategoryTreeFragment = gql`
 			category_level
 			category_url_path
 		}
-		products {
-			items {
-				sku
-			}
-		}
 		children_count
   }
 `;

--- a/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
@@ -41,7 +41,6 @@ describe('DaffMagentoCategoryTransformerService', () => {
       sku: stubCategory.product_ids[0],
       url_key: 'url_key',
       url_suffix: '.html',
-      image: null,
       price_range: null,
       image: {
         url: 'url',

--- a/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/category-transformer.service.spec.ts
@@ -15,6 +15,7 @@ describe('DaffMagentoCategoryTransformerService', () => {
   let service: DaffMagentoCategoryTransformerService;
   let categoryFactory: DaffCategoryFactory;
   let stubCategory: DaffCategory;
+  let mockProducts: MagentoProduct[];
 
   let url: DaffCategory['url'];
 
@@ -33,6 +34,20 @@ describe('DaffMagentoCategoryTransformerService', () => {
       id: '1',
       url: `/${url}.html`,
     });
+    mockProducts = [{
+      __typename: 'simple',
+      uid: '1',
+      name: 'name',
+      sku: stubCategory.product_ids[0],
+      url_key: 'url_key',
+      url_suffix: '.html',
+      image: null,
+      price_range: null,
+      image: {
+        url: 'url',
+        label: 'label',
+      },
+    }];
   });
 
   it('should be created', () => {
@@ -59,26 +74,11 @@ describe('DaffMagentoCategoryTransformerService', () => {
           category_url_path: stubCategory.breadcrumbs[0].url,
         }],
         description: stubCategory.description,
-        products: {
-          items: [{
-            __typename: 'simple',
-            uid: '1',
-            name: 'name',
-            sku: stubCategory.product_ids[0],
-            url_key: 'url_key',
-            url_suffix: '.html',
-            price_range: null,
-            image: {
-              url: 'url',
-              label: 'label',
-            },
-          }],
-        },
         children_count: stubCategory.children_count,
       };
 
       stubCategory.breadcrumbs[0].url = `/${stubCategory.breadcrumbs[0].url}.html`;
-      result = service.transform(magentoCategory, magentoCategory.products.items);
+      result = service.transform(magentoCategory, mockProducts);
     });
 
     describe('when the products are different than those nested in the category', () => {
@@ -103,7 +103,7 @@ describe('DaffMagentoCategoryTransformerService', () => {
 
       it('should set product_ids from the products response, not the category', () => {
         expect(result.product_ids).toContain(newProducts[0].sku);
-        expect(result.product_ids).not.toContain(magentoCategory.products.items[0].sku);
+        expect(result.product_ids).not.toContain(mockProducts[0].sku);
       });
     });
 
@@ -149,7 +149,7 @@ describe('DaffMagentoCategoryTransformerService', () => {
         url: '/urlKey3.html',
       }];
 
-      result = service.transform(magentoCategory, magentoCategory.products.items);
+      result = service.transform(magentoCategory, mockProducts);
       expect(result.breadcrumbs).toEqual(expectedBreadcrumbs);
     });
 

--- a/libs/category/driver/magento/testing/src/factories/category.factory.spec.ts
+++ b/libs/category/driver/magento/testing/src/factories/category.factory.spec.ts
@@ -39,7 +39,6 @@ describe('@daffodil/category/driver/magento/testing | DaffCategoryDriverMagentoC
       expect(result.level).toBeDefined();
       expect(result.children_count).toBeDefined();
       expect(result.children).toBeDefined();
-      expect(result.products).toBeDefined();
     });
   });
 });

--- a/libs/search-category/driver/magento/src/category-search.service.ts
+++ b/libs/search-category/driver/magento/src/category-search.service.ts
@@ -50,7 +50,8 @@ export class DaffSearchCategoryMagentoDriver implements DaffSearchCategoryDriver
         pageSize: options.limit,
       },
     }).pipe(
-      map(result => result.data.categories.items.map(category => this.magentoCategoryTransformerService.transform(category, category.products.items))),
+      // category search results don't need product IDs
+      map(result => result.data.categories.items.map(category => this.magentoCategoryTransformerService.transform(category, []))),
       map(searchResults => daffSearchTransformResultsToCollection(daffTransformCategoriesToSearchResults(searchResults))),
       map(collection => ({
         collection,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: perf
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the category Magento driver requests products nested in the category but never uses them


## What is the new behavior?
the unused fields are removed from the query

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
removes `MagentoCategory#products`

## Other information