### PR TITLE
feat: cart and auth flow

### DIFF
--- a/libs/auth/state/src/actions/auth.actions.ts
+++ b/libs/auth/state/src/actions/auth.actions.ts
@@ -3,12 +3,21 @@ import { Action } from '@ngrx/store';
 import { DaffStateError } from '@daffodil/core/state';
 
 export enum DaffAuthActionTypes {
+  ResetToUnauthenticatedAction = '[@daffodil/auth] Reset To Unauthenticated Action',
   AuthStorageFailureAction = '[@daffodil/auth] Auth Storage Failure Action',
   AuthGuardLogoutAction = '[@daffodil/auth] Auth Guard Logout Action',
   AuthServerSideAction = '[@daffodil/auth] Auth Server Side Action',
   AuthCheckAction = '[@daffodil/auth] Auth Check Action',
   AuthCheckSuccessAction = '[@daffodil/auth] Auth Check Success Action',
   AuthCheckFailureAction = '[@daffodil/auth] Auth Check Failure Action',
+}
+
+/*
+ * An action triggered when the authenicated status of the user is invalidated for some reason.
+ * That reason could be a logout, auth token check failure, or an unauthorized error.
+ */
+export class DaffAuthResetToUnauthenticated implements Action {
+  readonly type = DaffAuthActionTypes.ResetToUnauthenticatedAction;
 }
 
 /*
@@ -67,6 +76,7 @@ export class DaffAuthCheckFailure implements Action {
 }
 
 export type DaffAuthActions =
+  | DaffAuthResetToUnauthenticated
   | DaffAuthStorageFailure
   | DaffAuthGuardLogout
   | DaffAuthServerSide

--- a/libs/auth/state/src/effects/login.effects.ts
+++ b/libs/auth/state/src/effects/login.effects.ts
@@ -81,7 +81,7 @@ export class DaffAuthLoginEffects<
     switchMap((action: DaffAuthLogout) =>
       this.loginDriver.logout().pipe(
         map(() => new DaffAuthLogoutSuccess()),
-        tap(() =>  this.storage.removeAuthToken()),
+        tap(() => this.storage.removeAuthToken()),
         catchError((error: DaffError) => {
           switch (true) {
             case error instanceof DaffServerSideStorageError:

--- a/libs/auth/state/src/injection-tokens/public_api.ts
+++ b/libs/auth/state/src/injection-tokens/public_api.ts
@@ -1,0 +1,1 @@
+export * from './unauthenticated/public_api';

--- a/libs/auth/state/src/injection-tokens/unauthenticated/hook.token.spec.ts
+++ b/libs/auth/state/src/injection-tokens/unauthenticated/hook.token.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+
+import { daffAuthProvideUnauthenticatedHooks } from '@daffodil/auth/state';
+
+import { DAFF_AUTH_UNAUTHENTICATED_HOOK } from './hook.token';
+
+describe('@daffodil/auth/state | DAFF_AUTH_UNAUTHENTICATED_HOOK', () => {
+  let spy1: jasmine.Spy;
+  let spy2: jasmine.Spy;
+  let result: () => void;
+
+  beforeEach(() => {
+    spy1 = jasmine.createSpy();
+    spy2 = jasmine.createSpy();
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...daffAuthProvideUnauthenticatedHooks(
+          spy1,
+          spy2,
+        ),
+      ],
+    });
+
+    result = TestBed.inject(DAFF_AUTH_UNAUTHENTICATED_HOOK);
+  });
+
+  it('should provide a function that calls all the hooks', () => {
+    result();
+    expect(spy1).toHaveBeenCalledWith();
+    expect(spy2).toHaveBeenCalledWith();
+  });
+});

--- a/libs/auth/state/src/injection-tokens/unauthenticated/hook.token.ts
+++ b/libs/auth/state/src/injection-tokens/unauthenticated/hook.token.ts
@@ -1,0 +1,22 @@
+import {
+  inject,
+  InjectionToken,
+} from '@angular/core';
+
+import { DAFF_AUTH_UNAUTHENTICATED_HOOKS } from './hooks.token';
+
+/**
+ * An internal token to hold the unauthenticated hook.
+ * Combines the multi provided hooks into a single function.
+ *
+ * @docs-private
+ */
+export const DAFF_AUTH_UNAUTHENTICATED_HOOK = new InjectionToken<() => void>(
+  'DAFF_AUTH_UNAUTHENTICATED_HOOK',
+{
+  factory: () => inject(DAFF_AUTH_UNAUTHENTICATED_HOOKS).reduce((acc, hook) => () => {
+    acc();
+    hook();
+  }, () => {}),
+},
+);

--- a/libs/auth/state/src/injection-tokens/unauthenticated/hooks.token.spec.ts
+++ b/libs/auth/state/src/injection-tokens/unauthenticated/hooks.token.spec.ts
@@ -1,0 +1,32 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  daffAuthProvideUnauthenticatedHooks,
+  DAFF_AUTH_UNAUTHENTICATED_HOOKS,
+} from './hooks.token';
+
+describe('@daffodil/auth/state | daffAuthProvideUnauthenticatedHooks', () => {
+  let hooks: (() => void)[];
+  let result: (() => void)[];
+
+  beforeEach(() => {
+    hooks = [
+      () => {},
+      () => {},
+    ];
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...daffAuthProvideUnauthenticatedHooks(...hooks),
+      ],
+    });
+
+    result = TestBed.inject(DAFF_AUTH_UNAUTHENTICATED_HOOKS);
+  });
+
+  it('should provide the hooks to the token', () => {
+    hooks.forEach(hook => {
+      expect(result).toContain(hook);
+    });
+  });
+});

--- a/libs/auth/state/src/injection-tokens/unauthenticated/hooks.token.ts
+++ b/libs/auth/state/src/injection-tokens/unauthenticated/hooks.token.ts
@@ -1,0 +1,38 @@
+import {
+  InjectionToken,
+  Provider,
+} from '@angular/core';
+
+/**
+ * A token to hold the unauthenticated hooks.
+ * When a logged-in user is unauthenticated, various packages may perform cleanup tasks.
+ * These are guaranteed to run synchronously before the client driver state is fully reset.
+ *
+ * Prefer using {@link daffAuthProvideUnauthenticatedHooks}.
+ */
+export const DAFF_AUTH_UNAUTHENTICATED_HOOKS = new InjectionToken<(() => void)[]>(
+  'DAFF_AUTH_UNAUTHENTICATED_HOOKS',
+{ factory: () => []},
+);
+
+/**
+ * Provides {@link DAFF_AUTH_UNAUTHENTICATED_HOOKS}.
+ *
+ * ```ts
+ * providers: [
+ *   ...daffAuthProvideUnauthenticatedHooks(
+ *     myReducer1,
+ *     myReducer2
+ *   )
+ * ]
+ * ```
+ */
+export function daffAuthProvideUnauthenticatedHooks(
+  ...hooks: (() => void)[]
+): Provider[] {
+  return hooks.map(hook => ({
+    provide: DAFF_AUTH_UNAUTHENTICATED_HOOKS,
+    useValue: hook,
+    multi: true,
+  }));
+}

--- a/libs/auth/state/src/injection-tokens/unauthenticated/public_api.ts
+++ b/libs/auth/state/src/injection-tokens/unauthenticated/public_api.ts
@@ -1,0 +1,4 @@
+export {
+  daffAuthProvideUnauthenticatedHooks,
+  DAFF_AUTH_UNAUTHENTICATED_HOOKS,
+} from './hooks.token';

--- a/libs/auth/state/src/public_api.ts
+++ b/libs/auth/state/src/public_api.ts
@@ -3,6 +3,7 @@ export * from './reducers/public_api';
 export * from './selectors/public_api';
 export * from './facades/public_api';
 export * from './config/public_api';
+export * from './injection-tokens/public_api';
 
 export { DaffAuthStateModule } from './auth-state.module';
 

--- a/libs/cart-customer/state/src/reducers/login-mutating.ts
+++ b/libs/cart-customer/state/src/reducers/login-mutating.ts
@@ -1,0 +1,57 @@
+import {
+  ActionReducer,
+  ActionReducerMap,
+} from '@ngrx/store';
+
+import {
+  DaffAuthLoginActionTypes,
+  DaffAuthLoginActions,
+  DaffAuthRegisterActionTypes,
+  DaffAuthRegisterActions,
+  DaffAuthResetPasswordActionTypes,
+  DaffAuthResetPasswordActions,
+} from '@daffodil/auth/state';
+import {
+  DaffCartOperationType,
+  DaffCartReducerState,
+  DaffCartReducersState,
+  daffCartReducerInitialState,
+} from '@daffodil/cart/state';
+import {
+  DaffState,
+  daffIdentityReducer,
+} from '@daffodil/core/state';
+
+/**
+ * Sets cart to mutating when the user logs in.
+ * This is to correctly represent the cart merge operation that is performed after a login.
+ */
+export const daffCartCustomerLoginMutatingReducer: ActionReducer<DaffCartReducerState> = (
+  state = daffCartReducerInitialState,
+  action: DaffAuthLoginActions | DaffAuthRegisterActions | DaffAuthResetPasswordActions,
+) => {
+  switch (action.type) {
+    case DaffAuthLoginActionTypes.LoginSuccessAction:
+    case DaffAuthRegisterActionTypes.RegisterSuccessAction:
+    case DaffAuthResetPasswordActionTypes.ResetPasswordSuccessAction:
+      if ((action.type === DaffAuthRegisterActionTypes.RegisterSuccessAction || action.type === DaffAuthResetPasswordActionTypes.ResetPasswordSuccessAction) && !action.token) {
+        return state;
+      }
+      return {
+        ...state,
+        loading: {
+          ...state.loading,
+          [DaffCartOperationType.Cart]: DaffState.Mutating,
+        },
+      };
+
+    default:
+      return state;
+  }
+};
+
+export const daffCartCustomerLoginMutatingReducerMap: ActionReducerMap<DaffCartReducersState> = {
+  cart: daffCartCustomerLoginMutatingReducer,
+  cartItems: daffIdentityReducer,
+  order: daffIdentityReducer,
+};

--- a/libs/cart-customer/state/src/reducers/unauthenticated-reset.ts
+++ b/libs/cart-customer/state/src/reducers/unauthenticated-reset.ts
@@ -1,0 +1,34 @@
+import { ActionReducer } from '@ngrx/store';
+
+import {
+  DaffAuthActionTypes,
+  DaffAuthActions,
+} from '@daffodil/auth/state';
+import {
+  DaffCartReducersState,
+  daffCartItemEntitiesAdapter,
+  daffCartOrderInitialState,
+  daffCartReducerInitialState,
+} from '@daffodil/cart/state';
+
+const initialState: DaffCartReducersState = {
+  cart: daffCartReducerInitialState,
+  cartItems: daffCartItemEntitiesAdapter().getInitialState(),
+  order: daffCartOrderInitialState,
+};
+
+/**
+ * Resets cart state when the user is unauthenticated.
+ */
+export const daffCartCustomerUnauthenticatedReset: ActionReducer<DaffCartReducersState> = (
+  state = initialState,
+  action: DaffAuthActions,
+) => {
+  switch (action.type) {
+    case DaffAuthActionTypes.ResetToUnauthenticatedAction:
+      return initialState;
+
+    default:
+      return state;
+  }
+};

--- a/libs/cart-customer/state/src/state.module.ts
+++ b/libs/cart-customer/state/src/state.module.ts
@@ -3,11 +3,14 @@ import {
   inject,
 } from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
+import { combineReducers } from '@ngrx/store';
 
 import { DAFF_AUTH_UNAUTHENTICATED_HOOKS } from '@daffodil/auth/state';
 import { DaffCartStorageService } from '@daffodil/cart';
+import { daffCartProvideExtraReducers } from '@daffodil/cart/state';
 
 import { DaffCartCustomerAuthEffects } from './effects/auth.effects';
+import { daffCartCustomerLoginMutatingReducerMap } from './reducers/login-mutating';
 
 @NgModule({
   imports: [
@@ -28,6 +31,9 @@ import { DaffCartCustomerAuthEffects } from './effects/auth.effects';
       },
       multi: true,
     },
+    daffCartProvideExtraReducers(
+      combineReducers(daffCartCustomerLoginMutatingReducerMap),
+    ),
   ],
 })
 export class DaffCartCustomerStateModule {}

--- a/libs/cart-customer/state/src/state.module.ts
+++ b/libs/cart-customer/state/src/state.module.ts
@@ -11,6 +11,7 @@ import { daffCartProvideExtraReducers } from '@daffodil/cart/state';
 
 import { DaffCartCustomerAuthEffects } from './effects/auth.effects';
 import { daffCartCustomerLoginMutatingReducerMap } from './reducers/login-mutating';
+import { daffCartCustomerUnauthenticatedReset } from './reducers/unauthenticated-reset';
 
 @NgModule({
   imports: [
@@ -32,6 +33,7 @@ import { daffCartCustomerLoginMutatingReducerMap } from './reducers/login-mutati
       multi: true,
     },
     daffCartProvideExtraReducers(
+      daffCartCustomerUnauthenticatedReset,
       combineReducers(daffCartCustomerLoginMutatingReducerMap),
     ),
   ],

--- a/libs/cart-customer/state/src/state.module.ts
+++ b/libs/cart-customer/state/src/state.module.ts
@@ -1,5 +1,11 @@
-import { NgModule } from '@angular/core';
+import {
+  NgModule,
+  inject,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
+
+import { DAFF_AUTH_UNAUTHENTICATED_HOOKS } from '@daffodil/auth/state';
+import { DaffCartStorageService } from '@daffodil/cart';
 
 import { DaffCartCustomerAuthEffects } from './effects/auth.effects';
 
@@ -8,6 +14,20 @@ import { DaffCartCustomerAuthEffects } from './effects/auth.effects';
     EffectsModule.forFeature([
       DaffCartCustomerAuthEffects,
     ]),
+  ],
+  providers: [
+    {
+      provide: DAFF_AUTH_UNAUTHENTICATED_HOOKS,
+      useFactory: () => {
+        const storage = inject(DaffCartStorageService);
+        return () => {
+          try {
+            storage.removeCartId();
+          } catch {}
+        };
+      },
+      multi: true,
+    },
   ],
 })
 export class DaffCartCustomerStateModule {}

--- a/libs/cart-store-credit/state/src/reducers/cart.reducer.ts
+++ b/libs/cart-store-credit/state/src/reducers/cart.reducer.ts
@@ -3,7 +3,7 @@ import { DaffCartWithStoreCredit } from '@daffodil/cart-store-credit';
 import {
   DaffCartOperationType,
   DaffCartReducerState,
-  initialState,
+  daffCartReducerInitialState,
 } from '@daffodil/cart/state';
 import { DaffState } from '@daffodil/core/state';
 
@@ -13,7 +13,7 @@ import {
 } from '../actions/public_api';
 
 export function daffCartStoreCreditCartReducer<T extends DaffCartWithStoreCredit = DaffCartWithStoreCredit>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: DaffCartStoreCreditActions,
 ): DaffCartReducerState<T> {
   switch (action.type) {

--- a/libs/cart/routing/src/cart-routing.module.ts
+++ b/libs/cart/routing/src/cart-routing.module.ts
@@ -15,6 +15,7 @@ import {
   DaffCartPaymentMethodGuardRedirectUrl,
   DaffCartOrderResultGuardRedirectUrl,
   DaffCartItemsGuardRedirectUrl,
+  DaffResolveCartGuardRedirectUrl,
 } from './guards/public_api';
 import {
   DaffEmptyCartResolverRedirectUrl,
@@ -31,6 +32,7 @@ import {
     { provide: DaffCartOrderResultGuardRedirectUrl, useValue: '/' },
     { provide: DaffEmptyCartResolverRedirectUrl, useValue: '/' },
     { provide: DaffCartResolverRedirectUrl, useValue: '/' },
+    { provide: DaffResolveCartGuardRedirectUrl, useValue: '/' },
   ],
 })
 export class DaffCartRoutingModule {

--- a/libs/cart/routing/src/guards/public_api.ts
+++ b/libs/cart/routing/src/guards/public_api.ts
@@ -1,5 +1,6 @@
 export { DaffBillingAddressGuard } from './billing-address/billing-address.guard';
 export { DaffResolvedCartGuard } from './resolved-cart/resolved-cart.guard';
+export { DaffResolveCartGuard } from './resolve-cart/resolve-cart.guard';
 export { DaffCartItemsGuard } from './cart-items/cart-items.guard';
 export { DaffCartInStockItemsGuard } from './in-stock-items/in-stock-items.guard';
 export { DaffPaymentMethodGuard } from './payment-method/payment-method.guard';
@@ -13,3 +14,4 @@ export { DaffCartPaymentMethodGuardRedirectUrl } from './payment-method/payment-
 export { DaffCartShippingAddressGuardRedirectUrl } from './shipping-address/shipping-address-guard-redirect.token';
 export { DaffCartShippingMethodGuardRedirectUrl } from './shipping-method/shipping-method-guard-redirect.token';
 export { DaffCartOrderResultGuardRedirectUrl } from './order-result/order-result-guard-redirect.token';
+export { DaffResolveCartGuardRedirectUrl } from './resolve-cart/redirect.token';

--- a/libs/cart/routing/src/guards/resolve-cart/redirect.token.ts
+++ b/libs/cart/routing/src/guards/resolve-cart/redirect.token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const DaffResolveCartGuardRedirectUrl = new InjectionToken<string>('DaffResolveCartGuardRedirectUrl');

--- a/libs/cart/routing/src/guards/resolve-cart/resolve-cart.guard.spec.ts
+++ b/libs/cart/routing/src/guards/resolve-cart/resolve-cart.guard.spec.ts
@@ -1,0 +1,152 @@
+import {
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import {
+  StoreModule,
+  combineReducers,
+  Store,
+} from '@ngrx/store';
+import { Observable } from 'rxjs';
+
+import {
+  DaffCart,
+  DaffCartStorageService,
+} from '@daffodil/cart';
+import { DaffResolveCartGuardRedirectUrl } from '@daffodil/cart/routing';
+import {
+  daffCartReducers,
+  DaffCartStateRootSlice,
+  DaffResolveCartSuccess,
+  DaffResolveCartFailure,
+  DaffResolveCartServerSide,
+  DaffResolveCart,
+  DAFF_CART_STORE_FEATURE_KEY,
+  DaffResolveCartPartialSuccess,
+}  from '@daffodil/cart/state';
+import { DaffCartFactory } from '@daffodil/cart/testing';
+
+import { DaffResolveCartGuard } from './resolve-cart.guard';
+
+describe('@daffodil/cart/routing | DaffResolveCartGuard', () => {
+  const actions$: Observable<any> = null;
+  let cartResolver: DaffResolveCartGuard;
+  let store: Store<DaffCartStateRootSlice>;
+  let cartFactory: DaffCartFactory;
+
+  let cartStorageSpy: jasmine.SpyObj<DaffCartStorageService>;
+
+  let stubCart: DaffCart;
+  let router: Router;
+  const stubUrl = '/cart';
+
+  beforeEach(waitForAsync(() => {
+    cartStorageSpy = jasmine.createSpyObj('DaffCartStorageService', ['getCartId']);
+
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot({
+          [DAFF_CART_STORE_FEATURE_KEY]: combineReducers(daffCartReducers),
+        }),
+        RouterTestingModule,
+      ],
+      providers: [
+        provideMockActions(() => actions$),
+        { provide: DaffResolveCartGuardRedirectUrl, useValue: stubUrl },
+        {
+          provide: DaffCartStorageService,
+          useValue: cartStorageSpy,
+        },
+      ],
+    });
+
+    cartResolver = TestBed.inject(DaffResolveCartGuard);
+    cartFactory = TestBed.inject(DaffCartFactory);
+    store = TestBed.inject(Store);
+    router = TestBed.inject(Router);
+
+    stubCart = cartFactory.create();
+
+
+    spyOn(router, 'navigateByUrl');
+  }));
+
+  it('should be created', () => {
+    expect(cartResolver).toBeTruthy();
+  });
+
+  describe('canActivate', () => {
+    describe('when there is a cart ID in storage', () => {
+      beforeEach(() => {
+        cartStorageSpy.getCartId.and.returnValue(stubCart.id);
+      });
+
+      it('should dispatch a DaffResolveCart action', () => {
+        spyOn(store, 'dispatch');
+        cartResolver.canActivate().subscribe();
+
+        expect(store.dispatch).toHaveBeenCalledWith(new DaffResolveCart());
+      });
+
+      describe('when DaffResolveCartSuccess is dispatched', () => {
+        it('should return true', done => {
+          cartResolver.canActivate().subscribe((returnedValue) => {
+            expect(returnedValue).toBeTrue();
+            done();
+          });
+
+          store.dispatch(new DaffResolveCartPartialSuccess(stubCart, []));
+        });
+      });
+
+      describe('when DaffResolveCartPartialSuccess is dispatched', () => {
+        it('should return true', done => {
+          cartResolver.canActivate().subscribe((returnedValue) => {
+            expect(returnedValue).toBeTrue();
+            done();
+          });
+
+          store.dispatch(new DaffResolveCartPartialSuccess(stubCart, []));
+        });
+      });
+
+      describe('when DaffResolveCartFailure is dispatched', () => {
+        it('should redirect to the provided DaffResolveCartGuardRedirectUrl', done => {
+          cartResolver.canActivate().subscribe((resp) => {
+            expect(resp).toEqual(router.parseUrl(stubUrl));
+            done();
+          });
+
+          store.dispatch(new DaffResolveCartFailure([]));
+        });
+      });
+
+      describe('when DaffResolveCartServerSide is dispatched', () => {
+        it('should redirect to the provided DaffResolveCartGuardRedirectUrl', done => {
+          cartResolver.canActivate().subscribe((resp) => {
+            expect(resp).toEqual(router.parseUrl(stubUrl));
+            done();
+          });
+
+          store.dispatch(new DaffResolveCartServerSide(null));
+        });
+      });
+    });
+
+    describe('when there is not a cart ID in storage', () => {
+      beforeEach(() => {
+        cartStorageSpy.getCartId.and.returnValue(null);
+      });
+
+      it('should redirect', done => {
+        cartResolver.canActivate().subscribe((resp) => {
+          expect(resp).toEqual(router.parseUrl(stubUrl));
+          done();
+        });
+      });
+    });
+  });
+});

--- a/libs/cart/routing/src/guards/resolve-cart/resolve-cart.guard.ts
+++ b/libs/cart/routing/src/guards/resolve-cart/resolve-cart.guard.ts
@@ -1,0 +1,87 @@
+import {
+  Injectable,
+  Inject,
+} from '@angular/core';
+import {
+  CanActivate,
+  Router,
+  UrlTree,
+} from '@angular/router';
+import {
+  ActionsSubject,
+  Store,
+} from '@ngrx/store';
+import {
+  Observable,
+  of,
+} from 'rxjs';
+import {
+  tap,
+  filter,
+  take,
+  map,
+} from 'rxjs/operators';
+
+import { DaffCartStorageService } from '@daffodil/cart';
+import {
+  DaffCartActionTypes,
+  DaffCartActions,
+  DaffCartFacade,
+  DaffCartResolveState,
+  DaffCartStateRootSlice,
+  DaffResolveCart,
+} from '@daffodil/cart/state';
+
+import {
+  DaffCartRoutingConfiguration,
+  DAFF_CART_ROUTING_CONFIG,
+} from '../../config/config';
+import { DaffResolveCartGuardRedirectUrl } from './redirect.token';
+
+/**
+ * A routing guard that will optionally redirect to a given url if the cart is not properly resolved.
+ * It will initiate cart resolution.
+ * The url has no default and the guard will not redirect if no value is specified.
+ * Specify a redirect path with the {@link DaffResolvedCartGuardRedirectUrl} injection token.
+ * The guard will wait until the cart has been resolved before performing the check and emitting.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffResolveCartGuard implements CanActivate {
+  constructor(
+    private store: Store<DaffCartStateRootSlice>,
+    private dispatcher: ActionsSubject,
+    private router: Router,
+    @Inject(DaffResolveCartGuardRedirectUrl) private redirectUrl: string,
+    private storage: DaffCartStorageService,
+  ) {}
+
+  canActivate(): Observable<boolean | UrlTree> {
+    if (this.storage.getCartId()) {
+      this.store.dispatch(new DaffResolveCart());
+
+      return this.dispatcher.pipe(
+        filter<DaffCartActions>(action =>
+          action.type === DaffCartActionTypes.ResolveCartServerSideAction
+            || action.type === DaffCartActionTypes.ResolveCartFailureAction
+            || action.type === DaffCartActionTypes.ResolveCartSuccessAction
+            || action.type === DaffCartActionTypes.ResolveCartPartialSuccessAction,
+        ),
+        map((action) => {
+          if (
+            action.type === DaffCartActionTypes.ResolveCartSuccessAction
+            || action.type === DaffCartActionTypes.ResolveCartPartialSuccessAction
+          ) {
+            return true;
+          }
+
+          return this.router.parseUrl(this.redirectUrl);
+        }),
+        take(1),
+      );
+    } else {
+      return of(this.router.parseUrl(this.redirectUrl));
+    }
+  }
+}

--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -17,7 +17,7 @@ import {
   DaffCartItemInputType,
 } from '@daffodil/cart';
 import {
-  initialState,
+  daffCartReducerInitialState,
   DaffCartReducersState,
   DaffCartLoading,
   DaffCartErrors,
@@ -176,7 +176,7 @@ describe('DaffCartFacade', () => {
 
   describe('cart$', () => {
     it('should initially be cart with no defined properties', () => {
-      const expected = cold('a', { a: initialState.cart });
+      const expected = cold('a', { a: daffCartReducerInitialState.cart });
       expect(facade.cart$).toBeObservable(expected);
     });
 

--- a/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.spec.ts
@@ -11,7 +11,7 @@ import {
   DaffCartAddressUpdate,
   DaffCartAddressUpdateSuccess,
   DaffCartAddressUpdateFailure,
-  initialState,
+  daffCartReducerInitialState,
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import {
@@ -35,9 +35,9 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     it('should return the current state', () => {
       const action = <any>{};
 
-      const result = cartBillingAddressReducer(initialState, action);
+      const result = cartBillingAddressReducer(daffCartReducerInitialState, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(daffCartReducerInitialState);
     });
   });
 
@@ -45,7 +45,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     it('should set loading state to true', () => {
       const cartListLoadAction = new DaffCartBillingAddressLoad();
 
-      const result = cartBillingAddressReducer(initialState, cartListLoadAction);
+      const result = cartBillingAddressReducer(daffCartReducerInitialState, cartListLoadAction);
 
       expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Resolving);
     });
@@ -57,9 +57,9 @@ describe('Cart | Reducer | Cart Billing Address', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
       };
@@ -89,13 +89,13 @@ describe('Cart | Reducer | Cart Billing Address', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.BillingAddress]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -118,7 +118,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     it('should indicate that the cart billing address is being mutated', () => {
       const cartBillingAddressUpdateAction = new DaffCartBillingAddressUpdate(cart.billing_address);
 
-      const result = cartBillingAddressReducer(initialState, cartBillingAddressUpdateAction);
+      const result = cartBillingAddressReducer(daffCartReducerInitialState, cartBillingAddressUpdateAction);
 
       expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Mutating);
     });
@@ -131,9 +131,9 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     beforeEach(() => {
       const cartBillingAddressUpdateActionSuccess = new DaffCartBillingAddressUpdateSuccess(cart);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
       };
@@ -161,13 +161,13 @@ describe('Cart | Reducer | Cart Billing Address', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.BillingAddress]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -192,7 +192,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     it('should indicate that the cart billing address is being mutated', () => {
       const cartAddressUpdateAction = new DaffCartAddressUpdate(cart.billing_address);
 
-      const result = cartBillingAddressReducer(initialState, cartAddressUpdateAction);
+      const result = cartBillingAddressReducer(daffCartReducerInitialState, cartAddressUpdateAction);
 
       expect(result.loading[DaffCartOperationType.BillingAddress]).toEqual(DaffState.Mutating);
     });
@@ -205,9 +205,9 @@ describe('Cart | Reducer | Cart Billing Address', () => {
     beforeEach(() => {
       const cartAddressUpdateActionSuccess = new DaffCartAddressUpdateSuccess(cart);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
       };
@@ -235,13 +235,13 @@ describe('Cart | Reducer | Cart Billing Address', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.BillingAddress]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.BillingAddress]: [{ code: 'first error code', message: 'first error message' }],
         },
       };

--- a/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.ts
@@ -6,7 +6,7 @@ import {
   DaffCartAddressActionTypes,
 } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
-import { initialState } from '../cart-initial-state';
+import { daffCartReducerInitialState } from '../cart-initial-state';
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartReducerState } from '../cart-state.interface';
 import {
@@ -20,7 +20,7 @@ const resetErrors = initializeErrorResetter(DaffCartOperationType.BillingAddress
 const setLoading = initializeLoadingSetter(DaffCartOperationType.BillingAddress);
 
 export function cartBillingAddressReducer<T extends DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes,
 ): DaffCartReducerState<T> {
   switch (action.type) {

--- a/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.spec.ts
@@ -20,7 +20,7 @@ import {
   DaffCartCouponRemoveAll,
   DaffCartCouponRemoveAllSuccess,
   DaffCartCouponRemoveAllFailure,
-  initialState,
+  daffCartReducerInitialState,
   DaffCartCouponClearErrors,
 } from '@daffodil/cart/state';
 import {
@@ -54,9 +54,9 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     it('should return the current state', () => {
       const action = <any>{};
 
-      const result = reducer(initialState, action);
+      const result = reducer(daffCartReducerInitialState, action);
 
-      expect(result).toEqual(initialState);
+      expect(result).toEqual(daffCartReducerInitialState);
     });
   });
 
@@ -64,7 +64,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     it('should indicate that the cart coupon is being mutated', () => {
       const cartCouponApplyAction: DaffCartCouponApply = new DaffCartCouponApply(mockCoupon);
 
-      const result = reducer(initialState, cartCouponApplyAction);
+      const result = reducer(daffCartReducerInitialState, cartCouponApplyAction);
 
       expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Mutating);
     });
@@ -76,9 +76,9 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
       };
@@ -108,13 +108,13 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Coupon]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -137,7 +137,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     it('should set loading state to true', () => {
       const cartCouponListAction: DaffCartCouponList = new DaffCartCouponList();
 
-      const result = reducer(initialState, cartCouponListAction);
+      const result = reducer(daffCartReducerInitialState, cartCouponListAction);
 
       expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Resolving);
     });
@@ -149,9 +149,9 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
       };
@@ -181,13 +181,13 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Coupon]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -210,7 +210,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     it('should indicate that the cart coupon is being mutated', () => {
       const cartCouponRemoveAction: DaffCartCouponRemove = new DaffCartCouponRemove(mockCoupon);
 
-      const result = reducer(initialState, cartCouponRemoveAction);
+      const result = reducer(daffCartReducerInitialState, cartCouponRemoveAction);
 
       expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Mutating);
     });
@@ -223,9 +223,9 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     beforeEach(() => {
       const cartCouponRemoveActionSuccess: DaffCartCouponRemoveSuccess = new DaffCartCouponRemoveSuccess(cart);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
       };
@@ -253,13 +253,13 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Coupon]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -283,14 +283,14 @@ describe('Cart | Reducer | cartCouponReducer', () => {
   describe('when CartCouponRemoveAllAction is triggered', () => {
     it('should indicate that the cart coupon is being mutated', () => {
       const expectedState: DaffCartReducerState<DaffCart> = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Coupon]: DaffState.Mutating,
         },
       };
       const cartClear = new DaffCartCouponRemoveAll();
-      const result = reducer(initialState, cartClear);
+      const result = reducer(daffCartReducerInitialState, cartClear);
 
       expect(result).toEqual(expectedState);
     });
@@ -301,19 +301,19 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
     beforeEach(() => {
       const cartClearSuccess = new DaffCartCouponRemoveAllSuccess(cart);
-      result = reducer(initialState, cartClearSuccess);
+      result = reducer(daffCartReducerInitialState, cartClearSuccess);
     });
 
     it('should set the cart payload on state', () => {
       const expectedState = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         cart: {
-          ...initialState.cart,
+          ...daffCartReducerInitialState.cart,
           items: [],
           ...cart,
         },
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Coupon]: DaffState.Complete,
         },
       };
@@ -333,13 +333,13 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Coupon]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Coupon]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -367,9 +367,9 @@ describe('Cart | Reducer | cartCouponReducer', () => {
     beforeEach(() => {
       const cartCouponRemoveActionSuccess = new DaffCartCouponClearErrors();
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Coupon]: [{ code: 'first error code', message: 'first error message' }],
         },
       };

--- a/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.ts
@@ -4,7 +4,7 @@ import { DaffLoadingState } from '@daffodil/core/state';
 
 import { DaffCartCouponActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
-import { initialState } from '../cart-initial-state';
+import { daffCartReducerInitialState } from '../cart-initial-state';
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartReducerState } from '../cart-state.interface';
 import {
@@ -18,7 +18,7 @@ const resetErrors = initializeErrorResetter(DaffCartOperationType.Coupon);
 const setLoading = initializeLoadingSetter(DaffCartOperationType.Coupon);
 
 export function cartCouponReducer<T extends DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes,
 ): DaffCartReducerState<T> {
   switch (action.type) {

--- a/libs/cart/state/src/reducers/cart-initial-state.ts
+++ b/libs/cart/state/src/reducers/cart-initial-state.ts
@@ -4,7 +4,7 @@ import { DaffCartOperationType } from './cart-operation-type.enum';
 import { DaffCartResolveState } from './cart-resolve/cart-resolve-state.enum';
 import { DaffCartReducerState } from './cart-state.interface';
 
-export const initialState: DaffCartReducerState<any> = Object.freeze({
+export const daffCartReducerInitialState: DaffCartReducerState<any> = Object.freeze({
   cart: {
     id: null,
     subtotal: null,

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
@@ -19,7 +19,7 @@ import {
   DaffCartItemList,
   DaffCartItemListSuccess,
   DaffCartItemListFailure,
-  initialState,
+  daffCartReducerInitialState,
   DaffStatefulCartItem,
   DaffCartItemUpdate,
   DaffCartItemDelete,
@@ -59,23 +59,23 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
     it('should return the current state', () => {
       const action = <any>{};
 
-      result = cartItemReducer(initialState, action);
+      result = cartItemReducer(daffCartReducerInitialState, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(daffCartReducerInitialState);
     });
   });
 
   describe('when CartItemUpdateAction is triggered', () => {
     beforeEach(() => {
       const cartItemUpdate = new DaffCartItemUpdate('itemId', { qty: 4 });
-      result = cartItemReducer(initialState, cartItemUpdate);
+      result = cartItemReducer(daffCartReducerInitialState, cartItemUpdate);
     });
 
     it('should indicate that the cart is loading', () => {
       const expectedState: DaffCartReducerState<DaffCart> = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Mutating,
         },
       };
@@ -89,9 +89,9 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
@@ -120,13 +120,13 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Item]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -144,14 +144,14 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
   describe('when CartItemDeleteAction is triggered', () => {
     beforeEach(() => {
       const cartItemDelete = new DaffCartItemDelete('itemId');
-      result = cartItemReducer(initialState, cartItemDelete);
+      result = cartItemReducer(daffCartReducerInitialState, cartItemDelete);
     });
 
     it('should indicate that the cart is loading', () => {
       const expectedState: DaffCartReducerState<DaffCart> = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Mutating,
         },
       };
@@ -165,9 +165,9 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
@@ -196,13 +196,13 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Item]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -220,14 +220,14 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
   describe('when CartItemDeleteOutOfStockAction is triggered', () => {
     beforeEach(() => {
       const cartItemDeleteOutOfStock = new DaffCartItemDeleteOutOfStock();
-      result = cartItemReducer(initialState, cartItemDeleteOutOfStock);
+      result = cartItemReducer(daffCartReducerInitialState, cartItemDeleteOutOfStock);
     });
 
     it('should indicate that the cart is loading', () => {
       const expectedState: DaffCartReducerState<DaffCart> = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Mutating,
         },
       };
@@ -241,13 +241,13 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Item]: [{ code: 'code', message: 'message' }],
           [DaffCartOperationType.Cart]: [{ code: DaffCartDriverErrorCodes.PRODUCT_OUT_OF_STOCK, message: 'message' }],
         },
@@ -281,13 +281,13 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Item]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -314,7 +314,7 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
     it('should indicate that the cart item is being added', () => {
       const cartItemAddAction = new DaffCartItemAdd({ type, productId, qty });
 
-      result = cartItemReducer(initialState, cartItemAddAction);
+      result = cartItemReducer(daffCartReducerInitialState, cartItemAddAction);
 
       expect(result.loading[DaffCartOperationType.Item]).toEqual(DaffState.Adding);
     });
@@ -326,9 +326,9 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
     beforeEach(() => {
       const cartItemAddActionSuccess = new DaffCartItemAddSuccess(cart);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
@@ -355,13 +355,13 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Item]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -385,14 +385,14 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
   describe('when CartItemLoadAction is triggered', () => {
     it('should indicate that the cart is loading', () => {
       const expectedState: DaffCartReducerState<DaffCart> = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
       const cartItemLoad = new DaffCartItemLoad('itemId');
-      result = cartItemReducer(initialState, cartItemLoad);
+      result = cartItemReducer(daffCartReducerInitialState, cartItemLoad);
 
       expect(result).toEqual(expectedState);
     });
@@ -409,10 +409,10 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
       };
       const cartItemLoadActionSuccess = new DaffCartItemLoadSuccess(newCartItem);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         cart,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
@@ -439,13 +439,13 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Item]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -469,14 +469,14 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
   describe('when CartItemListAction is triggered', () => {
     it('should indicate that the cart is loading', () => {
       const expectedState: DaffCartReducerState<any> = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
       const cartItemList = new DaffCartItemList();
-      result = cartItemReducer(initialState, cartItemList);
+      result = cartItemReducer(daffCartReducerInitialState, cartItemList);
 
       expect(result).toEqual(expectedState);
     });
@@ -488,9 +488,9 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
     beforeEach(() => {
       const cartItemListActionSuccess = new DaffCartItemListSuccess([cartItem]);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
       };
@@ -517,13 +517,13 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Item]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Item]: [{ code: 'first error code', message: 'first error message' }],
         },
       };

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
@@ -4,7 +4,7 @@ import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartItemActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
-import { initialState } from '../cart-initial-state';
+import { daffCartReducerInitialState } from '../cart-initial-state';
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartReducerState } from '../cart-state.interface';
 import {
@@ -18,7 +18,7 @@ const resetErrors = initializeErrorResetter(DaffCartOperationType.Item);
 const setLoading = initializeLoadingSetter(DaffCartOperationType.Item);
 
 export function cartItemReducer<T extends DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes,
 ): DaffCartReducerState<T> {
   switch (action.type) {

--- a/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.spec.ts
@@ -5,7 +5,7 @@ import {
   DaffCartReducerState,
   DaffCartPaymentMethodsLoadSuccess,
   DaffCartPaymentMethodsLoadFailure,
-  initialState,
+  daffCartReducerInitialState,
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import {
@@ -30,9 +30,9 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
     it('should return the current state', () => {
       const action = <any>{};
 
-      const result = cartPaymentMethodsReducer(initialState, action);
+      const result = cartPaymentMethodsReducer(daffCartReducerInitialState, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(daffCartReducerInitialState);
     });
   });
 
@@ -40,7 +40,7 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
 
     it('should set loading state to true', () => {
       const cartPaymentMethodsLoadAction = new DaffCartPaymentMethodsLoad();
-      const result = cartPaymentMethodsReducer(initialState, cartPaymentMethodsLoadAction);
+      const result = cartPaymentMethodsReducer(daffCartReducerInitialState, cartPaymentMethodsLoadAction);
 
       expect(result.loading[DaffCartOperationType.PaymentMethods]).toEqual(DaffState.Resolving);
     });
@@ -52,9 +52,9 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.PaymentMethods]: DaffState.Resolving,
         },
       };
@@ -84,13 +84,13 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.PaymentMethods]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.PaymentMethods]: [{ code: 'first error code', message: 'first error message' }],
         },
       };

--- a/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.ts
@@ -3,7 +3,7 @@ import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartPaymentMethodsActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
-import { initialState } from '../cart-initial-state';
+import { daffCartReducerInitialState } from '../cart-initial-state';
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartReducerState } from '../cart-state.interface';
 import {
@@ -17,7 +17,7 @@ const resetErrors = initializeErrorResetter(DaffCartOperationType.PaymentMethods
 const setLoading = initializeLoadingSetter(DaffCartOperationType.PaymentMethods);
 
 export function cartPaymentMethodsReducer<T extends DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes,
 ): DaffCartReducerState<T> {
   switch (action.type) {

--- a/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.spec.ts
@@ -15,7 +15,7 @@ import {
   DaffCartPaymentRemoveSuccess,
   DaffCartPaymentRemoveFailure,
   DaffCartPaymentMethodAdd,
-  initialState,
+  daffCartReducerInitialState,
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import {
@@ -39,9 +39,9 @@ describe('Cart | Reducer | Cart Payment', () => {
     it('should return the current state', () => {
       const action = <any>{};
 
-      const result = cartPaymentReducer(initialState, action);
+      const result = cartPaymentReducer(daffCartReducerInitialState, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(daffCartReducerInitialState);
     });
   });
 
@@ -49,7 +49,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     it('should set loading state to true', () => {
       const cartListLoadAction = new DaffCartPaymentLoad();
 
-      const result = cartPaymentReducer(initialState, cartListLoadAction);
+      const result = cartPaymentReducer(daffCartReducerInitialState, cartListLoadAction);
 
       expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Resolving);
     });
@@ -61,9 +61,9 @@ describe('Cart | Reducer | Cart Payment', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
       };
@@ -93,13 +93,13 @@ describe('Cart | Reducer | Cart Payment', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Payment]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -122,7 +122,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     it('should indicate that the cart payment is being mutated', () => {
       const cartPaymentUpdateAction = new DaffCartPaymentUpdate(cart.payment);
 
-      const result = cartPaymentReducer(initialState, cartPaymentUpdateAction);
+      const result = cartPaymentReducer(daffCartReducerInitialState, cartPaymentUpdateAction);
 
       expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Mutating);
     });
@@ -135,9 +135,9 @@ describe('Cart | Reducer | Cart Payment', () => {
     beforeEach(() => {
       const cartPaymentUpdateActionSuccess = new DaffCartPaymentUpdateSuccess(cart);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
       };
@@ -165,13 +165,13 @@ describe('Cart | Reducer | Cart Payment', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Payment]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -196,7 +196,7 @@ describe('Cart | Reducer | Cart Payment', () => {
     it('should indicate that the cart payment is being mutated', () => {
       const cartPaymentUpdateWithBillingAction = new DaffCartPaymentUpdateWithBilling(cart.payment, cart.billing_address);
 
-      const result = cartPaymentReducer(initialState, cartPaymentUpdateWithBillingAction);
+      const result = cartPaymentReducer(daffCartReducerInitialState, cartPaymentUpdateWithBillingAction);
 
       expect(result.loading[DaffCartOperationType.Payment]).toEqual(DaffState.Mutating);
     });
@@ -209,9 +209,9 @@ describe('Cart | Reducer | Cart Payment', () => {
     beforeEach(() => {
       const cartPaymentUpdateWithBillingActionSuccess = new DaffCartPaymentUpdateWithBillingSuccess(cart);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
       };
@@ -239,13 +239,13 @@ describe('Cart | Reducer | Cart Payment', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Payment]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -269,14 +269,14 @@ describe('Cart | Reducer | Cart Payment', () => {
   describe('when CartPaymentRemoveAction is triggered', () => {
     it('should indicate that the cart payment is being mutated', () => {
       const expectedState: DaffCartReducerState<DaffCart> = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Payment]: DaffState.Mutating,
         },
       };
       const cartPaymentRemove = new DaffCartPaymentRemove();
-      const result = cartPaymentReducer(initialState, cartPaymentRemove);
+      const result = cartPaymentReducer(daffCartReducerInitialState, cartPaymentRemove);
 
       expect(result).toEqual(expectedState);
     });
@@ -289,7 +289,7 @@ describe('Cart | Reducer | Cart Payment', () => {
       cart.payment = null;
       const cartPaymentRemoveSuccess = new DaffCartPaymentRemoveSuccess();
 
-      result = cartPaymentReducer(initialState, cartPaymentRemoveSuccess);
+      result = cartPaymentReducer(daffCartReducerInitialState, cartPaymentRemoveSuccess);
     });
 
     it('should remove the payment from the cart', () => {
@@ -312,13 +312,13 @@ describe('Cart | Reducer | Cart Payment', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Payment]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Payment]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -349,7 +349,7 @@ describe('Cart | Reducer | Cart Payment', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
       };
 
       const cartPaymentMethodAdd = new DaffCartPaymentMethodAdd(stubPayment);

--- a/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.ts
@@ -4,7 +4,7 @@ import { DaffLoadingState } from '@daffodil/core/state';
 
 import { DaffCartPaymentActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
-import { initialState } from '../cart-initial-state';
+import { daffCartReducerInitialState } from '../cart-initial-state';
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartReducerState } from '../cart-state.interface';
 import {
@@ -18,7 +18,7 @@ const resetErrors = initializeErrorResetter(DaffCartOperationType.Payment);
 const setLoading = initializeLoadingSetter(DaffCartOperationType.Payment);
 
 export function cartPaymentReducer<T extends DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes,
 ): DaffCartReducerState<T> {
   switch (action.type) {

--- a/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
@@ -5,7 +5,7 @@ import {
   DaffResolveCart,
   DaffResolveCartSuccess,
   DaffResolveCartFailure,
-  initialState,
+  daffCartReducerInitialState,
   DaffCartReducerState,
   DaffCartResolveState,
 } from '@daffodil/cart/state';
@@ -34,9 +34,9 @@ describe('@daffodil/cart/state | cartResolveReducer', () => {
     it('should return the current state', () => {
       const action = <any>{};
 
-      const result = reducer(initialState, action);
+      const result = reducer(daffCartReducerInitialState, action);
 
-      expect(result).toEqual(initialState);
+      expect(result).toEqual(daffCartReducerInitialState);
     });
   });
 
@@ -44,7 +44,7 @@ describe('@daffodil/cart/state | cartResolveReducer', () => {
     it('should set resolved state to resolving', () => {
       const cartResolveAction: DaffResolveCart = new DaffResolveCart();
 
-      const result = reducer(initialState, cartResolveAction);
+      const result = reducer(daffCartReducerInitialState, cartResolveAction);
 
       expect(result.resolved).toEqual(DaffCartResolveState.Resolving);
     });
@@ -56,7 +56,7 @@ describe('@daffodil/cart/state | cartResolveReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         resolved: DaffCartResolveState.Resolving,
       };
 
@@ -76,7 +76,7 @@ describe('@daffodil/cart/state | cartResolveReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         resolved: DaffCartResolveState.Resolving,
       };
 
@@ -96,7 +96,7 @@ describe('@daffodil/cart/state | cartResolveReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         resolved: DaffCartResolveState.Resolving,
       };
 
@@ -117,7 +117,7 @@ describe('@daffodil/cart/state | cartResolveReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         resolved: DaffCartResolveState.Resolving,
       };
 
@@ -138,7 +138,7 @@ describe('@daffodil/cart/state | cartResolveReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         resolved: DaffCartResolveState.Resolving,
       };
 

--- a/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.ts
@@ -2,12 +2,12 @@ import { DaffCart } from '@daffodil/cart';
 
 import { DaffCartActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
-import { initialState } from '../cart-initial-state';
+import { daffCartReducerInitialState } from '../cart-initial-state';
 import { DaffCartReducerState } from '../cart-state.interface';
 import { DaffCartResolveState } from './cart-resolve-state.enum';
 
 export function cartResolveReducer<T extends DaffCart = DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes,
 ): DaffCartReducerState<T> {
   switch (action.type) {

--- a/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.spec.ts
@@ -11,7 +11,7 @@ import {
   DaffCartAddressUpdate,
   DaffCartAddressUpdateSuccess,
   DaffCartAddressUpdateFailure,
-  initialState,
+  daffCartReducerInitialState,
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import {
@@ -35,9 +35,9 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     it('should return the current state', () => {
       const action = <any>{};
 
-      const result = cartShippingAddressReducer(initialState, action);
+      const result = cartShippingAddressReducer(daffCartReducerInitialState, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(daffCartReducerInitialState);
     });
   });
 
@@ -45,7 +45,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     it('should set loading state to true', () => {
       const cartListLoadAction = new DaffCartShippingAddressLoad();
 
-      const result = cartShippingAddressReducer(initialState, cartListLoadAction);
+      const result = cartShippingAddressReducer(daffCartReducerInitialState, cartListLoadAction);
 
       expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Resolving);
     });
@@ -57,9 +57,9 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
       };
@@ -89,13 +89,13 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.ShippingAddress]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -118,7 +118,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     it('should indicate that the cart shipping address is being mutated', () => {
       const cartShippingAddressUpdateAction = new DaffCartShippingAddressUpdate(cart.shipping_address);
 
-      const result = cartShippingAddressReducer(initialState, cartShippingAddressUpdateAction);
+      const result = cartShippingAddressReducer(daffCartReducerInitialState, cartShippingAddressUpdateAction);
 
       expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Mutating);
     });
@@ -131,9 +131,9 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     beforeEach(() => {
       const cartShippingAddressUpdateActionSuccess = new DaffCartShippingAddressUpdateSuccess(cart);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
       };
@@ -161,13 +161,13 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.ShippingAddress]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -192,7 +192,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     it('should set loading state to true', () => {
       const cartAddressUpdateAction = new DaffCartAddressUpdate(cart.shipping_address);
 
-      const result = cartShippingAddressReducer(initialState, cartAddressUpdateAction);
+      const result = cartShippingAddressReducer(daffCartReducerInitialState, cartAddressUpdateAction);
 
       expect(result.loading[DaffCartOperationType.ShippingAddress]).toEqual(DaffState.Mutating);
     });
@@ -205,9 +205,9 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
     beforeEach(() => {
       const cartAddressUpdateActionSuccess = new DaffCartAddressUpdateSuccess(cart);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
       };
@@ -235,13 +235,13 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingAddress]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.ShippingAddress]: [{ code: 'first error code', message: 'first error message' }],
         },
       };

--- a/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.ts
@@ -7,7 +7,7 @@ import {
   DaffCartAddressActionTypes,
 } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
-import { initialState } from '../cart-initial-state';
+import { daffCartReducerInitialState } from '../cart-initial-state';
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartReducerState } from '../cart-state.interface';
 import {
@@ -21,7 +21,7 @@ const resetErrors = initializeErrorResetter(DaffCartOperationType.ShippingAddres
 const setLoading = initializeLoadingSetter(DaffCartOperationType.ShippingAddress);
 
 export function cartShippingAddressReducer<T extends DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes,
 ): DaffCartReducerState<T> {
   switch (action.type) {

--- a/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.spec.ts
@@ -14,7 +14,7 @@ import {
   DaffCartShippingInformationDelete,
   DaffCartShippingInformationDeleteSuccess,
   DaffCartShippingInformationDeleteFailure,
-  initialState,
+  daffCartReducerInitialState,
 } from '@daffodil/cart/state';
 import {
   DaffCartFactory,
@@ -48,9 +48,9 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
     it('should return the current state', () => {
       const action = <any>{};
 
-      const result = cartShippingInformationReducer(initialState, action);
+      const result = cartShippingInformationReducer(daffCartReducerInitialState, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(daffCartReducerInitialState);
     });
   });
 
@@ -58,7 +58,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
     it('should set loading state to true', () => {
       const cartShippingInformationLoadAction = new DaffCartShippingInformationLoad();
 
-      const result = cartShippingInformationReducer(initialState, cartShippingInformationLoadAction);
+      const result = cartShippingInformationReducer(daffCartReducerInitialState, cartShippingInformationLoadAction);
 
       expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffState.Resolving);
     });
@@ -70,10 +70,10 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         cart,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingInformation]: DaffState.Resolving,
         },
       };
@@ -103,13 +103,13 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingInformation]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.ShippingInformation]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -132,7 +132,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
     it('should set loading state to Mutating', () => {
       const cartShippingInformationUpdateAction = new DaffCartShippingInformationUpdate(cart.shipping_information);
 
-      const result = cartShippingInformationReducer(initialState, cartShippingInformationUpdateAction);
+      const result = cartShippingInformationReducer(daffCartReducerInitialState, cartShippingInformationUpdateAction);
 
       expect(result.loading[DaffCartOperationType.ShippingInformation]).toEqual(DaffState.Mutating);
     });
@@ -145,9 +145,9 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
     beforeEach(() => {
       const cartShippingInformationUpdateActionSuccess = new DaffCartShippingInformationUpdateSuccess(cart);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingInformation]: DaffState.Resolving,
         },
       };
@@ -175,13 +175,13 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingInformation]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.ShippingInformation]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -205,14 +205,14 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
   describe('when CartShippingInformationDeleteAction is triggered', () => {
     it('should indicate that the cart shipping information is being mutated', () => {
       const expectedState: DaffCartReducerState<DaffCart> = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingInformation]: DaffState.Mutating,
         },
       };
       const cartShippingInformationRemove = new DaffCartShippingInformationDelete();
-      const result = cartShippingInformationReducer(initialState, cartShippingInformationRemove);
+      const result = cartShippingInformationReducer(daffCartReducerInitialState, cartShippingInformationRemove);
 
       expect(result).toEqual(expectedState);
     });
@@ -224,20 +224,20 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
     beforeEach(() => {
       cart.shipping_information = null;
       const cartShippingInformationRemoveSuccess = new DaffCartShippingInformationDeleteSuccess(cart);
-      result = cartShippingInformationReducer(initialState, cartShippingInformationRemoveSuccess);
+      result = cartShippingInformationReducer(daffCartReducerInitialState, cartShippingInformationRemoveSuccess);
     });
 
     it('should remove the shipping information from the cart', () => {
 
       const expectedState = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         cart: {
-          ...initialState.cart,
+          ...daffCartReducerInitialState.cart,
           shipping_information: null,
           ...cart,
         },
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingInformation]: DaffState.Complete,
         },
       };
@@ -257,13 +257,13 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingInformation]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.ShippingInformation]: [{ code: 'first error code', message: 'first error message' }],
         },
       };

--- a/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.ts
@@ -3,7 +3,7 @@ import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartShippingInformationActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
-import { initialState } from '../cart-initial-state';
+import { daffCartReducerInitialState } from '../cart-initial-state';
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartReducerState } from '../cart-state.interface';
 import {
@@ -17,7 +17,7 @@ const resetErrors = initializeErrorResetter(DaffCartOperationType.ShippingInform
 const setLoading = initializeLoadingSetter(DaffCartOperationType.ShippingInformation);
 
 export function cartShippingInformationReducer<T extends DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes,
 ): DaffCartReducerState<T> {
   switch (action.type) {

--- a/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.spec.ts
@@ -10,7 +10,7 @@ import {
   DaffCartReducerState,
   DaffCartShippingMethodsLoadSuccess,
   DaffCartShippingMethodsLoadFailure,
-  initialState,
+  daffCartReducerInitialState,
 } from '@daffodil/cart/state';
 import {
   DaffCartFactory,
@@ -45,9 +45,9 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
     it('should return the current state', () => {
       const action = <any>{};
 
-      const result = cartShippingMethodsReducer(initialState, action);
+      const result = cartShippingMethodsReducer(daffCartReducerInitialState, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(daffCartReducerInitialState);
     });
   });
 
@@ -55,7 +55,7 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
 
     it('should set loading state to true', () => {
       const cartShippingMethodsLoadAction = new DaffCartShippingMethodsLoad();
-      const result = cartShippingMethodsReducer(initialState, cartShippingMethodsLoadAction);
+      const result = cartShippingMethodsReducer(daffCartReducerInitialState, cartShippingMethodsLoadAction);
 
       expect(result.loading[DaffCartOperationType.ShippingMethods]).toEqual(DaffState.Resolving);
     });
@@ -67,9 +67,9 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingMethods]: DaffState.Resolving,
         },
       };
@@ -99,13 +99,13 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.ShippingMethods]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.ShippingMethods]: [{ code: 'first error code', message: 'first error message' }],
         },
       };

--- a/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.ts
@@ -3,7 +3,7 @@ import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartShippingMethodsActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
-import { initialState } from '../cart-initial-state';
+import { daffCartReducerInitialState } from '../cart-initial-state';
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartReducerState } from '../cart-state.interface';
 import {
@@ -17,7 +17,7 @@ const resetErrors = initializeErrorResetter(DaffCartOperationType.ShippingMethod
 const setLoading = initializeLoadingSetter(DaffCartOperationType.ShippingMethods);
 
 export function cartShippingMethodsReducer<T extends DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes,
 ): DaffCartReducerState<T> {
   switch (action.type) {

--- a/libs/cart/state/src/reducers/cart.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart.reducer.spec.ts
@@ -1,5 +1,5 @@
 import { daffCartReducer } from '../reducers/cart.reducer';
-import { initialState } from './cart-initial-state';
+import { daffCartReducerInitialState as initialState } from './cart-initial-state';
 
 describe('Cart | Reducer | Cart', () => {
   describe('when an unknown action is triggered', () => {

--- a/libs/cart/state/src/reducers/cart.reducer.ts
+++ b/libs/cart/state/src/reducers/cart.reducer.ts
@@ -4,7 +4,7 @@ import { daffComposeReducers } from '@daffodil/core/state';
 import { ActionTypes } from './action-types.type';
 import { cartBillingAddressReducer } from './cart-billing-address/cart-billing-address.reducer';
 import { cartCouponReducer } from './cart-coupon/cart-coupon.reducer';
-import { initialState } from './cart-initial-state';
+import { daffCartReducerInitialState } from './cart-initial-state';
 import { cartItemReducer } from './cart-item/cart-item.reducer';
 import { cartPaymentMethodsReducer } from './cart-payment-methods/cart-payment-methods.reducer';
 import { cartPaymentReducer } from './cart-payment/cart-payment.reducer';
@@ -33,7 +33,7 @@ const composedReducers = daffComposeReducers([
  * passing the returned state into the next.
  */
 export function daffCartReducer<T extends DaffCart = DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes<T>,
 ): DaffCartReducerState<T> {
   return composedReducers(state, action);

--- a/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
@@ -17,7 +17,7 @@ import {
   DaffCartClear,
   DaffCartClearSuccess,
   DaffCartClearFailure,
-  initialState,
+  daffCartReducerInitialState,
   DaffResolveCartSuccess,
   DaffResolveCartFailure,
   DaffResolveCartServerSide,
@@ -53,9 +53,9 @@ describe('@daffodil/cart/state | cartReducer', () => {
     it('should return the current state', () => {
       const action = <any>{};
 
-      const result = cartReducer(initialState, action);
+      const result = cartReducer(daffCartReducerInitialState, action);
 
-      expect(result).toEqual(initialState);
+      expect(result).toEqual(daffCartReducerInitialState);
     });
   });
 
@@ -63,7 +63,7 @@ describe('@daffodil/cart/state | cartReducer', () => {
     it('should set loading state to true', () => {
       const cartListLoadAction: DaffCartLoad = new DaffCartLoad();
 
-      const result = cartReducer(initialState, cartListLoadAction);
+      const result = cartReducer(daffCartReducerInitialState, cartListLoadAction);
 
       expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Resolving);
     });
@@ -73,7 +73,7 @@ describe('@daffodil/cart/state | cartReducer', () => {
     it('should set loading state to true', () => {
       const cartResolveAction: DaffResolveCart = new DaffResolveCart();
 
-      const result = cartReducer(initialState, cartResolveAction);
+      const result = cartReducer(daffCartReducerInitialState, cartResolveAction);
 
       expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Resolving);
     });
@@ -85,9 +85,9 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
       };
@@ -116,13 +116,13 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Cart]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -152,9 +152,9 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
       };
@@ -183,13 +183,13 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Cart]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -219,13 +219,13 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Cart]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -250,13 +250,13 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Cart]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -282,13 +282,13 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Cart]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -311,7 +311,7 @@ describe('@daffodil/cart/state | cartReducer', () => {
     it('should indicate that the cart is being mutated', () => {
       const cartCreateAction: DaffCartCreate = new DaffCartCreate();
 
-      const result = cartReducer(initialState, cartCreateAction);
+      const result = cartReducer(daffCartReducerInitialState, cartCreateAction);
 
       expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Mutating);
     });
@@ -323,10 +323,10 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         cart: cartFactory.create(),
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
       };
@@ -338,7 +338,7 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     it('should set the cart to initial state plus the payload cart id', () => {
       expect(result.cart).toEqual({
-        ...initialState.cart,
+        ...daffCartReducerInitialState.cart,
         id: cart.id,
       });
     });
@@ -358,13 +358,13 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Cart]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -390,7 +390,7 @@ describe('@daffodil/cart/state | cartReducer', () => {
     it('should indicate that the cart is being mutated', () => {
       const addToCartAction: DaffAddToCart = new DaffAddToCart({ productId, qty });
 
-      const result = cartReducer(initialState, addToCartAction);
+      const result = cartReducer(daffCartReducerInitialState, addToCartAction);
 
       expect(result.loading[DaffCartOperationType.Cart]).toEqual(DaffState.Mutating);
     });
@@ -403,9 +403,9 @@ describe('@daffodil/cart/state | cartReducer', () => {
     beforeEach(() => {
       const addToCartActionSuccess: DaffAddToCartSuccess = new DaffAddToCartSuccess(cart);
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
       };
@@ -432,13 +432,13 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Cart]: [{ code: 'first error code', message: 'first error message' }],
         },
       };
@@ -460,14 +460,14 @@ describe('@daffodil/cart/state | cartReducer', () => {
   describe('when CartClearAction is triggered', () => {
     it('should indicate that the cart is being mutated', () => {
       const expectedState: DaffCartReducerState<DaffCart> = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Mutating,
         },
       };
       const cartClear = new DaffCartClear();
-      const result = cartReducer(initialState, cartClear);
+      const result = cartReducer(daffCartReducerInitialState, cartClear);
 
       expect(result).toEqual(expectedState);
     });
@@ -478,19 +478,19 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       const cartClearSuccess = new DaffCartClearSuccess(cart);
-      result = cartReducer(initialState, cartClearSuccess);
+      result = cartReducer(daffCartReducerInitialState, cartClearSuccess);
     });
 
     it('should set the cart payload on state', () => {
       const expectedState = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         cart: {
-          ...initialState.cart,
+          ...daffCartReducerInitialState.cart,
           items: [],
           ...cart,
         },
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Complete,
         },
       };
@@ -509,13 +509,13 @@ describe('@daffodil/cart/state | cartReducer', () => {
 
     beforeEach(() => {
       state = {
-        ...initialState,
+        ...daffCartReducerInitialState,
         loading: {
-          ...initialState.loading,
+          ...daffCartReducerInitialState.loading,
           [DaffCartOperationType.Cart]: DaffState.Resolving,
         },
         errors: {
-          ...initialState.errors,
+          ...daffCartReducerInitialState.errors,
           [DaffCartOperationType.Cart]: [{ code: 'first error code', message: 'first error message' }],
         },
       };

--- a/libs/cart/state/src/reducers/cart/cart.reducer.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.ts
@@ -3,7 +3,7 @@ import { DaffState } from '@daffodil/core/state';
 
 import { DaffCartActionTypes } from '../../actions/public_api';
 import { ActionTypes } from '../action-types.type';
-import { initialState } from '../cart-initial-state';
+import { daffCartReducerInitialState } from '../cart-initial-state';
 import { DaffCartOperationType } from '../cart-operation-type.enum';
 import { DaffCartReducerState } from '../cart-state.interface';
 import {
@@ -17,7 +17,7 @@ const resetErrors = initializeErrorResetter(DaffCartOperationType.Cart);
 const setLoading = initializeLoadingSetter(DaffCartOperationType.Cart);
 
 export function cartReducer<T extends DaffCart>(
-  state = initialState,
+  state = daffCartReducerInitialState,
   action: ActionTypes,
 ): DaffCartReducerState<T> {
   switch (action.type) {
@@ -55,7 +55,7 @@ export function cartReducer<T extends DaffCart>(
         ...state,
         ...resetErrors(state.errors),
         cart: {
-          ...initialState.cart,
+          ...daffCartReducerInitialState.cart,
           ...action.payload,
         },
         ...setLoading(state.loading, DaffState.Complete),

--- a/libs/cart/state/src/reducers/public_api.ts
+++ b/libs/cart/state/src/reducers/public_api.ts
@@ -11,12 +11,13 @@ export { DaffCartResolveState } from './cart-resolve/cart-resolve-state.enum';
 
 export { daffCartReducer } from './cart.reducer';
 export { DaffCartReducerState } from './cart-state.interface';
-export { initialState } from './cart-initial-state';
+export { daffCartReducerInitialState } from './cart-initial-state';
 
 export { daffCartOrderReducer } from './cart-order/cart-order.reducer';
 export { DaffCartOrderReducerState } from './cart-order/cart-order-state.interface';
 export { daffCartOrderInitialState } from './cart-order/cart-order-initial-state';
 
 export { DAFF_CART_STORE_FEATURE_KEY } from './cart-store-feature-key';
+export { daffCartItemEntitiesAdapter } from './cart-item-entities/cart-item-entities-reducer-adapter';
 
 export * from './token/public_api';

--- a/libs/cart/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/cart/state/src/reducers/token/reducers.token.spec.ts
@@ -5,7 +5,7 @@ import { DaffCartPaymentMethod } from '@daffodil/cart';
 import {
   daffCartProvideExtraReducers,
   DaffCartReducersState,
-  initialState as cartInitialState,
+  daffCartReducerInitialState as cartInitialState,
   DaffCartPaymentLoadSuccess,
 } from '@daffodil/cart/state';
 import { DaffCartPaymentFactory } from '@daffodil/cart/testing';


### PR DESCRIPTION
these should be broken up into separate PRs. The basic features are:
- don't perform cart operations when ID is not in storage
- wait for app to gracefully clean up before clearing client cache (reloading the page)