### PR TITLE
feat(daffio): create separate footer for docs and add footer to named views enum

### DIFF
--- a/apps/daffio/src/app/app-routing.module.ts
+++ b/apps/daffio/src/app/app-routing.module.ts
@@ -6,6 +6,8 @@ import {
 
 import { DaffRouteWithNamedViews } from '@daffodil/router';
 
+import { DaffioMarketingFooterComponent } from './core/footer/marketing-footer/marketing-footer.component';
+import { DaffioSimpleFooterComponent } from './core/footer/simple-footer/simple-footer.component';
 import { DaffioDocsHeaderContainer } from './core/header/containers/docs-header/docs-header.component';
 import { DaffioMarketingHeaderContainer } from './core/header/containers/marketing-header/marketing-header.component';
 import { DaffioDocsSidebarContentComponent } from './core/sidebar/components/docs-sidebar-content/docs-sidebar-content.component';
@@ -33,6 +35,7 @@ export const appRoutes: Routes = [
             [DaffioRouterNamedViewsEnum.SIDEBARHEADER]: DaffioSidebarHeaderComponent,
             [DaffioRouterNamedViewsEnum.SIDEBARCONTENT]: DaffioMarketingSidebarContentComponent,
             [DaffioRouterNamedViewsEnum.SIDEBARFOOTER]: DaffioSidebarFooterComponent,
+            [DaffioRouterNamedViewsEnum.FOOTER]: DaffioMarketingFooterComponent,
           },
         },
       },
@@ -49,6 +52,7 @@ export const appRoutes: Routes = [
             [DaffioRouterNamedViewsEnum.SIDEBARHEADER]: DaffioSidebarHeaderComponent,
             [DaffioRouterNamedViewsEnum.SIDEBARCONTENT]: DaffioDocsSidebarContentComponent,
             [DaffioRouterNamedViewsEnum.SIDEBARFOOTER]: DaffioSidebarFooterComponent,
+            [DaffioRouterNamedViewsEnum.FOOTER]: DaffioSimpleFooterComponent,
           },
         },
       },

--- a/apps/daffio/src/app/app.module.ts
+++ b/apps/daffio/src/app/app.module.ts
@@ -15,6 +15,8 @@ import { DAFF_THEME_INITIALIZER } from '@daffodil/design';
 
 import { AppRoutingModule } from './app-routing.module';
 import { DaffioAppComponent } from './app.component';
+import { DaffioMarketingFooterComponentModule } from './core/footer/marketing-footer/marketing-footer.module';
+import { DaffioSimpleFooterComponentModule } from './core/footer/simple-footer/simple-footer.module';
 import { DaffioDocsHeaderContainerModule } from './core/header/containers/docs-header/docs-header.module';
 import { DaffioMarketingHeaderContainerModule } from './core/header/containers/marketing-header/marketing-header.module';
 import { DaffioDocsSidebarContentComponentModule } from './core/sidebar/components/docs-sidebar-content/docs-sidebar-content.module';
@@ -40,6 +42,8 @@ import { environment } from '../environments/environment';
     DaffioDocsSidebarContentComponentModule,
     DaffioSidebarHeaderComponentModule,
     DaffioSidebarFooterComponentModule,
+    DaffioSimpleFooterComponentModule,
+    DaffioMarketingFooterComponentModule,
 
     //Make sure this loads after Router and Store
     StoreRouterConnectingModule.forRoot({ serializer: FullRouterStateSerializer,

--- a/apps/daffio/src/app/core/footer/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/footer/footer-theme.scss
@@ -1,18 +1,21 @@
 @use 'theme' as daff-theme;
+@use 'sass:map';
 
-@mixin daffio-simple-footer-theme($theme) {
+@mixin daffio-footer-theme($theme) {
 	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
 	$base: daff-theme.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: daff-theme.daff-map-deep-get($theme, 'core.base-contrast');
+	$secondary: map.get($theme, secondary);
 
-	.daffio-simple-footer {
+	.daffio-footer {
 		border-top: 1px solid daff-theme.daff-illuminate($base, $gray, 2);
 
 		&__copyright {
-			color: daff-theme.daff-illuminate($base-contrast, $gray, 4);
+			color: daff-theme.daff-illuminate($base-contrast, $gray, 3);
 		}
 
-		&__link {
+		&__link,
+		&__social-link {
 			color: daff-theme.daff-text-contrast($base);
 			transition: color 0.3s;
 

--- a/apps/daffio/src/app/core/footer/footer/footer.component.html
+++ b/apps/daffio/src/app/core/footer/footer/footer.component.html
@@ -1,0 +1,17 @@
+<daff-container size="md">
+  <div class="daffio-footer__grid">
+    <div class="daffio-footer__menu">
+      <a routerLink="{{ link.path }}" *ngFor="let link of links" class="daffio-footer__link">{{ link.title }}</a>
+      <a class="daffio-footer__link" href="https://github.com/sponsors/graycoreio" target="_blank" rel="noopener noreferrer">Sponsor</a>
+    </div>
+    <a class="daffio-footer__logo" routerLink="/">
+      <daff-branding-logo type="icon"></daff-branding-logo>
+    </a>
+    <div class="daffio-footer__social">
+      <a *ngFor="let socialLink of socialLinks" [href]="socialLink.link" target="_blank" rel="noopener noreferrer" class="daffio-footer__link">
+        <fa-icon [icon]="socialLink.icon" attr.aria-label="{{socialLink.title}} Logo"></fa-icon> <span>{{socialLink.title}}</span>
+      </a>
+    </div>
+  </div>
+  <daff-branding-copyright class="daffio-footer__copyright"></daff-branding-copyright>
+</daff-container>

--- a/apps/daffio/src/app/core/footer/footer/footer.component.scss
+++ b/apps/daffio/src/app/core/footer/footer/footer.component.scss
@@ -1,0 +1,82 @@
+@use 'utilities' as daff;
+
+:host {
+	display: block;
+	font-size: daff.$small-font-size;
+	padding: 24px;
+
+	@include daff.breakpoint(big-tablet) {
+		padding: 64px 48px;
+	}
+
+	@include daff.breakpoint(small-laptop) {
+		padding: 64px 0;
+	}
+}
+
+.daffio-footer {
+	&__grid {
+		display: flex;
+		align-items: center;
+		flex-direction: column;
+		gap: 16px;
+
+		@include daff.breakpoint(big-tablet) {
+			flex-direction: row;
+			gap: 48px;
+		}
+	}
+
+	&__menu {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px 16px;
+		justify-content: center;
+		order: 2;
+
+		@include daff.breakpoint(big-tablet) {
+			gap: 24px;
+			justify-content: flex-start;
+			order: 1;
+		}
+	}
+
+	&__logo {
+		display: flex;
+		justify-content: center;
+		width: 48px;
+		margin: 0 auto;
+		order: 1;
+
+		@include daff.breakpoint(big-tablet) {
+			order: 2;
+		}
+	}
+
+	&__social {
+		display: flex;
+		gap: 8px 16px;
+		justify-content: center;
+		order: 3;
+
+		@include daff.breakpoint(big-tablet) {
+			gap: 24px;
+			justify-content: flex-end;
+		}
+	}
+
+	&__link {
+		@include daff.embolden();
+		@include daff.uppercase();
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		text-decoration: none;
+	}
+
+	&__copyright {
+		display: block;
+		text-align: center;
+		margin-top: 32px;
+	}
+}

--- a/apps/daffio/src/app/core/footer/footer/footer.component.spec.ts
+++ b/apps/daffio/src/app/core/footer/footer/footer.component.spec.ts
@@ -1,0 +1,79 @@
+import {
+  Component,
+  DebugElement,
+} from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+
+import {
+  DaffLogoModule,
+  DaffCopyrightModule,
+} from '@daffodil/branding';
+import { DaffContainerModule } from '@daffodil/design/container';
+
+import { DaffioFooterComponent } from './footer.component';
+
+@Component({
+  template: `<daffio-footer></daffio-footer>`,
+})
+class WrapperComponent { }
+
+describe('DaffioFooterComponent', () => {
+  let wrapper: WrapperComponent;
+  let component: DaffioFooterComponent;
+  let de: DebugElement;
+  let fixture: ComponentFixture<WrapperComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        WrapperComponent,
+        DaffioFooterComponent,
+      ],
+      imports: [
+        RouterTestingModule,
+        DaffContainerModule,
+        DaffLogoModule,
+        DaffCopyrightModule,
+        FontAwesomeModule,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WrapperComponent);
+    wrapper = fixture.debugElement.componentInstance;
+    de = fixture.debugElement.query(By.css('daffio-footer'));
+    component = de.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should add a class of "daffio-footer" to the host element', () => {
+    expect(de.classes).toEqual(jasmine.objectContaining({
+      'daffio-footer': true,
+    }));
+  });
+
+  it('should show the copyright', () => {
+    expect(fixture.debugElement.query(By.css('daff-branding-copyright'))).toBeTruthy();
+  });
+
+  describe('on <daff-branding-logo>', () => {
+    it('should set type="icon"', () => {
+      const logo = fixture.debugElement.query(By.css('daff-branding-logo'));
+
+      expect(logo.componentInstance.type).toEqual('icon');
+    });
+  });
+});

--- a/apps/daffio/src/app/core/footer/footer/footer.component.ts
+++ b/apps/daffio/src/app/core/footer/footer/footer.component.ts
@@ -1,0 +1,33 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+} from '@angular/core';
+import {
+  faGithub,
+  faDiscord,
+} from '@fortawesome/free-brands-svg-icons';
+
+import { DAFF_BRANDING_CONSTANTS } from '@daffodil/branding';
+
+@Component({
+  selector: 'daffio-footer',
+  templateUrl: './footer.component.html',
+  styleUrls: ['./footer.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DaffioFooterComponent {
+
+  @HostBinding('class.daffio-footer') class = true;
+
+  links: any[] = [
+    { path: '/why-pwa', title: 'Why PWA' },
+    { path: '/api', title: 'Docs' },
+    { path: '/support', title: 'Support' },
+  ];
+
+  socialLinks: any[] = [
+    { link: DAFF_BRANDING_CONSTANTS.REPO_URL, title: 'Github',  icon: faGithub },
+    { link: DAFF_BRANDING_CONSTANTS.DISCORD_URL, title: 'Discord', icon: faDiscord },
+  ];
+}

--- a/apps/daffio/src/app/core/footer/footer/footer.module.ts
+++ b/apps/daffio/src/app/core/footer/footer/footer.module.ts
@@ -1,0 +1,31 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+
+import {
+  DaffCopyrightModule,
+  DaffLogoModule,
+} from '@daffodil/branding';
+import { DaffContainerModule } from '@daffodil/design/container';
+
+import { DaffioFooterComponent } from './footer.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+
+    FontAwesomeModule,
+    DaffContainerModule,
+    DaffLogoModule,
+    DaffCopyrightModule,
+  ],
+  declarations: [
+    DaffioFooterComponent,
+  ],
+  exports: [
+    DaffioFooterComponent,
+  ],
+})
+export class DaffioFooterComponentModule {}

--- a/apps/daffio/src/app/core/footer/marketing-footer/marketing-footer.component.html
+++ b/apps/daffio/src/app/core/footer/marketing-footer/marketing-footer.component.html
@@ -1,0 +1,2 @@
+<daffio-sub-footer></daffio-sub-footer>
+<daffio-footer></daffio-footer>

--- a/apps/daffio/src/app/core/footer/marketing-footer/marketing-footer.component.ts
+++ b/apps/daffio/src/app/core/footer/marketing-footer/marketing-footer.component.ts
@@ -1,0 +1,11 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+
+@Component({
+  selector: 'daffio-marketing-footer',
+  templateUrl: './marketing-footer.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DaffioMarketingFooterComponent {}

--- a/apps/daffio/src/app/core/footer/marketing-footer/marketing-footer.module.ts
+++ b/apps/daffio/src/app/core/footer/marketing-footer/marketing-footer.module.ts
@@ -1,0 +1,24 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { DaffioMarketingFooterComponent } from './marketing-footer.component';
+import { DaffioFooterComponentModule } from '../footer/footer.module';
+import { DaffioSubFooterComponentModule } from '../sub-footer/sub-footer.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+
+    DaffioSubFooterComponentModule,
+    DaffioFooterComponentModule,
+  ],
+  declarations: [
+    DaffioMarketingFooterComponent,
+  ],
+  exports: [
+    DaffioMarketingFooterComponent,
+  ],
+})
+export class DaffioMarketingFooterComponentModule {}

--- a/apps/daffio/src/app/core/footer/simple-footer/simple-footer.component.html
+++ b/apps/daffio/src/app/core/footer/simple-footer/simple-footer.component.html
@@ -1,15 +1,13 @@
 <daff-container size="md">
   <div class="daffio-simple-footer__grid">
-    <div class="daffio-simple-footer__menu">
-      <a routerLink="{{ link.path }}" *ngFor="let link of links" class="daffio-simple-footer__link">{{ link.title }}</a>
-      <a class="daffio-simple-footer__link" href="https://github.com/sponsors/graycoreio" target="_blank" rel="noopener noreferrer">Sponsor</a>
-    </div>
     <a class="daffio-simple-footer__logo" routerLink="/">
       <daff-branding-logo type="icon"></daff-branding-logo>
     </a>
-    <div class="daffio-simple-footer__social">
+    <div class="daffio-simple-footer__menu">
+      <a routerLink="{{ link.path }}" *ngFor="let link of links" class="daffio-simple-footer__link">{{ link.title }}</a>
+      <a class="daffio-simple-footer__link" href="https://github.com/sponsors/graycoreio" target="_blank" rel="noopener noreferrer">Sponsor</a>
       <a *ngFor="let socialLink of socialLinks" [href]="socialLink.link" target="_blank" rel="noopener noreferrer" class="daffio-simple-footer__link">
-        <fa-icon [icon]="socialLink.icon" attr.aria-label="{{socialLink.title}} Logo" class="daffio-simple-footer__social-icon"></fa-icon> <span>{{socialLink.title}}</span>
+        <fa-icon [icon]="socialLink.icon" attr.aria-label="{{socialLink.title}} Logo"></fa-icon> <span>{{socialLink.title}}</span>
       </a>
     </div>
   </div>

--- a/apps/daffio/src/app/core/footer/simple-footer/simple-footer.component.scss
+++ b/apps/daffio/src/app/core/footer/simple-footer/simple-footer.component.scss
@@ -6,30 +6,20 @@
 	padding: 24px;
 
 	@include daff.breakpoint(big-tablet) {
-		padding: 64px 48px;
+		padding: 48px;
 	}
 
 	@include daff.breakpoint(small-laptop) {
-		padding: 64px 0;
+		padding: 48px 0;
 	}
 }
 
 .daffio-simple-footer {
 	&__grid {
-		display: grid;
+		display: flex;
 		align-items: center;
-		grid-template-columns: 1fr;
-		grid-template-areas:
-			'logo'
-			'menu'
-			'social';
-		grid-gap: 16px;
-
-		@include daff.breakpoint(big-tablet) {
-			grid-template-columns: 2fr 1fr 2fr;
-			grid-template-areas: 'menu logo social';
-			grid-gap: 48px;
-		}
+		justify-content: center;
+		gap: 32px;
 	}
 
 	&__menu {
@@ -37,43 +27,23 @@
 		display: flex;
 		flex-wrap: wrap;
 		gap: 8px 16px;
-		justify-content: center;
 
 		@include daff.breakpoint(big-tablet) {
-			gap: 24px;
-			justify-content: flex-start;
+			gap: 32px;
 		}
 	}
 
 	&__logo {
-		grid-area: logo;
 		display: flex;
-		justify-content: center;
-		width: 48px;
-		margin: 0 auto;
-	}
-
-	&__social {
-		grid-area: social;
-		display: flex;
-		gap: 8px 16px;
-		justify-content: center;
-
-		@include daff.breakpoint(big-tablet) {
-			gap: 24px;
-			justify-content: flex-end;
-		}
+		width: 32px;
 	}
 
 	&__link {
-		@include daff.embolden();
-		@include daff.uppercase();
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-weight: 500;
 		text-decoration: none;
-	}
-
-	&__social-icon {
-		vertical-align: middle;
-		margin-right: 8px;
 	}
 
 	&__copyright {

--- a/apps/daffio/src/app/core/footer/simple-footer/simple-footer.module.ts
+++ b/apps/daffio/src/app/core/footer/simple-footer/simple-footer.module.ts
@@ -7,42 +7,27 @@ import {
   DaffLogoModule,
   DaffCopyrightModule,
 } from '@daffodil/branding';
-import {
-  DaffButtonSetModule,
-  DaffInputModule,
-} from '@daffodil/design';
-import { DaffButtonModule } from '@daffodil/design/button';
 import { DaffCalloutModule } from '@daffodil/design/callout';
 import { DaffContainerModule } from '@daffodil/design/container';
-import { DaffListModule } from '@daffodil/design/list';
 
-import { DaffioSimpleFooterComponent } from './simple-footer/simple-footer.component';
-import { DaffioSubFooterComponent } from './sub-footer/sub-footer.component';
-import { DaffioNewsletterModule } from '../../newsletter/newsletter.module';
+import { DaffioSimpleFooterComponent } from './simple-footer.component';
 
 @NgModule({
   imports: [
     CommonModule,
     RouterModule,
+    FontAwesomeModule,
 
     DaffCalloutModule,
-    DaffListModule,
-    DaffButtonModule,
-    DaffButtonSetModule,
     DaffContainerModule,
-    DaffInputModule,
     DaffLogoModule,
     DaffCopyrightModule,
-    DaffioNewsletterModule,
-    FontAwesomeModule,
   ],
   declarations: [
     DaffioSimpleFooterComponent,
-    DaffioSubFooterComponent,
   ],
   exports: [
     DaffioSimpleFooterComponent,
-    DaffioSubFooterComponent,
   ],
 })
-export class DaffioFooterModule {}
+export class DaffioSimpleFooterComponentModule {}

--- a/apps/daffio/src/app/core/footer/sub-footer/sub-footer.module.ts
+++ b/apps/daffio/src/app/core/footer/sub-footer/sub-footer.module.ts
@@ -1,0 +1,29 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+
+import { DaffButtonModule } from '@daffodil/design/button';
+import { DaffCalloutModule } from '@daffodil/design/callout';
+import { DaffContainerModule } from '@daffodil/design/container';
+
+import { DaffioSubFooterComponent } from './sub-footer.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+    FontAwesomeModule,
+
+    DaffCalloutModule,
+    DaffContainerModule,
+    DaffButtonModule,
+  ],
+  declarations: [
+    DaffioSubFooterComponent,
+  ],
+  exports: [
+    DaffioSubFooterComponent,
+  ],
+})
+export class DaffioSubFooterComponentModule {}

--- a/apps/daffio/src/app/core/template/template.component.html
+++ b/apps/daffio/src/app/core/template/template.component.html
@@ -1,6 +1,5 @@
 <daffio-sidebar-viewport-container>
   <ng-container [daffRouterNamedViewOutlet]="navNamedView" daff-sidebar-viewport-nav></ng-container>
   <router-outlet></router-outlet>
-  <daffio-sub-footer></daffio-sub-footer>
-  <daffio-simple-footer></daffio-simple-footer>
+  <ng-container [daffRouterNamedViewOutlet]="footerNamedView"></ng-container>
 </daffio-sidebar-viewport-container>

--- a/apps/daffio/src/app/core/template/template.component.ts
+++ b/apps/daffio/src/app/core/template/template.component.ts
@@ -12,4 +12,5 @@ import { DaffioRouterNamedViewsEnum } from '../../named-views/models/named-views
 })
 export class TemplateComponent {
   readonly navNamedView = DaffioRouterNamedViewsEnum.NAV;
+  readonly footerNamedView = DaffioRouterNamedViewsEnum.FOOTER;
 }

--- a/apps/daffio/src/app/core/template/template.module.ts
+++ b/apps/daffio/src/app/core/template/template.module.ts
@@ -6,7 +6,6 @@ import { RouterModule } from '@angular/router';
 import { DaffRouterNamedViewOutletModule } from '@daffodil/router';
 
 import { TemplateComponent } from './template.component';
-import { DaffioFooterModule } from '../footer/footer.module';
 import { DaffioSidebarModule } from '../sidebar/sidebar.module';
 
 @NgModule({
@@ -14,7 +13,6 @@ import { DaffioSidebarModule } from '../sidebar/sidebar.module';
     RouterModule,
     CommonModule,
     DaffioSidebarModule,
-    DaffioFooterModule,
     DaffRouterNamedViewOutletModule,
   ],
   declarations: [

--- a/apps/daffio/src/app/named-views/models/named-views.enum.ts
+++ b/apps/daffio/src/app/named-views/models/named-views.enum.ts
@@ -2,5 +2,6 @@ export enum DaffioRouterNamedViewsEnum {
   SIDEBARHEADER = 'sidebar-header',
   SIDEBARCONTENT = 'sidebar-content',
   SIDEBARFOOTER = 'sidebar-footer',
-  NAV = 'nav'
+  NAV = 'nav',
+  FOOTER = 'footer'
 }

--- a/apps/daffio/src/scss/component-themes.scss
+++ b/apps/daffio/src/scss/component-themes.scss
@@ -1,5 +1,6 @@
 @use '../app/content/why-pwa/components/feature-comparison/feature-comparison-theme' as feature-comparison;
 @use '../app/core/footer/simple-footer/simple-footer-theme' as simple-footer;
+@use '../app/core/footer/footer/footer-theme' as footer;
 @use '../app/core/footer/sub-footer/sub-footer-theme' as sub-footer;
 @use '../app/docs/components/table-of-contents/table-of-contents-theme' as toc;
 @use '../app/api/components/api-list/api-list-theme' as api-list;
@@ -8,6 +9,7 @@
 
 @mixin component-themes($theme) {
 	@include simple-footer.daffio-simple-footer-theme($theme);
+	@include footer.daffio-footer-theme($theme);
 	@include sub-footer.daffio-sub-footer-theme($theme);
 	@include feature-comparison.daffio-feature-comparison-theme($theme);
 	@include toc.daffio-table-of-contents-theme($theme);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The sub footer and simple footer is used on both the marketing and docs pages. It's not necessary to show all of that information on the docs pages.

Depends on: #2724 


## What is the new behavior?
Create new footers for marketing and docs. Add footer to the router named view.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information