### PR TITLE
fix(authorizenet): CC last 4 is too short

### DIFF
--- a/libs/authorizenet/driver/magento/src/transformers/authorize-net-transformer.spec.ts
+++ b/libs/authorizenet/driver/magento/src/transformers/authorize-net-transformer.spec.ts
@@ -54,7 +54,7 @@ describe('AuthorizeNet | Drivers | Magento | Transformers', () => {
           dataDescriptor: null,
         },
       };
-      const ccNumber = '1243123412341234';
+      const ccNumber = '1243112341234';
       const ccLast4 = '1234';
       expect(transformMagentoAuthorizeNetResponse(authorizeNetResponse, ccNumber)).toEqual(
         {

--- a/libs/authorizenet/driver/magento/src/transformers/authorize-net-transformer.ts
+++ b/libs/authorizenet/driver/magento/src/transformers/authorize-net-transformer.ts
@@ -29,7 +29,7 @@ export function transformMagentoAuthorizeNetResponse(response: AuthorizeNetRespo
   return {
     code: 'authorizenet_acceptjs',
     authorizenet_acceptjs: {
-      cc_last_4: parseInt(ccNumber.slice(12), 10),
+      cc_last_4: parseInt(ccNumber.slice(ccNumber.length - 4), 10),
       opaque_data_descriptor: 'COMMON.ACCEPT.INAPP.PAYMENT',
       opaque_data_value: response.opaqueData.dataValue,
     },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
the CC last 4 was just sliced 12 characters from the beginning of the CC number

## What is the new behavior?
the CC last 4 is actually calculated as 4 characters from the end of the number

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information