### PR TITLE
feat(cart-customer, magento): allow undefined billing address

### DIFF
--- a/libs/cart-customer/driver/magento/src/payment.service.spec.ts
+++ b/libs/cart-customer/driver/magento/src/payment.service.spec.ts
@@ -71,6 +71,14 @@ describe('@daffodil/cart-customer/driver/magento | DaffMagentoCartCustomerPaymen
       driverSpy.update.and.returnValue(of(null));
     });
 
+    it('should pass through an undefind value if the original value was undefined', (done) => {
+      service.update(cartId, undefined).subscribe(() => {
+        expect(driverSpy.update).toHaveBeenCalledWith(cartId, undefined);
+        done();
+      });
+    });
+
+
     describe('when the customer is logged in', () => {
       beforeEach(() => {
         authStorageSpy.getAuthToken.and.returnValue('token');

--- a/libs/cart-customer/driver/magento/src/payment.service.ts
+++ b/libs/cart-customer/driver/magento/src/payment.service.ts
@@ -37,6 +37,10 @@ export class DaffMagentoCartCustomerPaymentService implements DaffCartPaymentSer
     payment: Partial<DaffCartPaymentMethod>,
     billingAddress?: Partial<DaffCartAddress>,
   ): Observable<Partial<DaffCart>> {
+    if(!billingAddress){
+      return this.guestDriver.update(cartId, payment);
+    }
+
     const { email: _, ...addressWithoutEmail } = billingAddress || {};
 
     return this.guestDriver.update(cartId, payment, this.authStorage.getAuthToken() ? addressWithoutEmail : billingAddress);


### PR DESCRIPTION
f3759f3af2efbb97b5ddc6b297c3be3e3bf7bc29 inadvertently introduced a bug when attempting to set payment method on a cart when the billing address was (correctly) `undefined`.

The daffodil/cart payment driver allows a null or undefined billing address for DaffMagentoCartCustomerPaymentService::update, unfortunately, the cart-customer Magento driver did not respect this which mean that the driver call for authenticated customers attempting to apply payments to carts using payment methods that either:

1. Don't require a billing address (Paypal)
2. Set a billing address at a later point

will inappropriately call child drivers using an empty object as a third argument.

This will lead to errors that look like:

```
Variable $address got invalid value
Field value address.city of required type String! was not provided.
```

and other associated errors when authenticated customers attempt to use this driver to set this kind of payment method.

