### PR TITLE
feat(auth,cart-customer,customer-auth)!: don't call driver for missin…

### DIFF
--- a/libs/auth/driver/src/public_api.ts
+++ b/libs/auth/driver/src/public_api.ts
@@ -1,2 +1,3 @@
 export * from './interfaces/public_api';
 export * from './errors/public_api';
+export * from './services/public_api';

--- a/libs/auth/driver/src/services/auth-check.service.spec.ts
+++ b/libs/auth/driver/src/services/auth-check.service.spec.ts
@@ -1,0 +1,81 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  Observable,
+  catchError,
+  of,
+} from 'rxjs';
+
+import {
+  DaffAuthMissingTokenError,
+  DaffAuthStorageService,
+} from '@daffodil/auth';
+import {
+  DaffAuthDriver,
+  DaffAuthServiceInterface,
+} from '@daffodil/auth/driver';
+
+import { DaffAuthDriverTokenCheck } from './auth-check.service';
+
+describe('@daffodil/auth/driver | DaffAuthDriverTokenCheck', () => {
+  let service: DaffAuthDriverTokenCheck;
+  let daffAuthStorageService: jasmine.SpyObj<DaffAuthStorageService>;
+  let daffAuthDriver: jasmine.SpyObj<DaffAuthServiceInterface>;
+
+  beforeEach(() => {
+    daffAuthStorageService = jasmine.createSpyObj('DaffAuthStorageService', ['getAuthToken']);
+    daffAuthDriver = jasmine.createSpyObj('DaffAuthDriver', ['check']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DaffAuthStorageService,
+          useValue: daffAuthStorageService,
+        },
+        {
+          provide: DaffAuthDriver,
+          useValue: daffAuthDriver,
+        },
+      ],
+    });
+
+    service = TestBed.inject(DaffAuthDriverTokenCheck);
+    daffAuthDriver.check.and.returnValue(of(undefined));
+  });
+
+  describe('check', () => {
+    let result: Observable<void>;
+
+    describe('when there is a token in storage', () => {
+      beforeEach(() => {
+        daffAuthStorageService.getAuthToken.and.returnValue('token');
+        result = service.check();
+      });
+
+      it('should call the driver', (done) => {
+        result.subscribe(() => {
+          expect(daffAuthDriver.check).toHaveBeenCalledWith();
+          done();
+        });
+      });
+    });
+
+    describe('when there is not a token in storage', () => {
+      beforeEach(() => {
+        daffAuthStorageService.getAuthToken.and.returnValue(null);
+        result = service.check();
+      });
+
+      it('should throw a DaffAuthMissingTokenError into the stream', (done) => {
+        result.pipe(
+          catchError((err) => {
+            expect(err).toEqual(jasmine.any(DaffAuthMissingTokenError));
+            done();
+            return of();
+          }),
+        ).subscribe(() => {
+          fail('stream should not emit');
+        });
+      });
+    });
+  });
+});

--- a/libs/auth/driver/src/services/auth-check.service.ts
+++ b/libs/auth/driver/src/services/auth-check.service.ts
@@ -1,0 +1,50 @@
+import {
+  Inject,
+  Injectable,
+} from '@angular/core';
+import {
+  Observable,
+  map,
+  of,
+  switchMap,
+  throwError,
+} from 'rxjs';
+
+import {
+  DaffAuthStorageService,
+  DaffAuthMissingTokenError,
+} from '@daffodil/auth';
+
+import {
+  DaffAuthDriver,
+  DaffAuthServiceInterface,
+} from '../interfaces/public_api';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffAuthDriverTokenCheck {
+  constructor(
+    private storage: DaffAuthStorageService,
+    @Inject(DaffAuthDriver) private driver: DaffAuthServiceInterface,
+  ) {}
+
+  /**
+   * Checks if the auth token in storage is valid.
+   * If there is not an auth token in storage, the driver is not called
+   * and an error is immediately thrown.
+   */
+  check(): Observable<void> {
+    return of(null).pipe(
+      switchMap(() => {
+        const token = this.storage.getAuthToken();
+
+        if (!token) {
+          return throwError(() => new DaffAuthMissingTokenError('There is not an auth token in storage'));
+        }
+
+        return this.driver.check();
+      }),
+    );
+  }
+}

--- a/libs/auth/driver/src/services/public_api.ts
+++ b/libs/auth/driver/src/services/public_api.ts
@@ -1,0 +1,1 @@
+export * from './auth-check.service';

--- a/libs/auth/routing/src/config/default.ts
+++ b/libs/auth/routing/src/config/default.ts
@@ -4,4 +4,5 @@ export const DAFF_AUTH_ROUTING_CONFIG_DEFAULT: DaffAuthRoutingConfig = {
   resetPasswordTokenParam: 'token',
   authCompleteRedirectPath: '/',
   logoutRedirectPath: '/',
+  tokenExpirationRedirectPath: '/',
 };

--- a/libs/auth/routing/src/config/interface.ts
+++ b/libs/auth/routing/src/config/interface.ts
@@ -18,4 +18,10 @@ export interface DaffAuthRoutingConfig {
    * Defaults to `'/'`.
    */
   logoutRedirectPath: string;
+
+  /**
+   * The path to which the user will be redirected when their auth token is present but invalid.
+   * Defaults to `'/'`.
+   */
+  tokenExpirationRedirectPath: string;
 }

--- a/libs/auth/routing/src/effects/redirect.effects.spec.ts
+++ b/libs/auth/routing/src/effects/redirect.effects.spec.ts
@@ -10,9 +10,12 @@ import { Observable } from 'rxjs';
 
 import { provideDaffAuthRoutingConfig } from '@daffodil/auth/routing';
 import {
-  DaffAuthComplete,
+  DaffAuthCheckFailure,
+  DaffAuthGuardLogout,
+  DaffAuthLoginSuccess,
   DaffAuthLogoutSuccess,
-  DaffAuthRevoke,
+  DaffAuthRegisterSuccess,
+  DaffResetPasswordSuccess,
 } from '@daffodil/auth/state';
 
 import { DaffAuthRedirectEffects } from './redirect.effects';
@@ -26,10 +29,12 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
   let routerNavigateSpy: jasmine.Spy<Router['navigateByUrl']>;
   let authCompleteRedirectUrl: string;
   let logoutRedirectUrl: string;
+  let expirationRedirectUrl: string;
 
   beforeEach(() => {
     authCompleteRedirectUrl = '/customer';
     logoutRedirectUrl = '/login';
+    expirationRedirectUrl = '/';
 
     TestBed.configureTestingModule({
       imports: [
@@ -41,6 +46,7 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
         provideDaffAuthRoutingConfig({
           authCompleteRedirectPath: authCompleteRedirectUrl,
           logoutRedirectPath: logoutRedirectUrl,
+          tokenExpirationRedirectPath: expirationRedirectUrl,
         }),
       ],
     });
@@ -55,9 +61,9 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
     expect(effects).toBeTruthy();
   });
 
-  describe('when DaffAuthComplete is dispatched', () => {
+  describe('when DaffAuthLoginSuccess is dispatched', () => {
     beforeEach(() => {
-      actions$ = hot('--a', { a: new DaffAuthComplete() });
+      actions$ = hot('--a', { a: new DaffAuthLoginSuccess(null) });
     });
 
     it('should navigate to the customer dashboard page', () => {
@@ -68,9 +74,35 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
     });
   });
 
-  describe('when DaffAuthRevoke is dispatched', () => {
+  describe('when DaffAuthRegisterSuccess is dispatched', () => {
     beforeEach(() => {
-      actions$ = hot('--a', { a: new DaffAuthRevoke() });
+      actions$ = hot('--a', { a: new DaffAuthRegisterSuccess('token') });
+    });
+
+    it('should navigate to the customer dashboard page', () => {
+      const expected = cold('---');
+
+      expect(effects.redirectAfterLoginOrRegister$).toBeObservable(expected);
+      expect(routerNavigateSpy).toHaveBeenCalledWith(authCompleteRedirectUrl);
+    });
+  });
+
+  describe('when DaffResetPasswordSuccess is dispatched', () => {
+    beforeEach(() => {
+      actions$ = hot('--a', { a: new DaffResetPasswordSuccess('token') });
+    });
+
+    it('should navigate to the customer dashboard page', () => {
+      const expected = cold('---');
+
+      expect(effects.redirectAfterLoginOrRegister$).toBeObservable(expected);
+      expect(routerNavigateSpy).toHaveBeenCalledWith(authCompleteRedirectUrl);
+    });
+  });
+
+  describe('when DaffAuthLogoutSuccess is dispatched', () => {
+    beforeEach(() => {
+      actions$ = hot('--a', { a: new DaffAuthLogoutSuccess() });
     });
 
     it('should navigate to the login page', () => {
@@ -78,6 +110,32 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
 
       expect(effects.redirectAfterLogout$).toBeObservable(expected);
       expect(routerNavigateSpy).toHaveBeenCalledWith(logoutRedirectUrl);
+    });
+  });
+
+  describe('when DaffAuthCheckFailure is dispatched', () => {
+    beforeEach(() => {
+      actions$ = hot('--a', { a: new DaffAuthCheckFailure(null) });
+    });
+
+    it('should navigate to the home page', () => {
+      const expected = cold('---');
+
+      expect(effects.redirectAfterExpiration$).toBeObservable(expected);
+      expect(routerNavigateSpy).toHaveBeenCalledWith(expirationRedirectUrl);
+    });
+  });
+
+  describe('when DaffAuthGuardLogout is dispatched', () => {
+    beforeEach(() => {
+      actions$ = hot('--a', { a: new DaffAuthGuardLogout(null) });
+    });
+
+    it('should navigate to the home page', () => {
+      const expected = cold('---');
+
+      expect(effects.redirectAfterExpiration$).toBeObservable(expected);
+      expect(routerNavigateSpy).toHaveBeenCalledWith(expirationRedirectUrl);
     });
   });
 });

--- a/libs/auth/routing/src/guards/guest-only.guard.spec.ts
+++ b/libs/auth/routing/src/guards/guest-only.guard.spec.ts
@@ -1,104 +1,126 @@
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Actions } from '@ngrx/effects';
-import { provideMockActions } from '@ngrx/effects/testing';
+import {
+  MockStore,
+  provideMockStore,
+} from '@ngrx/store/testing';
 import {
   hot,
   cold,
 } from 'jasmine-marbles';
-import { Observable } from 'rxjs';
+import {
+  Observable,
+  of,
+} from 'rxjs';
 
+import { DaffAuthStorageService } from '@daffodil/auth';
 import {
-  DaffAuthGuardCheckCompletion,
-  DaffAuthGuardCheck,
-} from '@daffodil/auth/state';
-import {
-  DaffAuthTestingModule,
-  MockDaffAuthFacade,
-} from '@daffodil/auth/state/testing';
+  DaffAuthDriverTokenCheck,
+  DaffAuthInvalidAPIResponseError,
+  DaffUnauthorizedError,
+} from '@daffodil/auth/driver';
+import { DaffAuthGuardLogout } from '@daffodil/auth/state';
 
 import { DaffAuthGuestOnlyGuardRedirectUrl } from './guest-only-guard-redirect.token';
 import { GuestOnlyGuard } from './guest-only.guard';
 
 describe('@daffodil/auth/routing | GuestOnlyGuard', () => {
+  let daffAuthStorageService: jasmine.SpyObj<DaffAuthStorageService>;
+  let daffAuthCheckService: jasmine.SpyObj<DaffAuthDriverTokenCheck>;
   let guard: GuestOnlyGuard;
-  let actions$: Actions;
-
-  let mockFacade: MockDaffAuthFacade;
+  let mockStore: MockStore;
   let router: Router;
 
   let redirectUrl: string;
 
   beforeEach(() => {
     redirectUrl = 'redirectUrl';
+    daffAuthStorageService = jasmine.createSpyObj('DaffAuthStorageService', ['removeAuthToken']);
+    daffAuthCheckService = jasmine.createSpyObj('DaffAuthDriverTokenCheck', ['check']);
 
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule.withRoutes([]),
-        DaffAuthTestingModule,
       ],
       providers: [
-        provideMockActions(() => actions$),
+        provideMockStore(),
         {
           provide: DaffAuthGuestOnlyGuardRedirectUrl,
           useValue: redirectUrl,
+        },
+        {
+          provide: DaffAuthStorageService,
+          useValue: daffAuthStorageService,
+        },
+        {
+          provide: DaffAuthDriverTokenCheck,
+          useValue: daffAuthCheckService,
         },
       ],
     });
 
     guard = TestBed.inject(GuestOnlyGuard);
     router = TestBed.inject(Router);
-    mockFacade = TestBed.inject(MockDaffAuthFacade);
+    mockStore = TestBed.inject(MockStore);
 
-    spyOn(mockFacade, 'dispatch');
+    daffAuthCheckService.check.and.returnValue(of());
+
     spyOn(router, 'navigateByUrl');
+    spyOn(mockStore, 'dispatch');
   });
 
   describe('canActivate | checking if the route can be activated', () => {
     let expected;
     let result: Observable<boolean>;
 
-    const mockAuthCheckAction = new DaffAuthGuardCheck();
-
     beforeEach(() => {
       result = guard.canActivate();
     });
 
-    it('should initiate an auth check', () => {
-      expect(mockFacade.dispatch).toHaveBeenCalledWith(mockAuthCheckAction);
-    });
-
-    describe('when the user is authenticated', () => {
-      const mockAuthGuardCheckCompletionAction = new DaffAuthGuardCheckCompletion(true);
-
+    describe('when the check succeeds', () => {
       beforeEach(() => {
-        actions$ = hot('--a', { a: mockAuthGuardCheckCompletionAction });
-        expected = cold('--b', { b: false });
+        daffAuthCheckService.check.and.returnValue(hot('--a', { a: undefined }));
         result = guard.canActivate();
+        expected = cold('--b', { b: false });
       });
 
       it('should return false', () => {
         expect(result).toBeObservable(expected);
       });
-
-      it('should navigate to the redirect URL', () => {
-        expect(result).toBeObservable(expected);
-        expect(router.navigateByUrl).toHaveBeenCalledWith(redirectUrl);
-      });
     });
 
-    describe('when the user is not authenticated', () => {
-      const mockAuthGuardCheckCompletionAction = new DaffAuthGuardCheckCompletion(false);
-
+    describe('when the check fails', () => {
       beforeEach(() => {
-        actions$ = hot('--a', { a: mockAuthGuardCheckCompletionAction });
-        expected = cold('--b', { b: true });
+        daffAuthCheckService.check.and.returnValue(hot('--#', {}, new DaffAuthInvalidAPIResponseError('error')));
         result = guard.canActivate();
+        expected = cold('--(b|)', { b: true });
       });
 
       it('should return true', () => {
         expect(result).toBeObservable(expected);
+      });
+
+      describe('from an unauthorized error', () => {
+        beforeEach(() => {
+          daffAuthCheckService.check.and.returnValue(hot('--#', {}, new DaffUnauthorizedError('error')));
+          result = guard.canActivate();
+          expected = cold('--(b|)', { b: true });
+        });
+
+        it('should return true', () => {
+          expect(result).toBeObservable(expected);
+        });
+
+        it('should remove the token from storage', () => {
+          expect(result).toBeObservable(expected);
+          expect(daffAuthStorageService.removeAuthToken).toHaveBeenCalledWith();
+        });
+
+        it('should dispatch guard logout', () => {
+          expect(result).toBeObservable(expected);
+          expect(mockStore.dispatch).toHaveBeenCalledWith(jasmine.any(DaffAuthGuardLogout));
+        });
       });
     });
   });

--- a/libs/auth/routing/src/guards/member-only.guard.spec.ts
+++ b/libs/auth/routing/src/guards/member-only.guard.spec.ts
@@ -1,104 +1,126 @@
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Actions } from '@ngrx/effects';
-import { provideMockActions } from '@ngrx/effects/testing';
+import {
+  MockStore,
+  provideMockStore,
+} from '@ngrx/store/testing';
 import {
   hot,
   cold,
 } from 'jasmine-marbles';
-import { Observable } from 'rxjs';
+import {
+  Observable,
+  of,
+} from 'rxjs';
 
+import { DaffAuthStorageService } from '@daffodil/auth';
 import {
-  DaffAuthGuardCheckCompletion,
-  DaffAuthGuardCheck,
-} from '@daffodil/auth/state';
-import {
-  DaffAuthTestingModule,
-  MockDaffAuthFacade,
-} from '@daffodil/auth/state/testing';
+  DaffAuthDriverTokenCheck,
+  DaffAuthInvalidAPIResponseError,
+  DaffUnauthorizedError,
+} from '@daffodil/auth/driver';
+import { DaffAuthGuardLogout } from '@daffodil/auth/state';
 
 import { DaffAuthMemberOnlyGuardRedirectUrl } from './member-only-guard-redirect.token';
 import { MemberOnlyGuard } from './member-only.guard';
 
 describe('@daffodil/auth/routing | MemberOnlyGuard', () => {
+  let daffAuthStorageService: jasmine.SpyObj<DaffAuthStorageService>;
+  let daffAuthCheckService: jasmine.SpyObj<DaffAuthDriverTokenCheck>;
   let guard: MemberOnlyGuard;
-  let actions$: Actions;
-
-  let mockFacade: MockDaffAuthFacade;
+  let mockStore: MockStore;
   let router: Router;
 
   let redirectUrl: string;
 
   beforeEach(() => {
     redirectUrl = 'redirectUrl';
+    daffAuthStorageService = jasmine.createSpyObj('DaffAuthStorageService', ['removeAuthToken']);
+    daffAuthCheckService = jasmine.createSpyObj('DaffAuthDriverTokenCheck', ['check']);
 
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule.withRoutes([]),
-        DaffAuthTestingModule,
       ],
       providers: [
-        provideMockActions(() => actions$),
+        provideMockStore(),
         {
           provide: DaffAuthMemberOnlyGuardRedirectUrl,
           useValue: redirectUrl,
+        },
+        {
+          provide: DaffAuthStorageService,
+          useValue: daffAuthStorageService,
+        },
+        {
+          provide: DaffAuthDriverTokenCheck,
+          useValue: daffAuthCheckService,
         },
       ],
     });
 
     guard = TestBed.inject(MemberOnlyGuard);
     router = TestBed.inject(Router);
-    mockFacade = TestBed.inject(MockDaffAuthFacade);
+    mockStore = TestBed.inject(MockStore);
 
-    spyOn(mockFacade, 'dispatch');
+    daffAuthCheckService.check.and.returnValue(of());
+
     spyOn(router, 'navigateByUrl');
+    spyOn(mockStore, 'dispatch');
   });
 
   describe('canActivate | checking if the route can be activated', () => {
     let expected;
     let result: Observable<boolean>;
 
-    const mockAuthCheckAction = new DaffAuthGuardCheck();
-
     beforeEach(() => {
       result = guard.canActivate();
     });
 
-    it('should initiate an auth check', () => {
-      expect(mockFacade.dispatch).toHaveBeenCalledWith(mockAuthCheckAction);
+    describe('when the check succeeds', () => {
+      beforeEach(() => {
+        daffAuthCheckService.check.and.returnValue(hot('--a', { a: undefined }));
+        result = guard.canActivate();
+        expected = cold('--b', { b: true });
+      });
+
+      it('should return true', () => {
+        expect(result).toBeObservable(expected);
+      });
     });
 
-    describe('when the user is not authenticated', () => {
-      const mockAuthGuardCheckCompletionAction = new DaffAuthGuardCheckCompletion(false);
-
+    describe('when the check fails', () => {
       beforeEach(() => {
-        actions$ = hot('--a', { a: mockAuthGuardCheckCompletionAction });
-        expected = cold('--b', { b: false });
+        daffAuthCheckService.check.and.returnValue(hot('--#', {}, new DaffAuthInvalidAPIResponseError('error')));
         result = guard.canActivate();
+        expected = cold('--(b|)', { b: false });
       });
 
       it('should return false', () => {
         expect(result).toBeObservable(expected);
       });
 
-      it('should navigate to the redirect URL', () => {
-        expect(result).toBeObservable(expected);
-        expect(router.navigateByUrl).toHaveBeenCalledWith(redirectUrl);
-      });
-    });
+      describe('from an unauthorized error', () => {
+        beforeEach(() => {
+          daffAuthCheckService.check.and.returnValue(hot('--#', {}, new DaffUnauthorizedError('error')));
+          result = guard.canActivate();
+          expected = cold('--(b|)', { b: false });
+        });
 
-    describe('when the user is authenticated', () => {
-      const mockAuthGuardCheckCompletionAction = new DaffAuthGuardCheckCompletion(true);
+        it('should return false', () => {
+          expect(result).toBeObservable(expected);
+        });
 
-      beforeEach(() => {
-        actions$ = hot('--a', { a: mockAuthGuardCheckCompletionAction });
-        expected = cold('--b', { b: true });
-        result = guard.canActivate();
-      });
+        it('should remove the token from storage', () => {
+          expect(result).toBeObservable(expected);
+          expect(daffAuthStorageService.removeAuthToken).toHaveBeenCalledWith();
+        });
 
-      it('should return true', () => {
-        expect(result).toBeObservable(expected);
+        it('should dispatch guard logout', () => {
+          expect(result).toBeObservable(expected);
+          expect(mockStore.dispatch).toHaveBeenCalledWith(jasmine.any(DaffAuthGuardLogout));
+        });
       });
     });
   });

--- a/libs/auth/routing/src/guards/member-only.guard.ts
+++ b/libs/auth/routing/src/guards/member-only.guard.ts
@@ -6,54 +6,65 @@ import {
   CanActivate,
   Router,
 } from '@angular/router';
+import { Store } from '@ngrx/store';
 import {
-  Actions,
-  ofType,
-} from '@ngrx/effects';
-import { Observable } from 'rxjs';
+  Observable,
+  of,
+} from 'rxjs';
 import {
+  catchError,
   map,
   tap,
 } from 'rxjs/operators';
 
 import {
-  DaffAuthFacade,
-  DaffAuthGuardCheck,
-  DaffAuthActionTypes,
-  DaffAuthGuardCheckCompletion,
-} from '@daffodil/auth/state';
+  DAFF_AUTH_ERROR_MATCHER,
+  DaffAuthStorageService,
+} from '@daffodil/auth';
+import {
+  DaffAuthDriverErrorCodes,
+  DaffAuthDriverTokenCheck,
+} from '@daffodil/auth/driver';
+import { DaffAuthGuardLogout } from '@daffodil/auth/state';
+import { DaffError } from '@daffodil/core';
+import { ErrorTransformer } from '@daffodil/core/state';
 
 import { DaffAuthMemberOnlyGuardRedirectUrl } from './member-only-guard-redirect.token';
+
 
 @Injectable({
   providedIn: 'any',
 })
 export class MemberOnlyGuard implements CanActivate {
   constructor(
-    private facade: DaffAuthFacade,
-    private actions$: Actions,
+    private tokenCheck: DaffAuthDriverTokenCheck,
+    private storage: DaffAuthStorageService,
     private router: Router,
+    private store: Store,
+    @Inject(DAFF_AUTH_ERROR_MATCHER) private errorMatcher: ErrorTransformer,
     @Inject(DaffAuthMemberOnlyGuardRedirectUrl) private redirectUrl: string,
   ) {}
 
   canActivate(): Observable<boolean> {
-    const ret = this.isAuthenticated().pipe(
+    return this.isAuthenticated().pipe(
       tap(result => {
         if (!result) {
           this.router.navigateByUrl(this.redirectUrl);
         }
       }),
     );
-
-    this.facade.dispatch(new DaffAuthGuardCheck());
-
-    return ret;
   }
 
   private isAuthenticated(): Observable<boolean> {
-    return this.actions$.pipe(
-      ofType(DaffAuthActionTypes.AuthGuardCheckCompletionAction),
-      map((action: DaffAuthGuardCheckCompletion) => action.result),
+    return this.tokenCheck.check().pipe(
+      map(() => true),
+      catchError((error: DaffError) => {
+        if (error.code === DaffAuthDriverErrorCodes.UNAUTHORIZED) {
+          this.storage.removeAuthToken();
+          this.store.dispatch(new DaffAuthGuardLogout(this.errorMatcher(error)));
+        }
+        return of(false);
+      }),
     );
   }
 }

--- a/libs/auth/routing/src/guards/reset-password.guard.spec.ts
+++ b/libs/auth/routing/src/guards/reset-password.guard.spec.ts
@@ -12,10 +12,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Observable } from 'rxjs';
 
 import { DAFF_AUTH_ROUTING_CONFIG } from '@daffodil/auth/routing';
-import {
-  DaffAuthGuardCheck,
-  DaffResetPasswordLanding,
-} from '@daffodil/auth/state';
+import { DaffResetPasswordLanding } from '@daffodil/auth/state';
 import {
   DaffAuthTestingModule,
   MockDaffAuthFacade,

--- a/libs/auth/src/errors/codes.enum.ts
+++ b/libs/auth/src/errors/codes.enum.ts
@@ -1,0 +1,3 @@
+export enum DaffAuthErrorCodes {
+  MISSING_TOKEN = 'DAFF_AUTH_MISSING_TOKEN',
+}

--- a/libs/auth/src/errors/map.ts
+++ b/libs/auth/src/errors/map.ts
@@ -1,0 +1,9 @@
+import { DaffAuthErrorCodes } from './codes.enum';
+import { DaffAuthMissingTokenError } from './missing-token';
+
+/**
+ * A mapping from error codes to error class constructors.
+ */
+export const DaffAuthErrorMap = {
+  [DaffAuthErrorCodes.MISSING_TOKEN]: DaffAuthMissingTokenError,
+};

--- a/libs/auth/src/errors/missing-token.ts
+++ b/libs/auth/src/errors/missing-token.ts
@@ -1,0 +1,18 @@
+import {
+  DaffError,
+  DaffInheritableError,
+} from '@daffodil/core';
+
+import { DaffAuthErrorCodes } from './codes.enum';
+
+/**
+ * An error thrown when an authenticated action was initiated
+ * but an auth token was not present.
+ */
+export class DaffAuthMissingTokenError extends DaffInheritableError implements DaffError {
+  public readonly code: string = DaffAuthErrorCodes.MISSING_TOKEN;
+
+  constructor(public message: string) {
+    super(message);
+  }
+}

--- a/libs/auth/src/errors/public_api.ts
+++ b/libs/auth/src/errors/public_api.ts
@@ -1,0 +1,3 @@
+export { DaffAuthMissingTokenError } from './missing-token';
+export { DaffAuthErrorCodes } from './codes.enum';
+export { DaffAuthErrorMap } from './map';

--- a/libs/auth/src/public_api.ts
+++ b/libs/auth/src/public_api.ts
@@ -2,3 +2,4 @@ export { DaffAuthStorageService } from './storage/auth-storage.service';
 
 export * from './models/public_api';
 export * from './injection-tokens/public_api';
+export * from './errors/public_api';

--- a/libs/auth/state/src/actions/auth.actions.ts
+++ b/libs/auth/state/src/actions/auth.actions.ts
@@ -3,31 +3,12 @@ import { Action } from '@ngrx/store';
 import { DaffStateError } from '@daffodil/core/state';
 
 export enum DaffAuthActionTypes {
-  AuthGuardCheckAction = '[@daffodil/auth] Auth Guard Check Action',
-  AuthGuardCheckCompletionAction = '[@daffodil/auth] Auth Guard Check Completion Action',
   AuthStorageFailureAction = '[@daffodil/auth] Auth Storage Failure Action',
+  AuthGuardLogoutAction = '[@daffodil/auth] Auth Guard Logout Action',
   AuthServerSideAction = '[@daffodil/auth] Auth Server Side Action',
   AuthCheckAction = '[@daffodil/auth] Auth Check Action',
   AuthCheckSuccessAction = '[@daffodil/auth] Auth Check Success Action',
   AuthCheckFailureAction = '[@daffodil/auth] Auth Check Failure Action',
-  AuthCompleteAction = '[@daffodil/auth] Auth Complete Action',
-  AuthRevokeAction = '[@daffodil/auth] Auth Revoke Action',
-}
-
-/**
- * An action triggered by guards to initialize an auth check request.
- */
-export class DaffAuthGuardCheck implements Action {
-  readonly type = DaffAuthActionTypes.AuthGuardCheckAction;
-}
-
-/**
- * An action triggered on the completion of a guard token check.
- */
-export class DaffAuthGuardCheckCompletion implements Action {
-  readonly type = DaffAuthActionTypes.AuthGuardCheckCompletionAction;
-
-  constructor(public result: boolean) {}
 }
 
 /*
@@ -35,6 +16,15 @@ export class DaffAuthGuardCheckCompletion implements Action {
  */
 export class DaffAuthStorageFailure implements Action {
   readonly type = DaffAuthActionTypes.AuthStorageFailureAction;
+
+  constructor(public errorMessage: DaffStateError) {}
+}
+
+/*
+ * An action triggered when an auth token is cleared from storage by a routing guard.
+ */
+export class DaffAuthGuardLogout implements Action {
+  readonly type = DaffAuthActionTypes.AuthGuardLogoutAction;
 
   constructor(public errorMessage: DaffStateError) {}
 }
@@ -76,29 +66,10 @@ export class DaffAuthCheckFailure implements Action {
   constructor(public errorMessage: DaffStateError) {}
 }
 
-/**
- * An action triggered when the user authentication flow is completed.
- * The auth token is in storage at this point.
- */
-export class DaffAuthComplete implements Action {
-  readonly type = DaffAuthActionTypes.AuthCompleteAction;
-}
-
-/**
- * An action triggered when the user auth token is revoked.
- * The auth token has been removed from storage at this point.
- */
-export class DaffAuthRevoke implements Action {
-  readonly type = DaffAuthActionTypes.AuthRevokeAction;
-}
-
 export type DaffAuthActions =
-  | DaffAuthGuardCheckCompletion
-  | DaffAuthGuardCheck
   | DaffAuthStorageFailure
+  | DaffAuthGuardLogout
   | DaffAuthServerSide
   | DaffAuthCheck
   | DaffAuthCheckSuccess
-  | DaffAuthCheckFailure
-  | DaffAuthComplete
-  | DaffAuthRevoke;
+  | DaffAuthCheckFailure;

--- a/libs/auth/state/src/actions/reset-password.actions.ts
+++ b/libs/auth/state/src/actions/reset-password.actions.ts
@@ -54,6 +54,8 @@ export class DaffResetPassword<T extends DaffAuthResetPasswordInfo = DaffAuthRes
  */
 export class DaffResetPasswordSuccess implements Action {
   readonly type = DaffAuthResetPasswordActionTypes.ResetPasswordSuccessAction;
+
+  constructor(public token?: string) {}
 }
 
 /**

--- a/libs/auth/state/src/effects/login.effects.spec.ts
+++ b/libs/auth/state/src/effects/login.effects.spec.ts
@@ -29,8 +29,6 @@ import {
   DaffAuthLogout,
   DaffAuthLogoutSuccess,
   DaffAuthLogoutFailure,
-  DaffAuthComplete,
-  DaffAuthRevoke,
   DaffAuthServerSide,
 } from '@daffodil/auth/state';
 import {
@@ -182,9 +180,8 @@ describe('@daffodil/auth/state | DaffAuthLoginEffects', () => {
 
     beforeEach(() => {
       authLoginSuccessAction = new DaffAuthLoginSuccess(mockAuth);
-      const authCompleteAction = new DaffAuthComplete();
       actions$ = hot('--a', { a: authLoginSuccessAction });
-      expected = cold('--a', { a: authCompleteAction });
+      expected = cold('---');
     });
 
     it('should set the auth token in storage', () => {
@@ -225,7 +222,7 @@ describe('@daffodil/auth/state | DaffAuthLoginEffects', () => {
     beforeEach(() => {
       authLogoutSuccessAction = new DaffAuthLogoutSuccess();
       actions$ = hot('--a', { a: authLogoutSuccessAction });
-      expected = cold('--a', { a: new DaffAuthRevoke() });
+      expected = cold('---');
     });
 
     it('should remove the auth token from storage', () => {

--- a/libs/auth/state/src/effects/register.effects.spec.ts
+++ b/libs/auth/state/src/effects/register.effects.spec.ts
@@ -24,7 +24,6 @@ import {
   DaffAuthRegister,
   DaffAuthRegisterSuccess,
   DaffAuthRegisterFailure,
-  DaffAuthComplete,
   DaffAuthServerSide,
   DaffAuthStorageFailure,
 } from '@daffodil/auth/state';
@@ -107,10 +106,9 @@ describe('@daffodil/auth/state | DaffAuthRegisterEffects', () => {
 
         describe('and setToken is successful', () => {
           beforeEach(() => {
-            const mockAuthResetPasswordSuccessAction = new DaffAuthRegisterSuccess();
-            const mockAuthCompleteAction = new DaffAuthComplete();
+            const mockAuthResetPasswordSuccessAction = new DaffAuthRegisterSuccess(token);
 
-            expected = cold('--(ba)', { a: mockAuthCompleteAction, b: mockAuthResetPasswordSuccessAction });
+            expected = cold('--a', { a: mockAuthResetPasswordSuccessAction });
           });
 
           it('should notify state that the register was successful', () => {

--- a/libs/auth/state/src/effects/reset-password.effects.spec.ts
+++ b/libs/auth/state/src/effects/reset-password.effects.spec.ts
@@ -28,7 +28,6 @@ import {
   DaffSendResetEmail,
   DaffSendResetEmailSuccess,
   DaffSendResetEmailFailure,
-  DaffAuthComplete,
   DaffAuthServerSide,
   DaffAuthStorageFailure,
 } from '@daffodil/auth/state';
@@ -103,10 +102,9 @@ describe('@daffodil/auth/state | DaffAuthResetPasswordEffects', () => {
 
         describe('and setToken is successful', () => {
           beforeEach(() => {
-            const mockAuthResetPasswordSuccessAction = new DaffResetPasswordSuccess();
-            const mockAuthCompleteAction = new DaffAuthComplete();
+            const mockAuthResetPasswordSuccessAction = new DaffResetPasswordSuccess(token);
 
-            expected = cold('--(ba)', { a: mockAuthCompleteAction, b: mockAuthResetPasswordSuccessAction });
+            expected = cold('--a', { a: mockAuthResetPasswordSuccessAction });
           });
 
           it('should notify state that the resetPassword was successful', () => {

--- a/libs/auth/state/src/effects/reset-password.effects.ts
+++ b/libs/auth/state/src/effects/reset-password.effects.ts
@@ -44,7 +44,6 @@ import {
   DaffSendResetEmail,
   DaffSendResetEmailSuccess,
   DaffSendResetEmailFailure,
-  DaffAuthComplete,
   DaffAuthServerSide,
   DaffAuthStorageFailure,
 } from '../actions/public_api';
@@ -81,7 +80,7 @@ export class DaffAuthResetPasswordEffects<
         () => action.autoLogin,
         defer(() => this.driver.resetPassword(action.info).pipe(
           tap(token => this.storage.setAuthToken(token)),
-          switchMap(() => of(new DaffResetPasswordSuccess(), new DaffAuthComplete())),
+          map((token) => new DaffResetPasswordSuccess(token)),
         )),
         defer(() => this.driver.resetPasswordOnly(action.info).pipe(
           map(() => new DaffResetPasswordSuccess()),

--- a/libs/auth/state/src/facades/auth/facade.spec.ts
+++ b/libs/auth/state/src/facades/auth/facade.spec.ts
@@ -21,7 +21,6 @@ import {
   DaffAuthRegister,
   DaffAuthRegisterFailure,
   DaffAuthLoginSuccess,
-  DaffAuthComplete,
 } from '@daffodil/auth/state';
 import {
   DaffAuthTokenFactory,
@@ -129,7 +128,7 @@ describe('DaffAuthFacade', () => {
 
     it('should be true upon an auth complete', () => {
       const expected = cold('a', { a: true });
-      store.dispatch(new DaffAuthComplete());
+      store.dispatch(new DaffAuthLoginSuccess(null));
       expect(facade.loggedIn$).toBeObservable(expected);
     });
   });

--- a/libs/auth/state/src/reducers/auth/auth.reducer.spec.ts
+++ b/libs/auth/state/src/reducers/auth/auth.reducer.spec.ts
@@ -6,8 +6,10 @@ import {
   daffAuthInitialState as initialState,
   DaffAuthServerSide,
   DaffAuthStorageFailure,
-  DaffAuthComplete,
-  DaffAuthRevoke,
+  DaffAuthLoginSuccess,
+  DaffAuthLogoutSuccess,
+  DaffAuthGuardLogout,
+  DaffAuthRegisterSuccess,
 } from '@daffodil/auth/state';
 import { DaffStateError } from '@daffodil/core/state';
 
@@ -24,11 +26,11 @@ describe('@daffodil/auth/state | daffAuthReducer', () => {
     });
   });
 
-  describe('when AuthCompleteAction is triggered', () => {
+  describe('when DaffAuthLoginSuccess is triggered', () => {
     let result: DaffAuthReducerState;
 
     beforeEach(() => {
-      const authCompleteAction = new DaffAuthComplete();
+      const authCompleteAction = new DaffAuthLoginSuccess(null);
 
       result = reducer(initialState, authCompleteAction);
     });
@@ -38,11 +40,39 @@ describe('@daffodil/auth/state | daffAuthReducer', () => {
     });
   });
 
-  describe('when AuthRevokeAction is triggered', () => {
+  describe('when DaffAuthRegisterSuccess is triggered', () => {
+    let result: DaffAuthReducerState;
+
+    describe('and the token is present', () => {
+      beforeEach(() => {
+        const authCompleteAction = new DaffAuthRegisterSuccess('token');
+
+        result = reducer(initialState, authCompleteAction);
+      });
+
+      it('sets loggedIn state to true', () => {
+        expect(result.loggedIn).toBeTrue();
+      });
+    });
+
+    describe('and the token is not present', () => {
+      beforeEach(() => {
+        const authCompleteAction = new DaffAuthRegisterSuccess(null);
+
+        result = reducer(initialState, authCompleteAction);
+      });
+
+      it('does nothing to loggedIn state', () => {
+        expect(result.loggedIn).toEqual(initialState.loggedIn);
+      });
+    });
+  });
+
+  describe('when DaffAuthLogoutSuccess is triggered', () => {
     let result: DaffAuthReducerState;
 
     beforeEach(() => {
-      const authRevokeAction = new DaffAuthRevoke();
+      const authRevokeAction = new DaffAuthLogoutSuccess();
 
       result = reducer(initialState, authRevokeAction);
     });
@@ -110,6 +140,39 @@ describe('@daffodil/auth/state | daffAuthReducer', () => {
       };
 
       const authCheckFailure = new DaffAuthCheckFailure(error);
+
+      result = reducer(state, authCheckFailure);
+    });
+
+    it('sets loading to false', () => {
+      expect(result.loading).toEqual(false);
+    });
+
+    it('adds an error to state.errors', () => {
+      expect(result.errors).toEqual([error]);
+    });
+
+    it('sets loggedIn state to false', () => {
+      expect(result.loggedIn).toBeFalse();
+    });
+  });
+
+  describe('when DaffAuthGuardLogout is triggered', () => {
+    const error: DaffStateError = {
+      code: 'error code',
+      message: 'error message',
+    };
+    let result: DaffAuthReducerState;
+    let state: DaffAuthReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...initialState,
+        loading: true,
+        errors: [{ code: 'firstErrorCode', message: 'firstErrorMessage' }],
+      };
+
+      const authCheckFailure = new DaffAuthGuardLogout(error);
 
       result = reducer(state, authCheckFailure);
     });

--- a/libs/auth/state/src/reducers/auth/auth.reducer.ts
+++ b/libs/auth/state/src/reducers/auth/auth.reducer.ts
@@ -1,13 +1,19 @@
 import {
   DaffAuthActionTypes,
   DaffAuthActions,
+  DaffAuthLoginActionTypes,
+  DaffAuthLoginActions,
+  DaffAuthRegisterActionTypes,
+  DaffAuthRegisterSuccess,
+  DaffAuthResetPasswordActionTypes,
+  DaffAuthResetPasswordActions,
 } from '../../actions/public_api';
 import { daffAuthInitialState } from './auth-initial-state';
 import { DaffAuthReducerState } from './auth-reducer-state.interface';
 
 export function daffAuthReducer(
   state = daffAuthInitialState,
-  action: DaffAuthActions,
+  action: DaffAuthActions | DaffAuthLoginActions | DaffAuthRegisterSuccess | DaffAuthResetPasswordActions,
 ): DaffAuthReducerState {
   switch (action.type) {
     case DaffAuthActionTypes.AuthCheckAction:
@@ -25,6 +31,7 @@ export function daffAuthReducer(
       };
 
     case DaffAuthActionTypes.AuthCheckFailureAction:
+    case DaffAuthActionTypes.AuthGuardLogoutAction:
       return {
         ...state,
         loggedIn: false,
@@ -40,13 +47,20 @@ export function daffAuthReducer(
         errors: [action.errorMessage],
       };
 
-    case DaffAuthActionTypes.AuthCompleteAction:
+    case DaffAuthLoginActionTypes.LoginSuccessAction:
       return {
         ...state,
         loggedIn: true,
       };
 
-    case DaffAuthActionTypes.AuthRevokeAction:
+    case DaffAuthRegisterActionTypes.RegisterSuccessAction:
+    case DaffAuthResetPasswordActionTypes.ResetPasswordSuccessAction:
+      return action.token ? {
+        ...state,
+        loggedIn: true,
+      } : state;
+
+    case DaffAuthLoginActionTypes.LogoutSuccessAction:
       return {
         ...state,
         loggedIn: false,

--- a/libs/cart-customer/state/src/effects/auth.effects.spec.ts
+++ b/libs/cart-customer/state/src/effects/auth.effects.spec.ts
@@ -10,8 +10,10 @@ import {
 } from 'rxjs';
 
 import {
-  DaffAuthComplete,
+  DaffAuthLoginSuccess,
   DaffAuthLogoutSuccess,
+  DaffAuthRegisterSuccess,
+  DaffResetPasswordSuccess,
 } from '@daffodil/auth/state';
 import {
   DaffCart,
@@ -83,9 +85,131 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerAuthEffects', () => {
     expect(effects).toBeTruthy();
   });
 
-  describe('when AuthCompleteAction is triggered', () => {
+  describe('when DaffAuthLoginSuccess is triggered', () => {
     let expected;
-    const authCompleteAction = new DaffAuthComplete();
+    const authCompleteAction = new DaffAuthLoginSuccess(null);
+
+    describe('and the call to the driver is successful', () => {
+      beforeEach(() => {
+        driverMergeSpy.and.returnValue(of({
+          response: stubCart,
+          errors: [],
+        }));
+        const resolveSuccessAction = new DaffResolveCartSuccess(stubCart);
+        actions$ = hot('--a', { a: authCompleteAction });
+        expected = cold('--b', { b: resolveSuccessAction });
+      });
+
+      it('should dispatch a DaffResolveCartSuccess action', () => {
+        expect(effects.mergeAfterLogin$).toBeObservable(expected);
+      });
+    });
+
+    describe('and the call to the driver fails', () => {
+      beforeEach(() => {
+        const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to load cart' };
+        const response = cold('#', {}, error);
+        driverMergeSpy.and.returnValue(response);
+        actions$ = hot('--a', { a: authCompleteAction });
+      });
+
+      describe('and the call to the driver is successful', () => {
+        beforeEach(() => {
+          driverGetSpy.and.returnValue(of({
+            response: stubCart,
+            errors: [],
+          }));
+          const resolveSuccessAction = new DaffResolveCartSuccess(stubCart);
+          actions$ = hot('--a', { a: authCompleteAction });
+          expected = cold('--b', { b: resolveSuccessAction });
+        });
+
+        it('should dispatch a DaffResolveCartSuccess action', () => {
+          expect(effects.mergeAfterLogin$).toBeObservable(expected);
+        });
+      });
+
+      describe('and the call to the driver fails', () => {
+        beforeEach(() => {
+          const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to load cart' };
+          const response = cold('#', {}, error);
+          driverGetSpy.and.returnValue(response);
+          const resolveFailureAction = new DaffResolveCartFailure([error]);
+          actions$ = hot('--a', { a: authCompleteAction });
+          expected = cold('--b', { b: resolveFailureAction });
+        });
+
+        it('should dispatch a DaffResolveCartFailure action', () => {
+          expect(effects.mergeAfterLogin$).toBeObservable(expected);
+        });
+      });
+    });
+  });
+
+  describe('when DaffAuthLoginSuccess is triggered with a token', () => {
+    let expected;
+    const authCompleteAction = new DaffAuthRegisterSuccess('token');
+
+    describe('and the call to the driver is successful', () => {
+      beforeEach(() => {
+        driverMergeSpy.and.returnValue(of({
+          response: stubCart,
+          errors: [],
+        }));
+        const resolveSuccessAction = new DaffResolveCartSuccess(stubCart);
+        actions$ = hot('--a', { a: authCompleteAction });
+        expected = cold('--b', { b: resolveSuccessAction });
+      });
+
+      it('should dispatch a DaffResolveCartSuccess action', () => {
+        expect(effects.mergeAfterLogin$).toBeObservable(expected);
+      });
+    });
+
+    describe('and the call to the driver fails', () => {
+      beforeEach(() => {
+        const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to load cart' };
+        const response = cold('#', {}, error);
+        driverMergeSpy.and.returnValue(response);
+        actions$ = hot('--a', { a: authCompleteAction });
+      });
+
+      describe('and the call to the driver is successful', () => {
+        beforeEach(() => {
+          driverGetSpy.and.returnValue(of({
+            response: stubCart,
+            errors: [],
+          }));
+          const resolveSuccessAction = new DaffResolveCartSuccess(stubCart);
+          actions$ = hot('--a', { a: authCompleteAction });
+          expected = cold('--b', { b: resolveSuccessAction });
+        });
+
+        it('should dispatch a DaffResolveCartSuccess action', () => {
+          expect(effects.mergeAfterLogin$).toBeObservable(expected);
+        });
+      });
+
+      describe('and the call to the driver fails', () => {
+        beforeEach(() => {
+          const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to load cart' };
+          const response = cold('#', {}, error);
+          driverGetSpy.and.returnValue(response);
+          const resolveFailureAction = new DaffResolveCartFailure([error]);
+          actions$ = hot('--a', { a: authCompleteAction });
+          expected = cold('--b', { b: resolveFailureAction });
+        });
+
+        it('should dispatch a DaffResolveCartFailure action', () => {
+          expect(effects.mergeAfterLogin$).toBeObservable(expected);
+        });
+      });
+    });
+  });
+
+  describe('when DaffResetPasswordSuccess is triggered with a token', () => {
+    let expected;
+    const authCompleteAction = new DaffResetPasswordSuccess('token');
 
     describe('and the call to the driver is successful', () => {
       beforeEach(() => {

--- a/libs/customer-auth/state/src/reducers/address-entities.reducer.spec.ts
+++ b/libs/customer-auth/state/src/reducers/address-entities.reducer.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 
-import { DaffAuthRevoke } from '@daffodil/auth/state';
+import {
+  DaffAuthCheckFailure,
+  DaffAuthGuardLogout,
+  DaffAuthLogoutSuccess,
+} from '@daffodil/auth/state';
 import { DaffOperationEntityState } from '@daffodil/core/state';
 import { DaffCustomerAddress } from '@daffodil/customer';
 import { daffCustomerAddressEntitiesAdapter } from '@daffodil/customer/state';
@@ -29,10 +33,35 @@ describe('@daffodil/customer-auth/state | daffCustomerAuthResetAddressEntitiesAf
     });
   });
 
-  describe('when AuthRevokeAction is triggered', () => {
-
+  describe('when DaffAuthLogoutSuccess is triggered', () => {
     beforeEach(() => {
-      const revokeAction = new DaffAuthRevoke();
+      const revokeAction = new DaffAuthLogoutSuccess();
+      state = daffCustomerAddressEntitiesAdapter().list(addressFactory.createMany(5), initialState);
+
+      result = reducer(state, revokeAction);
+    });
+
+    it('resets state', () => {
+      expect(result).toEqual(initialState);
+    });
+  });
+
+  describe('when DaffAuthCheckFailure is triggered', () => {
+    beforeEach(() => {
+      const revokeAction = new DaffAuthCheckFailure(null);
+      state = daffCustomerAddressEntitiesAdapter().list(addressFactory.createMany(5), initialState);
+
+      result = reducer(state, revokeAction);
+    });
+
+    it('resets state', () => {
+      expect(result).toEqual(initialState);
+    });
+  });
+
+  describe('when DaffAuthGuardLogout is triggered', () => {
+    beforeEach(() => {
+      const revokeAction = new DaffAuthGuardLogout(null);
       state = daffCustomerAddressEntitiesAdapter().list(addressFactory.createMany(5), initialState);
 
       result = reducer(state, revokeAction);

--- a/libs/customer-auth/state/src/reducers/address-entities.reducer.ts
+++ b/libs/customer-auth/state/src/reducers/address-entities.reducer.ts
@@ -1,11 +1,13 @@
 import {
   DaffAuthActions,
   DaffAuthActionTypes,
+  DaffAuthLoginActions,
+  DaffAuthLoginActionTypes,
 } from '@daffodil/auth/state';
 import { DaffOperationEntityState } from '@daffodil/core/state';
 import { DaffCustomerAddress } from '@daffodil/customer';
 import { daffCustomerAddressEntitiesAdapter } from '@daffodil/customer/state';
 
-export function daffCustomerAuthResetAddressEntitiesAfterLogoutReducer(state: DaffOperationEntityState<DaffCustomerAddress>, action: DaffAuthActions): DaffOperationEntityState<DaffCustomerAddress> {
-  return action.type === DaffAuthActionTypes.AuthRevokeAction ? daffCustomerAddressEntitiesAdapter().getInitialState() : state;
+export function daffCustomerAuthResetAddressEntitiesAfterLogoutReducer(state: DaffOperationEntityState<DaffCustomerAddress>, action: DaffAuthActions | DaffAuthLoginActions): DaffOperationEntityState<DaffCustomerAddress> {
+  return action.type === DaffAuthActionTypes.AuthCheckFailureAction || action.type === DaffAuthActionTypes.AuthGuardLogoutAction || action.type === DaffAuthLoginActionTypes.LogoutSuccessAction ? daffCustomerAddressEntitiesAdapter().getInitialState() : state;
 }

--- a/libs/customer-auth/state/src/reducers/customer.reducer.spec.ts
+++ b/libs/customer-auth/state/src/reducers/customer.reducer.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 
-import { DaffAuthRevoke } from '@daffodil/auth/state';
+import {
+  DaffAuthCheckFailure,
+  DaffAuthGuardLogout,
+  DaffAuthLogoutSuccess,
+} from '@daffodil/auth/state';
 import {
   daffCustomerInitialState as initialState,
   DaffCustomerReducerState,
@@ -28,10 +32,41 @@ describe('@daffodil/customer-auth/state | daffCustomerAuthResetAfterLogoutReduce
     });
   });
 
-  describe('when AuthRevokeAction is triggered', () => {
-
+  describe('when DaffAuthLogoutSuccess is triggered', () => {
     beforeEach(() => {
-      const revokeAction = new DaffAuthRevoke();
+      const revokeAction = new DaffAuthLogoutSuccess();
+      state = {
+        ...initialState,
+        customer: customerFactory.create(),
+      };
+
+      result = reducer(state, revokeAction);
+    });
+
+    it('resets state', () => {
+      expect(result).toEqual(initialState);
+    });
+  });
+
+  describe('when DaffAuthCheckFailure is triggered', () => {
+    beforeEach(() => {
+      const revokeAction = new DaffAuthCheckFailure(null);
+      state = {
+        ...initialState,
+        customer: customerFactory.create(),
+      };
+
+      result = reducer(state, revokeAction);
+    });
+
+    it('resets state', () => {
+      expect(result).toEqual(initialState);
+    });
+  });
+
+  describe('when DaffAuthGuardLogout is triggered', () => {
+    beforeEach(() => {
+      const revokeAction = new DaffAuthGuardLogout(null);
       state = {
         ...initialState,
         customer: customerFactory.create(),

--- a/libs/customer-auth/state/src/reducers/customer.reducer.ts
+++ b/libs/customer-auth/state/src/reducers/customer.reducer.ts
@@ -1,12 +1,14 @@
 import {
   DaffAuthActions,
   DaffAuthActionTypes,
+  DaffAuthLoginActions,
+  DaffAuthLoginActionTypes,
 } from '@daffodil/auth/state';
 import {
   daffCustomerInitialState,
   DaffCustomerReducerState,
 } from '@daffodil/customer/state';
 
-export function daffCustomerAuthResetAfterLogoutReducer(state: DaffCustomerReducerState, action: DaffAuthActions): DaffCustomerReducerState {
-  return action.type === DaffAuthActionTypes.AuthRevokeAction ? daffCustomerInitialState : state;
+export function daffCustomerAuthResetAfterLogoutReducer(state: DaffCustomerReducerState, action: DaffAuthActions | DaffAuthLoginActions): DaffCustomerReducerState {
+  return action.type === DaffAuthActionTypes.AuthCheckFailureAction || action.type === DaffAuthActionTypes.AuthGuardLogoutAction || action.type === DaffAuthLoginActionTypes.LogoutSuccessAction ? daffCustomerInitialState : state;
 }


### PR DESCRIPTION
…g token

BREAKING CHANGE: `DaffAuthRevoke` and `DaffAuthComplete` have been removed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
The auth token is checked for existence before making a driver call.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information