### PR TITLE
feat(design): set sidebar header action's position  to absolute

### DIFF
--- a/libs/design/sidebar/src/sidebar-header/sidebar-header.component.scss
+++ b/libs/design/sidebar/src/sidebar-header/sidebar-header.component.scss
@@ -27,6 +27,7 @@
 		padding: 16px;
 
 		&__action {
+			position: absolute;
 			left: 0;
 			right: initial;
 			top: 0;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The sidebar header action is missing a position style. It causes the sidebar height to be much more than intended, especially when using it with the `<button daff-icon-button>`

Fixes: N/A


## What is the new behavior?
Add `position: absolute;` to sidebar header's action style.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information