### PR TITLE
feat(design): set the base stroked and flat button text color to currentColor

### DIFF
--- a/libs/design/src/atoms/button/button-theme.scss
+++ b/libs/design/src/atoms/button/button-theme.scss
@@ -294,7 +294,7 @@
 	.daff-stroked-button {
 		background: transparent;
 		border: 1px solid theming.daff-illuminate($base, $gray, 5);
-		color: theming.daff-text-contrast($base);
+		color: currentColor;
 
 		&:after {
 			background: theming.daff-illuminate($base, $gray, 2);
@@ -406,7 +406,7 @@
 	}
 
 	.daff-flat-button {
-		color: theming.daff-text-contrast($base);
+		color: currentColor;
 
 		&:after {
 			background-color: theming.daff-illuminate($base, $gray, 2);
@@ -416,6 +416,11 @@
 			&:after {
 				background-color: theming.daff-illuminate($base, $gray, 3);
 			}
+		}
+
+		&:hover,
+		&:active {
+			color: theming.daff-text-contrast(theming.daff-illuminate($base, $gray, 2));
 		}
 
 		&.daff-primary {


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The base stroked and flat button text colors don't work on dark theme or if the buttons are placed inside of a container that has a darker background color.

Fixes: N/A


## What is the new behavior?
Set the text color to `currentColor` so it inherits the container's colors. This allows for the base stroked and flat buttons to be used everywhere while passing accessibility.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information