### PR TITLE
feat(core)!: change fragment name spread to only get first fragment

### DIFF
--- a/libs/core/graphql/src/apollo/queued-apollo/queued-apollo.service.spec.ts
+++ b/libs/core/graphql/src/apollo/queued-apollo/queued-apollo.service.spec.ts
@@ -14,7 +14,7 @@ import { TestScheduler } from 'rxjs/testing';
 
 import { DaffQueuedApollo } from './queued-apollo.service';
 
-describe('Core | GraphQL | DaffQueuedApollo', () => {
+describe('@daffodil/core/graphql | DaffQueuedApollo', () => {
   let service: DaffQueuedApollo;
   let apollo: Apollo;
   let apolloMutateSpy: jasmine.Spy;

--- a/libs/core/graphql/src/fragments/build-fragment-definition.spec.ts
+++ b/libs/core/graphql/src/fragments/build-fragment-definition.spec.ts
@@ -3,7 +3,7 @@ import { DocumentNode } from 'graphql';
 
 import { daffBuildFragmentDefinition } from './build-fragment-definition';
 
-describe('Core | GraphQL | daffBuildFragmentDefinition', () => {
+describe('@daffodil/core/graphql | daffBuildFragmentDefinition', () => {
   let mockFragment1: DocumentNode;
   let mockFragment2: DocumentNode;
   let mockEmptyFragment: DocumentNode;

--- a/libs/core/graphql/src/fragments/build-fragment-name-spread.spec.ts
+++ b/libs/core/graphql/src/fragments/build-fragment-name-spread.spec.ts
@@ -3,7 +3,7 @@ import { DocumentNode } from 'graphql';
 
 import { daffBuildFragmentNameSpread } from './build-fragment-name-spread';
 
-describe('Core | GraphQL | daffBuildFragmentNameSpread', () => {
+describe('@daffodil/core/graphql | daffBuildFragmentNameSpread', () => {
   let mockFragment1: DocumentNode;
   let mockFragment2: DocumentNode;
   let mockEmptyFragment: DocumentNode;
@@ -52,7 +52,7 @@ describe('Core | GraphQL | daffBuildFragmentNameSpread', () => {
     });
 
     it('should return a string of the names separated by newlines', () => {
-      expect(names).toEqual(`...fragment11\n...fragment12\n...fragment21\n...fragment22\n`);
+      expect(names).toEqual(`...fragment11\n...fragment21\n`);
     });
   });
 

--- a/libs/core/graphql/src/fragments/build-fragment-name-spread.ts
+++ b/libs/core/graphql/src/fragments/build-fragment-name-spread.ts
@@ -13,18 +13,25 @@ export const getFragmentNames = (fragment: DocumentNode) =>
   );
 
 /**
- * Builds a list of fragment names present inside the specified GraphQL document nodes.
+ * Builds a list of the first fragment name present inside the specified GraphQL document nodes.
  * Returns an empty array if no fragments have been defined or if null is passed.
  *
  * @param fragments The created fragments.
  */
 const daffGetFragmentNames = (...fragments: DocumentNode[]): string[] =>
-  fragments.reduce((acc, fragment) => acc.concat(getFragmentNames(fragment)), []);
+  fragments.reduce((acc, fragment) => {
+    const names = getFragmentNames(fragment);
+    if (names[0]) {
+      acc.push(names[0]);
+    }
+    return acc;
+  }, []);
 
 /**
  * Builds a string of fragment names that can be interpolated into a GraphQL query.
  * Each name is separated by a newline character: '\n'.
  * If an empty array is passed, an empty string is returned.
+ * Only the first fragment name from each passed fragment is returned.
  *
  * @param fragments A list of GraphQL documents that contain fragments.
  */

--- a/libs/core/graphql/src/fragments/fragment.integration.spec.ts
+++ b/libs/core/graphql/src/fragments/fragment.integration.spec.ts
@@ -12,7 +12,7 @@ import { DocumentNode } from 'graphql';
 import { daffBuildFragmentDefinition } from './build-fragment-definition';
 import { daffBuildFragmentNameSpread } from './build-fragment-name-spread';
 
-describe('Core | GraphQL | Fragment Integration', () => {
+describe('@daffodil/core/graphql | Fragment Integration', () => {
   let controller: ApolloTestingController;
   let apollo: Apollo;
 
@@ -34,6 +34,7 @@ describe('Core | GraphQL | Fragment Integration', () => {
     mockFragment1 = gql`
       fragment fragment11 on Query {
         field11
+        ...fragment12
       }
       fragment fragment12 on Query {
         field12
@@ -42,6 +43,7 @@ describe('Core | GraphQL | Fragment Integration', () => {
     mockFragment2 = gql`
       fragment fragment21 on Query {
         field21
+        ...fragment22
       }
       fragment fragment22 on Query {
         field22


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
 `daffBuildFragmentNameSpread` now only uses the first fragment name from each passed definition. define muliple fragment defs if for each fragment you need to spread in.

## Other information
this is to allow additional fragments to be interpolated into injected fragments.