### PR TITLE
feat(design): create focus stack service

### DIFF
--- a/libs/design/src/core/focus/public_api.ts
+++ b/libs/design/src/core/focus/public_api.ts
@@ -1,1 +1,2 @@
 export { daffFocusableElementsSelector } from './focusable-elements';
+export { DaffFocusStackService } from './stack.service';

--- a/libs/design/src/core/focus/stack.service.spec.ts
+++ b/libs/design/src/core/focus/stack.service.spec.ts
@@ -6,28 +6,109 @@
 // if stack is empty and pop is called, document should become focused
 
 import { Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 
 import { DaffFocusStackService } from './stack.service';
 
-@Component({})
+@Component({
+  template: `
+    <button id="one">one</button>
+    <button id="two">two</button>
+    <button id="three">three</button>
+    <button id="four">four</button>
+  `,
+})
 export class FakeComponent {}
 
 describe('DaffFocusStackService', () => {
-  let service: DaffFocusStackService;
+  let stack: DaffFocusStackService;
+  let wrapper: ComponentFixture<FakeComponent>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         DaffFocusStackService,
       ],
+      declarations: [
+        FakeComponent,
+      ],
     });
 
-    service = TestBed.inject(DaffFocusStackService);
+    wrapper = TestBed.createComponent(FakeComponent);
+    stack = TestBed.inject(DaffFocusStackService);
   });
 
 
   it('should be created', () => {
-    expect(service).toBeTruthy();
+    expect(stack).toBeTruthy();
+  });
+
+  describe('focus', () => {
+    it('should not error in the event there is nothing in the stack', () => {
+      expect(() => stack.focus()).not.toThrowError();
+    });
+
+    it('it should focus on the item at the top of the stack ', () => {
+      const one = wrapper.debugElement.query(By.css('#one')).nativeElement;
+      const two = wrapper.debugElement.query(By.css('#two')).nativeElement;
+      expect(two).toBeInstanceOf(HTMLElement);
+
+      stack.push(one);
+      stack.push(two);
+      stack.focus();
+
+      expect(document.activeElement).toEqual(two);
+    });
+  });
+
+  describe('pop and push', () => {
+    it('it should add an item at the top of the stack', () => {
+      const one = wrapper.debugElement.query(By.css('#one')).nativeElement;
+      const two = wrapper.debugElement.query(By.css('#two')).nativeElement;
+      expect(two).toBeInstanceOf(HTMLElement);
+
+      stack.push(one);
+      stack.push(two);
+
+      expect(stack.length()).toEqual(2);
+      expect(stack.pop()).toEqual(two);
+    });
+  });
+
+  describe('pop', () => {
+    it('should pop an element off the stack and return it', () => {
+      const one = wrapper.debugElement.query(By.css('#one')).nativeElement;
+
+      stack.push(one);
+      expect(stack.length()).toEqual(1);
+      expect(stack.pop()).toEqual(one);
+      expect(stack.length()).toEqual(0);
+    });
+
+    it('should return the activeElement (in chrome, the body) if you pop an empty stack', () => {
+      expect(stack.pop()).toEqual(<HTMLElement>document.activeElement);
+    });
+
+    it('should focus the popped element if called with no arguments', () => {
+      const one = wrapper.debugElement.query(By.css('#one')).nativeElement;
+
+      stack.push(one);
+      expect(one).not.toEqual(document.activeElement);
+      stack.pop();
+      expect(one).toEqual(document.activeElement);
+    });
+
+    it('should not focus the popped element if pop is called with false', () => {
+      const one = wrapper.debugElement.query(By.css('#one')).nativeElement;
+
+      stack.push(one);
+      expect(one).not.toEqual(document.activeElement);
+      stack.pop(false);
+      expect(one).not.toEqual(document.activeElement);
+    });
   });
 });

--- a/libs/design/src/core/focus/stack.service.spec.ts
+++ b/libs/design/src/core/focus/stack.service.spec.ts
@@ -1,0 +1,33 @@
+// stack is empty array by default
+// when there is nothing in stack and focus is called, focus should doing nothing
+// when something is in stack and focus is called, element is focused
+// when push is called, it should add element to stack
+// when pop is called, it should remove element from stack and focus the element
+// if stack is empty and pop is called, document should become focused
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { DaffFocusStackService } from './stack.service';
+
+@Component({})
+export class FakeComponent {}
+
+describe('DaffFocusStackService', () => {
+  let service: DaffFocusStackService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DaffFocusStackService,
+      ],
+    });
+
+    service = TestBed.inject(DaffFocusStackService);
+  });
+
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/design/src/core/focus/stack.service.spec.ts
+++ b/libs/design/src/core/focus/stack.service.spec.ts
@@ -1,10 +1,3 @@
-// stack is empty array by default
-// when there is nothing in stack and focus is called, focus should doing nothing
-// when something is in stack and focus is called, element is focused
-// when push is called, it should add element to stack
-// when pop is called, it should remove element from stack and focus the element
-// if stack is empty and pop is called, document should become focused
-
 import { Component } from '@angular/core';
 import {
   ComponentFixture,
@@ -45,6 +38,7 @@ describe('DaffFocusStackService', () => {
 
   it('should be created', () => {
     expect(stack).toBeTruthy();
+    expect(stack.length()).toEqual(0);
   });
 
   describe('focus', () => {

--- a/libs/design/src/core/focus/stack.service.ts
+++ b/libs/design/src/core/focus/stack.service.ts
@@ -1,46 +1,71 @@
-import { Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import {
+  Inject,
+  Injectable,
+} from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class DaffFocusStackService {
-  _stack: HTMLElement[] = [];
+  private _stack: HTMLElement[] = [];
+
+  constructor(@Inject(DOCUMENT) private document: any) {
+
+  }
 
   /**
-   * @description
-   * Adds a HTML element to a focus stack.
-   * This method should be called to manage focus history. It should be
-   * called before focus is moved to the next element.
+   * Return the current length of the stack.
+   */
+  length(): number {
+    return this._stack.length;
+  }
+
+  /**
+   * Adds a HTML element to a focus stack and returns the new length of the stack.
+   *
+   * Generally, you will probably want to call this before you transition focus
+   * onto a new element.
    *
    * ```ts
    * this._focusStack.push(this._doc.activeElement);
    * ```
    */
-  push(el: HTMLElement) {
+  push(el: HTMLElement): number {
     this._stack.push(el);
+    return this._stack.length;
   }
 
   /**
-   * @description
    * Focuses on the HTML element at the top of a stack.
+   *
+   * ```ts
+   * this._focusStack.push(this._doc.activeElement);
+   * ```
    */
   focus() {
-    this._stack.slice(-1)[0].focus();
+    if(this._stack.length >= 1) {
+      this._stack.slice(-1)[0].focus();
+    } else {
+      (<HTMLElement>this.document.activeElement).blur();
+    }
   }
 
   /**
-   * @description
    * Removes the HMTL element at the top of a stack and focuses on it.
    */
-  pop() {
+  pop(focus: boolean = true): HTMLElement {
     let el = this._stack.pop();
     while(el === undefined && this._stack.length > 0) {
       el = this._stack.pop();
     }
 
     if(el) {
-      el.focus();
-      return;
+      if(focus) {
+        el.focus();
+      }
+      return el;
     }
 
-    (<HTMLElement>document.activeElement).blur();
+    (<HTMLElement>this.document.activeElement).blur();
+    return this.document.activeElement;
   }
 }

--- a/libs/design/src/core/focus/stack.service.ts
+++ b/libs/design/src/core/focus/stack.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class DaffFocusStackService {
+  _stack: HTMLElement[] = [];
+
+  /**
+   * @description
+   * Adds a HTML element to a focus stack.
+   * This method should be called to manage focus history. It should be
+   * called before focus is moved to the next element.
+   *
+   * ```ts
+   * this._focusStack.push(this._doc.activeElement);
+   * ```
+   */
+  push(el: HTMLElement) {
+    this._stack.push(el);
+  }
+
+  /**
+   * @description
+   * Focuses on the HTML element at the top of a stack.
+   */
+  focus() {
+    this._stack.slice(-1)[0].focus();
+  }
+
+  /**
+   * @description
+   * Removes the HMTL element at the top of a stack and focuses on it.
+   */
+  pop() {
+    let el = this._stack.pop();
+    while(el === undefined && this._stack.length > 0) {
+      el = this._stack.pop();
+    }
+
+    if(el) {
+      el.focus();
+      return;
+    }
+
+    (<HTMLElement>document.activeElement).blur();
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
We currently don't have a way of moving focus back to the activator of modal-like elements. Currently, focus can jump into the modal-like element when it opens, but when it closes, focus is lost and is reset to the body.

Fixes: #2565 


## What is the new behavior?
This service allows for focus to be placed back on the activator when the element is closed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information