### PR TITLE
feat(cart)!: change actions to implement `DaffCartRetrievalAction` and `DaffFailureAction`

### DIFF
--- a/libs/authorizenet/state/src/effects/authorize-net.effects.spec.ts
+++ b/libs/authorizenet/state/src/effects/authorize-net.effects.spec.ts
@@ -174,7 +174,7 @@ describe('DaffAuthorizeNetEffects', () => {
       const authorizeNetUpdatePayment = new DaffAuthorizeNetUpdatePayment(paymentTokenRequest, stubAddress);
       const mockCode = 'code';
       const mockErrorMessage = 'Cart payment with billing update failed.';
-      const cartPaymentUpdateWithBillingFailure = new DaffCartPaymentUpdateWithBillingFailure({ code: mockCode, recoverable: false, message: mockErrorMessage });
+      const cartPaymentUpdateWithBillingFailure = new DaffCartPaymentUpdateWithBillingFailure([{ code: mockCode, recoverable: false, message: mockErrorMessage }]);
       const authorizeNetPaymentUpdateFailure = new DaffAuthorizeNetUpdatePaymentFailure({
         code: mockCode,
         recoverable: false,

--- a/libs/authorizenet/state/src/effects/authorize-net.effects.ts
+++ b/libs/authorizenet/state/src/effects/authorize-net.effects.ts
@@ -105,7 +105,7 @@ export class DaffAuthorizeNetEffects<T extends DaffAuthorizeNetTokenRequest = Da
 	    DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingSuccessAction,
 	  ),
 	  map(([updatePaymentAction, updatePaymentFailureAction]: [DaffAuthorizeNetUpdatePayment, DaffCartPaymentUpdateWithBillingFailure]) =>
-	    new DaffAuthorizeNetUpdatePaymentFailure(this.errorMatcher(updatePaymentFailureAction.payload)),
+	    new DaffAuthorizeNetUpdatePaymentFailure(this.errorMatcher(updatePaymentFailureAction.payload[0])),
 	  ),
   ));
 

--- a/libs/cart-customer/state/src/effects/unauthorized.effects.spec.ts
+++ b/libs/cart-customer/state/src/effects/unauthorized.effects.spec.ts
@@ -140,7 +140,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartItemAddFailure(error);
+        const resolveCartFailureAction = new DaffCartItemAddFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -154,7 +154,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartItemAddFailure(error);
+        const resolveCartFailureAction = new DaffCartItemAddFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -171,7 +171,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartItemDeleteFailure(error, 'itemId');
+        const resolveCartFailureAction = new DaffCartItemDeleteFailure([error], 'itemId');
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -185,7 +185,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartItemDeleteFailure(error, 'itemId');
+        const resolveCartFailureAction = new DaffCartItemDeleteFailure([error], 'itemId');
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -202,7 +202,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartItemDeleteOutOfStockFailure(error);
+        const resolveCartFailureAction = new DaffCartItemDeleteOutOfStockFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -216,7 +216,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartItemDeleteOutOfStockFailure(error);
+        const resolveCartFailureAction = new DaffCartItemDeleteOutOfStockFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -233,7 +233,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartItemUpdateFailure(error, 'itemId');
+        const resolveCartFailureAction = new DaffCartItemUpdateFailure([error], 'itemId');
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -247,7 +247,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartItemUpdateFailure(error, 'itemId');
+        const resolveCartFailureAction = new DaffCartItemUpdateFailure([error], 'itemId');
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -264,7 +264,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartBillingAddressUpdateFailure(error);
+        const resolveCartFailureAction = new DaffCartBillingAddressUpdateFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -278,7 +278,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartBillingAddressUpdateFailure(error);
+        const resolveCartFailureAction = new DaffCartBillingAddressUpdateFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -295,7 +295,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartAddressUpdateFailure(error);
+        const resolveCartFailureAction = new DaffCartAddressUpdateFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -309,7 +309,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartAddressUpdateFailure(error);
+        const resolveCartFailureAction = new DaffCartAddressUpdateFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -326,7 +326,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartShippingAddressUpdateFailure(error);
+        const resolveCartFailureAction = new DaffCartShippingAddressUpdateFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -340,7 +340,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartShippingAddressUpdateFailure(error);
+        const resolveCartFailureAction = new DaffCartShippingAddressUpdateFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -357,7 +357,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartShippingInformationDeleteFailure(error);
+        const resolveCartFailureAction = new DaffCartShippingInformationDeleteFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -371,7 +371,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartShippingInformationDeleteFailure(error);
+        const resolveCartFailureAction = new DaffCartShippingInformationDeleteFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -388,7 +388,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartShippingInformationUpdateFailure(error);
+        const resolveCartFailureAction = new DaffCartShippingInformationUpdateFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -402,7 +402,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartShippingInformationUpdateFailure(error);
+        const resolveCartFailureAction = new DaffCartShippingInformationUpdateFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -419,7 +419,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartPaymentRemoveFailure(error);
+        const resolveCartFailureAction = new DaffCartPaymentRemoveFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -433,7 +433,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartPaymentRemoveFailure(error);
+        const resolveCartFailureAction = new DaffCartPaymentRemoveFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -450,7 +450,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartPaymentUpdateFailure(error);
+        const resolveCartFailureAction = new DaffCartPaymentUpdateFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -464,7 +464,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartPaymentUpdateFailure(error);
+        const resolveCartFailureAction = new DaffCartPaymentUpdateFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -481,7 +481,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartPaymentUpdateWithBillingFailure(error);
+        const resolveCartFailureAction = new DaffCartPaymentUpdateWithBillingFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -495,7 +495,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartPaymentUpdateWithBillingFailure(error);
+        const resolveCartFailureAction = new DaffCartPaymentUpdateWithBillingFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -512,7 +512,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartCouponApplyFailure(error);
+        const resolveCartFailureAction = new DaffCartCouponApplyFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -526,7 +526,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartCouponApplyFailure(error);
+        const resolveCartFailureAction = new DaffCartCouponApplyFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -543,7 +543,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartCouponRemoveFailure(error);
+        const resolveCartFailureAction = new DaffCartCouponRemoveFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -557,7 +557,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartCouponRemoveFailure(error);
+        const resolveCartFailureAction = new DaffCartCouponRemoveFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -574,7 +574,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartCouponRemoveAllFailure(error);
+        const resolveCartFailureAction = new DaffCartCouponRemoveAllFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -588,7 +588,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartCouponRemoveAllFailure(error);
+        const resolveCartFailureAction = new DaffCartCouponRemoveAllFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });
@@ -605,7 +605,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART, recoverable: false, message: 'Unauthorized' };
-        const resolveCartFailureAction = new DaffCartPlaceOrderFailure(error);
+        const resolveCartFailureAction = new DaffCartPlaceOrderFailure([error]);
         const checkAction = new DaffAuthCheck();
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('--b', { b: checkAction });
@@ -619,7 +619,7 @@ describe('@daffodil/cart-customer/state | DaffCartCustomerUnauthorizedEffects', 
     describe('and the error is not a DaffUnauthorizedForCartError', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Something went wrong' };
-        const resolveCartFailureAction = new DaffCartPlaceOrderFailure(error);
+        const resolveCartFailureAction = new DaffCartPlaceOrderFailure([error]);
         actions$ = hot('--a', { a: resolveCartFailureAction });
         expected = cold('---');
       });

--- a/libs/cart-customer/state/src/effects/unauthorized.effects.ts
+++ b/libs/cart-customer/state/src/effects/unauthorized.effects.ts
@@ -101,7 +101,7 @@ export class DaffCartCustomerUnauthorizedEffects {
       DaffCartOrderActionTypes.CartPlaceOrderFailureAction,
     ),
     filter((action) =>
-      action.payload.code === DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART,
+      !!action.payload.find(({ code }) => code === DaffCartDriverErrorCodes.UNAUTHORIZED_FOR_CART),
     ),
     map(() => new DaffAuthCheck()),
   ));

--- a/libs/cart-store-credit/state/src/effects/store-credit.effects.ts
+++ b/libs/cart-store-credit/state/src/effects/store-credit.effects.ts
@@ -28,8 +28,8 @@ import {
   DaffCartStoreCreditDriverInterface,
 } from '@daffodil/cart-store-credit/driver';
 import {
-  DaffError,
-  DaffStorageServiceError,
+  DAFF_STORAGE_SERVICE_ERROR_CODE,
+  catchAndArrayifyErrors,
 } from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
 
@@ -59,9 +59,9 @@ export class DaffCartStoreCreditEffects<
       defer(() => of(this.storage.getCartId())).pipe(
         switchMap((cartId) => this.driver.apply(cartId)),
         map(resp => new DaffCartStoreCreditApplySuccess<T>(resp)),
-        catchError((error: DaffError) => of(error instanceof DaffStorageServiceError
-          ? new DaffCartStorageFailure(this.errorMatcher(error))
-          : new DaffCartStoreCreditApplyFailure([this.errorMatcher(error)]))),
+        catchAndArrayifyErrors((error) => of(error.find((err) => err.code === DAFF_STORAGE_SERVICE_ERROR_CODE)
+          ? new DaffCartStorageFailure(error.map(this.errorMatcher))
+          : new DaffCartStoreCreditApplyFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));
@@ -72,9 +72,9 @@ export class DaffCartStoreCreditEffects<
       defer(() => of(this.storage.getCartId())).pipe(
         switchMap((cartId) => this.driver.remove(cartId)),
         map(resp => new DaffCartStoreCreditRemoveSuccess<T>(resp)),
-        catchError((error: DaffError) => of(error instanceof DaffStorageServiceError
-          ? new DaffCartStorageFailure(this.errorMatcher(error))
-          : new DaffCartStoreCreditRemoveFailure([this.errorMatcher(error)]))),
+        catchAndArrayifyErrors((error) => of(error.find((err) => err.code === DAFF_STORAGE_SERVICE_ERROR_CODE)
+          ? new DaffCartStorageFailure(error.map(this.errorMatcher))
+          : new DaffCartStoreCreditRemoveFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));

--- a/libs/cart/state/src/actions/cart-address.actions.ts
+++ b/libs/cart/state/src/actions/cart-address.actions.ts
@@ -4,7 +4,12 @@ import {
   DaffCartAddress,
   DaffCart,
 } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
+
+import { DaffCartRetrievalAction } from '../cart-retrieval/public_api';
 
 /**
  * An enum for the cart address action types.
@@ -27,7 +32,7 @@ export class DaffCartAddressUpdate<T extends DaffCartAddress = DaffCartAddress> 
 /**
  * Indicates the successful update of both the shipping and billing address of the cart.
  */
-export class DaffCartAddressUpdateSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartAddressUpdateSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartAddressActionTypes.CartAddressUpdateSuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -36,10 +41,10 @@ export class DaffCartAddressUpdateSuccess<T extends DaffCart = DaffCart> impleme
 /**
  * Indicates the failed update of either the shipping or billing address of the cart.
  */
-export class DaffCartAddressUpdateFailure implements Action {
+export class DaffCartAddressUpdateFailure implements DaffFailureAction {
   readonly type = DaffCartAddressActionTypes.CartAddressUpdateFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart-billing-address.actions.ts
+++ b/libs/cart/state/src/actions/cart-billing-address.actions.ts
@@ -4,7 +4,12 @@ import {
   DaffCartAddress,
   DaffCart,
 } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
+
+import { DaffCartRetrievalAction } from '../cart-retrieval/public_api';
 
 /**
  * An enum for the cart billing address action types.
@@ -37,10 +42,10 @@ export class DaffCartBillingAddressLoadSuccess<T extends DaffCartAddress> implem
 /**
  * Indicates the failed load of the cart's billing address.
  */
-export class DaffCartBillingAddressLoadFailure implements Action {
+export class DaffCartBillingAddressLoadFailure implements DaffFailureAction {
   readonly type = DaffCartBillingAddressActionTypes.CartBillingAddressLoadFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -55,7 +60,7 @@ export class DaffCartBillingAddressUpdate<T extends DaffCartAddress = DaffCartAd
 /**
  * Indicates the successful update of the cart's billing address.
  */
-export class DaffCartBillingAddressUpdateSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartBillingAddressUpdateSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartBillingAddressActionTypes.CartBillingAddressUpdateSuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -64,10 +69,10 @@ export class DaffCartBillingAddressUpdateSuccess<T extends DaffCart = DaffCart> 
 /**
  * Indicates the failed update of the cart's billing address.
  */
-export class DaffCartBillingAddressUpdateFailure implements Action {
+export class DaffCartBillingAddressUpdateFailure implements DaffFailureAction {
   readonly type = DaffCartBillingAddressActionTypes.CartBillingAddressUpdateFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart-coupon.actions.ts
+++ b/libs/cart/state/src/actions/cart-coupon.actions.ts
@@ -4,7 +4,12 @@ import {
   DaffCartCoupon,
   DaffCart,
 } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
+
+import { DaffCartRetrievalAction } from '../cart-retrieval/public_api';
 
 /**
  * An enum for the cart coupon action types.
@@ -37,7 +42,7 @@ export class DaffCartCouponApply<T extends DaffCartCoupon = DaffCartCoupon> impl
 /**
  * Indicates the successful application of a cart coupon.
  */
-export class DaffCartCouponApplySuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartCouponApplySuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartCouponActionTypes.CartCouponApplySuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -46,10 +51,10 @@ export class DaffCartCouponApplySuccess<T extends DaffCart = DaffCart> implement
 /**
  * Indicates the failed application of a cart coupon.
  */
-export class DaffCartCouponApplyFailure implements Action {
+export class DaffCartCouponApplyFailure implements DaffFailureAction {
   readonly type = DaffCartCouponActionTypes.CartCouponApplyFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -71,10 +76,10 @@ export class DaffCartCouponListSuccess<T extends DaffCartCoupon = DaffCartCoupon
 /**
  * Indicates the failed load of the cart's coupons.
  */
-export class DaffCartCouponListFailure implements Action {
+export class DaffCartCouponListFailure implements DaffFailureAction {
   readonly type = DaffCartCouponActionTypes.CartCouponListFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -89,7 +94,7 @@ export class DaffCartCouponRemove<T extends DaffCartCoupon = DaffCartCoupon> imp
 /**
  * Indicates the successful removal of a cart coupon.
  */
-export class DaffCartCouponRemoveSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartCouponRemoveSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartCouponActionTypes.CartCouponRemoveSuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -98,10 +103,10 @@ export class DaffCartCouponRemoveSuccess<T extends DaffCart = DaffCart> implemen
 /**
  * Indicates the failed removal of a cart coupon.
  */
-export class DaffCartCouponRemoveFailure implements Action {
+export class DaffCartCouponRemoveFailure implements DaffFailureAction {
   readonly type = DaffCartCouponActionTypes.CartCouponRemoveFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -114,7 +119,7 @@ export class DaffCartCouponRemoveAll implements Action {
 /**
  * Indicates the successful removal of all of the cart's coupons.
  */
-export class DaffCartCouponRemoveAllSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartCouponRemoveAllSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartCouponActionTypes.CartCouponRemoveAllSuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -123,10 +128,10 @@ export class DaffCartCouponRemoveAllSuccess<T extends DaffCart = DaffCart> imple
 /**
  * Indicates the failed removal of all of the cart's coupons.
  */
-export class DaffCartCouponRemoveAllFailure implements Action {
+export class DaffCartCouponRemoveAllFailure implements DaffFailureAction {
   readonly type = DaffCartCouponActionTypes.CartCouponRemoveAllFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart-item.actions.ts
+++ b/libs/cart/state/src/actions/cart-item.actions.ts
@@ -4,8 +4,12 @@ import {
   DaffCart,
   DaffCartItemInput,
 } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
 
+import { DaffCartRetrievalAction } from '../cart-retrieval/public_api';
 import { DaffStatefulCartItem } from '../models/public_api';
 
 /**
@@ -52,10 +56,10 @@ export class DaffCartItemListSuccess<T extends DaffStatefulCartItem = DaffStatef
 /**
  * Indicates the failed load of the cart's items.
  */
-export class DaffCartItemListFailure implements Action {
+export class DaffCartItemListFailure implements DaffFailureAction {
   readonly type = DaffCartItemActionTypes.CartItemListFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -82,7 +86,7 @@ export class DaffCartItemLoadSuccess<T extends DaffStatefulCartItem = DaffStatef
 export class DaffCartItemLoadFailure<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemLoadFailureAction;
 
-  constructor(public payload: DaffStateError, public itemId: T['id']) {}
+  constructor(public payload: DaffStateError[], public itemId: T['id']) {}
 }
 
 /**
@@ -112,7 +116,7 @@ export class DaffCartItemUpdateSuccess<
 export class DaffCartItemUpdateFailure<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemUpdateFailureAction;
 
-  constructor(public payload: DaffStateError, public itemId: T['id']) {}
+  constructor(public payload: DaffStateError[], public itemId: T['id']) {}
 }
 
 /**
@@ -127,7 +131,7 @@ export class DaffCartItemAdd<T extends DaffCartItemInput = DaffCartItemInput> im
 /**
  * Indicates the successful addition of a product to the cart.
  */
-export class DaffCartItemAddSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartItemAddSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartItemActionTypes.CartItemAddSuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -136,10 +140,10 @@ export class DaffCartItemAddSuccess<T extends DaffCart = DaffCart> implements Ac
 /**
  * Indicates the failed addition of a product to the cart.
  */
-export class DaffCartItemAddFailure implements Action {
+export class DaffCartItemAddFailure implements DaffFailureAction {
   readonly type = DaffCartItemActionTypes.CartItemAddFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -166,7 +170,7 @@ export class DaffCartItemDeleteSuccess<T extends DaffCart = DaffCart> implements
 export class DaffCartItemDeleteFailure<T extends DaffStatefulCartItem = DaffStatefulCartItem> implements Action {
   readonly type = DaffCartItemActionTypes.CartItemDeleteFailureAction;
 
-  constructor(public payload: DaffStateError, public itemId: T['id']) {}
+  constructor(public payload: DaffStateError[], public itemId: T['id']) {}
 }
 
 /**
@@ -188,10 +192,10 @@ export class DaffCartItemDeleteOutOfStockSuccess<T extends DaffCart = DaffCart> 
 /**
  * Indicates the failed deletion of all out of stock cart items.
  */
-export class DaffCartItemDeleteOutOfStockFailure implements Action {
+export class DaffCartItemDeleteOutOfStockFailure implements DaffFailureAction {
   readonly type = DaffCartItemActionTypes.CartItemDeleteOutOfStockFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart-order.actions.ts
+++ b/libs/cart/state/src/actions/cart-order.actions.ts
@@ -4,7 +4,10 @@ import {
   DaffCartPaymentMethod,
   DaffCartOrderResult,
 } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
 
 /**
  * An enum for the cart order action types.
@@ -36,10 +39,10 @@ export class DaffCartPlaceOrderSuccess<T extends DaffCartOrderResult = DaffCartO
 /**
  * Indicates the failed order placement for a cart.
  */
-export class DaffCartPlaceOrderFailure implements Action {
+export class DaffCartPlaceOrderFailure implements DaffFailureAction {
   readonly type = DaffCartOrderActionTypes.CartPlaceOrderFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart-payment-methods.actions.ts
+++ b/libs/cart/state/src/actions/cart-payment-methods.actions.ts
@@ -1,7 +1,10 @@
 import { Action } from '@ngrx/store';
 
 import { DaffCartPaymentMethod } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
 
 /**
  * An enum for the cart payment methods action types.
@@ -33,10 +36,10 @@ export class DaffCartPaymentMethodsLoadSuccess<T extends DaffCartPaymentMethod =
 /**
  * Indicates the failed load of the cart's available payment methods.
  */
-export class DaffCartPaymentMethodsLoadFailure implements Action {
+export class DaffCartPaymentMethodsLoadFailure implements DaffFailureAction {
   readonly type = DaffCartPaymentMethodsActionTypes.CartPaymentMethodsLoadFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart-payment.actions.ts
+++ b/libs/cart/state/src/actions/cart-payment.actions.ts
@@ -5,7 +5,12 @@ import {
   DaffCart,
   DaffCartAddress,
 } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
+
+import { DaffCartRetrievalAction } from '../cart-retrieval/public_api';
 
 /**
  * An enum for the cart payment action types.
@@ -45,10 +50,10 @@ export class DaffCartPaymentLoadSuccess<T extends DaffCartPaymentMethod = DaffCa
 /**
  * Indicates the failed load of the cart's selected payment method.
  */
-export class DaffCartPaymentLoadFailure implements Action {
+export class DaffCartPaymentLoadFailure implements DaffFailureAction {
   readonly type = DaffCartPaymentActionTypes.CartPaymentLoadFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -63,7 +68,7 @@ export class DaffCartPaymentUpdate<T extends DaffCartPaymentMethod = DaffCartPay
 /**
  * Indicates the successful update of the cart's selected payment method.
  */
-export class DaffCartPaymentUpdateSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartPaymentUpdateSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartPaymentActionTypes.CartPaymentUpdateSuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -72,10 +77,10 @@ export class DaffCartPaymentUpdateSuccess<T extends DaffCart = DaffCart> impleme
 /**
  * Indicates the failed update of the cart's selected payment method.
  */
-export class DaffCartPaymentUpdateFailure implements Action {
+export class DaffCartPaymentUpdateFailure implements DaffFailureAction {
   readonly type = DaffCartPaymentActionTypes.CartPaymentUpdateFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -98,7 +103,7 @@ export class DaffCartPaymentUpdateWithBilling<
  *
  * @param payload The updated cart.
  */
-export class DaffCartPaymentUpdateWithBillingSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartPaymentUpdateWithBillingSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingSuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -109,10 +114,10 @@ export class DaffCartPaymentUpdateWithBillingSuccess<T extends DaffCart = DaffCa
  *
  * @param payload The error message.
  */
-export class DaffCartPaymentUpdateWithBillingFailure implements Action {
+export class DaffCartPaymentUpdateWithBillingFailure implements DaffFailureAction {
   readonly type = DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -132,10 +137,10 @@ export class DaffCartPaymentRemoveSuccess implements Action {
 /**
  * Indicates the failed removal of the cart's selected payment method.
  */
-export class DaffCartPaymentRemoveFailure implements Action {
+export class DaffCartPaymentRemoveFailure implements DaffFailureAction {
   readonly type = DaffCartPaymentActionTypes.CartPaymentRemoveFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart-shipping-address.actions.ts
+++ b/libs/cart/state/src/actions/cart-shipping-address.actions.ts
@@ -4,7 +4,12 @@ import {
   DaffCartAddress,
   DaffCart,
 } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
+
+import { DaffCartRetrievalAction } from '../cart-retrieval/public_api';
 
 /**
  * An enum for the cart shipping address action types.
@@ -37,10 +42,10 @@ export class DaffCartShippingAddressLoadSuccess<T extends DaffCartAddress = Daff
 /**
  * Indicates the failed load of the cart's shipping address.
  */
-export class DaffCartShippingAddressLoadFailure implements Action {
+export class DaffCartShippingAddressLoadFailure implements DaffFailureAction {
   readonly type = DaffCartShippingAddressActionTypes.CartShippingAddressLoadFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -55,7 +60,7 @@ export class DaffCartShippingAddressUpdate<T extends DaffCartAddress = DaffCartA
 /**
  * Indicates the successful update of the cart's shipping address.
  */
-export class DaffCartShippingAddressUpdateSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartShippingAddressUpdateSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartShippingAddressActionTypes.CartShippingAddressUpdateSuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -64,10 +69,10 @@ export class DaffCartShippingAddressUpdateSuccess<T extends DaffCart = DaffCart>
 /**
  * Indicates the failed update of the cart's shipping address.
  */
-export class DaffCartShippingAddressUpdateFailure implements Action {
+export class DaffCartShippingAddressUpdateFailure implements DaffFailureAction {
   readonly type = DaffCartShippingAddressActionTypes.CartShippingAddressUpdateFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart-shipping-information.actions.ts
+++ b/libs/cart/state/src/actions/cart-shipping-information.actions.ts
@@ -4,7 +4,12 @@ import {
   DaffCartShippingRate,
   DaffCart,
 } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
+
+import { DaffCartRetrievalAction } from '../cart-retrieval/public_api';
 
 /**
  * An enum for the cart shipping information action types.
@@ -40,10 +45,10 @@ export class DaffCartShippingInformationLoadSuccess<T extends DaffCartShippingRa
 /**
  * Indicates the failed load of the cart's shipping information.
  */
-export class DaffCartShippingInformationLoadFailure implements Action {
+export class DaffCartShippingInformationLoadFailure implements DaffFailureAction {
   readonly type = DaffCartShippingInformationActionTypes.CartShippingInformationLoadFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -58,7 +63,7 @@ export class DaffCartShippingInformationUpdate<T extends DaffCartShippingRate = 
 /**
  * Indicates the successful update of the cart's shipping information.
  */
-export class DaffCartShippingInformationUpdateSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartShippingInformationUpdateSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartShippingInformationActionTypes.CartShippingInformationUpdateSuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -67,10 +72,10 @@ export class DaffCartShippingInformationUpdateSuccess<T extends DaffCart = DaffC
 /**
  * Indicates the failed update of the cart's shipping information.
  */
-export class DaffCartShippingInformationUpdateFailure implements Action {
+export class DaffCartShippingInformationUpdateFailure implements DaffFailureAction {
   readonly type = DaffCartShippingInformationActionTypes.CartShippingInformationUpdateFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -82,16 +87,16 @@ export class DaffCartShippingInformationDelete<T extends DaffCartShippingRate = 
   constructor(public id?: T['id']) {}
 }
 
-export class DaffCartShippingInformationDeleteSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartShippingInformationDeleteSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartShippingInformationActionTypes.CartShippingInformationDeleteSuccessAction;
 
   constructor(public payload: Partial<T>) {}
 }
 
-export class DaffCartShippingInformationDeleteFailure implements Action {
+export class DaffCartShippingInformationDeleteFailure implements DaffFailureAction {
   readonly type = DaffCartShippingInformationActionTypes.CartShippingInformationDeleteFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart-shipping-methods.actions.ts
+++ b/libs/cart/state/src/actions/cart-shipping-methods.actions.ts
@@ -1,7 +1,10 @@
 import { Action } from '@ngrx/store';
 
 import { DaffCartShippingRate } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
 
 /**
  * An enum for the cart shipping methods action types.
@@ -27,10 +30,10 @@ export class DaffCartShippingMethodsLoadSuccess<T extends DaffCartShippingRate =
   constructor(public payload: T[]) {}
 }
 
-export class DaffCartShippingMethodsLoadFailure implements Action {
+export class DaffCartShippingMethodsLoadFailure implements DaffFailureAction {
   readonly type = DaffCartShippingMethodsActionTypes.CartShippingMethodsLoadFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/actions/cart.actions.ts
+++ b/libs/cart/state/src/actions/cart.actions.ts
@@ -1,8 +1,13 @@
 import { Action } from '@ngrx/store';
 
 import { DaffCart } from '@daffodil/cart';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  DaffFailureAction,
+  DaffStateError,
+} from '@daffodil/core/state';
 import { DaffProduct } from '@daffodil/product';
+
+import { DaffCartRetrievalAction } from '../cart-retrieval/public_api';
 
 /**
  * An enum for the cart action types.
@@ -32,10 +37,10 @@ export enum DaffCartActionTypes {
 /**
  * Indicates that an error occured while either reading or writing the cart ID to or from storage.
  */
-export class DaffCartStorageFailure implements Action {
+export class DaffCartStorageFailure implements DaffFailureAction {
   readonly type = DaffCartActionTypes.CartStorageFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -48,7 +53,7 @@ export class DaffCartLoad implements Action {
 /**
  * Indicates the successful load of the cart.
  */
-export class DaffCartLoadSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartLoadSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartActionTypes.CartLoadSuccessAction;
 
   constructor(public payload: T) {}
@@ -60,7 +65,7 @@ export class DaffCartLoadSuccess<T extends DaffCart = DaffCart> implements Actio
  * but the user should probably be shown error messages as well.
  * A common example is some cart items being out of stock.
  */
-export class DaffCartLoadPartialSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartLoadPartialSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartActionTypes.CartLoadPartialSuccessAction;
 
   constructor(public payload: T, public errors: DaffStateError[]) {}
@@ -69,7 +74,7 @@ export class DaffCartLoadPartialSuccess<T extends DaffCart = DaffCart> implement
 /**
  * Indicates the failed load of the cart.
  */
-export class DaffCartLoadFailure implements Action {
+export class DaffCartLoadFailure implements DaffFailureAction {
   readonly type = DaffCartActionTypes.CartLoadFailureAction;
 
   constructor(public payload: DaffStateError[]) {}
@@ -88,16 +93,16 @@ export class DaffCartCreate implements Action {
 export class DaffCartCreateSuccess<T extends DaffCart = DaffCart> implements Action {
   readonly type = DaffCartActionTypes.CartCreateSuccessAction;
 
-  constructor(public payload: {id: T['id']}) {}
+  constructor(public payload: Pick<T, 'id'>) {}
 }
 
 /**
  * Indicates the failed creation of a new cart.
  */
-export class DaffCartCreateFailure implements Action {
+export class DaffCartCreateFailure implements DaffFailureAction {
   readonly type = DaffCartActionTypes.CartCreateFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 // TODO: deprecate
@@ -115,10 +120,10 @@ export class DaffAddToCartSuccess implements Action {
 }
 
 // TODO: deprecate
-export class DaffAddToCartFailure implements Action {
+export class DaffAddToCartFailure implements DaffFailureAction {
   readonly type = DaffCartActionTypes.AddToCartFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -131,7 +136,7 @@ export class DaffCartClear implements Action {
 /**
  * Indicates the successful removal of all items from the cart.
  */
-export class DaffCartClearSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffCartClearSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartActionTypes.CartClearSuccessAction;
 
   constructor(public payload: Partial<T>) {}
@@ -140,10 +145,10 @@ export class DaffCartClearSuccess<T extends DaffCart = DaffCart> implements Acti
 /**
  * Indicates the failed removal of all items from the cart.
  */
-export class DaffCartClearFailure implements Action {
+export class DaffCartClearFailure implements DaffFailureAction {
   readonly type = DaffCartActionTypes.CartClearFailureAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**
@@ -157,7 +162,7 @@ export class DaffResolveCart implements Action {
 /**
  * An action that indicates a user's cart is resolved successfully.
  */
-export class DaffResolveCartSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffResolveCartSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartActionTypes.ResolveCartSuccessAction;
 
   constructor(public payload: T) {}
@@ -169,7 +174,7 @@ export class DaffResolveCartSuccess<T extends DaffCart = DaffCart> implements Ac
  * but the user should probably be shown error messages as well.
  * A common example is some cart items being out of stock.
  */
-export class DaffResolveCartPartialSuccess<T extends DaffCart = DaffCart> implements Action {
+export class DaffResolveCartPartialSuccess<T extends DaffCart = DaffCart> implements DaffCartRetrievalAction<T> {
   readonly type = DaffCartActionTypes.ResolveCartPartialSuccessAction;
 
   constructor(public payload: T, public errors: DaffStateError[]) {}
@@ -178,7 +183,7 @@ export class DaffResolveCartPartialSuccess<T extends DaffCart = DaffCart> implem
 /**
  * An action that indicates that a cart failed to resolve.
  */
-export class DaffResolveCartFailure implements Action {
+export class DaffResolveCartFailure implements DaffFailureAction {
   readonly type = DaffCartActionTypes.ResolveCartFailureAction;
 
   constructor(public payload: DaffStateError[]) {}
@@ -191,7 +196,7 @@ export class DaffResolveCartFailure implements Action {
 export class DaffResolveCartServerSide implements Action {
   readonly type = DaffCartActionTypes.ResolveCartServerSideAction;
 
-  constructor(public payload: DaffStateError) {}
+  constructor(public payload: DaffStateError[]) {}
 }
 
 /**

--- a/libs/cart/state/src/effects/cart-address.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-address.effects.spec.ts
@@ -37,7 +37,7 @@ import {
 
 import { DaffCartAddressEffects } from './cart-address.effects';
 
-describe('Daffodil | Cart | CartAddressEffects', () => {
+describe('@daffodil/cart/state | DaffCartAddressEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCartAddressEffects<DaffCartAddress, DaffCart>;
 
@@ -50,10 +50,10 @@ describe('Daffodil | Cart | CartAddressEffects', () => {
   let daffAddressDriver: DaffCartAddressServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverUpdateSpy: jasmine.Spy;
-  let getCartIdSpy: jasmine.Spy;
+  let driverUpdateSpy: jasmine.Spy<DaffCartAddressServiceInterface['update']>;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
 
-  const cartStorageFailureAction = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
+  const cartStorageFailureAction = new DaffCartStorageFailure([daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.'))]);
   const throwStorageError = () => {
     throw new DaffStorageServiceError('An error occurred during storage.');
   };
@@ -130,7 +130,7 @@ describe('Daffodil | Cart | CartAddressEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to update cart address' };
         const response = cold('#', {}, error);
         driverUpdateSpy.and.returnValue(response);
-        const cartAddressUpdateFailureAction = new DaffCartAddressUpdateFailure(error);
+        const cartAddressUpdateFailureAction = new DaffCartAddressUpdateFailure([error]);
         actions$ = hot('--a', { a: cartAddressUpdateAction });
         expected = cold('--b', { b: cartAddressUpdateFailureAction });
       });

--- a/libs/cart/state/src/effects/cart-billing-address.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-billing-address.effects.spec.ts
@@ -35,7 +35,7 @@ import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffCartBillingAddressEffects } from './cart-billing-address.effects';
 
-describe('Daffodil | Cart | CartBillingAddressEffects', () => {
+describe('@daffodil/cart/state | DaffCartBillingAddressEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCartBillingAddressEffects<DaffCartAddress, DaffCart>;
 
@@ -48,9 +48,9 @@ describe('Daffodil | Cart | CartBillingAddressEffects', () => {
   let daffBillingAddressDriver: DaffCartBillingAddressServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverGetSpy: jasmine.Spy;
-  let driverUpdateSpy: jasmine.Spy;
-  let getCartIdSpy: jasmine.Spy;
+  let driverGetSpy: jasmine.Spy<DaffCartBillingAddressServiceInterface['get']>;
+  let driverUpdateSpy: jasmine.Spy<DaffCartBillingAddressServiceInterface['update']>;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -106,7 +106,7 @@ describe('Daffodil | Cart | CartBillingAddressEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to load cart billing address' };
         const response = cold('#', {}, error);
         driverGetSpy.and.returnValue(response);
-        const cartBillingAddressLoadFailureAction = new DaffCartBillingAddressLoadFailure(error);
+        const cartBillingAddressLoadFailureAction = new DaffCartBillingAddressLoadFailure([error]);
         actions$ = hot('--a', { a: cartBillingAddressLoadAction });
         expected = cold('--b', { b: cartBillingAddressLoadFailureAction });
       });
@@ -145,7 +145,7 @@ describe('Daffodil | Cart | CartBillingAddressEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to update cart billing address' };
         const response = cold('#', {}, error);
         driverUpdateSpy.and.returnValue(response);
-        const cartCreateFailureAction = new DaffCartBillingAddressUpdateFailure(error);
+        const cartCreateFailureAction = new DaffCartBillingAddressUpdateFailure([error]);
         actions$ = hot('--a', { a: cartCreateAction });
         expected = cold('--b', { b: cartCreateFailureAction });
       });

--- a/libs/cart/state/src/effects/cart-billing-address.effects.ts
+++ b/libs/cart/state/src/effects/cart-billing-address.effects.ts
@@ -24,6 +24,7 @@ import {
   DaffCartBillingAddressDriver,
   DaffCartBillingAddressServiceInterface,
 } from '@daffodil/cart/driver';
+import { catchAndArrayifyErrors } from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
 
 import {
@@ -51,7 +52,7 @@ export class DaffCartBillingAddressEffects<T extends DaffCartAddress, V extends 
     switchMap((action: DaffCartBillingAddressLoad) =>
       this.driver.get(this.storage.getCartId()).pipe(
         map((resp: T) => new DaffCartBillingAddressLoadSuccess(resp)),
-        catchError(error => of(new DaffCartBillingAddressLoadFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartBillingAddressLoadFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));
@@ -62,7 +63,7 @@ export class DaffCartBillingAddressEffects<T extends DaffCartAddress, V extends 
     switchMap((action: DaffCartBillingAddressUpdate<T>) =>
       this.driver.update(this.storage.getCartId(), action.payload).pipe(
         map((resp: V) => new DaffCartBillingAddressUpdateSuccess(resp)),
-        catchError(error => of(new DaffCartBillingAddressUpdateFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartBillingAddressUpdateFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));

--- a/libs/cart/state/src/effects/cart-coupon.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-coupon.effects.spec.ts
@@ -46,7 +46,7 @@ import {
 
 import { DaffCartCouponEffects } from './cart-coupon.effects';
 
-describe('Daffodil | Cart | CartCouponEffects', () => {
+describe('@daffodil/cart/state | DaffCartCouponEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCartCouponEffects<DaffCart>;
 
@@ -59,13 +59,13 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
   let daffDriver: DaffCartCouponServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverApplySpy: jasmine.Spy;
-  let driverListSpy: jasmine.Spy;
-  let driverRemoveSpy: jasmine.Spy;
-  let driverRemoveAllSpy: jasmine.Spy;
-  let getCartIdSpy: jasmine.Spy;
+  let driverApplySpy: jasmine.Spy<DaffCartCouponServiceInterface['apply']>;
+  let driverListSpy: jasmine.Spy<DaffCartCouponServiceInterface['list']>;
+  let driverRemoveSpy: jasmine.Spy<DaffCartCouponServiceInterface['remove']>;
+  let driverRemoveAllSpy: jasmine.Spy<DaffCartCouponServiceInterface['removeAll']>;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
 
-  const cartStorageFailureAction = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
+  const cartStorageFailureAction = new DaffCartStorageFailure([daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.'))]);
   const throwStorageError = () => {
     throw new DaffStorageServiceError('An error occurred during storage.');
   };
@@ -124,7 +124,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to apply coupon to cart' };
         const response = cold('#', {}, error);
         driverApplySpy.and.returnValue(response);
-        const cartCouponApplyFailureAction = new DaffCartCouponApplyFailure(error);
+        const cartCouponApplyFailureAction = new DaffCartCouponApplyFailure([error]);
         actions$ = hot('--a', { a: cartCouponApplyAction });
         expected = cold('--b', { b: cartCouponApplyFailureAction });
       });
@@ -170,7 +170,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to list coupons' };
         const response = cold('#', {}, error);
         driverListSpy.and.returnValue(response);
-        const cartCouponListFailureAction = new DaffCartCouponListFailure(error);
+        const cartCouponListFailureAction = new DaffCartCouponListFailure([error]);
         actions$ = hot('--a', { a: cartCouponListAction });
         expected = cold('--b', { b: cartCouponListFailureAction });
       });
@@ -216,7 +216,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to remove a coupon from the cart' };
         const response = cold('#', {}, error);
         driverRemoveSpy.and.returnValue(response);
-        const cartCouponRemoveFailureAction = new DaffCartCouponRemoveFailure(error);
+        const cartCouponRemoveFailureAction = new DaffCartCouponRemoveFailure([error]);
         actions$ = hot('--a', { a: cartCouponRemoveAction });
         expected = cold('--b', { b: cartCouponRemoveFailureAction });
       });
@@ -262,7 +262,7 @@ describe('Daffodil | Cart | CartCouponEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to remove all coupons from the cart' };
         const response = cold('#', {}, error);
         driverRemoveAllSpy.and.returnValue(response);
-        const cartCouponRemoveAllFailureAction = new DaffCartCouponRemoveAllFailure(error);
+        const cartCouponRemoveAllFailureAction = new DaffCartCouponRemoveAllFailure([error]);
         actions$ = hot('--a', { a: cartCouponRemoveAllAction });
         expected = cold('--b', { b: cartCouponRemoveAllFailureAction });
       });

--- a/libs/cart/state/src/effects/cart-coupon.effects.ts
+++ b/libs/cart/state/src/effects/cart-coupon.effects.ts
@@ -27,7 +27,11 @@ import {
   DaffCartCouponDriver,
   DaffCartCouponServiceInterface,
 } from '@daffodil/cart/driver';
-import { DaffStorageServiceError } from '@daffodil/core';
+import {
+  DAFF_STORAGE_SERVICE_ERROR_CODE,
+  DaffStorageServiceError,
+  catchAndArrayifyErrors,
+} from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
 
 import {
@@ -65,9 +69,9 @@ export class DaffCartCouponEffects<
     switchMap((action: DaffCartCouponApply<V>) => defer(() => of(this.storage.getCartId())).pipe(
       switchMap(cartId => this.driver.apply(cartId, action.payload)),
       map(resp => new DaffCartCouponApplySuccess(resp)),
-      catchError(error => of(error instanceof DaffStorageServiceError
-        ? new DaffCartStorageFailure(this.errorMatcher(error))
-        : new DaffCartCouponApplyFailure(this.errorMatcher(error)),
+      catchAndArrayifyErrors(error => of(error.find((err) => err.code === DAFF_STORAGE_SERVICE_ERROR_CODE)
+        ? new DaffCartStorageFailure(error.map(this.errorMatcher))
+        : new DaffCartCouponApplyFailure(error.map(this.errorMatcher)),
       )),
     )),
   ));
@@ -78,9 +82,9 @@ export class DaffCartCouponEffects<
     switchMap((action: DaffCartCouponList) => defer(() => of(this.storage.getCartId())).pipe(
       switchMap(cartId => this.driver.list(cartId)),
       map(resp => new DaffCartCouponListSuccess<V>(resp)),
-      catchError(error => of(error instanceof DaffStorageServiceError
-        ? new DaffCartStorageFailure(this.errorMatcher(error))
-        : new DaffCartCouponListFailure(this.errorMatcher(error)),
+      catchAndArrayifyErrors(error => of(error.find((err) => err.code === DAFF_STORAGE_SERVICE_ERROR_CODE)
+        ? new DaffCartStorageFailure(error.map(this.errorMatcher))
+        : new DaffCartCouponListFailure(error.map(this.errorMatcher)),
       )),
     )),
   ));
@@ -91,9 +95,9 @@ export class DaffCartCouponEffects<
     switchMap((action: DaffCartCouponRemove<V>) => defer(() => of(this.storage.getCartId())).pipe(
       switchMap(cartId => this.driver.remove(cartId, action.payload)),
       map(resp => new DaffCartCouponRemoveSuccess(resp)),
-      catchError(error => of(error instanceof DaffStorageServiceError
-        ? new DaffCartStorageFailure(this.errorMatcher(error))
-        : new DaffCartCouponRemoveFailure(this.errorMatcher(error)),
+      catchAndArrayifyErrors(error => of(error.find((err) => err.code === DAFF_STORAGE_SERVICE_ERROR_CODE)
+        ? new DaffCartStorageFailure(error.map(this.errorMatcher))
+        : new DaffCartCouponRemoveFailure(error.map(this.errorMatcher)),
       )),
     )),
   ));
@@ -104,9 +108,9 @@ export class DaffCartCouponEffects<
     switchMap((action: DaffCartCouponRemoveAll) => defer(() => of(this.storage.getCartId())).pipe(
       switchMap(cartId => this.driver.removeAll(cartId)),
       map(resp => new DaffCartCouponRemoveAllSuccess(resp)),
-      catchError(error => of(error instanceof DaffStorageServiceError
-        ? new DaffCartStorageFailure(this.errorMatcher(error))
-        : new DaffCartCouponRemoveAllFailure(this.errorMatcher(error)),
+      catchAndArrayifyErrors(error => of(error.find((err) => err.code === DAFF_STORAGE_SERVICE_ERROR_CODE)
+        ? new DaffCartStorageFailure(error.map(this.errorMatcher))
+        : new DaffCartCouponRemoveAllFailure(error.map(this.errorMatcher)),
       )),
     )),
   ));

--- a/libs/cart/state/src/effects/cart-item.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-item.effects.spec.ts
@@ -78,12 +78,12 @@ describe('@daffodil/cart/state | DaffCartItemEffects', () => {
   let daffCartItemDriver: DaffCartItemServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverGetSpy: jasmine.Spy;
-  let driverAddSpy: jasmine.Spy;
-  let driverListSpy: jasmine.Spy;
-  let driverUpdateSpy: jasmine.Spy;
-  let driverDeleteSpy: jasmine.Spy;
-  let getCartIdSpy: jasmine.Spy;
+  let driverGetSpy: jasmine.Spy<DaffCartItemServiceInterface['get']>;
+  let driverAddSpy: jasmine.Spy<DaffCartItemServiceInterface['add']>;
+  let driverListSpy: jasmine.Spy<DaffCartItemServiceInterface['list']>;
+  let driverUpdateSpy: jasmine.Spy<DaffCartItemServiceInterface['update']>;
+  let driverDeleteSpy: jasmine.Spy<DaffCartItemServiceInterface['delete']>;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
   let cartResolverSpy: jasmine.SpyObj<DaffCartDriverResolveService>;
 
   beforeEach(() => {
@@ -168,7 +168,7 @@ describe('@daffodil/cart/state | DaffCartItemEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to list cart items' };
         const response = cold('#', {}, error);
         driverListSpy.and.returnValue(response);
-        const cartItemListFailureAction = new DaffCartItemListFailure(error);
+        const cartItemListFailureAction = new DaffCartItemListFailure([error]);
         actions$ = hot('--a', { a: cartItemListAction });
         expected = cold('--b', { b: cartItemListFailureAction });
       });
@@ -205,7 +205,7 @@ describe('@daffodil/cart/state | DaffCartItemEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to load cart item' };
         const response = cold('#', {}, error);
         driverGetSpy.and.returnValue(response);
-        const cartItemLoadFailureAction = new DaffCartItemLoadFailure(error, mockCartItem.id);
+        const cartItemLoadFailureAction = new DaffCartItemLoadFailure([error], mockCartItem.id);
         actions$ = hot('--a', { a: cartItemLoadAction });
         expected = cold('--b', { b: cartItemLoadFailureAction });
       });
@@ -249,7 +249,7 @@ describe('@daffodil/cart/state | DaffCartItemEffects', () => {
           const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to add cart item' };
           const response = cold('#', {}, error);
           driverAddSpy.and.returnValue(response);
-          const cartItemAddFailureAction = new DaffCartItemAddFailure(error);
+          const cartItemAddFailureAction = new DaffCartItemAddFailure([error]);
           actions$ = hot('--a', { a: cartItemAddAction });
           expected = cold('--b', { b: cartItemAddFailureAction });
         });
@@ -263,7 +263,7 @@ describe('@daffodil/cart/state | DaffCartItemEffects', () => {
     describe('and the cart ID retrieval fails', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to add cart item' };
-        const cartItemAddFailureAction = new DaffCartItemAddFailure(error);
+        const cartItemAddFailureAction = new DaffCartItemAddFailure([error]);
         actions$ = hot('--a', { a: cartItemAddAction });
         expected = cold('--(b|)', { b: cartItemAddFailureAction });
         cartResolverSpy.getCartIdOrFail.and.returnValue(throwError(() => error));
@@ -323,7 +323,7 @@ describe('@daffodil/cart/state | DaffCartItemEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to update cart item' };
         const response = cold('#', {}, error);
         driverUpdateSpy.and.returnValue(response);
-        const cartItemUpdateFailureAction = new DaffCartItemUpdateFailure(error, mockCartItem.id);
+        const cartItemUpdateFailureAction = new DaffCartItemUpdateFailure([error], mockCartItem.id);
         actions$ = hot('--a', { a: cartItemUpdateAction });
         expected = cold('--b', { b: cartItemUpdateFailureAction });
       });
@@ -434,7 +434,7 @@ describe('@daffodil/cart/state | DaffCartItemEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to remove the cart item' };
         const response = cold('#', {}, error);
         driverDeleteSpy.and.returnValue(response);
-        const cartItemRemoveCartFailureAction = new DaffCartItemDeleteFailure(error, mockCartItem.id);
+        const cartItemRemoveCartFailureAction = new DaffCartItemDeleteFailure([error], mockCartItem.id);
         actions$ = hot('--a', { a: cartItemDeleteAction });
         expected = cold('--b', { b: cartItemRemoveCartFailureAction });
       });
@@ -503,7 +503,7 @@ describe('@daffodil/cart/state | DaffCartItemEffects', () => {
           const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to remove the cart item' };
           const response = cold('#', {}, error);
           driverDeleteSpy.and.returnValue(response);
-          const cartItemRemoveCartFailureAction = new DaffCartItemDeleteOutOfStockFailure(error);
+          const cartItemRemoveCartFailureAction = new DaffCartItemDeleteOutOfStockFailure([error]);
           actions$ = hot('--a', { a: cartItemDeleteOutOfStockAction });
           expected = cold('--(b|)', { b: cartItemRemoveCartFailureAction });
         });

--- a/libs/cart/state/src/effects/cart-item.effects.ts
+++ b/libs/cart/state/src/effects/cart-item.effects.ts
@@ -37,6 +37,7 @@ import {
   DaffCartItemServiceInterface,
   daffCartDriverHandleCartNotFound,
 } from '@daffodil/cart/driver';
+import { catchAndArrayifyErrors } from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
 
 import {
@@ -87,7 +88,7 @@ export class DaffCartItemEffects<
     switchMap((action: DaffCartItemList) =>
       this.driver.list(this.storage.getCartId()).pipe(
         map((resp: T[]) => new DaffCartItemListSuccess(resp)),
-        catchError(error => of(new DaffCartItemListFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartItemListFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));
@@ -98,7 +99,7 @@ export class DaffCartItemEffects<
     switchMap((action: DaffCartItemLoad<T>) =>
       this.driver.get(this.storage.getCartId(), action.itemId).pipe(
         map((resp: T) => new DaffCartItemLoadSuccess(resp)),
-        catchError(error => of(new DaffCartItemLoadFailure(this.errorMatcher(error), action.itemId))),
+        catchAndArrayifyErrors(error => of(new DaffCartItemLoadFailure(error.map(this.errorMatcher), action.itemId))),
       ),
     ),
   ));
@@ -111,8 +112,8 @@ export class DaffCartItemEffects<
       cartId,
       input,
     ).pipe(
-      map((resp: V) => new DaffCartItemAddSuccess(resp)),
-      catchError(error => of(new DaffCartItemAddFailure(this.errorMatcher(error)))),
+      map((resp) => new DaffCartItemAddSuccess(resp)),
+      catchAndArrayifyErrors(error => of(new DaffCartItemAddFailure(error.map(this.errorMatcher)))),
     );
   }
 
@@ -129,7 +130,7 @@ export class DaffCartItemEffects<
       ),
     ),
     daffCartDriverHandleCartNotFound(this.storage),
-    catchError(error => of(new DaffCartItemAddFailure(this.errorMatcher(error)))),
+    catchAndArrayifyErrors(error => of(new DaffCartItemAddFailure(error.map(this.errorMatcher)))),
   ));
 
 
@@ -142,7 +143,7 @@ export class DaffCartItemEffects<
         action.changes,
       ).pipe(
         map((resp: V) => new DaffCartItemUpdateSuccess(resp, action.itemId)),
-        catchError(error => of(new DaffCartItemUpdateFailure(this.errorMatcher(error), action.itemId))),
+        catchAndArrayifyErrors(error => of(new DaffCartItemUpdateFailure(error.map(this.errorMatcher), action.itemId))),
       ),
     ),
   ));
@@ -169,8 +170,8 @@ export class DaffCartItemEffects<
     ofType(DaffCartItemActionTypes.CartItemDeleteAction),
     mergeMap((action: DaffCartItemDelete<T>) =>
       this.driver.delete(this.storage.getCartId(), action.itemId).pipe(
-        map((resp: V) => new DaffCartItemDeleteSuccess(resp)),
-        catchError(error => of(new DaffCartItemDeleteFailure(this.errorMatcher(error), action.itemId))),
+        map((resp) => new DaffCartItemDeleteSuccess(resp)),
+        catchAndArrayifyErrors(error => of(new DaffCartItemDeleteFailure(error.map(this.errorMatcher), action.itemId))),
       ),
     ),
   ));
@@ -192,6 +193,6 @@ export class DaffCartItemEffects<
       ),
     ),
     map(cart => new DaffCartItemDeleteOutOfStockSuccess(cart)),
-    catchError(error => of(new DaffCartItemDeleteOutOfStockFailure(this.errorMatcher(error)))),
+    catchAndArrayifyErrors(error => of(new DaffCartItemDeleteOutOfStockFailure(error.map(this.errorMatcher)))),
   ));
 }

--- a/libs/cart/state/src/effects/cart-order.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-order.effects.spec.ts
@@ -39,7 +39,7 @@ import {
 
 import { DaffCartOrderEffects } from './cart-order.effects';
 
-describe('Cart | Effect | CartOrderEffects', () => {
+describe('@daffodil/cart/state | DaffCartOrderEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCartOrderEffects;
 
@@ -53,10 +53,10 @@ describe('Cart | Effect | CartOrderEffects', () => {
   let cartOrderDriver: DaffCartOrderServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverPlaceOrderSpy: jasmine.Spy;
-  let getCartIdSpy: jasmine.Spy;
+  let driverPlaceOrderSpy: jasmine.Spy<DaffCartOrderServiceInterface['placeOrder']>;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
 
-  const cartStorageFailureAction = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
+  const cartStorageFailureAction = new DaffCartStorageFailure([daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.'))]);
   const throwStorageError = () => {
     throw new DaffStorageServiceError('An error occurred during storage.');
   };
@@ -117,7 +117,7 @@ describe('Cart | Effect | CartOrderEffects', () => {
       beforeEach(() => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to place order' };
         const response = cold('#', {}, error);
-        const cartPlaceOrderFailureAction = new DaffCartPlaceOrderFailure(error);
+        const cartPlaceOrderFailureAction = new DaffCartPlaceOrderFailure([error]);
 
         driverPlaceOrderSpy.and.returnValue(response);
         actions$ = hot('--a', { a: cartPlaceOrderAction });

--- a/libs/cart/state/src/effects/cart-payment-methods.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-payment-methods.effects.spec.ts
@@ -32,7 +32,7 @@ import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffCartPaymentMethodsEffects } from './cart-payment-methods.effects';
 
-describe('Daffodil | Cart | DaffCartPaymentMethodsEffects', () => {
+describe('@daffodil/cart/state | DaffCartPaymentMethodsEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCartPaymentMethodsEffects<DaffCartPaymentMethod>;
 
@@ -45,8 +45,8 @@ describe('Daffodil | Cart | DaffCartPaymentMethodsEffects', () => {
   let paymentMethodsDriver: DaffCartPaymentMethodsServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverListSpy: jasmine.Spy;
-  let getCartIdSpy: jasmine.Spy;
+  let driverListSpy: jasmine.Spy<DaffCartPaymentMethodsServiceInterface['list']>;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -101,7 +101,7 @@ describe('Daffodil | Cart | DaffCartPaymentMethodsEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to list cart payment methods' };
         const response = cold('#', {}, error);
         driverListSpy.and.returnValue(response);
-        const cartCreateFailureAction = new DaffCartPaymentMethodsLoadFailure(error);
+        const cartCreateFailureAction = new DaffCartPaymentMethodsLoadFailure([error]);
         actions$ = hot('--a', { a: cartCreateAction });
         expected = cold('--b', { b: cartCreateFailureAction });
       });

--- a/libs/cart/state/src/effects/cart-payment-methods.effects.ts
+++ b/libs/cart/state/src/effects/cart-payment-methods.effects.ts
@@ -23,6 +23,7 @@ import {
   DaffCartPaymentMethodsDriver,
   DaffCartPaymentMethodsServiceInterface,
 } from '@daffodil/cart/driver';
+import { catchAndArrayifyErrors } from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
 
 import {
@@ -48,7 +49,7 @@ export class DaffCartPaymentMethodsEffects<T extends DaffCartPaymentMethod> {
     switchMap((action: DaffCartPaymentMethodsLoad) =>
       this.driver.list(this.storage.getCartId()).pipe(
         map((resp: T[]) => new DaffCartPaymentMethodsLoadSuccess(resp)),
-        catchError(error => of(new DaffCartPaymentMethodsLoadFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartPaymentMethodsLoadFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));

--- a/libs/cart/state/src/effects/cart-payment-processor.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-payment-processor.effects.spec.ts
@@ -170,7 +170,7 @@ describe('@daffodil/cart/state | DaffCartPaymentProcessorEffects', () => {
           const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to update cart payment' };
           const response = cold('#', {}, error);
           driverUpdateSpy.and.returnValue(response);
-          const cartPaymentUpdateFailureAction = new DaffCartPaymentUpdateFailure(error);
+          const cartPaymentUpdateFailureAction = new DaffCartPaymentUpdateFailure([error]);
           expected = cold('--b', { b: cartPaymentUpdateFailureAction });
         });
 

--- a/libs/cart/state/src/effects/cart-payment-processor.effects.ts
+++ b/libs/cart/state/src/effects/cart-payment-processor.effects.ts
@@ -29,6 +29,7 @@ import {
   DaffCartPaymentDriver,
   DaffCartPaymentServiceInterface,
 } from '@daffodil/cart/driver';
+import { catchAndArrayifyErrors } from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
 import {
   DaffPaymentResponse,
@@ -78,10 +79,10 @@ export class DaffCartPaymentProcessorEffects<
               payment_info: response.data,
             }, <R>act.address).pipe(
               map((resp: V) => new DaffCartPaymentUpdateSuccess(resp)),
-              catchError(error => of(new DaffCartPaymentUpdateFailure(this.errorMatcher(error)))),
+              catchAndArrayifyErrors(error => of(new DaffCartPaymentUpdateFailure(error.map(this.errorMatcher)))),
             ),
           ),
-          catchError(error => of(new DaffPaymentGenerateTokenFailure(this.paymentErrorMatcher(error)))),
+          catchAndArrayifyErrors(error => of(new DaffPaymentGenerateTokenFailure(this.paymentErrorMatcher(error[0])))),
         ),
       ),
     ),

--- a/libs/cart/state/src/effects/cart-payment.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-payment.effects.spec.ts
@@ -43,7 +43,7 @@ import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffCartPaymentEffects } from './cart-payment.effects';
 
-describe('Daffodil | Cart | CartPaymentEffects', () => {
+describe('@daffodil/cart/state | DaffCartPaymentEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCartPaymentEffects;
 
@@ -58,11 +58,11 @@ describe('Daffodil | Cart | CartPaymentEffects', () => {
   let daffPaymentDriver: DaffCartPaymentServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverGetSpy: jasmine.Spy;
-  let driverUpdateSpy: jasmine.Spy;
-  let driverUpdateWithBillingSpy: jasmine.Spy;
-  let driverRemoveSpy: jasmine.Spy;
-  let getCartIdSpy: jasmine.Spy;
+  let driverGetSpy: jasmine.Spy<DaffCartPaymentServiceInterface['get']>;
+  let driverUpdateSpy: jasmine.Spy<DaffCartPaymentServiceInterface['update']>;
+  let driverUpdateWithBillingSpy: jasmine.Spy<DaffCartPaymentServiceInterface['updateWithBilling']>;
+  let driverRemoveSpy: jasmine.Spy<DaffCartPaymentServiceInterface['remove']>;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -122,7 +122,7 @@ describe('Daffodil | Cart | CartPaymentEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to load cart payment' };
         const response = cold('#', {}, error);
         driverGetSpy.and.returnValue(response);
-        const cartPaymentLoadFailureAction = new DaffCartPaymentLoadFailure(error);
+        const cartPaymentLoadFailureAction = new DaffCartPaymentLoadFailure([error]);
         actions$ = hot('--a', { a: cartPaymentLoadAction });
         expected = cold('--b', { b: cartPaymentLoadFailureAction });
       });
@@ -161,7 +161,7 @@ describe('Daffodil | Cart | CartPaymentEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to update cart payment' };
         const response = cold('#', {}, error);
         driverUpdateSpy.and.returnValue(response);
-        const cartPaymentUpdateFailureAction = new DaffCartPaymentUpdateFailure(error);
+        const cartPaymentUpdateFailureAction = new DaffCartPaymentUpdateFailure([error]);
         actions$ = hot('--a', { a: cartPaymentUpdateAction });
         expected = cold('--b', { b: cartPaymentUpdateFailureAction });
       });
@@ -200,7 +200,7 @@ describe('Daffodil | Cart | CartPaymentEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to update cart payment and billing address' };
         const response = cold('#', {}, error);
         driverUpdateWithBillingSpy.and.returnValue(response);
-        const cartPaymentUpdateFailureAction = new DaffCartPaymentUpdateWithBillingFailure(error);
+        const cartPaymentUpdateFailureAction = new DaffCartPaymentUpdateWithBillingFailure([error]);
         actions$ = hot('--a', { a: cartPaymentUpdateAction });
         expected = cold('--b', { b: cartPaymentUpdateFailureAction });
       });
@@ -233,7 +233,7 @@ describe('Daffodil | Cart | CartPaymentEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to remove the cart payment' };
         const response = cold('#', {}, error);
         driverRemoveSpy.and.returnValue(response);
-        const cartPaymentRemoveFailureAction = new DaffCartPaymentRemoveFailure(error);
+        const cartPaymentRemoveFailureAction = new DaffCartPaymentRemoveFailure([error]);
         actions$ = hot('--a', { a: cartPaymentRemoveAction });
         expected = cold('--b', { b: cartPaymentRemoveFailureAction });
       });

--- a/libs/cart/state/src/effects/cart-payment.effects.ts
+++ b/libs/cart/state/src/effects/cart-payment.effects.ts
@@ -25,6 +25,7 @@ import {
   DaffCartPaymentDriver,
   DaffCartPaymentServiceInterface,
 } from '@daffodil/cart/driver';
+import { catchAndArrayifyErrors } from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
 
 import {
@@ -62,7 +63,7 @@ export class DaffCartPaymentEffects<
     switchMap((action: DaffCartPaymentLoad) =>
       this.driver.get(this.storage.getCartId()).pipe(
         map((resp: T) => new DaffCartPaymentLoadSuccess(resp)),
-        catchError(error => of(new DaffCartPaymentLoadFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartPaymentLoadFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));
@@ -73,7 +74,7 @@ export class DaffCartPaymentEffects<
     switchMap((action: DaffCartPaymentUpdate<T>) =>
       this.driver.update(this.storage.getCartId(), action.payload).pipe(
         map((resp: V) => new DaffCartPaymentUpdateSuccess(resp)),
-        catchError(error => of(new DaffCartPaymentUpdateFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartPaymentUpdateFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));
@@ -84,7 +85,7 @@ export class DaffCartPaymentEffects<
     switchMap((action: DaffCartPaymentUpdateWithBilling<T, R>) =>
       this.driver.updateWithBilling(this.storage.getCartId(), action.payment, action.address).pipe(
         map(resp => new DaffCartPaymentUpdateWithBillingSuccess(resp)),
-        catchError(error => of(new DaffCartPaymentUpdateWithBillingFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartPaymentUpdateWithBillingFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));
@@ -95,7 +96,7 @@ export class DaffCartPaymentEffects<
     switchMap((action: DaffCartPaymentRemove) =>
       this.driver.remove(this.storage.getCartId()).pipe(
         map(() => new DaffCartPaymentRemoveSuccess()),
-        catchError(error => of(new DaffCartPaymentRemoveFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartPaymentRemoveFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));

--- a/libs/cart/state/src/effects/cart-resolver.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-resolver.effects.spec.ts
@@ -50,7 +50,7 @@ describe('@daffodil/cart/state | DaffCartResolverEffects | in the browser', () =
 
   let cartResolverSpy: jasmine.SpyObj<DaffCartDriverResolveService>;
   let cartStorageService: DaffCartStorageService;
-  let getCartIdSpy: jasmine.Spy;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
 
   beforeEach(() => {
     cartResolverSpy = jasmine.createSpyObj('DaffCartDriverResolveService', ['getCartOrFail']);
@@ -138,7 +138,7 @@ describe('@daffodil/cart/state | DaffCartResolverEffects | in the browser', () =
 
       it('should emit an action indicating that server side resolution occurred', () => {
         const error = new DaffCartServerSideResolutionError(errorMessage);
-        const resolveCartServerSide = new DaffResolveCartServerSide(daffTransformErrorToStateError(error));
+        const resolveCartServerSide = new DaffResolveCartServerSide([daffTransformErrorToStateError(error)]);
         const expected = cold('--a', {
           a: resolveCartServerSide,
         });

--- a/libs/cart/state/src/effects/cart-shipping-address.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-shipping-address.effects.spec.ts
@@ -35,7 +35,7 @@ import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffCartShippingAddressEffects } from './cart-shipping-address.effects';
 
-describe('Daffodil | Cart | CartShippingAddressEffects', () => {
+describe('@daffodil/cart/state | DaffCartShippingAddressEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCartShippingAddressEffects<DaffCartAddress, DaffCart>;
 
@@ -48,9 +48,9 @@ describe('Daffodil | Cart | CartShippingAddressEffects', () => {
   let daffShippingAddressDriver: DaffCartShippingAddressServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverGetSpy: jasmine.Spy;
-  let driverUpdateSpy: jasmine.Spy;
-  let getCartIdSpy: jasmine.Spy;
+  let driverGetSpy: jasmine.Spy<DaffCartShippingAddressServiceInterface['get']>;
+  let driverUpdateSpy: jasmine.Spy<DaffCartShippingAddressServiceInterface['update']>;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -106,7 +106,7 @@ describe('Daffodil | Cart | CartShippingAddressEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to load cart shipping address' };
         const response = cold('#', {}, error);
         driverGetSpy.and.returnValue(response);
-        const cartShippingAddressLoadFailureAction = new DaffCartShippingAddressLoadFailure(error);
+        const cartShippingAddressLoadFailureAction = new DaffCartShippingAddressLoadFailure([error]);
         actions$ = hot('--a', { a: cartShippingAddressLoadAction });
         expected = cold('--b', { b: cartShippingAddressLoadFailureAction });
       });
@@ -145,7 +145,7 @@ describe('Daffodil | Cart | CartShippingAddressEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to update cart shipping address' };
         const response = cold('#', {}, error);
         driverUpdateSpy.and.returnValue(response);
-        const cartCreateFailureAction = new DaffCartShippingAddressUpdateFailure(error);
+        const cartCreateFailureAction = new DaffCartShippingAddressUpdateFailure([error]);
         actions$ = hot('--a', { a: cartCreateAction });
         expected = cold('--b', { b: cartCreateFailureAction });
       });

--- a/libs/cart/state/src/effects/cart-shipping-address.effects.ts
+++ b/libs/cart/state/src/effects/cart-shipping-address.effects.ts
@@ -24,6 +24,7 @@ import {
   DaffCartShippingAddressDriver,
   DaffCartShippingAddressServiceInterface,
 } from '@daffodil/cart/driver';
+import { catchAndArrayifyErrors } from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
 
 import {
@@ -51,7 +52,7 @@ export class DaffCartShippingAddressEffects<T extends DaffCartAddress, V extends
     switchMap((action: DaffCartShippingAddressLoad) =>
       this.driver.get(this.storage.getCartId()).pipe(
         map((resp: T) => new DaffCartShippingAddressLoadSuccess(resp)),
-        catchError(error => of(new DaffCartShippingAddressLoadFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartShippingAddressLoadFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));
@@ -62,7 +63,7 @@ export class DaffCartShippingAddressEffects<T extends DaffCartAddress, V extends
     switchMap((action: DaffCartShippingAddressUpdate<T>) =>
       this.driver.update(this.storage.getCartId(), action.payload).pipe(
         map((resp: V) => new DaffCartShippingAddressUpdateSuccess(resp)),
-        catchError(error => of(new DaffCartShippingAddressUpdateFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartShippingAddressUpdateFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));

--- a/libs/cart/state/src/effects/cart-shipping-information.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-shipping-information.effects.spec.ts
@@ -38,7 +38,7 @@ import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffCartShippingInformationEffects } from './cart-shipping-information.effects';
 
-describe('Daffodil | Cart | CartShippingInformationEffects', () => {
+describe('@daffodil/cart/state | DaffCartShippingInformationEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCartShippingInformationEffects<DaffCartShippingInformation, DaffCart>;
 
@@ -51,10 +51,10 @@ describe('Daffodil | Cart | CartShippingInformationEffects', () => {
   let daffShippingInformationDriver: DaffCartShippingInformationServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverGetSpy: jasmine.Spy;
-  let driverUpdateSpy: jasmine.Spy;
-  let driverDeleteSpy: jasmine.Spy;
-  let getCartIdSpy: jasmine.Spy;
+  let driverGetSpy: jasmine.Spy<DaffCartShippingInformationServiceInterface['get']>;
+  let driverUpdateSpy: jasmine.Spy<DaffCartShippingInformationServiceInterface['update']>;
+  let driverDeleteSpy: jasmine.Spy<DaffCartShippingInformationServiceInterface['delete']>;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -114,7 +114,7 @@ describe('Daffodil | Cart | CartShippingInformationEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to load cart shipping information' };
         const response = cold('#', {}, error);
         driverGetSpy.and.returnValue(response);
-        const cartShippingInformationLoadFailureAction = new DaffCartShippingInformationLoadFailure(error);
+        const cartShippingInformationLoadFailureAction = new DaffCartShippingInformationLoadFailure([error]);
         actions$ = hot('--a', { a: cartShippingInformationLoadAction });
         expected = cold('--b', { b: cartShippingInformationLoadFailureAction });
       });
@@ -153,7 +153,7 @@ describe('Daffodil | Cart | CartShippingInformationEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to update cart shipping information' };
         const response = cold('#', {}, error);
         driverUpdateSpy.and.returnValue(response);
-        const cartCreateFailureAction = new DaffCartShippingInformationUpdateFailure(error);
+        const cartCreateFailureAction = new DaffCartShippingInformationUpdateFailure([error]);
         actions$ = hot('--a', { a: cartCreateAction });
         expected = cold('--b', { b: cartCreateFailureAction });
       });
@@ -187,7 +187,7 @@ describe('Daffodil | Cart | CartShippingInformationEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to delete the cart shipping information' };
         const response = cold('#', {}, error);
         driverDeleteSpy.and.returnValue(response);
-        const cartShippingInformationDeleteFailureAction = new DaffCartShippingInformationDeleteFailure(error);
+        const cartShippingInformationDeleteFailureAction = new DaffCartShippingInformationDeleteFailure([error]);
         actions$ = hot('--a', { a: cartShippingInformationDeleteAction });
         expected = cold('--b', { b: cartShippingInformationDeleteFailureAction });
       });

--- a/libs/cart/state/src/effects/cart-shipping-information.effects.ts
+++ b/libs/cart/state/src/effects/cart-shipping-information.effects.ts
@@ -24,6 +24,7 @@ import {
   DaffCartShippingInformationDriver,
   DaffCartShippingInformationServiceInterface,
 } from '@daffodil/cart/driver';
+import { catchAndArrayifyErrors } from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
 
 import {
@@ -54,7 +55,7 @@ export class DaffCartShippingInformationEffects<T extends DaffCartShippingInform
     switchMap((action: DaffCartShippingInformationLoad) =>
       this.driver.get(this.storage.getCartId()).pipe(
         map((resp: T) => new DaffCartShippingInformationLoadSuccess(resp)),
-        catchError(error => of(new DaffCartShippingInformationLoadFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartShippingInformationLoadFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));
@@ -65,7 +66,7 @@ export class DaffCartShippingInformationEffects<T extends DaffCartShippingInform
     switchMap((action: DaffCartShippingInformationUpdate<T>) =>
       this.driver.update(this.storage.getCartId(), action.payload).pipe(
         map((resp: V) => new DaffCartShippingInformationUpdateSuccess(resp)),
-        catchError(error => of(new DaffCartShippingInformationUpdateFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartShippingInformationUpdateFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));
@@ -76,7 +77,7 @@ export class DaffCartShippingInformationEffects<T extends DaffCartShippingInform
     switchMap((action: DaffCartShippingInformationDelete<V['shipping_information']>) =>
       this.driver.delete(this.storage.getCartId()).pipe(
         map((resp: V) => new DaffCartShippingInformationDeleteSuccess(resp)),
-        catchError(error => of(new DaffCartShippingInformationDeleteFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartShippingInformationDeleteFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));

--- a/libs/cart/state/src/effects/cart-shipping-methods.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart-shipping-methods.effects.spec.ts
@@ -32,7 +32,7 @@ import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffCartShippingMethodsEffects } from './cart-shipping-methods.effects';
 
-describe('Daffodil | Cart | DaffCartShippingMethodsEffects', () => {
+describe('@daffodil/cart/state | DaffCartShippingMethodsEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCartShippingMethodsEffects<DaffCartShippingRate>;
 
@@ -45,8 +45,8 @@ describe('Daffodil | Cart | DaffCartShippingMethodsEffects', () => {
   let shippingMethodsDriver: DaffCartShippingMethodsServiceInterface;
   let daffCartStorageService: DaffCartStorageService;
 
-  let driverListSpy: jasmine.Spy;
-  let getCartIdSpy: jasmine.Spy;
+  let driverListSpy: jasmine.Spy<DaffCartShippingMethodsServiceInterface['list']>;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -101,7 +101,7 @@ describe('Daffodil | Cart | DaffCartShippingMethodsEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to list cart shipping methods' };
         const response = cold('#', {}, error);
         driverListSpy.and.returnValue(response);
-        const cartCreateFailureAction = new DaffCartShippingMethodsLoadFailure(error);
+        const cartCreateFailureAction = new DaffCartShippingMethodsLoadFailure([error]);
         actions$ = hot('--a', { a: cartCreateAction });
         expected = cold('--b', { b: cartCreateFailureAction });
       });

--- a/libs/cart/state/src/effects/cart-shipping-methods.effects.ts
+++ b/libs/cart/state/src/effects/cart-shipping-methods.effects.ts
@@ -23,6 +23,7 @@ import {
   DaffCartShippingMethodsDriver,
   DaffCartShippingMethodsServiceInterface,
 } from '@daffodil/cart/driver';
+import { catchAndArrayifyErrors } from '@daffodil/core';
 import { ErrorTransformer } from '@daffodil/core/state';
 
 import {
@@ -48,7 +49,7 @@ export class DaffCartShippingMethodsEffects<T extends DaffCartShippingRate> {
     switchMap((action: DaffCartShippingMethodsLoad) =>
       this.driver.list(this.storage.getCartId()).pipe(
         map((resp: T[]) => new DaffCartShippingMethodsLoadSuccess(resp)),
-        catchError(error => of(new DaffCartShippingMethodsLoadFailure(this.errorMatcher(error)))),
+        catchAndArrayifyErrors(error => of(new DaffCartShippingMethodsLoadFailure(error.map(this.errorMatcher)))),
       ),
     ),
   ));

--- a/libs/cart/state/src/effects/cart.effects.spec.ts
+++ b/libs/cart/state/src/effects/cart.effects.spec.ts
@@ -60,10 +60,10 @@ describe('@daffodil/cart/state | DaffCartEffects', () => {
   let driverCreateSpy: jasmine.Spy<DaffCartServiceInterface['create']>;
   let driverClearSpy: jasmine.Spy<DaffCartServiceInterface['clear']>;
   let driverAddToCartSpy: jasmine.Spy<DaffCartServiceInterface['addToCart']>;
-  let getCartIdSpy: jasmine.Spy;
+  let getCartIdSpy: jasmine.Spy<DaffCartStorageService['getCartId']>;
   let setCartIdSpy: jasmine.Spy;
 
-  const cartStorageFailureAction = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
+  const cartStorageFailureAction = new DaffCartStorageFailure([daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.'))]);
   const throwStorageError = () => {
     throw new DaffStorageServiceError('An error occurred during storage.');
   };
@@ -190,7 +190,7 @@ describe('@daffodil/cart/state | DaffCartEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to create cart' };
         const response = cold('#', {}, error);
         driverCreateSpy.and.returnValue(response);
-        const cartCreateFailureAction = new DaffCartCreateFailure(error);
+        const cartCreateFailureAction = new DaffCartCreateFailure([error]);
         actions$ = hot('--a', { a: cartCreateAction });
         expected = cold('--b', { b: cartCreateFailureAction });
       });
@@ -287,7 +287,7 @@ describe('@daffodil/cart/state | DaffCartEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to add item to cart' };
         const response = cold('#', {}, error);
         driverAddToCartSpy.and.returnValue(response);
-        const addToCartFailureAction = new DaffAddToCartFailure(error);
+        const addToCartFailureAction = new DaffAddToCartFailure([error]);
         actions$ = hot('--a', { a: addToCartAction });
         expected = cold('--b', { b: addToCartFailureAction });
       });
@@ -320,7 +320,7 @@ describe('@daffodil/cart/state | DaffCartEffects', () => {
         const error: DaffStateError = { code: 'code', recoverable: false, message: 'Failed to clear the cart.' };
         const response = cold('#', {}, error);
         driverClearSpy.and.returnValue(response);
-        const cartClearFailureAction = new DaffCartClearFailure(error);
+        const cartClearFailureAction = new DaffCartClearFailure([error]);
         actions$ = hot('--a', { a: cartClearAction });
         expected = cold('--b', { b: cartClearFailureAction });
       });

--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -832,7 +832,7 @@ describe('DaffCartFacade', () => {
     it('should contain an error upon a failed item load', () => {
       const error: DaffStateError = { code: 'error code', message: 'error message' };
       const expected = cold('a', { a: [error]});
-      facade.dispatch(new DaffCartItemLoadFailure(error, 'itemId'));
+      facade.dispatch(new DaffCartItemLoadFailure([error], 'itemId'));
       expect(facade.itemErrors$).toBeObservable(expected);
     });
   });
@@ -846,7 +846,7 @@ describe('DaffCartFacade', () => {
     it('should contain an error upon a failed billing address load', () => {
       const error: DaffStateError = { code: 'error code', message: 'error message' };
       const expected = cold('a', { a: [error]});
-      facade.dispatch(new DaffCartBillingAddressLoadFailure(error));
+      facade.dispatch(new DaffCartBillingAddressLoadFailure([error]));
       expect(facade.billingAddressErrors$).toBeObservable(expected);
     });
   });
@@ -860,7 +860,7 @@ describe('DaffCartFacade', () => {
     it('should contain an error upon a failed shipping address load', () => {
       const error: DaffStateError = { code: 'error code', message: 'error message' };
       const expected = cold('a', { a: [error]});
-      facade.dispatch(new DaffCartShippingAddressLoadFailure(error));
+      facade.dispatch(new DaffCartShippingAddressLoadFailure([error]));
       expect(facade.shippingAddressErrors$).toBeObservable(expected);
     });
   });
@@ -874,7 +874,7 @@ describe('DaffCartFacade', () => {
     it('should contain an error upon a failed shipping information load', () => {
       const error: DaffStateError = { code: 'error code', message: 'error message' };
       const expected = cold('a', { a: [error]});
-      facade.dispatch(new DaffCartShippingInformationLoadFailure(error));
+      facade.dispatch(new DaffCartShippingInformationLoadFailure([error]));
       expect(facade.shippingInformationErrors$).toBeObservable(expected);
     });
   });
@@ -888,7 +888,7 @@ describe('DaffCartFacade', () => {
     it('should contain an error upon a failed shipping methods load', () => {
       const error: DaffStateError = { code: 'error code', message: 'error message' };
       const expected = cold('a', { a: [error]});
-      facade.dispatch(new DaffCartShippingMethodsLoadFailure(error));
+      facade.dispatch(new DaffCartShippingMethodsLoadFailure([error]));
       expect(facade.shippingMethodsErrors$).toBeObservable(expected);
     });
   });
@@ -902,7 +902,7 @@ describe('DaffCartFacade', () => {
     it('should contain an error upon a failed payment load', () => {
       const error: DaffStateError = { code: 'error code', message: 'error message' };
       const expected = cold('a', { a: [error]});
-      facade.dispatch(new DaffCartPaymentLoadFailure(error));
+      facade.dispatch(new DaffCartPaymentLoadFailure([error]));
       expect(facade.paymentErrors$).toBeObservable(expected);
     });
   });
@@ -916,7 +916,7 @@ describe('DaffCartFacade', () => {
     it('should contain an error upon a failed payment methods load', () => {
       const error: DaffStateError = { code: 'error code', message: 'error message' };
       const expected = cold('a', { a: [error]});
-      facade.dispatch(new DaffCartPaymentMethodsLoadFailure(error));
+      facade.dispatch(new DaffCartPaymentMethodsLoadFailure([error]));
       expect(facade.paymentMethodsErrors$).toBeObservable(expected);
     });
   });
@@ -930,7 +930,7 @@ describe('DaffCartFacade', () => {
     it('should contain an error upon a failed coupon list', () => {
       const error: DaffStateError = { code: 'error code', message: 'error message' };
       const expected = cold('a', { a: [error]});
-      facade.dispatch(new DaffCartCouponListFailure(error));
+      facade.dispatch(new DaffCartCouponListFailure([error]));
       expect(facade.couponErrors$).toBeObservable(expected);
     });
   });
@@ -1435,7 +1435,7 @@ describe('DaffCartFacade', () => {
 
       beforeEach(() => {
         error = 'error';
-        facade.dispatch(new DaffCartPlaceOrderFailure(error));
+        facade.dispatch(new DaffCartPlaceOrderFailure([error]));
       });
 
       it('should contain the error', () => {
@@ -1759,7 +1759,7 @@ describe('DaffCartFacade', () => {
       });
       const expected = cold('a', { a: [error]});
       facade.dispatch(new DaffCartLoadSuccess(cart));
-      facade.dispatch(new DaffCartItemUpdateFailure(error, cart.items[0].id));
+      facade.dispatch(new DaffCartItemUpdateFailure([error], cart.items[0].id));
       expect(facade.getCartItemErrors(cart.items[0].id)).toBeObservable(expected);
     });
   });

--- a/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.spec.ts
@@ -23,7 +23,7 @@ import {
 
 import { cartBillingAddressReducer } from './cart-billing-address.reducer';
 
-describe('Cart | Reducer | Cart Billing Address', () => {
+describe('@daffodil/cart/state | cartBillingAddressReducer', () => {
   let cartFactory: DaffCartFactory;
   let cart: DaffCart;
 
@@ -102,7 +102,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
         },
       };
 
-      const cartListLoadFailure = new DaffCartBillingAddressLoadFailure(error);
+      const cartListLoadFailure = new DaffCartBillingAddressLoadFailure([error]);
 
       result = cartBillingAddressReducer(state, cartListLoadFailure);
     });
@@ -176,7 +176,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartBillingAddressUpdateFailure = new DaffCartBillingAddressUpdateFailure(error);
+      const cartBillingAddressUpdateFailure = new DaffCartBillingAddressUpdateFailure([error]);
 
       result = cartBillingAddressReducer(state, cartBillingAddressUpdateFailure);
     });
@@ -250,7 +250,7 @@ describe('Cart | Reducer | Cart Billing Address', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartAddressUpdateFailure = new DaffCartAddressUpdateFailure(error);
+      const cartAddressUpdateFailure = new DaffCartAddressUpdateFailure([error]);
 
       result = cartBillingAddressReducer(state, cartAddressUpdateFailure);
     });

--- a/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-billing-address/cart-billing-address.reducer.ts
@@ -65,7 +65,7 @@ export function cartBillingAddressReducer<T extends DaffCart>(
     case DaffCartAddressActionTypes.CartAddressUpdateFailureAction:
       return {
         ...state,
-        ...addError(state.errors, action.payload),
+        ...addError(state.errors, ...action.payload),
         ...setLoading(state.loading, DaffState.Complete),
       };
 

--- a/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.spec.ts
@@ -32,8 +32,7 @@ import { DaffStateError } from '@daffodil/core/state';
 
 import { cartCouponReducer as reducer } from './cart-coupon.reducer';
 
-
-describe('Cart | Reducer | cartCouponReducer', () => {
+describe('@daffodil/cart/state | cartCouponReducer', () => {
   let cartFactory: DaffCartFactory;
   let cartCouponFactory: DaffCartCouponFactory;
 
@@ -88,10 +87,6 @@ describe('Cart | Reducer | cartCouponReducer', () => {
       result = reducer(state, cartCouponApplySuccess);
     });
 
-    it('should set cart from action.payload', () => {
-      expect(result.cart).toEqual(cart);
-    });
-
     it('should indicate that the cart is not loading', () => {
       expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Complete);
     });
@@ -119,7 +114,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         },
       };
 
-      const cartCouponApplyFailure = new DaffCartCouponApplyFailure(error);
+      const cartCouponApplyFailure = new DaffCartCouponApplyFailure([error]);
 
       result = reducer(state, cartCouponApplyFailure);
     });
@@ -192,7 +187,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
         },
       };
 
-      const cartCouponListFailure = new DaffCartCouponListFailure(error);
+      const cartCouponListFailure = new DaffCartCouponListFailure([error]);
 
       result = reducer(state, cartCouponListFailure);
     });
@@ -233,10 +228,6 @@ describe('Cart | Reducer | cartCouponReducer', () => {
       result = reducer(state, cartCouponRemoveActionSuccess);
     });
 
-    it('should set cart from action.payload', () => {
-      expect(result.cart).toEqual(cart);
-    });
-
     it('should indicate that the cart is not loading', () => {
       expect(result.loading[DaffCartOperationType.Coupon]).toEqual(DaffState.Complete);
     });
@@ -266,7 +257,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartCouponRemoveFailure = new DaffCartCouponRemoveFailure(error);
+      const cartCouponRemoveFailure = new DaffCartCouponRemoveFailure([error]);
 
       result = reducer(state, cartCouponRemoveFailure);
     });
@@ -346,7 +337,7 @@ describe('Cart | Reducer | cartCouponReducer', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartClearFailure = new DaffCartCouponRemoveAllFailure(error);
+      const cartClearFailure = new DaffCartCouponRemoveAllFailure([error]);
 
       result = reducer(state, cartClearFailure);
     });

--- a/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-coupon/cart-coupon.reducer.ts
@@ -72,7 +72,7 @@ export function cartCouponReducer<T extends DaffCart>(
     case DaffCartCouponActionTypes.CartCouponRemoveFailureAction:
       return {
         ...state,
-        ...addError(state.errors, action.payload),
+        ...addError(state.errors, ...action.payload),
         ...setLoading(state.loading, DaffState.Complete),
       };
 

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.spec.ts
@@ -23,6 +23,7 @@ import {
   DaffCartItemDeleteOutOfStockSuccess,
   DaffCartLoadPartialSuccess,
   DaffResolveCartPartialSuccess,
+  daffCartItemEntitiesAdapter,
 } from '@daffodil/cart/state';
 import { DaffStatefulCartItemFactory } from '@daffodil/cart/state/testing';
 import {
@@ -31,10 +32,9 @@ import {
 } from '@daffodil/cart/testing';
 import { DaffStateError } from '@daffodil/core/state';
 
-import { daffCartItemEntitiesAdapter } from './cart-item-entities-reducer-adapter';
 import { daffCartItemEntitiesReducer } from './cart-item-entities.reducer';
 
-describe('Cart | Cart Item Entities Reducer', () => {
+describe('@daffodil/cart/state | daffCartItemEntitiesReducer', () => {
   let error: DaffStateError;
   let statefulCartItemFactory: DaffStatefulCartItemFactory;
   let cartFactory: DaffCartFactory;
@@ -567,7 +567,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
       };
       statefulCartItem = statefulCartItemFactory.create();
       const cartItemLoadSuccess = new DaffCartItemLoadSuccess(statefulCartItem);
-      const cartItemLoadFailure = new DaffCartItemLoadFailure(error, statefulCartItem.id);
+      const cartItemLoadFailure = new DaffCartItemLoadFailure([error], statefulCartItem.id);
 
       result = daffCartItemEntitiesReducer(daffCartItemEntitiesReducer(initialState, cartItemLoadSuccess), cartItemLoadFailure);
     });
@@ -588,7 +588,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
       };
       statefulCartItem = statefulCartItemFactory.create();
       const cartItemLoadSuccess = new DaffCartItemLoadSuccess(statefulCartItem);
-      const cartItemDeleteFailure = new DaffCartItemDeleteFailure(error, statefulCartItem.id);
+      const cartItemDeleteFailure = new DaffCartItemDeleteFailure([error], statefulCartItem.id);
 
       result = daffCartItemEntitiesReducer(daffCartItemEntitiesReducer(initialState, cartItemLoadSuccess), cartItemDeleteFailure);
     });
@@ -609,7 +609,7 @@ describe('Cart | Cart Item Entities Reducer', () => {
       };
       statefulCartItem = statefulCartItemFactory.create();
       const cartItemLoadSuccess = new DaffCartItemLoadSuccess(statefulCartItem);
-      const cartItemUpdateFailure = new DaffCartItemUpdateFailure(error, statefulCartItem.id);
+      const cartItemUpdateFailure = new DaffCartItemUpdateFailure([error], statefulCartItem.id);
 
       result = daffCartItemEntitiesReducer(daffCartItemEntitiesReducer(initialState, cartItemLoadSuccess), cartItemUpdateFailure);
     });

--- a/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item-entities/cart-item-entities.reducer.ts
@@ -65,7 +65,7 @@ export function daffCartItemEntitiesReducer<
       return adapter.upsertOne({
         ...state.entities[action.itemId],
         daffState: DaffCartItemStateEnum.Error,
-        daffErrors: state.entities[action.itemId]?.daffErrors?.concat(action.payload) || [action.payload],
+        daffErrors: state.entities[action.itemId]?.daffErrors?.concat(action.payload) || action.payload,
       }, state);
     case DaffCartItemActionTypes.CartItemDeleteSuccessAction:
     case DaffCartItemActionTypes.CartItemDeleteOutOfStockSuccessAction:
@@ -83,14 +83,17 @@ export function daffCartItemEntitiesReducer<
         ...state.entities[key],
         daffState: DaffCartItemStateEnum.Default,
       })), state);
+
     case DaffCartItemActionTypes.CartItemUpdateAction:
     case DaffCartItemActionTypes.CartItemDeleteAction:
       return adapter.upsertOne({
         ...state.entities[action.itemId],
         daffState: DaffCartItemStateEnum.Mutating,
       }, state);
+
     case DaffCartActionTypes.CartCreateSuccessAction:
       return adapter.removeAll(state);
+
     default:
       return state;
   }

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.spec.ts
@@ -133,7 +133,7 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
         },
       };
 
-      const cartItemUpdateFailure = new DaffCartItemUpdateFailure(error, cartItem.id);
+      const cartItemUpdateFailure = new DaffCartItemUpdateFailure([error], cartItem.id);
 
       result = cartItemReducer(state, cartItemUpdateFailure);
     });
@@ -209,7 +209,7 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
         },
       };
 
-      const cartItemRemoveFailure = new DaffCartItemDeleteFailure(error, cartItem.id);
+      const cartItemRemoveFailure = new DaffCartItemDeleteFailure([error], cartItem.id);
 
       result = cartItemReducer(state, cartItemRemoveFailure);
     });
@@ -294,7 +294,7 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
         },
       };
 
-      const cartItemRemoveFailure = new DaffCartItemDeleteOutOfStockFailure(error);
+      const cartItemRemoveFailure = new DaffCartItemDeleteOutOfStockFailure([error]);
 
       result = cartItemReducer(state, cartItemRemoveFailure);
     });
@@ -370,7 +370,7 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartItemAddFailure = new DaffCartItemAddFailure(error);
+      const cartItemAddFailure = new DaffCartItemAddFailure([error]);
 
       result = cartItemReducer(state, cartItemAddFailure);
     });
@@ -454,7 +454,7 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartItemLoadFailure = new DaffCartItemLoadFailure(error, cartItem.id);
+      const cartItemLoadFailure = new DaffCartItemLoadFailure([error], cartItem.id);
 
       result = cartItemReducer(state, cartItemLoadFailure);
     });
@@ -532,7 +532,7 @@ describe('@daffodil/cart/state | cartItemReducer', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartItemListFailure = new DaffCartItemListFailure(error);
+      const cartItemListFailure = new DaffCartItemListFailure([error]);
 
       result = cartItemReducer(state, cartItemListFailure);
     });

--- a/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-item/cart-item.reducer.ts
@@ -103,7 +103,7 @@ export function cartItemReducer<T extends DaffCart>(
     case DaffCartItemActionTypes.CartItemDeleteOutOfStockFailureAction:
       return {
         ...state,
-        ...addError(state.errors, action.payload),
+        ...addError(state.errors, ...action.payload),
         ...setLoading(state.loading, DaffState.Complete),
       };
 

--- a/libs/cart/state/src/reducers/cart-order/cart-order.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order.reducer.spec.ts
@@ -38,7 +38,7 @@ import {
 
 import { daffCartOrderReducer as reducer } from './cart-order.reducer';
 
-describe('Cart | Reducer | CartOrder', () => {
+describe('@daffodil/cart/state | daffCartOrderReducer', () => {
   describe('when an unknown action is triggered', () => {
     it('should return the current state', () => {
       const action = <any>{};
@@ -109,7 +109,7 @@ describe('Cart | Reducer | CartOrder', () => {
         ],
       };
 
-      const cartPlaceOrderFailure = new DaffCartPlaceOrderFailure(error);
+      const cartPlaceOrderFailure = new DaffCartPlaceOrderFailure([error]);
 
       result = reducer(state, cartPlaceOrderFailure);
     });
@@ -118,8 +118,8 @@ describe('Cart | Reducer | CartOrder', () => {
       expect(result.loading).toEqual(DaffState.Complete);
     });
 
-    it('should add an error to state', () => {
-      expect(result.errors.length).toEqual(2);
+    it('should set the action errors in state', () => {
+      expect(result.errors).toEqual([error]);
     });
   });
 

--- a/libs/cart/state/src/reducers/cart-order/cart-order.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-order/cart-order.reducer.ts
@@ -58,10 +58,7 @@ export function daffCartOrderReducer<T extends DaffCartOrderResult = DaffCartOrd
       return {
         ...state,
         loading: DaffState.Complete,
-        errors: [
-          ...state.errors,
-          action.payload,
-        ],
+        errors: action.payload,
       };
 
     case DaffCartActionTypes.CartClearSuccessAction:

--- a/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.spec.ts
@@ -17,7 +17,7 @@ import {
 
 import { cartPaymentMethodsReducer } from './cart-payment-methods.reducer';
 
-describe('Cart | Reducer | Cart Payment Methods', () => {
+describe('@daffodil/cart/state | cartPaymentMethodsReducer', () => {
   let cartFactory: DaffCartFactory;
   let cart: DaffCart;
 
@@ -97,7 +97,7 @@ describe('Cart | Reducer | Cart Payment Methods', () => {
         },
       };
 
-      const cartPaymentMethodsLoadFailure = new DaffCartPaymentMethodsLoadFailure(error);
+      const cartPaymentMethodsLoadFailure = new DaffCartPaymentMethodsLoadFailure([error]);
 
       result = cartPaymentMethodsReducer(state, cartPaymentMethodsLoadFailure);
     });

--- a/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-payment-methods/cart-payment-methods.reducer.ts
@@ -41,7 +41,7 @@ export function cartPaymentMethodsReducer<T extends DaffCart>(
     case DaffCartPaymentMethodsActionTypes.CartPaymentMethodsLoadFailureAction:
       return {
         ...state,
-        ...addError(state.errors, action.payload),
+        ...addError(state.errors, ...action.payload),
         ...setLoading(state.loading, DaffState.Complete),
       };
 

--- a/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.spec.ts
@@ -27,7 +27,7 @@ import {
 
 import { cartPaymentReducer } from './cart-payment.reducer';
 
-describe('Cart | Reducer | Cart Payment', () => {
+describe('@daffodil/cart/state | cartPaymentReducer', () => {
   let cartFactory: DaffCartFactory;
   let cart: DaffCart;
 
@@ -106,7 +106,7 @@ describe('Cart | Reducer | Cart Payment', () => {
         },
       };
 
-      const cartListLoadFailure = new DaffCartPaymentLoadFailure(error);
+      const cartListLoadFailure = new DaffCartPaymentLoadFailure([error]);
 
       result = cartPaymentReducer(state, cartListLoadFailure);
     });
@@ -180,7 +180,7 @@ describe('Cart | Reducer | Cart Payment', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartPaymentUpdateFailure = new DaffCartPaymentUpdateFailure(error);
+      const cartPaymentUpdateFailure = new DaffCartPaymentUpdateFailure([error]);
 
       result = cartPaymentReducer(state, cartPaymentUpdateFailure);
     });
@@ -254,7 +254,7 @@ describe('Cart | Reducer | Cart Payment', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartPaymentUpdateWithBillingFailure = new DaffCartPaymentUpdateWithBillingFailure(error);
+      const cartPaymentUpdateWithBillingFailure = new DaffCartPaymentUpdateWithBillingFailure([error]);
 
       result = cartPaymentReducer(state, cartPaymentUpdateWithBillingFailure);
     });
@@ -327,7 +327,7 @@ describe('Cart | Reducer | Cart Payment', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartPaymentRemoveFailure = new DaffCartPaymentRemoveFailure(error);
+      const cartPaymentRemoveFailure = new DaffCartPaymentRemoveFailure([error]);
 
       result = cartPaymentReducer(state, cartPaymentRemoveFailure);
     });

--- a/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-payment/cart-payment.reducer.ts
@@ -76,7 +76,7 @@ export function cartPaymentReducer<T extends DaffCart>(
     case DaffCartPaymentActionTypes.CartPaymentRemoveFailureAction:
       return {
         ...state,
-        ...addError(state.errors, action.payload),
+        ...addError(state.errors, ...action.payload),
         ...setLoading(state.loading, DaffState.Complete),
       };
 

--- a/libs/cart/state/src/reducers/cart-payment/payment.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-payment/payment.reducer.ts
@@ -23,7 +23,7 @@ export const daffCartPaymentReducer: ActionReducer<DaffPaymentReducerState> = (
 
     case DaffCartPaymentActionTypes.CartPaymentUpdateFailureAction:
     case DaffCartPaymentActionTypes.CartPaymentUpdateWithBillingFailureAction:
-      return adapter.storeError([action.payload], state);
+      return adapter.storeError(action.payload, state);
 
     default:
       return state;

--- a/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-resolve/cart-resolve.reducer.spec.ts
@@ -142,7 +142,7 @@ describe('@daffodil/cart/state | cartResolveReducer', () => {
         resolved: DaffCartResolveState.Resolving,
       };
 
-      const serverSideResolve = new DaffResolveCartServerSide(error);
+      const serverSideResolve = new DaffResolveCartServerSide([error]);
 
       result = reducer(state, serverSideResolve);
     });

--- a/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.spec.ts
@@ -23,7 +23,7 @@ import {
 
 import { cartShippingAddressReducer } from './cart-shipping-address.reducer';
 
-describe('Cart | Reducer | Cart Shipping Address', () => {
+describe('@daffodil/cart/state | cartShippingAddressReducer', () => {
   let cartFactory: DaffCartFactory;
   let cart: DaffCart;
 
@@ -102,7 +102,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
         },
       };
 
-      const cartListLoadFailure = new DaffCartShippingAddressLoadFailure(error);
+      const cartListLoadFailure = new DaffCartShippingAddressLoadFailure([error]);
 
       result = cartShippingAddressReducer(state, cartListLoadFailure);
     });
@@ -176,7 +176,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartShippingAddressUpdateFailure = new DaffCartShippingAddressUpdateFailure(error);
+      const cartShippingAddressUpdateFailure = new DaffCartShippingAddressUpdateFailure([error]);
 
       result = cartShippingAddressReducer(state, cartShippingAddressUpdateFailure);
     });
@@ -250,7 +250,7 @@ describe('Cart | Reducer | Cart Shipping Address', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartAddressUpdateFailure = new DaffCartAddressUpdateFailure(error);
+      const cartAddressUpdateFailure = new DaffCartAddressUpdateFailure([error]);
 
       result = cartShippingAddressReducer(state, cartAddressUpdateFailure);
     });

--- a/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-address/cart-shipping-address.reducer.ts
@@ -66,7 +66,7 @@ export function cartShippingAddressReducer<T extends DaffCart>(
     case DaffCartAddressActionTypes.CartAddressUpdateFailureAction:
       return {
         ...state,
-        ...addError(state.errors, action.payload),
+        ...addError(state.errors, ...action.payload),
         ...setLoading(state.loading, DaffState.Complete),
       };
 

--- a/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.spec.ts
@@ -29,7 +29,7 @@ import {
 
 import { cartShippingInformationReducer } from './cart-shipping-information.reducer';
 
-describe('Cart | Reducer | Cart Shipping Information', () => {
+describe('@daffodil/cart/state | cartShippingInformationReducer', () => {
   let cartFactory: DaffCartFactory;
   let cartShippingInformationFactory: DaffCartShippingRateFactory;
   let cart: DaffCart;
@@ -116,7 +116,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
         },
       };
 
-      const cartShippingInformationLoadFailure = new DaffCartShippingInformationLoadFailure(error);
+      const cartShippingInformationLoadFailure = new DaffCartShippingInformationLoadFailure([error]);
 
       result = cartShippingInformationReducer(state, cartShippingInformationLoadFailure);
     });
@@ -190,7 +190,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartShippingInformationUpdateFailure = new DaffCartShippingInformationUpdateFailure(error);
+      const cartShippingInformationUpdateFailure = new DaffCartShippingInformationUpdateFailure([error]);
 
       result = cartShippingInformationReducer(state, cartShippingInformationUpdateFailure);
     });
@@ -272,7 +272,7 @@ describe('Cart | Reducer | Cart Shipping Information', () => {
 
       error = { code: 'error code', message: 'error message' };
 
-      const cartShippingInformationRemoveFailure = new DaffCartShippingInformationDeleteFailure(error);
+      const cartShippingInformationRemoveFailure = new DaffCartShippingInformationDeleteFailure([error]);
 
       result = cartShippingInformationReducer(state, cartShippingInformationRemoveFailure);
     });

--- a/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-information/cart-shipping-information.reducer.ts
@@ -65,7 +65,7 @@ export function cartShippingInformationReducer<T extends DaffCart>(
     case DaffCartShippingInformationActionTypes.CartShippingInformationDeleteFailureAction:
       return {
         ...state,
-        ...addError(state.errors, action.payload),
+        ...addError(state.errors, ...action.payload),
         ...setLoading(state.loading, DaffState.Complete),
       };
 

--- a/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.spec.ts
@@ -21,10 +21,9 @@ import {
   DaffStateError,
 } from '@daffodil/core/state';
 
-
 import { cartShippingMethodsReducer } from './cart-shipping-methods.reducer';
 
-describe('Cart | Reducer | Cart Shipping Methods', () => {
+describe('@daffodil/cart/state | cartShippingMethodsReducer', () => {
   let cartFactory: DaffCartFactory;
   let cartShippingRateFactory: DaffCartShippingRateFactory;
   let cart: DaffCart;
@@ -110,7 +109,7 @@ describe('Cart | Reducer | Cart Shipping Methods', () => {
         },
       };
 
-      const cartShippingMethodsLoadFailure = new DaffCartShippingMethodsLoadFailure(error);
+      const cartShippingMethodsLoadFailure = new DaffCartShippingMethodsLoadFailure([error]);
 
       result = cartShippingMethodsReducer(state, cartShippingMethodsLoadFailure);
     });

--- a/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.ts
+++ b/libs/cart/state/src/reducers/cart-shipping-methods/cart-shipping-methods.reducer.ts
@@ -41,7 +41,7 @@ export function cartShippingMethodsReducer<T extends DaffCart>(
     case DaffCartShippingMethodsActionTypes.CartShippingMethodsLoadFailureAction:
       return {
         ...state,
-        ...addError(state.errors, action.payload),
+        ...addError(state.errors, ...action.payload),
         ...setLoading(state.loading, DaffState.Complete),
       };
 

--- a/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.spec.ts
@@ -1,4 +1,3 @@
-
 import { TestBed } from '@angular/core/testing';
 
 import { DaffCart } from '@daffodil/cart';
@@ -22,8 +21,8 @@ import {
   daffCartReducerInitialState,
   DaffResolveCartSuccess,
   DaffResolveCartFailure,
-  DaffResolveCartServerSide,
   DaffResolveCartPartialSuccess,
+  DaffCartLoadPartialSuccess,
 } from '@daffodil/cart/state';
 import { DaffCartFactory } from '@daffodil/cart/testing';
 import { DaffStorageServiceError } from '@daffodil/core';
@@ -34,7 +33,6 @@ import {
 } from '@daffodil/core/state';
 
 import { cartReducer } from './cart.reducer';
-import { DaffCartLoadPartialSuccess } from '../../actions/public_api';
 
 describe('@daffodil/cart/state | cartReducer', () => {
   let cartFactory: DaffCartFactory;
@@ -295,7 +293,7 @@ describe('@daffodil/cart/state | cartReducer', () => {
         },
       };
 
-      const cartStorageFailure = new DaffCartStorageFailure(daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.')));
+      const cartStorageFailure = new DaffCartStorageFailure([daffTransformErrorToStateError(new DaffStorageServiceError('An error occurred during storage.'))]);
 
       result = cartReducer(state, cartStorageFailure);
     });
@@ -371,7 +369,7 @@ describe('@daffodil/cart/state | cartReducer', () => {
         },
       };
 
-      const cartCreateFailure = new DaffCartCreateFailure(error);
+      const cartCreateFailure = new DaffCartCreateFailure([error]);
 
       result = cartReducer(state, cartCreateFailure);
     });
@@ -445,7 +443,7 @@ describe('@daffodil/cart/state | cartReducer', () => {
         },
       };
 
-      const addToCartFailure = new DaffAddToCartFailure(error);
+      const addToCartFailure = new DaffAddToCartFailure([error]);
 
       result = cartReducer(state, addToCartFailure);
     });
@@ -522,7 +520,7 @@ describe('@daffodil/cart/state | cartReducer', () => {
         },
       };
 
-      const cartClearFailure = new DaffCartClearFailure(error);
+      const cartClearFailure = new DaffCartClearFailure([error]);
 
       result = cartReducer(state, cartClearFailure);
     });

--- a/libs/cart/state/src/reducers/cart/cart.reducer.ts
+++ b/libs/cart/state/src/reducers/cart/cart.reducer.ts
@@ -66,7 +66,7 @@ export function cartReducer<T extends DaffCart>(
     case DaffCartActionTypes.CartStorageFailureAction:
       return {
         ...state,
-        ...addError(state.errors, action.payload),
+        ...addError(state.errors, ...action.payload),
         ...setLoading(state.loading, DaffState.Complete),
       };
 

--- a/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.spec.ts
+++ b/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.spec.ts
@@ -538,7 +538,7 @@ describe('@daffodil/cart/state | selectCartItemEntitiesState', () => {
 
     it('should return the errors of the cart item', () => {
       store.dispatch(new DaffCartItemListSuccess(mockCartItems));
-      store.dispatch(new DaffCartItemUpdateFailure(error, mockCartItems[0].id));
+      store.dispatch(new DaffCartItemUpdateFailure([error], mockCartItems[0].id));
       const selector = store.pipe(select(selectCartItemErrors(mockCartItems[0].id)));
       const expected = cold('a', { a: [error]});
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

most failure actions have a single error as their payload


## What is the new behavior?
failure actions now carry an array of errors

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
failure actions' payload type has changed from `DaffStateError` to `DaffStateError[]`

## Other information