### PR TITLE
feat(customer): correctly handle missing customer address ID

### DIFF
--- a/libs/customer/driver/magento/src/models/responses/customer-address.type.ts
+++ b/libs/customer/driver/magento/src/models/responses/customer-address.type.ts
@@ -1,18 +1,18 @@
 export interface MagentoCustomerAddress {
-  id: number;
+  id?: number;
   region: {
     region_code: string;
     region_id: number;
   };
-  country_code: string;
-  street: string[];
-  company: string;
-  telephone: string;
-  postcode: string;
-  city: string;
-  firstname: string;
-  lastname: string;
-  email: string;
-  default_billing: boolean;
-  default_shipping: boolean;
+  country_code?: string;
+  street?: string[];
+  company?: string;
+  telephone?: string;
+  postcode?: string;
+  city?: string;
+  firstname?: string;
+  lastname?: string;
+  email?: string;
+  default_billing?: boolean;
+  default_shipping?: boolean;
 }

--- a/libs/customer/driver/magento/src/transforms/responses/customer-address.spec.ts
+++ b/libs/customer/driver/magento/src/transforms/responses/customer-address.spec.ts
@@ -36,4 +36,17 @@ describe('@daffodil/customer/driver/magento | magentoCustomerAddressTransform', 
     expect(result.defaultBilling).toEqual(mockAddress.default_billing);
     expect(result.defaultShipping).toEqual(mockAddress.default_shipping);
   });
+
+  describe('when the ID is null', () => {
+    beforeEach(() => {
+      mockAddress = addressFactory.create({
+        id: null,
+      });
+      result = magentoCustomerAddressTransform(mockAddress);
+    });
+
+    it('should set ID to null', () => {
+      expect(result.id).toBeNull();
+    });
+  });
 });

--- a/libs/customer/driver/magento/src/transforms/responses/customer-address.ts
+++ b/libs/customer/driver/magento/src/transforms/responses/customer-address.ts
@@ -3,7 +3,7 @@ import { DaffCustomerAddress } from '@daffodil/customer';
 import { MagentoCustomerAddress } from '../../models/public_api';
 
 export const magentoCustomerAddressTransform = (address: MagentoCustomerAddress): DaffCustomerAddress => ({
-  id: String(address.id),
+  id: address.id ? String(address.id) : null,
   street: address.street[0],
   street2: address.street[1],
   city: address.city,


### PR DESCRIPTION
yes this can really happen

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- magento can return null customer IDs and the ID being `'null'` breaks things
- daffodil types are not aligned to the Magento schema

## What is the new behavior?
- Magento customer address type correctly matches GQL schema
- missing customer address IDs get transformed to `null`, which is handled gracefully by daffodil

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
the GQL schema:
```gql
type CustomerAddress @doc(description: "Contains detailed information about a customer's billing or shipping address."){
    id: Int @doc(description: "The ID of a `CustomerAddress` object.")
    customer_id: Int @doc(description: "The customer ID") @deprecated(reason: "`customer_id` is not needed as part of `CustomerAddress`. The `id` is a unique identifier for the addresses.")
    region: CustomerAddressRegion @doc(description: "An object containing the region name, region code, and region ID.")
    region_id: Int @doc(description: "The unique ID for a pre-defined region.")
    country_id: String @doc(description: "The customer's country.") @deprecated(reason: "Use `country_code` instead.")
    country_code: CountryCodeEnum @doc(description: "The customer's country.")
    street: [String] @doc(description: "An array of strings that define the street number and name.")
    company: String @doc(description: "The customer's company.")
    telephone: String @doc(description: "The customer's telephone number.")
    fax: String @doc(description: "The customer's fax number.")
    postcode: String @doc(description: "The customer's ZIP or postal code.")
    city: String @doc(description: "The customer's city or town.")
    firstname: String @doc(description: "The first name of the person associated with the shipping/billing address.")
    lastname: String @doc(description: "The family name of the person associated with the shipping/billing address.")
    middlename: String @doc(description: "The middle name of the person associated with the shipping/billing address.")
    prefix: String @doc(description: "An honorific, such as Dr., Mr., or Mrs.")
    suffix: String @doc(description: "A value such as Sr., Jr., or III.")
    vat_id: String @doc(description: "The customer's Value-added tax (VAT) number (for corporate customers).")
    default_shipping: Boolean @doc(description: "Indicates whether the address is the customer's default shipping address.")
    default_billing: Boolean @doc(description: "Indicates whether the address is the customer's default billing address.")
    custom_attributes: [CustomerAddressAttribute] @deprecated(reason: "Custom attributes should not be put into a container.")
    extension_attributes: [CustomerAddressAttribute] @doc(description: "Contains any extension attributes for the address.")
}
```