### PR TITLE
fix(auth): guest guard always triggers logout for a guest user

### DIFF
--- a/libs/auth/driver/src/constants/unauthenticated-error-codes.ts
+++ b/libs/auth/driver/src/constants/unauthenticated-error-codes.ts
@@ -1,5 +1,3 @@
-import { DaffAuthErrorCodes } from '@daffodil/auth';
-
 import { DaffAuthDriverErrorCodes } from '../errors/public_api';
 
 /**
@@ -11,5 +9,4 @@ import { DaffAuthDriverErrorCodes } from '../errors/public_api';
 export const DAFF_AUTH_UNAUTHENTICATED_ERROR_CODES = {
   [DaffAuthDriverErrorCodes.UNAUTHORIZED]: true,
   [DaffAuthDriverErrorCodes.AUTHENTICATION_FAILED]: true,
-  [DaffAuthErrorCodes.MISSING_TOKEN]: true,
 };

--- a/libs/auth/state/src/effects/auth.effects.spec.ts
+++ b/libs/auth/state/src/effects/auth.effects.spec.ts
@@ -203,20 +203,6 @@ describe('@daffodil/auth/state | DaffAuthEffects', () => {
       });
     });
 
-    describe('when DaffAuthCheckFailure is dispatched for an missing token error', () => {
-      let revokeAction: DaffAuthCheckFailure;
-
-      beforeEach(() => {
-        revokeAction = new DaffAuthCheckFailure(new DaffAuthMissingTokenError('error'));
-        actions$ = hot('--a', { a: revokeAction });
-        expected = cold('--a', { a: new DaffAuthResetToUnauthenticated(revokeAction.type) });
-      });
-
-      it('should dispatch DaffAuthResetToUnauthenticated', () => {
-        expect(effects.resetToUnauthenticated$).toBeObservable(expected);
-      });
-    });
-
     describe('when DaffAuthCheckFailure is dispatched for some random reason', () => {
       let revokeAction: DaffAuthCheckFailure;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
the guards always trigger a logout when the auth token is missing, refreshing the page
this basically means that a guest user cannot visit any guarded pages

## What is the new behavior?
missing token errors are not treated as unauthentications, and the reset to unauthenticated flow will not get triggered. This could leave the user in an unfortunate state if they clear localstorage while using the app but its the lesser of 2 evils.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information