### PR TITLE
feat(cart, magento): always load shipping methods on cart

### DIFF
--- a/libs/cart/driver/magento/src/queries/fragments/cart.ts
+++ b/libs/cart/driver/magento/src/queries/fragments/cart.ts
@@ -22,6 +22,16 @@ export const cartFragment = gql`
           ...selectedShippingMethod
         }
       }
+      available_shipping_methods {
+        amount {
+          currency
+          value
+        }
+        carrier_code
+        method_code
+        carrier_title
+        method_title
+      }
     }
     items {
       ...cartItem


### PR DESCRIPTION
Previously, we attempted to snag some performance wins in https://github.com/graycoreio/daffodil/pull/1080 by not loading the cart's shipping methods node in Magento in an attempt to avoid potential external service calls by the platform.

Turns out, this was naive. They're called during collect totals on every cart load, so it doesn't matter anyways.
