### PR TITLE
ci: split apart fork PR previews into workflow_run

### DIFF
--- a/.github/actions/vercel-from-workflow-run/action.yml
+++ b/.github/actions/vercel-from-workflow-run/action.yml
@@ -1,0 +1,80 @@
+name: vercel-from-workflow-run
+
+inputs:
+  artifact: 
+    description: 'The name of the artifact to deploy to Vercel'
+    required: true
+  artifact-zip-name:
+    required: false
+    description: 'The name of the zip file in the artifact (omit if you do not store a zip INSIDE your artifact).'
+    type: string
+  vercel-token:
+    reqired: true
+    description: "A secret representing the used Vercel Token"
+    type: string
+  vercel-org:
+    reqired: true
+    description: "A secret representing the used Vercel Organization"
+    type: string
+  vercel-project-id:
+    reqired: true
+    description: "A secret representing the used Vercel Project ID"
+    type: string
+
+outputs:
+  url:
+    description: "The Vercel URL for the deployment"
+    value: ${{ steps.vercel-deploy.outputs.url }}
+    
+runs:
+  using: 'composite'
+  steps:
+  - run: rm -rf ${{ github.workspace }}/ && mkdir -p ${{ github.workspace }}/
+    shell: bash
+  - name: 'Download ${{ inputs.artifact }}'
+    uses: actions/github-script@v3.1.0
+    with:
+      script: |
+        var artifacts = await github.actions.listWorkflowRunArtifacts({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          run_id: ${{ github.event.workflow_run.id }},
+        });
+        var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+          return artifact.name == "${{ inputs.artifact }}"
+        })[0];
+        var download = await github.actions.downloadArtifact({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          artifact_id: matchArtifact.id,
+          archive_format: 'zip',
+        });
+        var fs = require('fs');
+        fs.writeFileSync('${{github.workspace}}/${{ inputs.artifact }}.zip', Buffer.from(download.data))
+  
+  - run: ls -Al .
+    name: Review Folder
+    shell: bash
+        
+  - run: unzip -q ${{ inputs.artifact }}.zip -d . && rm ${{ inputs.artifact }}.zip
+    name: Unzip {{ inputs.artifact }}.zip
+    shell: bash
+
+  - run: ls -Al .
+    name: Review Folder
+    shell: bash
+
+  - run: unzip -q ${{ inputs.artifact-zip-name }} -d . && rm ${{ inputs.artifact-zip-name }}
+    name: Unzip ${{ inputs.artifact-zip-name }}
+    shell: bash
+  
+  - run: ls -Al .
+    name: Review Folder
+    shell: bash
+
+  - uses: graycoreio/github-actions/angular-universal-vercel@main
+    id: vercel-deploy
+    with:
+      vercel_token: ${{ inputs.vercel-token }}
+      vercel_org: ${{ inputs.vercel-org }}
+      vercel_project_id: ${{ inputs.vercel-project-id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,29 +19,6 @@ on:
       VERCEL_PROJECT_ID:
         required: true
 jobs:
-  preview:
-    name: 'Preview'
-    runs-on: ubuntu-latest
-    environment: 
-      name: preview
-      url: ${{ steps.vercel-deploy.outputs.url }}
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.artifact }}
-      
-      - run: unzip -q ${{ inputs.artifact-zip-name }} -d . && rm ${{ inputs.artifact-zip-name }}
-        name: Unzip internal artifact zip
-        if: inputs.artifact-zip-name
-
-      - uses: graycoreio/github-actions/angular-universal-vercel@main
-        id: vercel-deploy
-        with:
-          vercel_token: ${{ secrets.VERCEL_TOKEN }}
-          vercel_org: ${{ secrets.VERCEL_ORG }}
-          vercel_project_id: ${{ secrets.VERCEL_NEXT_PROJECT_ID }}
-
   next:
     name: 'Next'
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -1,0 +1,42 @@
+name: Daffodil PR Preview
+
+on:
+  workflow_run:
+    workflows: ["Daffodil Build"]
+    branches-ignore: ["master", "main", "develop"]
+    types:
+      - completed
+
+#####
+# WARNING: This code operates in a privileged context.
+#####
+# We only allow workflow runs from forks that we know are safe via a control
+# in the Github UI called "Require approval for all outside collaborators".
+#    
+# It's a little painful to have to keep clicking the button in the UI,
+# but it's generally safer for us (from a security standpoint), 
+# while still allowing trusted users to contribute 
+# to the project without annoying CI failures.
+# 
+# We have understood the risk and attempted to handle the concern outlined here:
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ 
+jobs:
+  deploy_daffio:
+    name: Deploy Daff.io
+    runs-on: ubuntu-latest 
+    environment: 
+      name: preview
+      url: ${{ steps.vercel.outputs.url }}
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - uses: ./.github/actions/vercel-from-workflow-run
+      id: vercel
+      with:
+        artifact: daffio-16.x
+        artifact-zip-name: daffio.zip
+        vercel-token: ${{ secrets.VERCEL_TOKEN }}
+        vercel-org: ${{ secrets.VERCEL_ORG }}
+        vercel-project-id: ${{ secrets.VERCEL_DAFFIO_NEXT_PROJECT_ID }}


### PR DESCRIPTION
I tried to fix https://github.com/graycoreio/daffodil/issues/2422 but I inadvertently made a vulnerability when I did it even though I had read https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ thouroughy.

It appears that the best solution is this workflow_run event combined with the pull_request event type. It allows us:

1. In-repo branch PRs run CI as usual
2. Internal contributors can operate from forks and have CI as if they were in-repo
3. Outside collaborators require maintainer/repo writers to click "run workflow" when they submit/modify a PRs

We only allow workflow runs from forks that we know are safe via a control in the Github UI called "Require approval for all outside collaborators".

It's a little painful to have to keep clicking the button in the UI, but it's generally safer for us (from a security standpoint), while still allowing trusted users to contribute
to the project without annoying CI failures.

We have understood the risk and attempted to handle the concern outlined here: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/