### PR TITLE
feat(product-composite): add service for generating share codes

### DIFF
--- a/libs/product-composite/routing/src/effects/product-page.effects.spec.ts
+++ b/libs/product-composite/routing/src/effects/product-page.effects.spec.ts
@@ -28,7 +28,7 @@ import { DaffProductCompositePageEffects } from './product-page.effects';
 @Component({ template: '' })
 class TestComponent {}
 
-describe('@daffodil/product-composite/state | DaffProductCompositePageEffects', () => {
+describe('@daffodil/product-composite/routing | DaffProductCompositePageEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffProductCompositePageEffects;
   let router: Router;

--- a/libs/product-composite/routing/src/services/share-code.service.spec.ts
+++ b/libs/product-composite/routing/src/services/share-code.service.spec.ts
@@ -1,0 +1,93 @@
+import { TestBed } from '@angular/core/testing';
+import { Dictionary } from '@ngrx/entity';
+import {
+  BehaviorSubject,
+  Observable,
+  withLatestFrom,
+} from 'rxjs';
+
+import {
+  DaffCompositeProduct,
+  DaffCompositeProductItemOption,
+} from '@daffodil/product-composite';
+import { daffProductCompositeRoutingProvideConfig } from '@daffodil/product-composite/routing';
+import {
+  DaffCompositeProductStateTestingModule,
+  MockDaffCompositeProductFacade,
+} from '@daffodil/product-composite/state/testing';
+import { DaffCompositeProductFactory } from '@daffodil/product-composite/testing';
+import {
+  DaffProductStateTestingModule,
+  MockDaffProductPageFacade,
+} from '@daffodil/product/state/testing';
+
+import { DaffProductCompositeRoutingShareCodeService } from './share-code.service';
+
+describe('@daffodil/product-composite/routing | DaffProductCompositeRoutingShareCodeService', () => {
+  let service: DaffProductCompositeRoutingShareCodeService;
+  let productFacade: MockDaffProductPageFacade;
+  let compositeFacade: MockDaffCompositeProductFacade;
+  let productFactory: DaffCompositeProductFactory;
+
+  let product: DaffCompositeProduct;
+  let appliedOptions: Dictionary<DaffCompositeProductItemOption>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        DaffProductStateTestingModule,
+        DaffCompositeProductStateTestingModule,
+      ],
+      providers: [
+        daffProductCompositeRoutingProvideConfig({
+          compositeSelectionQueryParam: 'queryParam',
+        }),
+      ],
+    });
+
+    service = TestBed.inject(DaffProductCompositeRoutingShareCodeService);
+    productFacade = TestBed.inject(MockDaffProductPageFacade);
+    compositeFacade = TestBed.inject(MockDaffCompositeProductFacade);
+    productFactory = TestBed.inject(DaffCompositeProductFactory);
+
+    product = productFactory.create();
+    productFacade.product$.next(product);
+    appliedOptions = {
+      [product.items[0].id]: product.items[0].options[1],
+    };
+    spyOn(compositeFacade, 'getAppliedOptions').withArgs(product.id).and.returnValue(new BehaviorSubject(appliedOptions));
+  });
+
+  describe('shareCode$', () => {
+    let result: Observable<string>;
+
+    beforeEach(() => {
+      result = service.shareCode$;
+    });
+
+    it('should return the base64 and JSON stringified version of the applied options', (done) => {
+      result.subscribe((res) => {
+        const payload = JSON.parse(atob(res));
+        expect(payload[product.items[0].id]).toEqual([product.items[0].options[1].id]);
+        done();
+      });
+    });
+  });
+
+  describe('queryParam$', () => {
+    let result: Observable<string>;
+
+    beforeEach(() => {
+      result = service.queryParam$;
+    });
+
+    it('should return the query param set to the share code', (done) => {
+      result.pipe(
+        withLatestFrom(service.shareCode$),
+      ).subscribe(([res, shareCode]) => {
+        expect(res).toEqual(`queryParam=${shareCode}`);
+        done();
+      });
+    });
+  });
+});

--- a/libs/product-composite/routing/src/services/share-code.service.ts
+++ b/libs/product-composite/routing/src/services/share-code.service.ts
@@ -1,0 +1,64 @@
+import {
+  Inject,
+  Injectable,
+} from '@angular/core';
+import {
+  Observable,
+  map,
+  switchMap,
+} from 'rxjs';
+
+import {
+  DaffBase64Service,
+  DaffBase64ServiceToken,
+} from '@daffodil/core';
+import {
+  DaffProductCompositeSelectionPayload,
+  daffProductCompositeBuildSelectionPayload,
+} from '@daffodil/product-composite';
+import { DaffCompositeProductFacade } from '@daffodil/product-composite/state';
+import { DaffProductPageFacade } from '@daffodil/product/state';
+
+import {
+  DAFF_PRODUCT_COMPOSITE_ROUTING_CONFIG,
+  DaffProductCompositeRoutingConfig,
+} from '../config/public_api';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffProductCompositeRoutingShareCodeService {
+  /**
+   * The current configuration share code set to the configured query parameter.
+   * This is URI encoded and can be interpolated directly into a link.
+   * It is of the form `query_param=value`.
+   *
+   * See {@link DaffProductCompositeRoutingShareCodeService#shareCode$}.
+   */
+  queryParam$: Observable<string>;
+
+  /**
+   * Gets the base64 encoded selection payload which,
+   * when set to the appropriate query param in the product page URL,
+   * will preselect item options.
+   * Note that this is *not* URI encoded.
+   *
+   * See {@link DaffProductCompositeSelectionPayload}.
+   */
+  shareCode$: Observable<string>;
+
+  constructor(
+    protected facade: DaffProductPageFacade,
+    protected compositeFacade: DaffCompositeProductFacade,
+    @Inject(DAFF_PRODUCT_COMPOSITE_ROUTING_CONFIG) protected config: DaffProductCompositeRoutingConfig,
+    @Inject(DaffBase64ServiceToken) protected base64: DaffBase64Service,
+  ) {
+    this.shareCode$ = this.facade.product$.pipe(
+      switchMap((product) => this.compositeFacade.getAppliedOptions(product.id)),
+      map((appliedOptions) => this.base64.encode(JSON.stringify(daffProductCompositeBuildSelectionPayload(appliedOptions)))),
+    );
+    this.queryParam$ = this.shareCode$.pipe(
+      map(shareCode => `${this.config.compositeSelectionQueryParam}=${encodeURIComponent(shareCode)}`),
+    );
+  }
+}

--- a/libs/product-composite/src/helpers/build-selection-payload.spec.ts
+++ b/libs/product-composite/src/helpers/build-selection-payload.spec.ts
@@ -1,0 +1,31 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  DaffCompositeProductItem,
+  DaffCompositeProductItemOption,
+  DaffProductCompositeSelectionPayload,
+} from '@daffodil/product-composite';
+import { DaffCompositeProductItemOptionFactory } from '@daffodil/product-composite/testing';
+
+import { daffProductCompositeBuildSelectionPayload } from './build-selection-payload';
+
+describe('@daffodil/product-composite | daffProductCompositeBuildSelectionPayload', () => {
+  let appliedOptions: Record<DaffCompositeProductItem['id'], DaffCompositeProductItemOption>;
+  let optionFactory: DaffCompositeProductItemOptionFactory;
+  let result: DaffProductCompositeSelectionPayload;
+
+  beforeEach(() => {
+    optionFactory = TestBed.inject(DaffCompositeProductItemOptionFactory);
+
+    appliedOptions = {
+      itemId: optionFactory.create(),
+      itemId2: optionFactory.create(),
+    };
+    result = daffProductCompositeBuildSelectionPayload(appliedOptions);
+  });
+
+  it('should set the item to the array of option IDs', () => {
+    expect(result.itemId).toEqual([appliedOptions.itemId.id]);
+    expect(result.itemId2).toEqual([appliedOptions.itemId2.id]);
+  });
+});

--- a/libs/product-composite/src/helpers/build-selection-payload.ts
+++ b/libs/product-composite/src/helpers/build-selection-payload.ts
@@ -1,0 +1,20 @@
+import {
+  DaffCompositeProductItem,
+  DaffCompositeProductItemOption,
+  DaffProductCompositeSelectionPayload,
+} from '../models/public_api';
+
+export function daffProductCompositeBuildSelectionPayload(appliedOptions: Record<DaffCompositeProductItem['id'], DaffCompositeProductItemOption>): DaffProductCompositeSelectionPayload {
+  return Object.keys(appliedOptions).reduce<DaffProductCompositeSelectionPayload>(
+    (selection, itemId) => {
+      const optionId = appliedOptions[itemId].id;
+
+      if (optionId) {
+        selection[itemId] = [optionId];
+      }
+
+      return selection;
+    },
+    {},
+  );
+}

--- a/libs/product-composite/src/helpers/public_api.ts
+++ b/libs/product-composite/src/helpers/public_api.ts
@@ -1,0 +1,1 @@
+export { daffProductCompositeBuildSelectionPayload } from './build-selection-payload';

--- a/libs/product-composite/src/models/public_api.ts
+++ b/libs/product-composite/src/models/public_api.ts
@@ -1,0 +1,4 @@
+export * from './composite-configuration-item';
+export * from './composite-product';
+export * from './composite-product-item';
+export * from './selection-payload.type';

--- a/libs/product-composite/src/public_api.ts
+++ b/libs/product-composite/src/public_api.ts
@@ -1,4 +1,2 @@
-export * from './models/composite-configuration-item';
-export * from './models/composite-product';
-export * from './models/composite-product-item';
-export * from './models/selection-payload.type';
+export * from './helpers/public_api';
+export * from './models/public_api';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- Adds a service which can generate base 64 encoded composite option selection payloads
- also adds a helper function to build selection payloads

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information