### PR TITLE
feat(authorizenet): add state config for accept retry backoff

### DIFF
--- a/libs/authorizenet/state/src/authorize-net-state.module.ts
+++ b/libs/authorizenet/state/src/authorize-net-state.module.ts
@@ -1,7 +1,15 @@
-import { NgModule } from '@angular/core';
+import {
+  ModuleWithProviders,
+  NgModule,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 
+import {
+  DaffAuthorizeNetStateConfig,
+  daffAuthorizeNetStateDefaultConfig,
+  provideDaffAuthorizeNetStateConfig,
+} from './config/public_api';
 import { DaffAuthorizeNetEffects } from './effects/authorize-net.effects';
 import { DAFF_AUTHORIZENET_STORE_FEATURE_KEY } from './reducers/authorizenet-store-feature-key';
 import { DAFF_AUTHORIZE_NET_REDUCERS } from './reducers/token/reducers.token';
@@ -12,4 +20,16 @@ import { DAFF_AUTHORIZE_NET_REDUCERS } from './reducers/token/reducers.token';
     EffectsModule.forFeature([DaffAuthorizeNetEffects]),
   ],
 })
-export class DaffAuthorizeNetStateModule { }
+export class DaffAuthorizeNetStateModule {
+  static withConfig(config: Partial<DaffAuthorizeNetStateConfig> = {}): ModuleWithProviders<DaffAuthorizeNetStateModule> {
+    return {
+      ngModule: DaffAuthorizeNetStateModule,
+      providers: [
+        provideDaffAuthorizeNetStateConfig({
+          ...daffAuthorizeNetStateDefaultConfig,
+          ...config,
+        }),
+      ],
+    };
+  }
+}

--- a/libs/authorizenet/state/src/config/default.ts
+++ b/libs/authorizenet/state/src/config/default.ts
@@ -1,0 +1,6 @@
+import { DaffAuthorizeNetStateConfig } from './type';
+
+export const daffAuthorizeNetStateDefaultConfig: DaffAuthorizeNetStateConfig = {
+  acceptMaxRetries: 5,
+  acceptBackoffTiming: 30,
+};

--- a/libs/authorizenet/state/src/config/public_api.ts
+++ b/libs/authorizenet/state/src/config/public_api.ts
@@ -1,0 +1,6 @@
+export { daffAuthorizeNetStateDefaultConfig } from './default';
+export {
+  DAFF_AUTHORIZE_NET_STATE_CONFIG,
+  provideDaffAuthorizeNetStateConfig,
+} from './token';
+export { DaffAuthorizeNetStateConfig } from './type';

--- a/libs/authorizenet/state/src/config/token.ts
+++ b/libs/authorizenet/state/src/config/token.ts
@@ -1,0 +1,14 @@
+import {
+  InjectionToken,
+  ValueProvider,
+} from '@angular/core';
+
+import { daffAuthorizeNetStateDefaultConfig } from './default';
+import { DaffAuthorizeNetStateConfig } from './type';
+
+export const DAFF_AUTHORIZE_NET_STATE_CONFIG = new InjectionToken('DAFF_AUTHORIZE_NET_STATE_CONFIG', { factory: () => daffAuthorizeNetStateDefaultConfig });
+
+export const provideDaffAuthorizeNetStateConfig = (config: DaffAuthorizeNetStateConfig): ValueProvider => ({
+  provide: DAFF_AUTHORIZE_NET_STATE_CONFIG,
+  useValue: config,
+});

--- a/libs/authorizenet/state/src/config/type.ts
+++ b/libs/authorizenet/state/src/config/type.ts
@@ -1,0 +1,13 @@
+export interface DaffAuthorizeNetStateConfig {
+  /**
+   * How many times Daffodil will retry the Accept.js load.
+   * Defaults to 5.
+   */
+  acceptMaxRetries: number;
+
+  /**
+   * The Accept.js loading retry backoff timing in milliseconds.
+   * Defaults to 30.
+   */
+  acceptBackoffTiming: number;
+}

--- a/libs/authorizenet/state/src/effects/authorize-net.effects.ts
+++ b/libs/authorizenet/state/src/effects/authorize-net.effects.ts
@@ -53,6 +53,10 @@ import {
   DaffLoadAcceptJsFailure,
   DaffLoadAcceptJsSuccess,
 } from '../actions/authorizenet.actions';
+import {
+  DAFF_AUTHORIZE_NET_STATE_CONFIG,
+  DaffAuthorizeNetStateConfig,
+} from '../config/public_api';
 
 @Injectable()
 export class DaffAuthorizeNetEffects<T extends DaffAuthorizeNetTokenRequest = DaffAuthorizeNetTokenRequest> {
@@ -62,6 +66,7 @@ export class DaffAuthorizeNetEffects<T extends DaffAuthorizeNetTokenRequest = Da
     @Inject(DaffAuthorizeNetDriver) private driver: DaffAuthorizeNetService<T>,
     @Inject(DaffAuthorizeNetPaymentId) private authorizeNetPaymentId: string,
     @Inject(DAFF_AUTHORIZENET_ERROR_MATCHER) private errorMatcher: ErrorTransformer,
+    @Inject(DAFF_AUTHORIZE_NET_STATE_CONFIG) private config: DaffAuthorizeNetStateConfig,
     private acceptJsLoadingService: DaffAcceptJsLoadingService,
   ) {}
 
@@ -105,7 +110,7 @@ export class DaffAuthorizeNetEffects<T extends DaffAuthorizeNetTokenRequest = Da
   ));
 
 
-  loadAcceptJs$ = createEffect(() => (maxTries = 3, ms = 30): Observable<any> => this.actions$.pipe(
+  loadAcceptJs$ = createEffect(() => (maxTries = this.config.acceptMaxRetries, ms = this.config.acceptBackoffTiming): Observable<any> => this.actions$.pipe(
     ofType(DaffAuthorizeNetActionTypes.LoadAcceptJsAction),
     tap((action: DaffLoadAcceptJs) => this.acceptJsLoadingService.load()),
     switchMap(() => defer(() => of(this.acceptJsLoadingService.getAccept())).pipe(

--- a/libs/authorizenet/state/src/public_api.ts
+++ b/libs/authorizenet/state/src/public_api.ts
@@ -1,6 +1,7 @@
 export * from './actions/authorizenet.actions';
 export * from './selectors/authorize-net.selector';
 export * from './reducers/public_api';
+export * from './config/public_api';
 
 export { DaffAuthorizeNetFacade } from './facades/authorize-net.facade';
 export { DaffAuthorizeNetFacadeInterface } from './facades/authorize-net-facade.interface';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Accept.js loading retry behavior is not configable

## What is the new behavior?
Max retries and backoff timing are now configable

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information