### PR TITLE
ci: add Github workflow to lint packages

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -24,35 +24,6 @@ stages:
       # These are the files that, when changed, will incur a full build
       buildRootFiles: angular.json | lerna.json | package.json | package-lock.json | tsconfig.json | tools/karma/karma.conf.js
     jobs:
-      - job: Lint
-        displayName: Lint
-
-        strategy:
-          matrix:
-            node_16_x:
-              node_version: 16.x
-        steps:
-          - template: ./templates/setup-node.yml
-
-          # This cache step is purely for the purpose of diffing the specified files
-          # These files are those that would incur a repository-wide linting change
-          # Therefore every package must be relinted
-          - task: Cache@2
-            displayName: Cache .vscode For Lint Diff
-            inputs:
-              key: '"lint" | "$(node_version)" | angular.json | lerna.json | package.json | package-lock.json | .prettierrc | .stylelintrc | .eslintrc.js'
-              path: $(Build.SourcesDirectory)/.vscode
-              cacheHitVar: ngLintCache
-
-          - template: ./templates/lerna-lint.yml
-            parameters:
-              incremental: |
-                and(
-                  eq(variables['ngLintCache'], 'true'),
-                  eq(variables['Build.Reason'], 'PullRequest')
-                )
-
-
       - job: Build_And_Test
         displayName: Build
         strategy:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
 		"mrmlnc.vscode-scss",
 		"naumovs.color-highlight",
 		"stylelint.vscode-stylelint",
-		"tehnix.vscode-tidymarkdown"
+		"tehnix.vscode-tidymarkdown",
+		"github.vscode-github-actions"
 	],
 	"runArgs": [
 		"--security-opt",

--- a/.github/actions/clear-old-nx-cache/action.yml
+++ b/.github/actions/clear-old-nx-cache/action.yml
@@ -1,0 +1,57 @@
+name: clear-old-nx-cache
+
+inputs:
+  size-in-mb: 
+    description: 'Cache Size in Mb'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    # Seth Davenport, thanks much!
+    # https://github.com/SethDavenport
+    # https://github.com/nrwl/nx/issues/2883#issuecomment-1449078285
+    - name: Clear old cache entries
+      env: 
+        SIZE: ${{ inputs.size-in-mb }}
+      run: |
+        # Create a potential empty folder.
+        mkdir -p .nx_cache
+
+        # This script accepts as an argument a number of megabytes. It will then
+        # delete entries in the nx cache, oldest first, until the overall size
+        # of the folder's contents is beneath that number of megabytes.
+
+        maxSizeKB=$(($SIZE*1024)) # in MB
+
+        # Sort files by modification time, oldest first
+        taskHashes=($(ls -tr .nx_cache | grep -v -E "(\.commit|^d|^terminalOutputs|nxdeps.json)$" || [[ $? == 1 ]]))
+
+        # Calculate current total size
+        totalSize=0
+        for hash in "${taskHashes[@]}"; do
+          totalSize=$((totalSize + $(du -sk ".nx_cache/$hash" | cut -f 1)))
+          totalSize=$((totalSize + $(du -sk ".nx_cache/$hash.commit" | cut -f 1)))
+          totalSize=$((totalSize + $(du -sk ".nx_cache/terminalOutputs/$hash" | cut -f 1)))
+        done
+
+        echo "Starting total size: $totalSize, requested max size: $maxSizeKB KB"
+
+        # Delete oldest files until the total size is below the threshold
+        i=0
+        while [ "$totalSize" -gt "$maxSizeKB" ]; do
+          hash=${taskHashes[$i]}
+          totalSize=$((totalSize - $(du -sk ".nx_cache/$hash" | cut -f 1)))
+          totalSize=$((totalSize - $(du -sk ".nx_cache/$hash.commit" | cut -f 1)))
+          totalSize=$((totalSize - $(du -sk ".nx_cache/terminalOutputs/$hash" | cut -f 1)))
+
+          echo "Deleting files associated with hash $hash; totalSize is now $totalSize"
+          rm -rf ".nx_cache/$hash"
+          rm -rf ".nx_cache/$hash.commit"
+          rm -rf ".nx_cache/terminalOutputs/$hash"
+          i=$i+1
+        done
+
+        echo "Finished total size: $totalSize"
+      shell: bash
+      

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,70 @@
+name: setup-node
+
+inputs:
+  node-version: 
+    description: 'Node Versions'
+    required: true
+  use-stamp-cache:
+    description: 'Whether or not to use the stamp cache (skip install, use old node_modules)'
+    default: false
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@v3
+      name: Set Node Version
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Get npm cache directory
+      id: npm-cache-dir
+      shell: bash
+      env:
+        STAMP: ${{ inputs.use-stamp-cache }}
+      run: |        
+        if [ "$STAMP" == "true" ] 
+        then
+          echo "dir=$GITHUB_WORKSPACE/node_modules" >> ${GITHUB_OUTPUT}
+        else
+          echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+        fi
+
+    - name: Get cache keys
+      id: npm-cache-keys
+      shell: bash
+      env: 
+        NODE_VERSION: ${{ inputs.node-version }}
+        PACKAGE_HASH: ${{ hashFiles('**/package-lock.json') }}
+        OS: ${{ runner.os }}
+        STAMP: ${{ inputs.use-stamp-cache }}
+      run: |
+        if [ "$STAMP" == "true" ] 
+        then
+          echo "key=npm-stamp-$OS-$NODE_VERSION-$PACKAGE_HASH" >> ${GITHUB_OUTPUT}
+          echo "restore=npm-stamp-$OS-$NODE_VERSION-" >> ${GITHUB_OUTPUT}
+        else
+          echo "key=npm-$OS-$NODE_VERSION-$PACKAGE_HASH" >> ${GITHUB_OUTPUT}
+          echo "restore=npm-$OS-$NODE_VERSION-" >> ${GITHUB_OUTPUT}
+        fi
+
+    - uses: actions/cache@v3
+      id: npm-cache
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ steps.npm-cache-keys.outputs.key }}
+        restore-keys: |
+          ${{ steps.npm-cache-keys.outputs.restore }}
+
+    - run: npx npm ci --prefer-offline --no-audit --no-shrinkwrap
+      shell: bash
+      name: Install Dependencies
+      if: inputs.use-stamp-cache && steps.npm-cache.outputs.cache-hit != 'true'
+
+    - run: |  
+        rm -rf node_modules/.ng-packagr-ngcc
+        rm -rf node_modules/.cli-ngcc
+        rm -rf node_modules/.cache
+      shell: bash
+      name: Clear nx and angular junk
+      if: inputs.use-stamp-cache && steps.npm-cache.outputs.cache-hit == 'true'
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,59 @@
+name: Daffodil Lint
+
+on:
+  push:
+    paths:
+      - '**.ts'
+      - '**.scss'
+      - '**.html'
+      - '**.js'
+      - '**.json'
+      - '.github/**'
+    branches:
+      - develop
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - '**.ts'
+      - '**.scss'
+      - '**.html'
+      - '**.js'
+      - '**.json'
+      - '.github/**'
+    branches:
+      - develop
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [16.x]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - uses: nrwl/nx-set-shas@v3
+        name: Derive appropriate SHAs for base and head for `nx affected` commands
+        with: 
+          main-branch-name: 'develop'
+
+      - uses: actions/cache@v3
+        name: Lint Cache
+        id: lint_cache
+        with:
+          path: .nx_cache
+          key: lint-${{ matrix.node }}
+
+      - uses: ./.github/actions/clear-old-nx-cache
+        with:
+          size-in-mb: 10
+
+      - uses: ./.github/actions/setup-node
+        with:
+          node-version: ${{ matrix.node }}
+          use-stamp-cache: true
+
+      - run:  npx nx affected --target=lint

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
         "bierner.markdown-preview-github-styles",
         "mrmlnc.vscode-scss",
         "tehnix.vscode-tidymarkdown",
-        "dbaeumer.vscode-eslint"
+        "dbaeumer.vscode-eslint",
+        "github.vscode-github-actions"
     ]
 }


### PR DESCRIPTION
This also adds a few supplemental actions called `clear-old-nx-cache` and `setup-node` which, respectively, take care of keeping the `nx-cache` trim and setting up node.

`clear-old-nx-cache` accepts `size-in-mb` param, which allows a consumer to specify what they want as the maximal storage size of cache. This is useful because the `lint` cache is
significantly smaller than the `build` cache.

`setup-node` does a little bit more than the "out-of-box" `setup-node`. It also adds caching and, in particular, a "stamp" cache of "node_modules". The "stamp" cache is very useful when you don't want skip "npm ci" or related commands. Stamp-cache is a little dangerous, as the folders within node_modules can by changed by builds, but it's much faster (90s vs. 5s).
