### PR TITLE
fix(cart): magento driver resolution fails for no discounts

### DIFF
--- a/libs/cart/driver/magento/src/models/responses/cart.ts
+++ b/libs/cart/driver/magento/src/models/responses/cart.ts
@@ -27,7 +27,7 @@ export interface MagentoCart {
       amount: MagentoMoney;
       label: string;
     }[];
-    discounts: {
+    discounts?: {
       amount: MagentoMoney;
       label: string;
     }[];

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-totals-transformer.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-totals-transformer.spec.ts
@@ -88,4 +88,16 @@ describe('transformCartTotals', () => {
     expect(transformedTotals[DaffCartTotalTypeEnum.tax].value).toEqual(0);
     expect(transformedTotals[DaffCartTotalTypeEnum.shipping].value).toEqual(null);
   });
+
+  describe('when discounts is null', () => {
+    beforeEach(() => {
+      stubMagentoCart.prices.discounts = null;
+    });
+
+    it('should set discount value to 0', () => {
+      const transformedTotals = transformCartTotals(stubMagentoCart).totals;
+
+      expect(transformedTotals[DaffCartTotalTypeEnum.discount].value).toEqual(0);
+    });
+  });
 });

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-totals-transformer.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-totals-transformer.ts
@@ -55,7 +55,7 @@ export function transformCartTotals(cart: Partial<MagentoCart>): {totals: DaffCa
       [DaffCartTotalTypeEnum.discount]: {
         name: DaffCartTotalTypeEnum.discount,
         label: 'Discounts',
-        value: daffAdd(...cart.prices.discounts.map((discount) => discount.amount.value)),
+        value: cart.prices.discounts ? daffAdd(...cart.prices.discounts.map((discount) => discount.amount.value)) : 0,
         order: 6,
       },
       [DaffCartTotalTypeEnum.shipping]: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

cart resolution crashes from an NPE when Magento sends `null` discounts


## What is the new behavior?
`null` discounts are guarded

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information