### PR TITLE
feat(design): add deprecation notice for DaffNavAccordionItemComponent

### DIFF
--- a/apps/design-land/src/app/accordion/accordion.component.html
+++ b/apps/design-land/src/app/accordion/accordion.component.html
@@ -7,5 +7,6 @@
 <h3>Content Accordion Item</h3>
 <design-land-example-viewer-container example="basic-accordion"></design-land-example-viewer-container>
 
-<h3>Navigation Accordion Item</h3>
+<h3>(DEPRECATED) Navigation Accordion Item</h3>
+<p>Use the <code>DaffTreeComponent</code> instead.</p>
 <design-land-example-viewer-container example="nav-accordion"></design-land-example-viewer-container>

--- a/apps/design-land/src/app/accordion/accordion.module.ts
+++ b/apps/design-land/src/app/accordion/accordion.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 import { DaffArticleModule } from '@daffodil/design';
 
@@ -14,6 +15,8 @@ import { DesignLandAccordionComponent } from './accordion.component';
   ],
   imports: [
     CommonModule,
+    RouterModule,
+
     DesignLandAccordionRoutingModule,
     DesignLandExampleViewerModule,
     DaffArticleModule,

--- a/libs/design/src/molecules/accordion/nav-accordion-item/nav-accordion-item.component.ts
+++ b/libs/design/src/molecules/accordion/nav-accordion-item/nav-accordion-item.component.ts
@@ -18,6 +18,9 @@ import { DaffAccordionComponent } from '../accordion/accordion.component';
 import { daffAccordionAnimations } from '../animation/accordion-animation';
 import { getAnimationState } from '../animation/accordion-animation-state';
 
+/**
+ * @deprecated in v1.0.0. Use DaffTreeComponent instead.
+ */
 @Component({
   selector: 'daff-nav-accordion-item',
   templateUrl: './nav-accordion-item.component.html',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`DaffNavAccordionItemComponent` is a usable component in the library. It should be deprecated in favor of the `DaffTreeComponent`. The nav accordion item was only created as a temporary solution to the lack of a tree component. It now serves no purpose and should be removed from the codebase.

Fixes: #2574 


## What is the new behavior?
Add deprecation notice to `DaffNavAccordionItemComponent` and add suggestion to use `DaffTreeComponent` instead.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information