### PR TITLE
build(all): remove `package.json` `sharedGlobal` from NX config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/nx-schema.json",
   "affected": {
     "defaultBase": "develop"
   },
@@ -11,8 +12,6 @@
       "!{projectRoot}/**/*.spec.{ts,tsx}"
     ],
     "sharedGlobals": [
-      "{workspaceRoot}/package.json",
-      "{workspaceRoot}/package-lock.json",
       "{workspaceRoot}/angular.json",
       "{workspaceRoot}/tsconfig.json",
       "{workspaceRoot}/lerna.json"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When `package.json` is changed (due to a version bump), the NX cache is invalidated and a full build is ran.

## What is the new behavior?
Only when `package-lock.json` changes is the NX cache invalidated. Should speed up release builds significantly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
There's no need to manually specify these shared globals:
```
sharedGlobals contains root level files that should invalidate the cache for all projects. Note that tsconfig.base.json and the package.json lock files are handled behind the scenes by Nx so that when you modify the specific properties that affect your project, the cache is invalidated.
```
https://nx.dev/more-concepts/customizing-inputs#global-settings