### PR TITLE
feat(design): add word wrap style to article headings

### DIFF
--- a/libs/design/article/src/article/article.component.scss
+++ b/libs/design/article/src/article/article.component.scss
@@ -3,6 +3,7 @@
 
 .daff-article {
 	display: block;
+	overflow: hidden;
 
 	@include stopsArticleCascade(a) {
 		font-weight: 600;
@@ -15,6 +16,7 @@
 
 	@include stopsArticleCascade(h1, h2, h3, h4, h5, h6) {
 		margin-bottom: 1.5rem;
+		word-wrap: break-word;
 	}
 
 	@include stopsArticleCascade(h2, h3, h4, h5, h6) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Long words that exceed the with of a viewport in article headings (h1 to h6) cause the page width to expand more than it should.

Fixes: N/A


## What is the new behavior?
Add overflow and word-wrap style to article and article headings.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information