### PR TITLE
feat(auth): handle missing token errors by resetting to unauthenticated state

### DIFF
--- a/libs/auth/driver/src/constants/public_api.ts
+++ b/libs/auth/driver/src/constants/public_api.ts
@@ -1,0 +1,1 @@
+export * from './unauthenticated-error-codes';

--- a/libs/auth/driver/src/constants/unauthenticated-error-codes.ts
+++ b/libs/auth/driver/src/constants/unauthenticated-error-codes.ts
@@ -8,8 +8,8 @@ import { DaffAuthDriverErrorCodes } from '../errors/public_api';
  * These are contrasted to network failures and other sporadic and generic errors that aren't
  * a guarantee of the token's invalidity.
  */
-export const DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES = [
-  DaffAuthDriverErrorCodes.UNAUTHORIZED,
-  DaffAuthDriverErrorCodes.AUTHENTICATION_FAILED,
-  DaffAuthErrorCodes.MISSING_TOKEN,
-];
+export const DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES = {
+  [DaffAuthDriverErrorCodes.UNAUTHORIZED]: true,
+  [DaffAuthDriverErrorCodes.AUTHENTICATION_FAILED]: true,
+  [DaffAuthErrorCodes.MISSING_TOKEN]: true,
+};

--- a/libs/auth/driver/src/constants/unauthenticated-error-codes.ts
+++ b/libs/auth/driver/src/constants/unauthenticated-error-codes.ts
@@ -1,0 +1,15 @@
+import { DaffAuthErrorCodes } from '@daffodil/auth';
+
+import { DaffAuthDriverErrorCodes } from '../errors/public_api';
+
+/**
+ * The error codes that indicate that the user definitely should not be in an unauthenticated state
+ * and if an auth token exists in storage, it is invalid.
+ * These are contrasted to network failures and other sporadic and generic errors that aren't
+ * a guarantee of the token's invalidity.
+ */
+export const DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES = [
+  DaffAuthDriverErrorCodes.UNAUTHORIZED,
+  DaffAuthDriverErrorCodes.AUTHENTICATION_FAILED,
+  DaffAuthErrorCodes.MISSING_TOKEN,
+];

--- a/libs/auth/driver/src/public_api.ts
+++ b/libs/auth/driver/src/public_api.ts
@@ -1,3 +1,4 @@
 export * from './interfaces/public_api';
 export * from './errors/public_api';
 export * from './services/public_api';
+export * from './constants/public_api';

--- a/libs/auth/routing/src/guards/guest-only.guard.ts
+++ b/libs/auth/routing/src/guards/guest-only.guard.ts
@@ -59,7 +59,7 @@ export class GuestOnlyGuard implements CanActivate {
     return this.tokenCheck.check().pipe(
       map(() => false),
       catchError((error: DaffError) => {
-        if (DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES.find((code) => code === error.code)) {
+        if (DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES[error.code]) {
           this.storage.removeAuthToken();
           this.store.dispatch(new DaffAuthGuardLogout(this.errorMatcher(error)));
         }

--- a/libs/auth/routing/src/guards/guest-only.guard.ts
+++ b/libs/auth/routing/src/guards/guest-only.guard.ts
@@ -22,6 +22,7 @@ import {
   DaffAuthStorageService,
 } from '@daffodil/auth';
 import {
+  DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES,
   DaffAuthDriverErrorCodes,
   DaffAuthDriverTokenCheck,
 } from '@daffodil/auth/driver';
@@ -58,7 +59,7 @@ export class GuestOnlyGuard implements CanActivate {
     return this.tokenCheck.check().pipe(
       map(() => false),
       catchError((error: DaffError) => {
-        if (error.code === DaffAuthDriverErrorCodes.UNAUTHORIZED || error.code === DaffAuthDriverErrorCodes.AUTHENTICATION_FAILED) {
+        if (DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES.find((code) => code === error.code)) {
           this.storage.removeAuthToken();
           this.store.dispatch(new DaffAuthGuardLogout(this.errorMatcher(error)));
         }

--- a/libs/auth/routing/src/guards/member-only.guard.ts
+++ b/libs/auth/routing/src/guards/member-only.guard.ts
@@ -60,7 +60,7 @@ export class MemberOnlyGuard implements CanActivate {
     return this.tokenCheck.check().pipe(
       map(() => true),
       catchError((error: DaffError) => {
-        if (DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES.find((code) => code === error.code)) {
+        if (DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES[error.code]) {
           this.storage.removeAuthToken();
           this.store.dispatch(new DaffAuthGuardLogout(this.errorMatcher(error)));
         }

--- a/libs/auth/routing/src/guards/member-only.guard.ts
+++ b/libs/auth/routing/src/guards/member-only.guard.ts
@@ -22,6 +22,7 @@ import {
   DaffAuthStorageService,
 } from '@daffodil/auth';
 import {
+  DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES,
   DaffAuthDriverErrorCodes,
   DaffAuthDriverTokenCheck,
 } from '@daffodil/auth/driver';
@@ -59,7 +60,7 @@ export class MemberOnlyGuard implements CanActivate {
     return this.tokenCheck.check().pipe(
       map(() => true),
       catchError((error: DaffError) => {
-        if (error.code === DaffAuthDriverErrorCodes.UNAUTHORIZED || error.code === DaffAuthDriverErrorCodes.AUTHENTICATION_FAILED) {
+        if (DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES.find((code) => code === error.code)) {
           this.storage.removeAuthToken();
           this.store.dispatch(new DaffAuthGuardLogout(this.errorMatcher(error)));
         }

--- a/libs/auth/state/src/effects/auth.effects.spec.ts
+++ b/libs/auth/state/src/effects/auth.effects.spec.ts
@@ -10,7 +10,10 @@ import {
 } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
-import { DaffAuthStorageService } from '@daffodil/auth';
+import {
+  DaffAuthMissingTokenError,
+  DaffAuthStorageService,
+} from '@daffodil/auth';
 import {
   DaffAuthDriver,
   DaffAuthInvalidAPIResponseError,
@@ -221,6 +224,34 @@ describe('@daffodil/auth/state | DaffAuthEffects', () => {
 
       beforeEach(() => {
         revokeAction = new DaffAuthCheckFailure(new DaffUnauthorizedError('error'));
+        actions$ = hot('--a', { a: revokeAction });
+        expected = cold('--a', { a: new DaffAuthResetToUnauthenticated(revokeAction.type) });
+      });
+
+      it('should dispatch DaffAuthResetToUnauthenticated', () => {
+        expect(effects.resetToUnauthenticated$).toBeObservable(expected);
+      });
+    });
+
+    describe('when DaffAuthCheckFailure is dispatched for an authentication failed error', () => {
+      let revokeAction: DaffAuthCheckFailure;
+
+      beforeEach(() => {
+        revokeAction = new DaffAuthCheckFailure(new DaffAuthenticationFailedError('error'));
+        actions$ = hot('--a', { a: revokeAction });
+        expected = cold('--a', { a: new DaffAuthResetToUnauthenticated(revokeAction.type) });
+      });
+
+      it('should dispatch DaffAuthResetToUnauthenticated', () => {
+        expect(effects.resetToUnauthenticated$).toBeObservable(expected);
+      });
+    });
+
+    describe('when DaffAuthCheckFailure is dispatched for an missing token error', () => {
+      let revokeAction: DaffAuthCheckFailure;
+
+      beforeEach(() => {
+        revokeAction = new DaffAuthCheckFailure(new DaffAuthMissingTokenError('error'));
         actions$ = hot('--a', { a: revokeAction });
         expected = cold('--a', { a: new DaffAuthResetToUnauthenticated(revokeAction.type) });
       });

--- a/libs/auth/state/src/effects/auth.effects.ts
+++ b/libs/auth/state/src/effects/auth.effects.ts
@@ -129,7 +129,7 @@ export class DaffAuthEffects {
       // such as a network failure, don't reset
       if (
         action.type === DaffAuthActionTypes.AuthCheckFailureAction
-          && !DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES.find((code) => code === action.errorMessage.code)
+          && !DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES[action.errorMessage.code]
       ) {
         return false;
       }

--- a/libs/auth/state/src/effects/auth.effects.ts
+++ b/libs/auth/state/src/effects/auth.effects.ts
@@ -25,6 +25,7 @@ import {
 import {
   DaffAuthStorageService,
   DAFF_AUTH_ERROR_MATCHER,
+  DaffAuthErrorCodes,
 } from '@daffodil/auth';
 import {
   DaffAuthDriverErrorCodes,
@@ -59,6 +60,12 @@ import {
 } from '../config/public_api';
 import { DaffAuthUnauthenticatedHook } from '../injection-tokens/public_api';
 import { DAFF_AUTH_UNAUTHENTICATED_HOOK } from '../injection-tokens/unauthenticated/hook.token';
+
+const CLIENT_RESET_ERROR_CODES = [
+  DaffAuthDriverErrorCodes.UNAUTHORIZED,
+  DaffAuthDriverErrorCodes.AUTHENTICATION_FAILED,
+  DaffAuthErrorCodes.MISSING_TOKEN,
+];
 
 @Injectable()
 export class DaffAuthEffects {
@@ -127,11 +134,11 @@ export class DaffAuthEffects {
       DaffAuthLoginActionTypes.LogoutSuccessAction,
     ),
     filter((action) => {
-      // if the auth check failure is for any reason other than auth failure, don't reset
+      // if the auth check failure is for any reason other than auth failure,
+      // such as a network failure, don't reset
       if (
         action.type === DaffAuthActionTypes.AuthCheckFailureAction
-        && action.errorMessage.code !== DaffAuthDriverErrorCodes.UNAUTHORIZED
-        && action.errorMessage.code !== DaffAuthDriverErrorCodes.AUTHENTICATION_FAILED
+          && !CLIENT_RESET_ERROR_CODES.find((code) => code === action.errorMessage.code)
       ) {
         return false;
       }

--- a/libs/auth/state/src/effects/auth.effects.ts
+++ b/libs/auth/state/src/effects/auth.effects.ts
@@ -10,7 +10,6 @@ import {
 import {
   of,
   EMPTY,
-  asyncScheduler,
 } from 'rxjs';
 import {
   switchMap,
@@ -19,16 +18,14 @@ import {
   repeat,
   filter,
   tap,
-  delay,
 } from 'rxjs/operators';
 
 import {
   DaffAuthStorageService,
   DAFF_AUTH_ERROR_MATCHER,
-  DaffAuthErrorCodes,
 } from '@daffodil/auth';
 import {
-  DaffAuthDriverErrorCodes,
+  DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES,
   DaffAuthDriverTokenCheck,
 } from '@daffodil/auth/driver';
 import {
@@ -60,12 +57,6 @@ import {
 } from '../config/public_api';
 import { DaffAuthUnauthenticatedHook } from '../injection-tokens/public_api';
 import { DAFF_AUTH_UNAUTHENTICATED_HOOK } from '../injection-tokens/unauthenticated/hook.token';
-
-const CLIENT_RESET_ERROR_CODES = [
-  DaffAuthDriverErrorCodes.UNAUTHORIZED,
-  DaffAuthDriverErrorCodes.AUTHENTICATION_FAILED,
-  DaffAuthErrorCodes.MISSING_TOKEN,
-];
 
 @Injectable()
 export class DaffAuthEffects {
@@ -138,7 +129,7 @@ export class DaffAuthEffects {
       // such as a network failure, don't reset
       if (
         action.type === DaffAuthActionTypes.AuthCheckFailureAction
-          && !CLIENT_RESET_ERROR_CODES.find((code) => code === action.errorMessage.code)
+          && !DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES.find((code) => code === action.errorMessage.code)
       ) {
         return false;
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
if an auth check fails due to a missing auth token, the reset flow will not get triggered

## What is the new behavior?
token missing errors cause auth reset

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
this might get annoying if auth checks are dispatched periodically without first checking the presence of the auth token