### PR TITLE
fix(core): subsequent preadds don't update entity after initial preadd

### DIFF
--- a/libs/core/state/src/operation/entity/adapter.spec.ts
+++ b/libs/core/state/src/operation/entity/adapter.spec.ts
@@ -95,6 +95,25 @@ describe('@daffodil/core/state | daffCreateOperationEntityStateAdapter', () => {
       expect(result.entities[placeholderId].daffState).toEqual(DaffState.Adding);
       expect(result.entities[placeholderId].daffTemp).toBeTrue();
     });
+
+    describe('when the operation fails and another preadd is initiated', () => {
+      let errors: DaffStateError[];
+
+      beforeEach(() => {
+        errors = [
+          { code: 'code', message: 'message' },
+        ];
+        result = adapter.preadd(entity, adapter.operationFailed(placeholderId, errors, result), placeholderId);
+      });
+
+      it('should reset errors', () => {
+        expect(result.entities[placeholderId].daffErrors).toEqual([]);
+      });
+
+      it('should change state to adding', () => {
+        expect(result.entities[placeholderId].daffState).toEqual(DaffState.Adding);
+      });
+    });
   });
 
   describe('add', () => {

--- a/libs/core/state/src/operation/entity/adapter.ts
+++ b/libs/core/state/src/operation/entity/adapter.ts
@@ -100,7 +100,7 @@ export function daffCreateOperationEntityStateAdapter<T extends DaffIdentifiable
       }, state),
     preadd: (entity, state, placeholderId) =>
       placeholderId
-        ? adapter.addOne({
+        ? adapter.upsertOne({
           ...entity,
           // TODO: allow for non identifiable entities?
           id: placeholderId,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

adding after a fail does not update entity in state


## What is the new behavior?
it does

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information