### PR TITLE
feat(design): add DaffSizeable to design core's public api

### DIFF
--- a/libs/design/src/core/public_api.ts
+++ b/libs/design/src/core/public_api.ts
@@ -14,3 +14,4 @@ export * from './article-encapsulated/public_api';
 export * from './theming/public_api';
 export * from './lazy/public_api';
 export * from './focus/public_api';
+export * from './sizeable/public_api';

--- a/libs/design/src/core/sizeable/public_api.ts
+++ b/libs/design/src/core/sizeable/public_api.ts
@@ -1,0 +1,11 @@
+export {
+  DaffSizeable,
+  DaffSizeAllType,
+  DaffSizeableEnum,
+  DaffSizeXSmallType,
+  DaffSizeSmallType,
+  DaffSizeMediumType,
+  DaffSizeLargeType,
+  DaffSizeXLargeType,
+} from './sizeable';
+export { daffSizeMixin } from './sizeable-mixin';

--- a/libs/design/src/core/sizeable/sizeable.ts
+++ b/libs/design/src/core/sizeable/sizeable.ts
@@ -1,6 +1,15 @@
+/**
+ * An interface for giving a component the ability to customize sizing for component-specific UI.
+ * In order to be sizable, a component class must implement this property.
+ */
+
 export interface DaffSizeable<T extends DaffSizeAllType> {
   size: T;
 }
+
+/**
+ * The possible types that can be passed to a component that implements DaffSizeable
+ */
 
 export type DaffSizeXSmallType = 'xs';
 export type DaffSizeSmallType = 'sm';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`DaffSizeable` is not exposed to `@daffodil/design`s public api. This means the interface is not usable outside of the main design package.

Fixes: N/A


## What is the new behavior?
`DaffSizeable` interface, types, and enums is now part of design's core public api.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information