### PR TITLE
ci: add Vercel Deploy from Github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,14 @@ jobs:
           use-stamp-cache: true
 
       - run: npx lerna run build --concurrency=1
+
+      - run: cd dist/apps/daffio && zip -r ../daffio.zip . 
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: daffio-${{ matrix.node }}
+          path: dist/apps/daffio.zip
+          if-no-files-found: error
       
   compute_packages:
     name: Compute Packages to Test
@@ -107,4 +115,17 @@ jobs:
 
       - run: npx lerna run test --scope="${{ matrix.package }}" --concurrency=1
         name: Test ${{ matrix.package }}
-        
+
+  deploy_daffio:
+    name: Deploy Daff.io
+    needs: 
+      - build
+    uses: ./.github/workflows/deploy.yml
+    secrets: 
+      VERCEL_NEXT_PROJECT_ID: ${{ secrets.VERCEL_DAFFIO_NEXT_PROJECT_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DAFFIO_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG: ${{ secrets.VERCEL_ORG }}
+    with:
+      artifact: daffio-16.x
+      artifact-zip-name: daffio.zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,91 @@
+on:
+  workflow_call: 
+    inputs: 
+      artifact:
+        required: true
+        description: 'The name of the artifact to download'
+        type: string
+      artifact-zip-name:
+          required: false
+          description: 'The name of the zip file in the artifact (omit if you do not store a zip INSIDE your artifact).'
+          type: string
+    secrets:
+      VERCEL_TOKEN:
+        required: true
+      VERCEL_ORG:
+        required: true
+      VERCEL_NEXT_PROJECT_ID:
+        required: true
+      VERCEL_PROJECT_ID:
+        required: true
+jobs:
+  preview:
+    name: 'Preview'
+    runs-on: ubuntu-latest
+    environment: 
+      name: preview
+      url: ${{ steps.vercel-deploy.outputs.url }}
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifact }}
+      
+      - run: unzip -q ${{ inputs.artifact-zip-name }} -d . && rm ${{ inputs.artifact-zip-name }}
+        name: Unzip internal artifact zip
+        if: inputs.artifact-zip-name
+
+      - uses: graycoreio/github-actions/angular-universal-vercel@main
+        id: vercel-deploy
+        with:
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          vercel_org: ${{ secrets.VERCEL_ORG }}
+          vercel_project_id: ${{ secrets.VERCEL_NEXT_PROJECT_ID }}
+
+  next:
+    name: 'Next'
+    runs-on: ubuntu-latest
+    environment: 
+      name: next
+      url: ${{ steps.vercel-deploy.outputs.url }}
+    if: github.ref == 'refs/heads/develop'
+    steps: 
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifact }}
+      
+      - run: unzip -q ${{ inputs.artifact-zip-name }} -d . && rm ${{ inputs.artifact-zip-name }}
+        name: Unzip internal artifact zip
+        if: inputs.artifact-zip-name
+
+      - uses: graycoreio/github-actions/angular-universal-vercel@main
+        id: vercel-deploy
+        with:
+          prod: true
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          vercel_org: ${{ secrets.VERCEL_ORG }}
+          vercel_project_id: ${{ secrets.VERCEL_NEXT_PROJECT_ID }}
+    
+  production:
+    name: 'Production'
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') 
+    environment: 
+      name: production
+      url: ${{ steps.vercel-deploy.outputs.url }}
+    steps: 
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifact }}
+      
+      - run: unzip -q ${{ inputs.artifact-zip-name }} -d . && rm ${{ inputs.artifact-zip-name }}
+        name: Unzip internal artifact zip
+        if: inputs.artifact-zip-name
+
+      - uses: graycoreio/github-actions/angular-universal-vercel@main
+        id: vercel-deploy
+        with:
+          prod: true
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          vercel_org: ${{ secrets.VERCEL_ORG }}
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
I've leveraged the pre-existing actions in https://github.com/graycoreio/github-actions along with a new re-usable workflow (deploy.yml) to migrate our Vercel deployments to Github Actions.

Importantly, `deploy.yml` can be repeated for other kinds of environments, say, for example, the demo or any other kind of Angular Universal Application.

Additionally, as the deployment requires it, I've published the `daffio-16.x` artifact alongside builds as well. This artifact is zipped ahead-of-time for performance so if you're downloading it from Github, you will have a zip of a zip.

Finally, and this is perhaps my favorite feature, we now have:

![image](https://user-images.githubusercontent.com/9029654/236704513-51016b4f-389a-4115-b4aa-e72c97e7746e.png)

on these PRs. I did have to update https://github.com/graycoreio/github-actions/tree/main/angular-universal-vercel to make that work, since we didn't have the output before.