### PR TITLE
fix(daffio): wrong asset path on prod

### DIFF
--- a/apps/daffio/package.json
+++ b/apps/daffio/package.json
@@ -25,7 +25,7 @@
     "lint": "cd ../.. && ng lint daffio",
     "lint:fix": "npm run lint -- --fix",
     "dev:ssr": "ng run daffio:serve-ssr",
-    "serve:ssr": "DAFFIO_DOCS_PATH=../../dist/apps/daffio/browser/assets/daffio/docs/ node ../../dist/apps/daffio/server/main.js"
+    "serve:ssr": "node ../../dist/apps/daffio/server/main.js"
   },
   "homepage": "https://github.com/graycoreio/daffodil",
   "description": "A documentation site for the daffodil project",

--- a/apps/daffio/src/app/app.server.module.ts
+++ b/apps/daffio/src/app/app.server.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
 
-import { environment } from '../environments/environment';
 import { DaffioAppComponent } from './app.component';
 import { AppModule } from './app.module';
 import { DaffioAssetFetchServerService } from './core/assets/fetch/server.service';
 import { DaffioAssetFetchService } from './core/assets/fetch/service.interface';
 import { DAFFIO_DOCS_PATH_TOKEN } from './docs/services/docs-path.token';
+import { environment } from '../environments/environment';
 
 @NgModule({
   imports: [

--- a/apps/daffio/src/app/app.server.module.ts
+++ b/apps/daffio/src/app/app.server.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
 
+import { environment } from '../environments/environment';
 import { DaffioAppComponent } from './app.component';
 import { AppModule } from './app.module';
 import { DaffioAssetFetchServerService } from './core/assets/fetch/server.service';
@@ -16,7 +17,7 @@ import { DAFFIO_DOCS_PATH_TOKEN } from './docs/services/docs-path.token';
   providers: [
     {
       provide: DAFFIO_DOCS_PATH_TOKEN,
-      useValue: process.env.DAFFIO_DOCS_PATH || '',
+      useValue: environment.docsPath,
     },
     {
       provide: DaffioAssetFetchService,

--- a/apps/daffio/src/environments/environment.prod.ts
+++ b/apps/daffio/src/environments/environment.prod.ts
@@ -1,3 +1,6 @@
-export const environment = {
+import { DaffioEnvironment } from './type';
+
+export const environment: DaffioEnvironment = {
   production: true,
+  docsPath: 'browser/assets/daffio/docs/',
 };

--- a/apps/daffio/src/environments/environment.ts
+++ b/apps/daffio/src/environments/environment.ts
@@ -2,8 +2,11 @@
 // `ng build --configuration production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import { DaffioEnvironment } from './type';
+
+export const environment: DaffioEnvironment = {
   production: false,
+  docsPath: '../../dist/apps/daffio/browser/assets/daffio/docs/',
 };
 
 /*

--- a/apps/daffio/src/environments/type.ts
+++ b/apps/daffio/src/environments/type.ts
@@ -1,0 +1,4 @@
+export interface DaffioEnvironment {
+  production: boolean;
+  docsPath: string;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When daffio is run by vercel, the docs path is not correctly set

## What is the new behavior?
The docs path is pulled from the `environment.ts` file and is set to an appropriate value for vercel.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information