### PR TITLE
feat(core,product): support product filters in discrete query params

### DIFF
--- a/libs/core/routing/src/public_api.ts
+++ b/libs/core/routing/src/public_api.ts
@@ -1,2 +1,3 @@
 export * from './uri/public_api';
 export * from './reducers/public_api';
+export * from './query-param-filter/public_api';

--- a/libs/core/routing/src/query-param-filter/public_api.ts
+++ b/libs/core/routing/src/query-param-filter/public_api.ts
@@ -1,0 +1,2 @@
+export { DaffRoutingQueryParamFilter } from './type';
+export * from './request-builder/public_api';

--- a/libs/core/routing/src/query-param-filter/request-builder/equal.spec.ts
+++ b/libs/core/routing/src/query-param-filter/request-builder/equal.spec.ts
@@ -14,7 +14,7 @@ describe('@daffodil/core/routing | daffRoutingQueryParamFilterRequestEqualBuilde
     filterName = 'filterName';
     values = ['5', '3'];
 
-    result = daffRoutingQueryParamFilterRequestEqualBuilder(() => values, filterName);
+    result = daffRoutingQueryParamFilterRequestEqualBuilder(filterName, values);
   });
 
   it('should build an equal filter from the param map', () => {

--- a/libs/core/routing/src/query-param-filter/request-builder/equal.spec.ts
+++ b/libs/core/routing/src/query-param-filter/request-builder/equal.spec.ts
@@ -1,0 +1,25 @@
+import {
+  DaffFilterEqualRequest,
+  DaffFilterType,
+} from '@daffodil/core';
+
+import { daffRoutingQueryParamFilterRequestEqualBuilder } from './equal';
+
+describe('@daffodil/core/routing | daffRoutingQueryParamFilterRequestEqualBuilder', () => {
+  let filterName: string;
+  let values: string[];
+  let result: DaffFilterEqualRequest;
+
+  beforeEach(() => {
+    filterName = 'filterName';
+    values = ['5', '3'];
+
+    result = daffRoutingQueryParamFilterRequestEqualBuilder(() => values, filterName);
+  });
+
+  it('should build an equal filter from the param map', () => {
+    expect(result.type).toEqual(DaffFilterType.Equal);
+    expect(result.name).toEqual(filterName);
+    expect(result.value).toEqual(values);
+  });
+});

--- a/libs/core/routing/src/query-param-filter/request-builder/equal.ts
+++ b/libs/core/routing/src/query-param-filter/request-builder/equal.ts
@@ -9,8 +9,8 @@ import { DaffRoutingQueryParamFilterRequestBuilder } from './type';
  * A standard filter request builder that creates an equal filter request with the query params values.
  */
 export const daffRoutingQueryParamFilterRequestEqualBuilder: DaffRoutingQueryParamFilterRequestBuilder<DaffFilterEqualRequest>
- = (getQPValues, filterName) => ({
+ = (qpValue, filterName) => ({
    type: DaffFilterType.Equal,
    name: filterName,
-   value: getQPValues(),
+   value: qpValue,
  });

--- a/libs/core/routing/src/query-param-filter/request-builder/equal.ts
+++ b/libs/core/routing/src/query-param-filter/request-builder/equal.ts
@@ -9,7 +9,7 @@ import { DaffRoutingQueryParamFilterRequestBuilder } from './type';
  * A standard filter request builder that creates an equal filter request with the query params values.
  */
 export const daffRoutingQueryParamFilterRequestEqualBuilder: DaffRoutingQueryParamFilterRequestBuilder<DaffFilterEqualRequest>
- = (qpValue, filterName) => ({
+ = (filterName, qpValue) => ({
    type: DaffFilterType.Equal,
    name: filterName,
    value: qpValue,

--- a/libs/core/routing/src/query-param-filter/request-builder/equal.ts
+++ b/libs/core/routing/src/query-param-filter/request-builder/equal.ts
@@ -1,0 +1,16 @@
+import {
+  DaffFilterEqualRequest,
+  DaffFilterType,
+} from '@daffodil/core';
+
+import { DaffRoutingQueryParamFilterRequestBuilder } from './type';
+
+/**
+ * A standard filter request builder that creates an equal filter request with the query params values.
+ */
+export const daffRoutingQueryParamFilterRequestEqualBuilder: DaffRoutingQueryParamFilterRequestBuilder<DaffFilterEqualRequest>
+ = (getQPValues, filterName) => ({
+   type: DaffFilterType.Equal,
+   name: filterName,
+   value: getQPValues(),
+ });

--- a/libs/core/routing/src/query-param-filter/request-builder/public_api.ts
+++ b/libs/core/routing/src/query-param-filter/request-builder/public_api.ts
@@ -1,0 +1,2 @@
+export { daffRoutingQueryParamFilterRequestEqualBuilder } from './equal';
+export { DaffRoutingQueryParamFilterRequestBuilder } from './type';

--- a/libs/core/routing/src/query-param-filter/request-builder/type.ts
+++ b/libs/core/routing/src/query-param-filter/request-builder/type.ts
@@ -5,4 +5,4 @@ import { DaffFilterRequest } from '@daffodil/core';
 /**
  * Accepts a list of values set to a particular URL query param and returns a filter request.
  */
-export type DaffRoutingQueryParamFilterRequestBuilder<T extends DaffFilterRequest = DaffFilterRequest> = (getQPValues: () => ReturnType<ParamMap['getAll']>, filterName: string) => T;
+export type DaffRoutingQueryParamFilterRequestBuilder<T extends DaffFilterRequest = DaffFilterRequest> = (qpValue: ReturnType<ParamMap['getAll']>, filterName: string) => T;

--- a/libs/core/routing/src/query-param-filter/request-builder/type.ts
+++ b/libs/core/routing/src/query-param-filter/request-builder/type.ts
@@ -5,4 +5,4 @@ import { DaffFilterRequest } from '@daffodil/core';
 /**
  * Accepts a list of values set to a particular URL query param and returns a filter request.
  */
-export type DaffRoutingQueryParamFilterRequestBuilder<T extends DaffFilterRequest = DaffFilterRequest> = (qpValue: ReturnType<ParamMap['getAll']>, filterName: string) => T;
+export type DaffRoutingQueryParamFilterRequestBuilder<T extends DaffFilterRequest = DaffFilterRequest> = (filterName: string, qpValue: ReturnType<ParamMap['getAll']>) => T;

--- a/libs/core/routing/src/query-param-filter/request-builder/type.ts
+++ b/libs/core/routing/src/query-param-filter/request-builder/type.ts
@@ -1,0 +1,8 @@
+import { ParamMap } from '@angular/router';
+
+import { DaffFilterRequest } from '@daffodil/core';
+
+/**
+ * Accepts a list of values set to a particular URL query param and returns a filter request.
+ */
+export type DaffRoutingQueryParamFilterRequestBuilder<T extends DaffFilterRequest = DaffFilterRequest> = (getQPValues: () => ReturnType<ParamMap['getAll']>, filterName: string) => T;

--- a/libs/core/routing/src/query-param-filter/type.ts
+++ b/libs/core/routing/src/query-param-filter/type.ts
@@ -1,0 +1,18 @@
+import { DaffFilter } from '@daffodil/core';
+
+import { DaffRoutingQueryParamFilterRequestBuilder } from './request-builder/type';
+
+export interface DaffRoutingQueryParamFilter {
+  /**
+   * The name of the filter.
+   */
+  filterName: DaffFilter['name'];
+  /**
+   * The query param to use for this filter.
+   */
+  queryParam: string;
+  /**
+   * The filter request builder.
+   */
+  builder: DaffRoutingQueryParamFilterRequestBuilder;
+}

--- a/libs/product/routing/src/discrete-filter-params/public_api.ts
+++ b/libs/product/routing/src/discrete-filter-params/public_api.ts
@@ -1,0 +1,1 @@
+export * from './token';

--- a/libs/product/routing/src/discrete-filter-params/token.ts
+++ b/libs/product/routing/src/discrete-filter-params/token.ts
@@ -1,0 +1,39 @@
+import {
+  InjectionToken,
+  ValueProvider,
+} from '@angular/core';
+
+import {
+  DaffRoutingQueryParamFilter,
+  daffRoutingQueryParamFilterRequestEqualBuilder,
+} from '@daffodil/core/routing';
+
+/**
+ * A list of product filter requests that are contained directly in query params,
+ * with a one-to-one mapping between filters and query params.
+ * This is constrasted to {@link DaffCollectionRequestQueryParams#filterRequests}
+ * which remains the actual canonical source of truth of the filter requests.
+ * The discrete filter params persist in the URL as long as the corresponding filter remains applied.
+ */
+export const DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS = new InjectionToken<DaffRoutingQueryParamFilter[]>('DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS', {
+  factory: () => [],
+  providedIn: 'any',
+});
+
+/**
+ * A multi-provider for {@link DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS}.
+ *
+ * @param queryParam Defaults to `filterName`.
+ * @param builder Defaults to {@link daffRoutingQueryParamFilterRequestEqualBuilder}.
+ */
+export function daffProductRoutingProvideDiscreteFilterParams(filterName: DaffRoutingQueryParamFilter['filterName'], queryParam?: DaffRoutingQueryParamFilter['queryParam'], builder?: DaffRoutingQueryParamFilter['builder']): ValueProvider {
+  return {
+    provide: DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS,
+    useValue: {
+      filterName,
+      queryParam: queryParam || filterName,
+      builder: builder || daffRoutingQueryParamFilterRequestEqualBuilder,
+    },
+    multi: true,
+  };
+}

--- a/libs/product/routing/src/discrete-filter-params/token.ts
+++ b/libs/product/routing/src/discrete-filter-params/token.ts
@@ -26,7 +26,7 @@ export const DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS = new InjectionToken<Da
  * @param queryParam Defaults to `filterName`.
  * @param builder Defaults to {@link daffRoutingQueryParamFilterRequestEqualBuilder}.
  */
-export function daffProductRoutingProvideDiscreteFilterParams(filterName: DaffRoutingQueryParamFilter['filterName'], queryParam?: DaffRoutingQueryParamFilter['queryParam'], builder?: DaffRoutingQueryParamFilter['builder']): ValueProvider {
+export function daffProductRoutingProvideDiscreteFilterParam(filterName: DaffRoutingQueryParamFilter['filterName'], queryParam?: DaffRoutingQueryParamFilter['queryParam'], builder?: DaffRoutingQueryParamFilter['builder']): ValueProvider {
   return {
     provide: DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS,
     useValue: {

--- a/libs/product/routing/src/public_api.ts
+++ b/libs/product/routing/src/public_api.ts
@@ -4,4 +4,5 @@ export * from './services/public_api';
 export * from './models/public_api';
 export * from './constants/public_api';
 export * from './effects/public_api';
+export * from './discrete-filter-params/public_api';
 export * from './module';

--- a/libs/product/routing/src/services/get-query-params-from-request.service.spec.ts
+++ b/libs/product/routing/src/services/get-query-params-from-request.service.spec.ts
@@ -5,8 +5,12 @@ import {
   DaffCollectionRequest,
   daffFiltersToRequests,
 } from '@daffodil/core';
+import { daffRoutingQueryParamFilterRequestEqualBuilder } from '@daffodil/core/routing';
 import { DaffCollectionMetadataFactory } from '@daffodil/core/testing';
-import { DaffCollectionRequestQueryParamTransform } from '@daffodil/product/routing';
+import {
+  DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS,
+  DaffCollectionRequestQueryParamTransform,
+} from '@daffodil/product/routing';
 
 import { DAFF_PRODUCT_ROUTING_CONFIG } from '../config/token';
 import { DaffProductGetQueryParamsFromRequest } from './get-query-params-from-request.service';
@@ -42,6 +46,14 @@ describe('@daffodil/product/routing | DaffProductGetQueryParamsFromRequest', () 
             },
           },
         },
+        {
+          provide: DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS,
+          useValue: [{
+            filterName: 'discrete',
+            queryParam: 'discrete',
+            builder: daffRoutingQueryParamFilterRequestEqualBuilder,
+          }],
+        },
       ],
     });
 
@@ -56,6 +68,16 @@ describe('@daffodil/product/routing | DaffProductGetQueryParamsFromRequest', () 
       pageSize: metadata.pageSize,
       filterRequests: daffFiltersToRequests(metadata.filters),
     };
+  });
+
+  describe('when the filter requests don\'t have the discrete filter request', () => {
+    beforeEach(() => {
+      result = service.getQueryParams(mockRequest);
+    });
+
+    it('should set that query param to undefined', () => {
+      expect(result.discrete).toBeUndefined();
+    });
   });
 
   describe('when the value should be set to a custom query param', () => {

--- a/libs/product/routing/src/services/get-query-params-from-request.service.ts
+++ b/libs/product/routing/src/services/get-query-params-from-request.service.ts
@@ -4,13 +4,18 @@ import {
 } from '@angular/core';
 import { Params } from '@angular/router';
 
-import { DaffCollectionRequest } from '@daffodil/core';
+import {
+  DaffCollectionRequest,
+  daffArrayToDict,
+} from '@daffodil/core';
+import { DaffRoutingQueryParamFilter } from '@daffodil/core/routing';
 
 import {
   DaffProductRoutingConfig,
   DAFF_PRODUCT_ROUTING_CONFIG,
 } from '../config/public_api';
 import { DAFF_PRODUCT_COLLECTION_REQUEST_FIELDS } from '../constants/public_api';
+import { DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS } from '../discrete-filter-params/public_api';
 
 /**
  * Builds a query param map from a {@link DaffCollectionRequest}.
@@ -20,15 +25,29 @@ import { DAFF_PRODUCT_COLLECTION_REQUEST_FIELDS } from '../constants/public_api'
 export class DaffProductGetQueryParamsFromRequest {
   constructor(
     @Inject(DAFF_PRODUCT_ROUTING_CONFIG) private config: DaffProductRoutingConfig,
+    @Inject(DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS) private discreteFilters: DaffRoutingQueryParamFilter[],
   ) {}
 
   getQueryParams(request: DaffCollectionRequest): Params {
+    const filterRequests = daffArrayToDict(request.filterRequests, (fr) => fr.name);
+    // Specifically sets filter names missing from the filter requests to undefined
+    // in order to remove them from the URL
+    const trimmedQueryParams = this.discreteFilters.reduce(
+      (acc, { filterName, queryParam }) => {
+        if (!filterRequests[filterName]) {
+          acc[queryParam] = undefined;
+        }
+        return acc;
+      },
+      {},
+    );
+
     return DAFF_PRODUCT_COLLECTION_REQUEST_FIELDS.reduce<Params>((acc, field) => {
       const val = request[field];
       if (val) {
         acc[this.config.params[field] || field] = this.config.transforms?.[field]?.queryParam?.(val) || String(val);
       }
       return acc;
-    }, {});
+    }, trimmedQueryParams);
   }
 }

--- a/libs/product/routing/src/services/get-request-from-route.service.spec.ts
+++ b/libs/product/routing/src/services/get-request-from-route.service.spec.ts
@@ -10,8 +10,15 @@ import {
 } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { DaffCollectionRequest } from '@daffodil/core';
-import { DaffCollectionRequestQueryParamTransform } from '@daffodil/product/routing';
+import {
+  DaffCollectionRequest,
+  DaffFilterType,
+} from '@daffodil/core';
+import { daffRoutingQueryParamFilterRequestEqualBuilder } from '@daffodil/core/routing';
+import {
+  DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS,
+  DaffCollectionRequestQueryParamTransform,
+} from '@daffodil/product/routing';
 
 import { DAFF_PRODUCT_ROUTING_CONFIG } from '../config/token';
 import { DaffProductGetCollectionRequestFromRoute } from './get-request-from-route.service';
@@ -55,6 +62,14 @@ describe('@daffodil/product/routing | DaffProductGetCollectionRequestFromRoute',
               currentPage: customCurrentPageTransform,
             },
           },
+        },
+        {
+          provide: DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS,
+          useValue: [{
+            filterName: 'discrete',
+            queryParam: 'discrete',
+            builder: daffRoutingQueryParamFilterRequestEqualBuilder,
+          }],
         },
       ],
     });
@@ -121,6 +136,25 @@ describe('@daffodil/product/routing | DaffProductGetCollectionRequestFromRoute',
 
     it('should set the request field to the value returned by the custom transform', () => {
       expect(result.currentPage).toEqual(customCurrentPageTransform.request(currentPageValue));
+    });
+  });
+
+  describe('when the value is passed through a discrete query param', () => {
+    let filterValue: string;
+
+    beforeEach(fakeAsync(() => {
+      filterValue = '2';
+      router.navigateByUrl(`/test?discrete=${filterValue}`);
+      tick();
+      result = service.getRequest(TestBed.inject(ActivatedRoute).snapshot.queryParamMap);
+    }));
+
+    it('should set the request field to the value returned by the custom transform', () => {
+      expect(result.filterRequests).toContain(jasmine.objectContaining({
+        type: DaffFilterType.Equal,
+        name: 'discrete',
+        value: [filterValue],
+      }));
     });
   });
 });

--- a/libs/product/routing/src/services/get-request-from-route.service.ts
+++ b/libs/product/routing/src/services/get-request-from-route.service.ts
@@ -42,20 +42,21 @@ export class DaffProductGetCollectionRequestFromRoute {
       }
       return acc;
     }, {});
+    const filterRequests = this.discreteFilters.reduce<DaffFilterRequest[]>(
+      (acc, { filterName, builder, queryParam }) =>
+        queryParamMap.has(queryParam)
+          ? [
+            ...acc,
+            builder(() => queryParamMap.getAll(queryParam), filterName),
+          ]
+          : acc,
+      request.filterRequests || [],
+    );
+    // add discrete filter params to the list of requests
+    if (filterRequests.length > 0) {
+      request.filterRequests = filterRequests;
+    }
 
-    return {
-      ...request,
-      // add discrete filter params to the list of requests
-      filterRequests: this.discreteFilters.reduce<DaffFilterRequest[]>(
-        (acc, { filterName, builder, queryParam }) =>
-          queryParamMap.has(queryParam)
-            ? [
-              ...acc,
-              builder(() => queryParamMap.getAll(queryParam), filterName),
-            ]
-            : acc,
-        request.filterRequests || [],
-      ),
-    };
+    return request;
   }
 }

--- a/libs/product/routing/src/services/get-request-from-route.service.ts
+++ b/libs/product/routing/src/services/get-request-from-route.service.ts
@@ -47,7 +47,7 @@ export class DaffProductGetCollectionRequestFromRoute {
         queryParamMap.has(queryParam)
           ? [
             ...acc,
-            builder(queryParamMap.getAll(queryParam), filterName),
+            builder(filterName, queryParamMap.getAll(queryParam)),
           ]
           : acc,
       request.filterRequests || [],

--- a/libs/product/routing/src/services/get-request-from-route.service.ts
+++ b/libs/product/routing/src/services/get-request-from-route.service.ts
@@ -47,7 +47,7 @@ export class DaffProductGetCollectionRequestFromRoute {
         queryParamMap.has(queryParam)
           ? [
             ...acc,
-            builder(() => queryParamMap.getAll(queryParam), filterName),
+            builder(queryParamMap.getAll(queryParam), filterName),
           ]
           : acc,
       request.filterRequests || [],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
Adds support for generating product filter requests through discrete query params. In addition to supporting the base64 encoded filter object, URLs like `url?size=m` can also generate filter requests, given the correct config with `DAFF_PRODUCT_ROUTING_DISCRETE_FILTER_PARAMS`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information