### PR TITLE
fix(cart-store-credit, magento): handle guest store credit

### DIFF
--- a/libs/cart-store-credit/driver/magento/src/models/responses/cart-with-store-credit.type.ts
+++ b/libs/cart-store-credit/driver/magento/src/models/responses/cart-with-store-credit.type.ts
@@ -2,7 +2,7 @@ import { MagentoCart } from '@daffodil/cart/driver/magento';
 import { MagentoMoney } from '@daffodil/driver/magento';
 
 export interface MagentoCartWithStoreCredit extends MagentoCart {
-  applied_store_credit: {
+  applied_store_credit?: {
     applied_balance: MagentoMoney;
     enabled: boolean;
   };

--- a/libs/cart-store-credit/driver/magento/src/transforms/responses/cart-with-store-credit.spec.ts
+++ b/libs/cart-store-credit/driver/magento/src/transforms/responses/cart-with-store-credit.spec.ts
@@ -16,13 +16,28 @@ describe('@daffodil/cart-store-credit/driver/magento | magentoCartWithStoreCredi
   beforeEach(() => {
     storeCreditFactory = TestBed.inject(MagentoCartWithStoreCreditFactory);
     cartFactory = TestBed.inject(DaffCartFactory);
-
-    mockStoreCredit = storeCreditFactory.create();
-
-    result = magentoCartWithStoreCreditTransform(cartFactory.create(), mockStoreCredit);
   });
 
   it('should transform', () => {
-    expect(result.appliedStoreCredit).toEqual(mockStoreCredit.applied_store_credit.applied_balance.value);
+    const credit = storeCreditFactory.create();
+    expect(
+      magentoCartWithStoreCreditTransform(cartFactory.create(), credit).appliedStoreCredit,
+    ).toEqual(credit.applied_store_credit.applied_balance.value);
+  });
+
+  it('should transform 0 safely', () => {
+    const magentoCart = storeCreditFactory.create();
+    magentoCart.applied_store_credit.applied_balance.value = 0;
+    expect(
+      magentoCartWithStoreCreditTransform(cartFactory.create(), magentoCart).appliedStoreCredit,
+    ).toEqual(0);
+  });
+
+  it('should transform to null if the cart does not have store credit (guest checkout)', () => {
+    const magentoCart = storeCreditFactory.create();
+    magentoCart.applied_store_credit = null;
+    expect(
+      magentoCartWithStoreCreditTransform(cartFactory.create(), magentoCart).appliedStoreCredit,
+    ).toEqual(0);
   });
 });

--- a/libs/cart-store-credit/driver/magento/src/transforms/responses/cart-with-store-credit.ts
+++ b/libs/cart-store-credit/driver/magento/src/transforms/responses/cart-with-store-credit.ts
@@ -4,7 +4,9 @@ import { DaffCartMagentoCartTransform } from '@daffodil/cart/driver/magento';
 
 import { MagentoCartWithStoreCredit } from '../../models/public_api';
 
-export const magentoCartWithStoreCreditTransform: DaffCartMagentoCartTransform<MagentoCartWithStoreCredit, DaffCartWithStoreCredit> = (daffCart: DaffCart, storeCredit: MagentoCartWithStoreCredit): DaffCartWithStoreCredit => ({
-  ...daffCart,
-  appliedStoreCredit: storeCredit.applied_store_credit.applied_balance.value,
-});
+export const magentoCartWithStoreCreditTransform:
+DaffCartMagentoCartTransform<MagentoCartWithStoreCredit, DaffCartWithStoreCredit> =
+  (daffCart: DaffCart, magentoCart: MagentoCartWithStoreCredit): DaffCartWithStoreCredit => ({
+    ...daffCart,
+    appliedStoreCredit: magentoCart.applied_store_credit?.applied_balance.value ?? 0,
+  });


### PR DESCRIPTION
Magento, on guest orders, returns a null for the applied store credit, we now handle this case.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Using a guest cart crashes when using the store credit Magento driver

Fixes: N/A


## What is the new behavior?
The request no longer crashes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information