### PR TITLE
feat(paypal): set payment loading for generate express token

### DIFF
--- a/libs/paypal/state/src/payment-state.module.ts
+++ b/libs/paypal/state/src/payment-state.module.ts
@@ -1,16 +1,23 @@
 import { NgModule } from '@angular/core';
 import { combineReducers } from '@ngrx/store';
 
+import { daffComposeReducers } from '@daffodil/core/state';
 import {
+  DaffPaymentActions,
   daffPaymentProvideAvailableProcessors,
   daffPaymentProvideExtraReducers,
   daffPaymentReducerFactory,
+  DaffPaymentReducerState,
   DaffPaymentStateModule,
 } from '@daffodil/payment/state';
 import { DAFF_PAYPAL_PAYMENT_KIND } from '@daffodil/paypal';
 import { DaffPaypalExpressPaymentDriver } from '@daffodil/paypal/driver';
 
-import { DaffPaypalActionTypes } from './actions/paypal.actions';
+import {
+  DaffPaypalActions,
+  DaffPaypalActionTypes,
+} from './actions/paypal.actions';
+import { daffPaypalPaymentReducer } from './reducers/payment/reducer';
 
 @NgModule({
   imports: [
@@ -23,7 +30,7 @@ import { DaffPaypalActionTypes } from './actions/paypal.actions';
       action: DaffPaypalActionTypes.ApplyPaymentAction,
     }),
     ...daffPaymentProvideExtraReducers(combineReducers({
-      payment: daffPaymentReducerFactory([DaffPaypalActionTypes.ApplyPaymentAction]),
+      payment: daffComposeReducers<DaffPaymentReducerState, DaffPaypalActions | DaffPaymentActions>([daffPaymentReducerFactory([DaffPaypalActionTypes.ApplyPaymentAction]), daffPaypalPaymentReducer]),
     })),
   ],
 })

--- a/libs/paypal/state/src/reducers/payment/reducer.spec.ts
+++ b/libs/paypal/state/src/reducers/payment/reducer.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffPaymentReducerState,
+  daffPaymentInitialState,
+} from '@daffodil/payment/state';
+import {
+  DaffPaypalExpressTokenResponse,
+  DaffPaypalExpressTokenRequest,
+} from '@daffodil/paypal';
+import {
+  DaffGeneratePaypalExpressToken,
+  DaffGeneratePaypalExpressTokenSuccess,
+  DaffGeneratePaypalExpressTokenFailure,
+} from '@daffodil/paypal/state';
+import {
+  DaffPaypalExpressTokenRequestFactory,
+  DaffPaypalExpressTokenResponseFactory,
+} from '@daffodil/paypal/testing';
+
+import { daffPaypalPaymentReducer } from './reducer';
+
+describe('@daffodil/paypal/state | daffPaypalPaymentReducer', () => {
+  let paypalTokenResponseFactory: DaffPaypalExpressTokenResponseFactory;
+  let paypalTokenRequestFactory: DaffPaypalExpressTokenRequestFactory;
+  let paypalTokenResponse: DaffPaypalExpressTokenResponse;
+  let paypalRequest: DaffPaypalExpressTokenRequest;
+
+  beforeEach(() => {
+    paypalTokenResponseFactory = TestBed.inject(DaffPaypalExpressTokenResponseFactory);
+    paypalTokenRequestFactory = TestBed.inject(DaffPaypalExpressTokenRequestFactory);
+
+    paypalTokenResponse = paypalTokenResponseFactory.create();
+    paypalRequest = paypalTokenRequestFactory.create();
+  });
+
+  describe('when an unknown action is triggered', () => {
+
+    it('should return the current state', () => {
+      const action = <any>{};
+
+      const result = daffPaypalPaymentReducer(daffPaymentInitialState, action);
+
+      expect(result).toBe(daffPaymentInitialState);
+    });
+  });
+
+  describe('when a GeneratePaypalExpressTokenAction is triggered', () => {
+    let result: DaffPaymentReducerState;
+
+    beforeEach(() => {
+      const generatePaypalExpressTokenAction = new DaffGeneratePaypalExpressToken(paypalRequest);
+
+      result = daffPaypalPaymentReducer(daffPaymentInitialState, generatePaypalExpressTokenAction);
+    });
+
+    it('sets loading state to true', () => {
+      expect(result.loading).toEqual(true);
+    });
+  });
+
+  describe('when a GeneratePaypalExpressTokenSuccessAction is triggered', () => {
+    let result: DaffPaymentReducerState;
+    let state: DaffPaymentReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...daffPaymentInitialState,
+        loading: true,
+      };
+
+      const generatePaypalExpressTokenSuccessAction = new DaffGeneratePaypalExpressTokenSuccess(paypalTokenResponse);
+      result = daffPaypalPaymentReducer(state, generatePaypalExpressTokenSuccessAction);
+    });
+
+    it('sets loading to false', () => {
+      expect(result.loading).toEqual(false);
+    });
+
+    it('resets errors', () => {
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('when GeneratePaypalExpressTokenFailureAction is triggered', () => {
+    const error: DaffStateError = { code: 'code', recoverable: false, message: 'error message' };
+    let result: DaffPaymentReducerState;
+    let state: DaffPaymentReducerState;
+
+    beforeEach(() => {
+      state = {
+        ...daffPaymentInitialState,
+        loading: true,
+        errors: [{ code: 'firstErrorCode', message: 'firstErrorMessage' }],
+      };
+
+      const generatePaypalExpressTokenFailureAction = new DaffGeneratePaypalExpressTokenFailure(error);
+
+      result = daffPaypalPaymentReducer(state, generatePaypalExpressTokenFailureAction);
+    });
+
+    it('sets loading to false', () => {
+      expect(result.loading).toEqual(false);
+    });
+
+    it('sets the error', () => {
+      expect(result.errors).toEqual([error]);
+    });
+  });
+});

--- a/libs/paypal/state/src/reducers/payment/reducer.ts
+++ b/libs/paypal/state/src/reducers/payment/reducer.ts
@@ -1,0 +1,30 @@
+import {
+  daffPaymentInitialState,
+  DaffPaymentReducerState,
+  DaffPaymentStateReducerAdapter,
+} from '@daffodil/payment/state';
+
+import {
+  DaffPaypalActionTypes,
+  DaffPaypalActions,
+} from '../../actions/paypal.actions';
+
+export function daffPaypalPaymentReducer(
+  state = daffPaymentInitialState,
+  action: DaffPaypalActions,
+): DaffPaymentReducerState {
+  const adapter = new DaffPaymentStateReducerAdapter();
+  switch (action.type) {
+    case DaffPaypalActionTypes.GeneratePaypalExpressTokenAction:
+      return adapter.generateToken(state);
+
+    case DaffPaypalActionTypes.GeneratePaypalExpressTokenSuccessAction:
+      return adapter.tokenGenerated(state);
+
+    case DaffPaypalActionTypes.GeneratePaypalExpressTokenFailureAction:
+      return adapter.storeError([action.payload], state);
+
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
injects a reducer into payment state that manages loading and errors in response to paypal express generate token actions.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information