### PR TITLE
feat(design): add skeletonable public api to design core's public api

### DIFF
--- a/libs/design/src/core/public_api.ts
+++ b/libs/design/src/core/public_api.ts
@@ -5,7 +5,7 @@ export * from './colorable/public_api';
 export * from './breakpoints/breakpoints';
 export * from './constructor/constructor';
 export * from './statusable/public_api';
-export * from './skeletonable/skeletonable';
+export * from './skeletonable/public_api';
 export * from './mutable/mutable';
 export * from './text-alignable/text-alignable';
 export * from './compactable/public_api';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Design core only exposes the `DaffSkeletonable` interface to the public. `daffSkeletonableMixin` is not usable by the public.
Fixes: N/A


## What is the new behavior?
Update design core's public_api to export the skeletonable public_api instead of only the DaffSkeletonable interface.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information