### PR TITLE
feat(cart): handle create errors in Magento driver

### DIFF
--- a/libs/cart/driver/magento/src/cart.service.spec.ts
+++ b/libs/cart/driver/magento/src/cart.service.spec.ts
@@ -279,6 +279,34 @@ describe('@daffodil/cart/driver/magento | DaffMagentoCartService', () => {
   });
 
   describe('create | creates the cart', () => {
+    describe('when there are graphQL errors', () => {
+      it('should throw the error', done => {
+        service.create().pipe(
+          catchError((err) => {
+            expect(err).toEqual(jasmine.any(DaffCartNotFoundError));
+            done();
+            return of();
+          }),
+        ).subscribe(result => {
+          fail('create should throw, not emit');
+        });
+
+        const op = controller.expectOne(addTypenameToDocument(createCart));
+
+        op.flush({
+          errors: [new GraphQLError(
+            'Can\'t find a cart with that ID.',
+            null,
+            null,
+            null,
+            null,
+            null,
+            { category: 'graphql-no-such-entity' },
+          )],
+        });
+      });
+    });
+
     it('should return an observable with the cart ID', done => {
       service.create().subscribe(result => {
         expect(result.id).toEqual(cartId);

--- a/libs/cart/driver/magento/src/cart.service.ts
+++ b/libs/cart/driver/magento/src/cart.service.ts
@@ -105,6 +105,7 @@ export class DaffMagentoCartService implements DaffCartServiceInterface<DaffCart
   create(): Observable<{id: DaffCart['id']}> {
     return this.mutationQueue.mutate<MagentoCreateCartResponse>({ mutation: createCart }).pipe(
       map(result => ({ id: result.data.createEmptyCart })),
+      catchError(err => throwError(() => transformCartMagentoError(err))),
     );
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Create cart in Magento driver does not handle errors.

## What is the new behavior?
Now it does, in particular network errors during get ID or fail are now appropriately transformed

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information