### PR TITLE
feat(auth): redirect to query param value when present

### DIFF
--- a/libs/auth/routing/src/config/default.ts
+++ b/libs/auth/routing/src/config/default.ts
@@ -2,6 +2,7 @@ import { DaffAuthRoutingConfig } from './interface';
 
 export const DAFF_AUTH_ROUTING_CONFIG_DEFAULT: DaffAuthRoutingConfig = {
   resetPasswordTokenParam: 'token',
+  redirectUrlParam: 'redirect',
   authCompleteRedirectPath: '/',
   logoutRedirectPath: '/',
   tokenExpirationRedirectPath: '/',

--- a/libs/auth/routing/src/config/interface.ts
+++ b/libs/auth/routing/src/config/interface.ts
@@ -5,7 +5,13 @@ export interface DaffAuthRoutingConfig {
   /**
    * The name of the query param to which the reset password token will be set.
    */
-  resetPasswordTokenParam?: string;
+  resetPasswordTokenParam: string;
+
+  /**
+   * The name of the query param from which the redirect URL will be fetched.
+   * Defaults to `redirect`.
+   */
+  redirectUrlParam: string;
 
   /**
    * The path to which the user will be redirected when they are logged in and the auth token is stored.

--- a/libs/auth/routing/src/config/token.ts
+++ b/libs/auth/routing/src/config/token.ts
@@ -13,10 +13,12 @@ export const DAFF_AUTH_ROUTING_CONFIG = new InjectionToken<DaffAuthRoutingConfig
   factory: () => DAFF_AUTH_ROUTING_CONFIG_DEFAULT,
 });
 
-export const provideDaffAuthRoutingConfig = (config: Partial<DaffAuthRoutingConfig>): ValueProvider => ({
-  provide: DAFF_AUTH_ROUTING_CONFIG,
-  useValue: {
-    ...DAFF_AUTH_ROUTING_CONFIG_DEFAULT,
-    ...config,
-  },
-});
+export function provideDaffAuthRoutingConfig(config?: Partial<DaffAuthRoutingConfig>): ValueProvider {
+  return {
+    provide: DAFF_AUTH_ROUTING_CONFIG,
+    useValue: {
+      ...DAFF_AUTH_ROUTING_CONFIG_DEFAULT,
+      ...config || {},
+    },
+  };
+};

--- a/libs/auth/routing/src/effects/redirect.effects.spec.ts
+++ b/libs/auth/routing/src/effects/redirect.effects.spec.ts
@@ -1,5 +1,9 @@
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import {
+  ActivatedRoute,
+  ParamMap,
+  Router,
+} from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import {
@@ -27,14 +31,19 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
   let router: Router;
 
   let routerNavigateSpy: jasmine.Spy<Router['navigateByUrl']>;
+  let qpSpy: jasmine.SpyObj<ParamMap>;
   let authCompleteRedirectUrl: string;
   let logoutRedirectUrl: string;
   let expirationRedirectUrl: string;
+  let redirectUrl: string;
 
   beforeEach(() => {
     authCompleteRedirectUrl = '/customer';
     logoutRedirectUrl = '/login';
     expirationRedirectUrl = '/';
+    redirectUrl = '/redirect';
+
+    qpSpy = jasmine.createSpyObj('ParamMap', ['get']);
 
     TestBed.configureTestingModule({
       imports: [
@@ -48,6 +57,14 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
           logoutRedirectPath: logoutRedirectUrl,
           tokenExpirationRedirectPath: expirationRedirectUrl,
         }),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: qpSpy,
+            },
+          },
+        },
       ],
     });
 
@@ -72,6 +89,19 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
       expect(effects.redirectAfterLoginOrRegister$).toBeObservable(expected);
       expect(routerNavigateSpy).toHaveBeenCalledWith(authCompleteRedirectUrl);
     });
+
+    describe('and when the redirect QP is set', () => {
+      beforeEach(() => {
+        qpSpy.get.withArgs('redirect').and.returnValue(redirectUrl);
+      });
+
+      it('should navigate to the redirect URL', () => {
+        const expected = cold('---');
+
+        expect(effects.redirectAfterLoginOrRegister$).toBeObservable(expected);
+        expect(routerNavigateSpy).toHaveBeenCalledWith(redirectUrl);
+      });
+    });
   });
 
   describe('when DaffAuthRegisterSuccess is dispatched', () => {
@@ -84,6 +114,19 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
 
       expect(effects.redirectAfterLoginOrRegister$).toBeObservable(expected);
       expect(routerNavigateSpy).toHaveBeenCalledWith(authCompleteRedirectUrl);
+    });
+
+    describe('and when the redirect QP is set', () => {
+      beforeEach(() => {
+        qpSpy.get.withArgs('redirect').and.returnValue(redirectUrl);
+      });
+
+      it('should navigate to the redirect URL', () => {
+        const expected = cold('---');
+
+        expect(effects.redirectAfterLoginOrRegister$).toBeObservable(expected);
+        expect(routerNavigateSpy).toHaveBeenCalledWith(redirectUrl);
+      });
     });
   });
 
@@ -98,6 +141,19 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
       expect(effects.redirectAfterLoginOrRegister$).toBeObservable(expected);
       expect(routerNavigateSpy).toHaveBeenCalledWith(authCompleteRedirectUrl);
     });
+
+    describe('and when the redirect QP is set', () => {
+      beforeEach(() => {
+        qpSpy.get.withArgs('redirect').and.returnValue(redirectUrl);
+      });
+
+      it('should navigate to the redirect URL', () => {
+        const expected = cold('---');
+
+        expect(effects.redirectAfterLoginOrRegister$).toBeObservable(expected);
+        expect(routerNavigateSpy).toHaveBeenCalledWith(redirectUrl);
+      });
+    });
   });
 
   describe('when DaffAuthLogoutSuccess is dispatched', () => {
@@ -110,6 +166,19 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
 
       expect(effects.redirectAfterLogout$).toBeObservable(expected);
       expect(routerNavigateSpy).toHaveBeenCalledWith(logoutRedirectUrl);
+    });
+
+    describe('and when the redirect QP is set', () => {
+      beforeEach(() => {
+        qpSpy.get.withArgs('redirect').and.returnValue(redirectUrl);
+      });
+
+      it('should navigate to the redirect URL', () => {
+        const expected = cold('---');
+
+        expect(effects.redirectAfterLogout$).toBeObservable(expected);
+        expect(routerNavigateSpy).toHaveBeenCalledWith(redirectUrl);
+      });
     });
   });
 
@@ -124,6 +193,19 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
       expect(effects.redirectAfterExpiration$).toBeObservable(expected);
       expect(routerNavigateSpy).toHaveBeenCalledWith(expirationRedirectUrl);
     });
+
+    describe('and when the redirect QP is set', () => {
+      beforeEach(() => {
+        qpSpy.get.withArgs('redirect').and.returnValue(redirectUrl);
+      });
+
+      it('should navigate to the redirect URL', () => {
+        const expected = cold('---');
+
+        expect(effects.redirectAfterExpiration$).toBeObservable(expected);
+        expect(routerNavigateSpy).toHaveBeenCalledWith(redirectUrl);
+      });
+    });
   });
 
   describe('when DaffAuthGuardLogout is dispatched', () => {
@@ -136,6 +218,19 @@ describe('@daffodil/auth/routing | DaffAuthRedirectEffects', () => {
 
       expect(effects.redirectAfterExpiration$).toBeObservable(expected);
       expect(routerNavigateSpy).toHaveBeenCalledWith(expirationRedirectUrl);
+    });
+
+    describe('and when the redirect QP is set', () => {
+      beforeEach(() => {
+        qpSpy.get.withArgs('redirect').and.returnValue(redirectUrl);
+      });
+
+      it('should navigate to the redirect URL', () => {
+        const expected = cold('---');
+
+        expect(effects.redirectAfterExpiration$).toBeObservable(expected);
+        expect(routerNavigateSpy).toHaveBeenCalledWith(redirectUrl);
+      });
     });
   });
 });

--- a/libs/auth/routing/src/effects/redirect.effects.ts
+++ b/libs/auth/routing/src/effects/redirect.effects.ts
@@ -2,7 +2,10 @@ import {
   Inject,
   Injectable,
 } from '@angular/core';
-import { Router } from '@angular/router';
+import {
+  ActivatedRoute,
+  Router,
+} from '@angular/router';
 import {
   Actions,
   createEffect,
@@ -39,6 +42,7 @@ export class DaffAuthRedirectEffects {
   constructor(
     private actions$: Actions<DaffAuthLoginActions | DaffAuthActions | DaffAuthRegisterActions | DaffAuthResetPasswordActions>,
     private router: Router,
+    private route: ActivatedRoute,
     @Inject(DAFF_AUTH_ROUTING_CONFIG) private config: DaffAuthRoutingConfig,
   ) {}
 
@@ -54,16 +58,16 @@ export class DaffAuthRedirectEffects {
       }
       return true;
     }),
-    tap(() => {
-      this.router.navigateByUrl(this.config.authCompleteRedirectPath);
+    tap((action) => {
+      this.router.navigateByUrl(this.route.snapshot.queryParamMap.get(this.config.redirectUrlParam) || this.config.authCompleteRedirectPath);
     }),
     switchMap(() => EMPTY),
   ), { dispatch: false });
 
   redirectAfterLogout$ = createEffect(() => this.actions$.pipe(
     ofType(DaffAuthLoginActionTypes.LogoutSuccessAction),
-    tap(() => {
-      this.router.navigateByUrl(this.config.logoutRedirectPath);
+    tap((action) => {
+      this.router.navigateByUrl(this.route.snapshot.queryParamMap.get(this.config.redirectUrlParam) || this.config.logoutRedirectPath);
     }),
     switchMap(() => EMPTY),
   ), { dispatch: false });
@@ -74,7 +78,7 @@ export class DaffAuthRedirectEffects {
       DaffAuthActionTypes.AuthGuardLogoutAction,
     ),
     tap(() => {
-      this.router.navigateByUrl(this.config.tokenExpirationRedirectPath);
+      this.router.navigateByUrl(this.route.snapshot.queryParamMap.get(this.config.redirectUrlParam) || this.config.tokenExpirationRedirectPath);
     }),
     switchMap(() => EMPTY),
   ), { dispatch: false });

--- a/libs/auth/routing/src/module.ts
+++ b/libs/auth/routing/src/module.ts
@@ -7,6 +7,7 @@ import {
   DaffAuthRoutingConfig,
   DAFF_AUTH_ROUTING_CONFIG,
   DAFF_AUTH_ROUTING_CONFIG_DEFAULT,
+  provideDaffAuthRoutingConfig,
 } from './config/public_api';
 import {
   DaffAuthResetPasswordGuard,
@@ -26,10 +27,7 @@ export class DaffAuthRoutingModule {
     return {
       ngModule: DaffAuthRoutingModule,
       providers: [
-        {
-          provide: DAFF_AUTH_ROUTING_CONFIG,
-          useValue: config || DAFF_AUTH_ROUTING_CONFIG_DEFAULT,
-        },
+        provideDaffAuthRoutingConfig(config),
       ],
     };
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
When the `redirect` (configable) query param is set, auth redirect effects navigate to that value. Otherwise they fall back to the static configuration

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information