### PR TITLE
build(dgeni): trigger rebuild when files in libs folder changes

### DIFF
--- a/tools/dgeni/package.json
+++ b/tools/dgeni/package.json
@@ -14,7 +14,11 @@
     "targets": {
       "build": {
         "inputs": [
-          "{workspaceRoot}/**/*.md"
+          "{workspaceRoot}/**/*.md",
+          "{workspaceRoot}/libs/**/*.ts",
+          "{workspaceRoot}/libs/**/*.tsx",
+          "{workspaceRoot}/libs/**/*.html",
+          "{workspaceRoot}/libs/**/*.scss"
         ],
         "outputs": ["{workspaceRoot}/dist/docs"]
       }

--- a/tools/dgeni/package.json
+++ b/tools/dgeni/package.json
@@ -16,7 +16,6 @@
         "inputs": [
           "{workspaceRoot}/**/*.md",
           "{workspaceRoot}/libs/**/*.ts",
-          "{workspaceRoot}/libs/**/*.tsx",
           "{workspaceRoot}/libs/**/*.html",
           "{workspaceRoot}/libs/**/*.scss"
         ],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Changing the Typescript, HTML, or SASS files in the libs folder does not trigger Dgeni rebuild

Fixes: #2445 

## What is the new behavior?
Changing the Typescript, HTML, or SASS files in the libs folder triggers Dgeni rebuild

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information