### PR TITLE
build(all): specify nx output path

### DIFF
--- a/apps/daffio/package.json
+++ b/apps/daffio/package.json
@@ -7,6 +7,13 @@
   "bugs": {
     "url": "https://github.com/graycoreio/daffodil/issues"
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/apps/daffio"]
+      }
+    }
+  },
   "scripts": {
     "build": "npm run build:client && npm run build:server && npm run build:serverless",
     "build:client": "ng build daffio --prod",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -7,6 +7,13 @@
   "bugs": {
     "url": "https://github.com/graycoreio/daffodil/issues"
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/apps/demo"]
+      }
+    }
+  },
   "scripts": {
     "build": "ng build demo --prod",
     "lint": "npm run lint:scss && cd ../.. && ng lint demo",

--- a/apps/design-land/package.json
+++ b/apps/design-land/package.json
@@ -20,6 +20,9 @@
   },
   "nx": {
     "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/apps/design-land"]
+      },
       "test": {
         "dependsOn": [
           "^build"

--- a/libs/analytics-provider-data-layer/package.json
+++ b/libs/analytics-provider-data-layer/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/analytics-provider-data-layer",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/analytics-provider-data-layer"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Provides interfaces and services for pushing analytics events using the data layer schema.",
   "repository": {

--- a/libs/analytics/package.json
+++ b/libs/analytics/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/analytics",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/analytics"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "General package for piping ngrx actions into provided external analytics services.",
   "repository": {

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/auth",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/auth"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Reducers, State, Selectors, and Drivers for logging in and registering users.",
   "repository": {

--- a/libs/authorizenet/package.json
+++ b/libs/authorizenet/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/authorizenet",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/authorizenet"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "An ecommerce package that has multi-platform support and state management features for managing authorize.net payments.",
   "repository": {

--- a/libs/branding/package.json
+++ b/libs/branding/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/branding",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/branding"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "private": true,
   "scripts": {

--- a/libs/cart-customer/package.json
+++ b/libs/cart-customer/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/cart-customer",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/cart-customer"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/cart-store-credit/package.json
+++ b/libs/cart-store-credit/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/cart-store-credit",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/cart-store-credit"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A client-side Angular package for managing ecommerce cart-store-credits agnostic to the ecommerce platform.",
   "repository": {

--- a/libs/cart/package.json
+++ b/libs/cart/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/cart",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/cart"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/category/package.json
+++ b/libs/category/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/category",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/category"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "An ecommerce categories package that has multi-platform support and state management features.",
   "repository": {

--- a/libs/checkout/package.json
+++ b/libs/checkout/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/checkout",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/checkout"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/contact/package.json
+++ b/libs/contact/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/contact",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/contact"]
+      }
+    }
+  },
   "version": "0.0.1",
   "repository": {
     "type": "git",

--- a/libs/content/package.json
+++ b/libs/content/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/content",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/content"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A client-side Angular package for fetching static content provided by the platform.",
   "repository": {

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/core",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/core"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/customer-auth/package.json
+++ b/libs/customer-auth/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/customer-auth",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/customer-auth"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/customer-order/package.json
+++ b/libs/customer-order/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/customer-order",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/customer-order"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A client-side Angular package for managing ecommerce customers agnostic to the ecommerce platform.",
   "repository": {

--- a/libs/customer-store-credit/package.json
+++ b/libs/customer-store-credit/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/customer-store-credit",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/customer-store-credit"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A client-side Angular package for managing ecommerce customer-store-credits agnostic to the ecommerce platform.",
   "repository": {

--- a/libs/customer/package.json
+++ b/libs/customer/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/customer",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/customer"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A client-side Angular package for managing ecommerce customers agnostic to the ecommerce platform.",
   "repository": {

--- a/libs/design/package.json
+++ b/libs/design/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/design",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/design"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "author": "Graycore LLC",
   "license": "MIT",

--- a/libs/docs-utils/package.json
+++ b/libs/docs-utils/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/docs-utils",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/docs-utils"]
+      }
+    }
+  },
   "private": true,
   "version": "0.0.0-PLACEHOLDER",
   "main": "index.js",

--- a/libs/driver/package.json
+++ b/libs/driver/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/driver",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/driver"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A consistent, sane api driver that works with different ecommerce systems.",
   "repository": {

--- a/libs/external-router/package.json
+++ b/libs/external-router/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/external-router",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/external-router"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A platform-agnostic package that connects the @angular/router with an external routing service (e.g. an API), allowing for runtime route resolution.",
   "repository": {

--- a/libs/forms/package.json
+++ b/libs/forms/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/forms",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/forms"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "General package for forms related features.",
   "repository": {

--- a/libs/geography/package.json
+++ b/libs/geography/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/geography",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/geography"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A package for interacting with platforms that provide geographic data information like States and Countries",
   "repository": {

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/navigation",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/navigation"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Reducers, State, Selectors, and Drivers for retrieving navigation/category trees",
   "repository": {

--- a/libs/newsletter/package.json
+++ b/libs/newsletter/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/newsletter",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/newsletter"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "peerDependencies": {
     "@angular/common": "0.0.0-PLACEHOLDER",

--- a/libs/order/package.json
+++ b/libs/order/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/order",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/order"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A client-side Angular package for managing ecommerce orders agnostic to the ecommerce platform.",
   "repository": {

--- a/libs/payment/package.json
+++ b/libs/payment/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/payment",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/payment"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A client-side Angular package for managing ecommerce payments agnostic to the ecommerce platform.",
   "repository": {

--- a/libs/paypal/package.json
+++ b/libs/paypal/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/paypal",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/paypal"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Reducers, State, Selectors, and Drivers for generating paypal tokens",
   "repository": {

--- a/libs/product-composite/package.json
+++ b/libs/product-composite/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/product-composite",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/product-composite"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/product-configurable/package.json
+++ b/libs/product-configurable/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/product-configurable",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/product-configurable"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/product/package.json
+++ b/libs/product/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/product",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/product"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/related-products/package.json
+++ b/libs/related-products/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/related-products",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/related-products"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/reviews/package.json
+++ b/libs/reviews/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/reviews",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/reviews"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/search-category/package.json
+++ b/libs/search-category/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/search-category",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/search-category"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/search-product-composite/package.json
+++ b/libs/search-product-composite/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/search-product-composite",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/search-product-composite"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/search-product-configurable/package.json
+++ b/libs/search-product-configurable/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/search-product-configurable",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/search-product-configurable"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/search-product/package.json
+++ b/libs/search-product/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/search-product",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/search-product"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/libs/search/package.json
+++ b/libs/search/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/search",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/search"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A client-side Angular package for managing ecommerce orders agnostic to the ecommerce platform.",
   "repository": {

--- a/libs/seo/package.json
+++ b/libs/seo/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/seo",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/seo"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "A client-side Angular package for managing canonical URLs and other SEO features.",
   "repository": {

--- a/libs/theme-switch/package.json
+++ b/libs/theme-switch/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/theme-switch",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/theme-switch"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "private": true,
   "scripts": {

--- a/libs/upsell-products/package.json
+++ b/libs/upsell-products/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@daffodil/upsell-products",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/upsell-products"]
+      }
+    }
+  },
   "version": "0.0.0-PLACEHOLDER",
   "description": "Interfaces built for daffodil/state",
   "repository": {

--- a/nx.json
+++ b/nx.json
@@ -35,9 +35,6 @@
     "build": {
       "dependsOn": [
         "^build"
-      ],
-      "outputs": [
-        "{projectRoot}/dist"
       ]
     },
     "test": {
@@ -45,7 +42,7 @@
         "build"
       ],
       "outputs": [
-        "{projectRoot}/coverage"
+        "{workspaceRoot}/{projectRoot}/coverage"
       ]
     }
   }

--- a/tools/dgeni/package.json
+++ b/tools/dgeni/package.json
@@ -15,7 +15,8 @@
       "build": {
         "inputs": [
           "{workspaceRoot}/**/*.md"
-        ]
+        ],
+        "outputs": ["{workspaceRoot}/dist/docs"]
       }
     }
   },

--- a/tools/eslint/config/package.json
+++ b/tools/eslint/config/package.json
@@ -20,6 +20,13 @@
     "publish": "npm publish --access=public",
     "build": "shx mkdir -p ../../../dist/eslint-config && shx cp -r . ../../../dist/eslint-config"
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/eslint-config"]
+      }
+    }
+  },
   "keywords": [
     "code checker",
     "code linter",

--- a/tools/jasmine/package.json
+++ b/tools/jasmine/package.json
@@ -17,6 +17,13 @@
     "lint:fix": "eslint src/**/*.ts --fix",
     "test": "ts-node --project tsconfig.spec.json -r tsconfig-paths/register ../../node_modules/jasmine/bin/jasmine.js --config=jasmine.json"
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": ["{workspaceRoot}/dist/jasmine"]
+      }
+    }
+  },
   "homepage": "https://github.com/graycoreio/daffodil",
   "peerDependencies": {
     "jasmine": "0.0.0-PLACEHOLDER",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
nx doesn't know about package outputs and can't cache the outputs properly

## What is the new behavior?
Nx now will re-output build results when it encounters a cache hit on inputs. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information