### PR TITLE
fix(cart): cart resolution effects unsafely call storage in SSR

### DIFF
--- a/libs/cart/state/src/effects/cart-resolver.effects.ts
+++ b/libs/cart/state/src/effects/cart-resolver.effects.ts
@@ -1,6 +1,8 @@
+import { isPlatformBrowser } from '@angular/common';
 import {
   Injectable,
   Inject,
+  PLATFORM_ID,
 } from '@angular/core';
 import {
   Actions,
@@ -51,6 +53,7 @@ import {
   DaffResolveCartServerSide,
   DaffResolveCart,
   DaffResolveCartPartialSuccess,
+  DaffCartActions,
 } from '../actions/public_api';
 
 /**
@@ -64,19 +67,22 @@ import {
 export class DaffCartResolverEffects<T extends DaffCart = DaffCart>
 implements OnInitEffects {
   constructor(
-    private actions$: Actions,
+    private actions$: Actions<DaffCartActions<T>>,
     @Inject(DAFF_CART_ERROR_MATCHER) private errorMatcher: ErrorTransformer,
     private cartStorage: DaffCartStorageService,
     private cartResolver: DaffCartDriverResolveService,
-    @Inject(DaffCartDriver) private driver: DaffCartServiceInterface<T>,
+    @Inject(PLATFORM_ID) private platformId: string,
   ) {}
 
   ngrxOnInitEffects(): Action {
-    return this.cartStorage.getCartId() ? new DaffResolveCart() : { type: '' };
+    return isPlatformBrowser(this.platformId) && this.cartStorage.getCartId() ? new DaffResolveCart() : { type: '' };
   }
 
   onResolveCart = createEffect(() => (): Observable<Action> => this.actions$.pipe(
-    ofType<DaffResolveCart | DaffResolveCartSuccess>(DaffCartActionTypes.ResolveCartAction, DaffCartActionTypes.ResolveCartSuccessAction),
+    ofType(
+      DaffCartActionTypes.ResolveCartAction,
+      DaffCartActionTypes.ResolveCartSuccessAction,
+    ),
     switchMap(action =>
       iif(
         // if something else resolves the cart during an outstanding resolve


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
cart resolver effects call storage always, which breaks SSR

## What is the new behavior?
the platform is checked before calling the storage service. the storage service is only called in the browser

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information