### PR TITLE
feat(design): clean up `<pre>` styling and add margin styles to stop article cascade

### DIFF
--- a/libs/design/src/molecules/article/article/article-theme.scss
+++ b/libs/design/src/molecules/article/article/article-theme.scss
@@ -34,8 +34,8 @@
 		}
 
 		pre {
-			background: rgba(theming.daff-illuminate($base, $gray, 2), 0.3);
-			border: 1px solid rgba(theming.daff-illuminate($base, $gray, 2), 0.6);
+			background: theming.daff-illuminate($base, $gray, 1);
+			border: 1px solid theming.daff-illuminate($base, $gray, 2);
 			color: $base-contrast;
 
 			code {

--- a/libs/design/src/molecules/article/article/article.component.scss
+++ b/libs/design/src/molecules/article/article/article.component.scss
@@ -58,12 +58,19 @@
 		@include t.embolden;
 	}
 
+	@include stopsArticleCascade(pre) {
+		margin: 1.5rem 0;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
 	pre {
 		display: block;
 		border-radius: 4px;
 		font-size: t.$small-font-size;
 		line-height: 1.5rem;
-		margin: 1.5rem 0;
 		padding: 1.5rem;
 		overflow: auto;
 		white-space: pre-wrap;
@@ -71,10 +78,6 @@
 		code {
 			display: block;
 			padding: 0;
-		}
-
-		&:last-child {
-			margin-bottom: 0;
 		}
 	}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`<pre>` styling is using opacity for its borders when it doesn't need to be. `<pre>` margins are affecting how it's displayed in code preview because it's not part of stop article cascade.

Fixes: N/A


## What is the new behavior?
Update `<pre>` styling and include the margin styles as part of stop article cascade.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information