### PR TITLE
refactor(design, daffio)!: update `daff-gray` palette name to `daff-neutral`

### DIFF
--- a/apps/daffio/src/app/api/components/api-list/api-list-theme.scss
+++ b/apps/daffio/src/app/api/components/api-list/api-list-theme.scss
@@ -1,7 +1,7 @@
 @use 'theme' as daff-theme;
 
 @mixin daffio-api-list-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 	$base: daff-theme.daff-map-deep-get($theme, "core.base");
 	$base-contrast: daff-theme.daff-map-deep-get($theme, "core.base-contrast");
 
@@ -16,7 +16,7 @@
 			}
 
 			&:hover {
-				color: daff-theme.daff-illuminate($base-contrast, $gray, 3);
+				color: daff-theme.daff-illuminate($base-contrast, $neutral, 3);
 			}
 		}
 
@@ -27,7 +27,7 @@
 			}
 
 			&:after {
-				background: daff-theme.daff-illuminate($base, $gray, 2);
+				background: daff-theme.daff-illuminate($base, $neutral, 2);
 			}
 		}
 	}

--- a/apps/daffio/src/app/core/footer/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/footer/footer-theme.scss
@@ -2,16 +2,16 @@
 @use 'sass:map';
 
 @mixin daffio-footer-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 	$base: daff-theme.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: daff-theme.daff-map-deep-get($theme, 'core.base-contrast');
 	$secondary: map.get($theme, secondary);
 
 	.daffio-footer {
-		border-top: 1px solid daff-theme.daff-illuminate($base, $gray, 2);
+		border-top: 1px solid daff-theme.daff-illuminate($base, $neutral, 2);
 
 		&__copyright {
-			color: daff-theme.daff-illuminate($base-contrast, $gray, 3);
+			color: daff-theme.daff-illuminate($base-contrast, $neutral, 3);
 		}
 
 		&__link,
@@ -20,7 +20,7 @@
 			transition: color 0.3s;
 
 			&:hover {
-				color: daff-theme.daff-illuminate($base-contrast, $gray, 3);
+				color: daff-theme.daff-illuminate($base-contrast, $neutral, 3);
 			}
 		}
 	}

--- a/apps/daffio/src/app/core/footer/simple-footer/simple-footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/simple-footer/simple-footer-theme.scss
@@ -1,12 +1,12 @@
 @use 'theme' as daff-theme;
 
 @mixin daffio-simple-footer-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 	$base: daff-theme.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: daff-theme.daff-map-deep-get($theme, 'core.base-contrast');
 
 	.daffio-simple-footer {
-		border-top: 1px solid daff-theme.daff-illuminate($base, $gray, 2);
+		border-top: 1px solid daff-theme.daff-illuminate($base, $neutral, 2);
 
 		&__copyright {
 			color: daff-theme.daff-illuminate($base-contrast, $gray, 4);
@@ -17,7 +17,7 @@
 			transition: color 0.3s;
 
 			&:hover {
-				color: daff-theme.daff-illuminate($base-contrast, $gray, 3);
+				color: daff-theme.daff-illuminate($base-contrast, $neutral, 3);
 			}
 		}
 	}

--- a/apps/daffio/src/app/core/footer/simple-footer/simple-footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/simple-footer/simple-footer-theme.scss
@@ -9,7 +9,7 @@
 		border-top: 1px solid daff-theme.daff-illuminate($base, $neutral, 2);
 
 		&__copyright {
-			color: daff-theme.daff-illuminate($base-contrast, $gray, 4);
+			color: daff-theme.daff-illuminate($base-contrast, $neutral, 4);
 		}
 
 		&__link {

--- a/apps/daffio/src/app/core/sidebar/components/sidebar-footer/sidebar-footer-theme.scss
+++ b/apps/daffio/src/app/core/sidebar/components/sidebar-footer/sidebar-footer-theme.scss
@@ -2,16 +2,16 @@
 @use 'theme' as daff-theme;
 
 @mixin daffio-sidebar-footer-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 	$base: daff-theme.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: daff-theme.daff-map-deep-get($theme, 'core.base-contrast');
 	$primary: map.get($theme, primary);
 
 	.daffio-sidebar-footer {
-		background: daff-theme.daff-illuminate($base, $gray, 2);
+		background: daff-theme.daff-illuminate($base, $neutral, 2);
 
 		&:hover {
-			background: daff-theme.daff-illuminate($base, $gray, 3);
+			background: daff-theme.daff-illuminate($base, $neutral, 3);
 		}
 	}
 }

--- a/apps/daffio/src/app/core/sidebar/containers/sidebar-viewport/sidebar-viewport-theme.scss
+++ b/apps/daffio/src/app/core/sidebar/containers/sidebar-viewport/sidebar-viewport-theme.scss
@@ -2,17 +2,17 @@
 @use 'theme' as daff-theme;
 
 @mixin daffio-sidebar-viewport-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 	$base: daff-theme.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: daff-theme.daff-map-deep-get($theme, 'core.base-contrast');
 	$primary: map.get($theme, primary);
 
 	.daffio-sidebar-viewport {
 		&__get-started {
-			background: daff-theme.daff-illuminate($base, $gray, 2);
+			background: daff-theme.daff-illuminate($base, $neutral, 2);
 
 			&:hover {
-				background: daff-theme.daff-illuminate($base, $gray, 3);
+				background: daff-theme.daff-illuminate($base, $neutral, 3);
 			}
 		}
 	}

--- a/apps/daffio/src/app/design/device/iphone/iphone.component.scss
+++ b/apps/daffio/src/app/design/device/iphone/iphone.component.scss
@@ -2,7 +2,7 @@
 // @import 'utilities';
 
 // $phoneColor: daff-map-deep-get($theme, "core.base");
-// $phoneShadow: daff-illuminate($phoneColor, $daff-gray, 3);
+// $phoneShadow: daff-illuminate($phoneColor, $daff-neutral, 3);
 
 // .iphone {
 //     background: $phoneColor;

--- a/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents-theme.scss
+++ b/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents-theme.scss
@@ -1,16 +1,16 @@
 @use 'theme' as daff-theme;
 
 @mixin daffio-table-of-contents-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 	$base: daff-theme.daff-map-deep-get($theme, "core.base");
 	$base-contrast: daff-theme.daff-map-deep-get($theme, "core.base-contrast");
 
 	.daffio-table-of-contents {
 		&__item {
-			color: daff-theme.daff-illuminate($base-contrast, $gray, 4);
+			color: daff-theme.daff-illuminate($base-contrast, $neutral, 4);
 
 			&:first-of-type {
-				border-bottom: 1px solid daff-theme.daff-illuminate($base, $gray, 3);
+				border-bottom: 1px solid daff-theme.daff-illuminate($base, $neutral, 3);
 			}
 		}
 	}

--- a/apps/daffio/src/app/newsletter/newsletter-theme.scss
+++ b/apps/daffio/src/app/newsletter/newsletter-theme.scss
@@ -1,13 +1,13 @@
 @use 'theme' as daff-theme;
 
 @mixin daffio-newsletter-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 	$base: daff-theme.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: daff-theme.daff-map-deep-get($theme, 'core.base-contrast');
 
 	.newsletter {
 		&__input {
-			border-color: daff-theme.daff-color($gray, 30);
+			border-color: daff-theme.daff-color($neutral, 30);
 		}
 	}
 }

--- a/apps/demo/src/app/cart/components/cart-item-count/cart-item-count.component.scss
+++ b/apps/demo/src/app/cart/components/cart-item-count/cart-item-count.component.scss
@@ -2,6 +2,6 @@
 @import 'theme';
 
 .demo-cart-item-count {
-	color: daff-color($daff-gray, 80);
+	color: daff-color($daff-neutral, 80);
 	font-size: $small-font-size;
 }

--- a/apps/demo/src/app/cart/components/cart-item/cart-item.component.scss
+++ b/apps/demo/src/app/cart/components/cart-item/cart-item.component.scss
@@ -56,7 +56,7 @@
 	}
 
 	&__change {
-		color: demo-theme.daff-color(demo-theme.$gray, 80);
+		color: demo-theme.daff-color(demo-theme.$neutral, 80);
 		margin-top: 15px;
 
 		> a {

--- a/apps/demo/src/app/cart/components/cart-summary/cart-summary.component.scss
+++ b/apps/demo/src/app/cart/components/cart-summary/cart-summary.component.scss
@@ -47,7 +47,7 @@
 
 	&__item-count {
 		float: right;
-		color: daff-color($daff-gray, 80);
+		color: daff-color($daff-neutral, 80);
 		font-size: $small-font-size;
 	}
 }

--- a/apps/demo/src/app/cart/components/minicart-item/minicart-item.component.scss
+++ b/apps/demo/src/app/cart/components/minicart-item/minicart-item.component.scss
@@ -32,7 +32,7 @@
 
 	&__info {
 		font-size: $small-font-size;
-		color: demo-theme.daff-color(demo-theme.$gray, 90);
+		color: demo-theme.daff-color(demo-theme.$neutral, 90);
 		line-height: 1.25rem;
 	}
 
@@ -46,7 +46,7 @@
 
 		> * {
 			font-size: $small-font-size;
-			color: demo-theme.daff-color(demo-theme.$gray);
+			color: demo-theme.daff-color(demo-theme.$neutral);
 			text-decoration: underline;
 
 			&:last-child {

--- a/apps/demo/src/app/checkout/pages/checkout-view/checkout-view.component.scss
+++ b/apps/demo/src/app/checkout/pages/checkout-view/checkout-view.component.scss
@@ -26,10 +26,10 @@
 
 	&__shipping {
 		padding: 25px 0;
-		border-bottom: 1px solid daff-color($daff-gray, 20);
+		border-bottom: 1px solid daff-color($daff-neutral, 20);
 
 		@include breakpoint(big-tablet) {
-			border-top: 1px solid daff-color($daff-gray, 20);
+			border-top: 1px solid daff-color($daff-neutral, 20);
 		}
 	}
 
@@ -53,7 +53,7 @@
 
 	&__mobile-cart {
 		display: block;
-		border-top: 1px solid daff-color($daff-gray, 20);
+		border-top: 1px solid daff-color($daff-neutral, 20);
 
 		@include breakpoint(big-tablet) {
 			display: none;

--- a/apps/demo/src/app/core/header/components/header/header.component.scss
+++ b/apps/demo/src/app/core/header/components/header/header.component.scss
@@ -6,7 +6,7 @@
 	@include section-divider;
 
 	&__menu {
-		border-right: 1px solid daff-color($daff-gray, 20);
+		border-right: 1px solid daff-color($daff-neutral, 20);
 		padding: 15px;
 	}
 

--- a/apps/demo/src/app/misc/help-box/help-box.component.scss
+++ b/apps/demo/src/app/misc/help-box/help-box.component.scss
@@ -2,7 +2,7 @@
 @import 'theme';
 
 .demo-help-box {
-	border: 1px solid daff-color($daff-gray, 20);
+	border: 1px solid daff-color($daff-neutral, 20);
 	padding: 25px;
 
 	&__title {

--- a/apps/demo/src/app/newsletter/newsletter.component.scss
+++ b/apps/demo/src/app/newsletter/newsletter.component.scss
@@ -3,7 +3,7 @@
 
 :host {
 	display: block;
-	background: demo-theme.daff-color(demo-theme.$gray, 100);
+	background: demo-theme.daff-color(demo-theme.$neutral, 100);
 	color: demo-theme.$white;
 	padding: 50px 25px;
 	margin: 0;

--- a/apps/demo/src/app/product/components/product/product.component.scss
+++ b/apps/demo/src/app/product/components/product/product.component.scss
@@ -50,7 +50,7 @@
 	}
 
 	&__brand {
-		color: daff-color($daff-gray, 80);
+		color: daff-color($daff-neutral, 80);
 		font-size: $medium-font-size;
 		font-weight: normal;
 	}
@@ -84,7 +84,7 @@
 	}
 
 	&__accordion {
-		border-top: 1px solid daff-color($daff-gray, 20);
+		border-top: 1px solid daff-color($daff-neutral, 20);
 		margin: 50px 0 0;
 
 		a {

--- a/apps/demo/src/app/thank-you/components/thank-you/thank-you.component.scss
+++ b/apps/demo/src/app/thank-you/components/thank-you/thank-you.component.scss
@@ -7,7 +7,7 @@
 
 	@include breakpoint(big-tablet) {
 		padding: 50px 0;
-		border-top: 1px solid daff-color($daff-gray, 20);
+		border-top: 1px solid daff-color($daff-neutral, 20);
 	}
 
 	&__title {

--- a/apps/demo/src/app/thank-you/pages/thank-you-view.component.scss
+++ b/apps/demo/src/app/thank-you/pages/thank-you-view.component.scss
@@ -21,7 +21,7 @@
 
 	&__mobile-cart {
 		display: block;
-		border-top: 1px solid daff-color($daff-gray, 20);
+		border-top: 1px solid daff-color($daff-neutral, 20);
 
 		@include breakpoint(big-tablet) {
 			display: none;

--- a/apps/demo/src/scss/demo-theme.scss
+++ b/apps/demo/src/scss/demo-theme.scss
@@ -9,4 +9,4 @@ $theme: daff-theme.daff-configure-theme($primary, $secondary, $tertiary, 'light'
 
 $black: daff-theme.daff-map-deep-get($theme, 'core.black');
 $white: daff-theme.daff-map-deep-get($theme, 'core.white');
-$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');

--- a/apps/demo/src/scss/mixins/_dividers.scss
+++ b/apps/demo/src/scss/mixins/_dividers.scss
@@ -1,5 +1,5 @@
 @use 'demo-theme';
 
-@mixin section-divider($size: 1px, $color: demo-theme.daff-color(demo-theme.$gray, 20)) {
+@mixin section-divider($size: 1px, $color: demo-theme.daff-color(demo-theme.$neutral, 20)) {
 	border-bottom: solid 1px $color;
 }

--- a/apps/design-land/src/app/core/code-preview/component/code-preview-theme.scss
+++ b/apps/design-land/src/app/core/code-preview/component/code-preview-theme.scss
@@ -3,11 +3,11 @@
 
 
 @mixin code-preview-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 	$base: daff-theme.daff-map-deep-get($theme, 'core.base');
 	$primary: map.get(daff-theme.$theme, primary);
 	$font-color: daff-theme.daff-map-deep-get($theme, 'core.font-color');
-	$border: 1px solid daff-theme.daff-illuminate($base, $gray, 2);
+	$border: 1px solid daff-theme.daff-illuminate($base, $neutral, 2);
 
 	.design-land-code-preview {
 		&__content {

--- a/apps/design-land/src/app/core/sidebar-viewport/sidebar-viewport-theme.scss
+++ b/apps/design-land/src/app/core/sidebar-viewport/sidebar-viewport-theme.scss
@@ -2,21 +2,21 @@
 @use 'theme' as daff-theme;
 
 @mixin sidebar-viewport-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 	$base: daff-theme.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: daff-theme.daff-map-deep-get($theme, 'core.base-contrast');
 	$primary: map.get($theme, primary);
 
 	.design-land-sidebar-viewport {
 		&__sidebar {
-			border-right: 1px solid daff-theme.daff-illuminate($base, $gray, 2);
+			border-right: 1px solid daff-theme.daff-illuminate($base, $neutral, 2);
 		}
 
 		&__get-started-button {
-			background: daff-theme.daff-illuminate($base, $gray, 1);
+			background: daff-theme.daff-illuminate($base, $neutral, 1);
 
 			&:hover {
-				background: daff-theme.daff-illuminate($base, $gray, 2);
+				background: daff-theme.daff-illuminate($base, $neutral, 2);
 			}
 		}
 

--- a/apps/design-land/src/app/typography/typography-theme.scss
+++ b/apps/design-land/src/app/typography/typography-theme.scss
@@ -2,16 +2,16 @@
 @use 'theme' as daff-theme;
 
 @mixin typography-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 
 	.dl-typography {
 		&__typescale-card {
-			border: 1px solid daff-theme.daff-color($gray, 20);
+			border: 1px solid daff-theme.daff-color($neutral, 20);
 		}
 		
 		&__desktop-subheading,
 		&__mobile-subheading {
-			color: daff-theme.daff-color($gray);
+			color: daff-theme.daff-color($neutral);
 		}
 	}	
 }

--- a/libs/branding/src/lib/logo/logo-theme.scss
+++ b/libs/branding/src/lib/logo/logo-theme.scss
@@ -2,11 +2,11 @@
 @use 'theme' as daff-theme;
 
 @mixin daff-logo-theme($theme) {
-	$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+	$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 	$base: branding-theme.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: branding-theme.daff-map-deep-get($theme, 'core.base-contrast');
 
 	.daff-branding-logo {
-		fill: daff-theme.daff-illuminate($base-contrast, $gray, 1);
+		fill: daff-theme.daff-illuminate($base-contrast, $neutral, 1);
 	}
 }

--- a/libs/design/accordion/src/accordion-theme.scss
+++ b/libs/design/accordion/src/accordion-theme.scss
@@ -3,10 +3,10 @@
 @use '../../scss/theming';
 
 @mixin daff-accordion-theme($theme) {
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$base: core.daff-map-deep-get($theme, 'core.base');
 
 	.daff-accordion-item {
-		border-bottom: 1px solid theming.daff-illuminate($base, $gray, 2);
+		border-bottom: 1px solid theming.daff-illuminate($base, $neutral, 2);
 	}
 }

--- a/libs/design/article/src/article-theme.scss
+++ b/libs/design/article/src/article-theme.scss
@@ -11,14 +11,14 @@
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$white: core.daff-map-deep-get($theme, 'core.white');
 	$black: core.daff-map-deep-get($theme, 'core.black');
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 
-	$text-color: theming.daff-illuminate($base-contrast, $gray, 2);
-	$table-border-color: theming.daff-illuminate($base, $gray, 2);
+	$text-color: theming.daff-illuminate($base-contrast, $neutral, 2);
+	$table-border-color: theming.daff-illuminate($base, $neutral, 2);
 
 	.daff-article {
 		&__meta {
-			color: theming.daff-illuminate($base-contrast, $gray, 3);
+			color: theming.daff-illuminate($base-contrast, $neutral, 3);
 		}
 
 		@include stopsArticleCascade(a) {
@@ -34,8 +34,8 @@
 		}
 
 		pre {
-			background: theming.daff-illuminate($base, $gray, 1);
-			border: 1px solid theming.daff-illuminate($base, $gray, 2);
+			background: theming.daff-illuminate($base, $neutral, 1);
+			border: 1px solid theming.daff-illuminate($base, $neutral, 2);
 			color: $base-contrast;
 
 			code {
@@ -45,12 +45,12 @@
 		}
 
 		code {
-			background: rgba(theming.daff-illuminate($base, $gray, 2), 0.5);
+			background: rgba(theming.daff-illuminate($base, $neutral, 2), 0.5);
 			color: $base-contrast;
 		}
 
 		hr {
-			background: theming.daff-illuminate($base, $gray, 2);
+			background: theming.daff-illuminate($base, $neutral, 2);
 		}
 
 		blockquote {
@@ -66,7 +66,7 @@
 
 		table {
 			th {
-				background: theming.daff-illuminate($base, $gray, 1);
+				background: theming.daff-illuminate($base, $neutral, 1);
 				border: 1px solid $table-border-color;
 			}
 

--- a/libs/design/button/src/button-theme-variants/raised.scss
+++ b/libs/design/button/src/button-theme-variants/raised.scss
@@ -3,7 +3,7 @@
 @use '../../../scss/theming';
 @use '../../../scss/accessibility' as a11y;
 
-$black: theming.daff-color(theming.$daff-gray, 110);
+$black: theming.daff-color(theming.$daff-neutral, 110);
 
 @mixin daff-raised-button-theme-variant(
 	$base-color,

--- a/libs/design/button/src/button-theme.scss
+++ b/libs/design/button/src/button-theme.scss
@@ -16,13 +16,13 @@
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$white: core.daff-map-deep-get($theme, 'core.white');
 	$black: core.daff-map-deep-get($theme, 'core.black');
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 
 	.daff-button {
 		@include button.daff-button-theme-variant(
-			theming.daff-illuminate($base, $gray, 2),
-			theming.daff-illuminate($base, $gray, 3),
-			theming.daff-illuminate($base, $gray, 4)
+			theming.daff-illuminate($base, $neutral, 2),
+			theming.daff-illuminate($base, $neutral, 3),
+			theming.daff-illuminate($base, $neutral, 4)
 		);
 
 		&.daff-primary {
@@ -52,46 +52,46 @@
 		&.daff-black {
 			@include button.daff-button-theme-variant(
 				$black,
-				theming.daff-color($gray, 90),
-				theming.daff-color($gray, 80)
+				theming.daff-color($neutral, 90),
+				theming.daff-color($neutral, 80)
 			);
 		}
 
 		&.daff-white {
 			@include button.daff-button-theme-variant(
 				$white,
-				theming.daff-color($gray, 20),
-				theming.daff-color($gray, 30)
+				theming.daff-color($neutral, 20),
+				theming.daff-color($neutral, 30)
 			);
 		}
 
 		&.daff-theme {
 			@include button.daff-button-theme-variant(
 				$base,
-				theming.daff-illuminate($base, $gray, 2),
-				theming.daff-illuminate($base, $gray, 3)
+				theming.daff-illuminate($base, $neutral, 2),
+				theming.daff-illuminate($base, $neutral, 3)
 			);
 		}
 
 		&.daff-theme-contrast {
 			@include button.daff-button-theme-variant(
 				$base-contrast,
-				theming.daff-illuminate($base-contrast, $gray, 2),
-				theming.daff-illuminate($base-contrast, $gray, 3)
+				theming.daff-illuminate($base-contrast, $neutral, 2),
+				theming.daff-illuminate($base-contrast, $neutral, 3)
 			);
 		}
 
 		&[disabled],
 		&.daff-button--disabled {
 			@include button.daff-button-theme-variant(
-				theming.daff-illuminate($base, $gray, 3),
-				theming.daff-illuminate($base, $gray, 3),
-				theming.daff-illuminate($base, $gray, 3)
+				theming.daff-illuminate($base, $neutral, 3),
+				theming.daff-illuminate($base, $neutral, 3),
+				theming.daff-illuminate($base, $neutral, 3)
 			);
-			color: theming.daff-illuminate($base, $gray, 5);
+			color: theming.daff-illuminate($base, $neutral, 5);
 
 			&:hover {
-				color: theming.daff-illuminate($base, $gray, 5);
+				color: theming.daff-illuminate($base, $neutral, 5);
 			}
 		}
 
@@ -122,7 +122,7 @@
 
 	.daff-raised-button {
 		@include raised.daff-raised-button-theme-variant(
-			theming.daff-illuminate($base, $gray, 2)
+			theming.daff-illuminate($base, $neutral, 2)
 		);
 
 		&.daff-primary {
@@ -162,9 +162,9 @@
 		&[disabled],
 		&.daff-button--disabled {
 			@include raised.daff-raised-button-theme-variant(
-				theming.daff-illuminate($base, $gray, 3)
+				theming.daff-illuminate($base, $neutral, 3)
 			);
-			color: theming.daff-illuminate($base, $gray, 5);
+			color: theming.daff-illuminate($base, $neutral, 5);
 
 			&:after {
 				box-shadow: none;
@@ -192,9 +192,9 @@
 
 	.daff-icon-button {
 		@include icon.daff-icon-button-theme-variant(
-			theming.daff-illuminate($base, $gray, 5),
-			theming.daff-illuminate($base, $gray, 6),
-			theming.daff-illuminate($base, $gray, 7)
+			theming.daff-illuminate($base, $neutral, 5),
+			theming.daff-illuminate($base, $neutral, 6),
+			theming.daff-illuminate($base, $neutral, 7)
 		);
 
 		&.daff-primary {
@@ -224,45 +224,45 @@
 		&.daff-black {
 			@include icon.daff-icon-button-theme-variant(
 				$black,
-				theming.daff-color($gray, 100),
-				theming.daff-color($gray, 80)
+				theming.daff-color($neutral, 100),
+				theming.daff-color($neutral, 80)
 			);
 		}
 
 		&.daff-white {
 			@include icon.daff-icon-button-theme-variant(
 				$white,
-				theming.daff-color($gray, 20),
-				theming.daff-color($gray, 30)
+				theming.daff-color($neutral, 20),
+				theming.daff-color($neutral, 30)
 			);
 		}
 
 		&.daff-theme {
 			@include icon.daff-icon-button-theme-variant(
 				$base,
-				theming.daff-illuminate($base, $gray, 1),
-				theming.daff-illuminate($base, $gray, 2)
+				theming.daff-illuminate($base, $neutral, 1),
+				theming.daff-illuminate($base, $neutral, 2)
 			);
 		}
 
 		&.daff-theme-contrast {
 			@include icon.daff-icon-button-theme-variant(
 				$base-contrast,
-				theming.daff-illuminate($base-contrast, $gray, 1),
-				theming.daff-illuminate($base-contrast, $gray, 2)
+				theming.daff-illuminate($base-contrast, $neutral, 1),
+				theming.daff-illuminate($base-contrast, $neutral, 2)
 			);
 		}
 
 		&[disabled],
 		&.daff-button--disabled {
 			@include icon.daff-icon-button-theme-variant(
-				theming.daff-illuminate($base, $gray, 4),
-				theming.daff-illuminate($base, $gray, 4),
-				theming.daff-illuminate($base, $gray, 4)
+				theming.daff-illuminate($base, $neutral, 4),
+				theming.daff-illuminate($base, $neutral, 4),
+				theming.daff-illuminate($base, $neutral, 4)
 			);
 
 			&:hover {
-				color: theming.daff-illuminate($base, $gray, 4);
+				color: theming.daff-illuminate($base, $neutral, 4);
 			}
 		}
 
@@ -293,28 +293,28 @@
 
 	.daff-stroked-button {
 		background: transparent;
-		border: 1px solid theming.daff-illuminate($base, $gray, 5);
+		border: 1px solid theming.daff-illuminate($base, $neutral, 5);
 		color: currentColor;
 
 		&:after {
-			background: theming.daff-illuminate($base, $gray, 2);
+			background: theming.daff-illuminate($base, $neutral, 2);
 		}
 
 		&:hover {
-			border: 1px solid theming.daff-illuminate($base, $gray, 2);
+			border: 1px solid theming.daff-illuminate($base, $neutral, 2);
 			color: theming.daff-text-contrast(
-				theming.daff-illuminate($base, $gray, 2)
+				theming.daff-illuminate($base, $neutral, 2)
 			);
 		}
 
 		&:active {
-			border: 1px solid theming.daff-illuminate($base, $gray, 3);
+			border: 1px solid theming.daff-illuminate($base, $neutral, 3);
 			color: theming.daff-text-contrast(
-				theming.daff-illuminate($base, $gray, 3)
+				theming.daff-illuminate($base, $neutral, 3)
 			);
 
 			&:after {
-				background: theming.daff-illuminate($base, $gray, 3);
+				background: theming.daff-illuminate($base, $neutral, 3);
 			}
 		}
 
@@ -342,39 +342,39 @@
 		&.daff-black {
 			@include stroked.daff-stroked-button-theme-variant(
 				$black,
-				theming.daff-color($gray, 100)
+				theming.daff-color($neutral, 100)
 			);
 		}
 
 		&.daff-white {
 			@include stroked.daff-stroked-button-theme-variant(
 				$white,
-				theming.daff-color($gray, 20)
+				theming.daff-color($neutral, 20)
 			);
 		}
 
 		&.daff-theme {
 			@include stroked.daff-stroked-button-theme-variant(
 				$base,
-				theming.daff-illuminate($base, $gray, 2)
+				theming.daff-illuminate($base, $neutral, 2)
 			);
 		}
 
 		&.daff-theme-contrast {
 			@include stroked.daff-stroked-button-theme-variant(
 				$base-contrast,
-				theming.daff-illuminate($base-contrast, $gray, 2)
+				theming.daff-illuminate($base-contrast, $neutral, 2)
 			);
 		}
 
 		&[disabled],
 		&.daff-button--disabled {
 			background-color: transparent;
-			border-color: theming.daff-illuminate($base, $gray, 3);
-			color: theming.daff-illuminate($base, $gray, 5);
+			border-color: theming.daff-illuminate($base, $neutral, 3);
+			color: theming.daff-illuminate($base, $neutral, 5);
 
 			&:hover {
-				color: theming.daff-illuminate($base, $gray, 5);
+				color: theming.daff-illuminate($base, $neutral, 5);
 
 				&:after {
 					background-color: transparent;
@@ -409,18 +409,18 @@
 		color: currentColor;
 
 		&:after {
-			background-color: theming.daff-illuminate($base, $gray, 2);
+			background-color: theming.daff-illuminate($base, $neutral, 2);
 		}
 
 		&:active {
 			&:after {
-				background-color: theming.daff-illuminate($base, $gray, 3);
+				background-color: theming.daff-illuminate($base, $neutral, 3);
 			}
 		}
 
 		&:hover,
 		&:active {
-			color: theming.daff-text-contrast(theming.daff-illuminate($base, $gray, 2));
+			color: theming.daff-text-contrast(theming.daff-illuminate($base, $neutral, 2));
 		}
 
 		&.daff-primary {
@@ -447,34 +447,34 @@
 		&.daff-black {
 			@include flat.daff-flat-button-theme-variant(
 				$black,
-				theming.daff-color($gray, 100)
+				theming.daff-color($neutral, 100)
 			);
 		}
 
 		&.daff-white {
 			@include flat.daff-flat-button-theme-variant(
 				$white,
-				theming.daff-color($gray, 20)
+				theming.daff-color($neutral, 20)
 			);
 		}
 
 		&.daff-theme {
 			@include flat.daff-flat-button-theme-variant(
 				$base,
-				theming.daff-illuminate($base, $gray, 2)
+				theming.daff-illuminate($base, $neutral, 2)
 			);
 		}
 
 		&.daff-theme-contrast {
 			@include flat.daff-flat-button-theme-variant(
 				$base-contrast,
-				theming.daff-illuminate($base-contrast, $gray, 2)
+				theming.daff-illuminate($base-contrast, $neutral, 2)
 			);
 		}
 
 		&[disabled],
 		&.daff-button--disabled {
-			color: theming.daff-illuminate($base, $gray, 5);
+			color: theming.daff-illuminate($base, $neutral, 5);
 
 			&:hover,
 			&:focus,
@@ -509,7 +509,7 @@
 
 	.daff-underline-button {
 		@include underline.daff-underline-button-theme-variant(
-			theming.daff-illuminate($base, $gray, 7)
+			theming.daff-illuminate($base, $neutral, 7)
 		);
 
 		&.daff-primary {
@@ -549,7 +549,7 @@
 		&[disabled],
 		&.daff-button--disabled {
 			@include underline.daff-underline-button-theme-variant(
-				theming.daff-illuminate($base, $gray, 4)
+				theming.daff-illuminate($base, $neutral, 4)
 			);
 		}
 

--- a/libs/design/callout/src/callout-theme.scss
+++ b/libs/design/callout/src/callout-theme.scss
@@ -11,7 +11,7 @@
 	$primary: map.get($theme, primary);
 	$secondary: map.get($theme, secondary);
 	$tertiary: map.get($theme, tertiary);
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$base: core.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$white: core.daff-map-deep-get($theme, 'core.white');
@@ -19,7 +19,7 @@
 
 	.daff-callout {
 		@include daff-callout-theme-variant(
-			theming.daff-illuminate($base, $gray, 1)
+			theming.daff-illuminate($base, $neutral, 1)
 		);
 
 		&.daff-primary {

--- a/libs/design/card/src/card-theme.scss
+++ b/libs/design/card/src/card-theme.scss
@@ -13,12 +13,12 @@
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$white: core.daff-map-deep-get($theme, 'core.white');
 	$black: core.daff-map-deep-get($theme, 'core.black');
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 
 	.daff-card {
 		$root: &;
 		@include basic.daff-basic-card-theme-variant(
-			theming.daff-illuminate($base, $gray, 1)
+			theming.daff-illuminate($base, $neutral, 1)
 		);
 
 		&.daff-primary {
@@ -63,7 +63,7 @@
 
 	.daff-stroked-card {
 		@include stroked.daff-stroked-card-theme-variant(
-			theming.daff-illuminate($base, $gray, 2)
+			theming.daff-illuminate($base, $neutral, 2)
 		);
 
 		&.daff-primary {
@@ -86,25 +86,25 @@
 
 		&.daff-theme {
 			@include stroked.daff-stroked-card-theme-variant(
-				theming.daff-illuminate($base, $gray, 2)
+				theming.daff-illuminate($base, $neutral, 2)
 			);
 		}
 
 		&.daff-theme-contrast {
 			@include stroked.daff-stroked-card-theme-variant(
-				theming.daff-illuminate($base-contrast, $gray, 2)
+				theming.daff-illuminate($base-contrast, $neutral, 2)
 			);
 		}
 
 		&.daff-black {
 			@include stroked.daff-stroked-card-theme-variant(
-				theming.daff-color($gray, 90)
+				theming.daff-color($neutral, 90)
 			);
 		}
 
 		&.daff-white {
 			@include stroked.daff-stroked-card-theme-variant(
-				theming.daff-color($gray, 20)
+				theming.daff-color($neutral, 20)
 			);
 		}
 	}
@@ -112,7 +112,7 @@
 	a {
 		&.daff-card {
 			@include linkable.daff-linkable-card-theme-variant(
-				theming.daff-illuminate($base, $gray, 2)
+				theming.daff-illuminate($base, $neutral, 2)
 			);
 
 			&.daff-primary {
@@ -135,25 +135,25 @@
 
 			&.daff-theme {
 				@include linkable.daff-linkable-card-theme-variant(
-					theming.daff-illuminate($base, $gray, 1)
+					theming.daff-illuminate($base, $neutral, 1)
 				);
 			}
 
 			&.daff-theme-contrast {
 				@include linkable.daff-linkable-card-theme-variant(
-					theming.daff-illuminate($base-contrast, $gray, 1)
+					theming.daff-illuminate($base-contrast, $neutral, 1)
 				);
 			}
 
 			&.daff-black {
 				@include linkable.daff-linkable-card-theme-variant(
-					theming.daff-color($gray, 100)
+					theming.daff-color($neutral, 100)
 				);
 			}
 
 			&.daff-white {
 				@include linkable.daff-linkable-card-theme-variant(
-					theming.daff-color($gray, 10)
+					theming.daff-color($neutral, 10)
 				);
 			}
 		}

--- a/libs/design/guides/color.md
+++ b/libs/design/guides/color.md
@@ -28,5 +28,5 @@ Normal text must have a contrast ratio of at least 4.5:1 to pass AA guidelines a
 #### Large Text
 Large text must have a contrast ratio of at least 3:1 to pass AA guidelines and 4.5:1 to pass AAA guidelines. This is accurate only if your font is **at least 18.66px with bold weight or 24px.**
 
-The `10-50` steps all meet a 4:5:1 contrast ratio or higher against `$daff-gray, 110 (#070707)` or darker, while the `60-100` steps all meet a 4:5:1 contrast ratio against `$daff-gray, 10 (#fafafa)`.
+The `10-50` steps all meet a 4:5:1 contrast ratio or higher against `$daff-neutral, 110 (#070707)` or darker, while the `60-100` steps all meet a 4:5:1 contrast ratio against `$daff-neutral, 10 (#fafafa)`.
 

--- a/libs/design/hero/src/hero-theme.scss
+++ b/libs/design/hero/src/hero-theme.scss
@@ -11,7 +11,7 @@
 	$primary: map.get($theme, primary);
 	$secondary: map.get($theme, secondary);
 	$tertiary: map.get($theme, tertiary);
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$base: core.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$white: core.daff-map-deep-get($theme, 'core.white');
@@ -19,7 +19,7 @@
 
 	.daff-hero {
 		@include daff-hero-theme-variant(
-			theming.daff-illuminate($base, $gray, 1)
+			theming.daff-illuminate($base, $neutral, 1)
 		);
 
 		&.daff-primary {

--- a/libs/design/list/src/list-theme.scss
+++ b/libs/design/list/src/list-theme.scss
@@ -3,7 +3,7 @@
 @use '../../scss/theming';
 
 @mixin daff-list-theme($theme) {
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$base: core.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 
@@ -15,7 +15,7 @@
 				}
 
 				*:nth-child(n + 2) { /* stylelint-disable-line scss/selector-nest-combinators */
-					color: theming.daff-illuminate($base-contrast, $gray, 3);
+					color: theming.daff-illuminate($base-contrast, $neutral, 3);
 				}
 			}
 		}
@@ -25,7 +25,7 @@
 		&--navigation {
 			a {
 				&:hover {
-					color: theming.daff-color($gray, 80);
+					color: theming.daff-color($neutral, 80);
 				}
 			}
 		}
@@ -34,7 +34,7 @@
 		&--navigation {
 			.daff-list-item {
 				&:hover {
-					background-color: theming.daff-illuminate($base, $gray, 1);
+					background-color: theming.daff-illuminate($base, $neutral, 1);
 				}
 			}
 		}
@@ -48,7 +48,7 @@
 					}
 
 					*:nth-child(n + 2) { /* stylelint-disable-line scss/selector-nest-combinators */
-						color: theming.daff-illuminate($base-contrast, $gray, 3);
+						color: theming.daff-illuminate($base-contrast, $neutral, 3);
 					}
 				}
 			}
@@ -63,7 +63,7 @@
 
 			&:hover {
 				&:after {
-					background-color: theming.daff-illuminate($base, $gray, 1);
+					background-color: theming.daff-illuminate($base, $neutral, 1);
 				}
 			}
 		}

--- a/libs/design/media-gallery/src/media-gallery-theme.scss
+++ b/libs/design/media-gallery/src/media-gallery-theme.scss
@@ -3,7 +3,7 @@
 @use '../../scss/core';
 
 @mixin daff-media-gallery-theme($theme) {
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 
 	.daff-media-gallery {
 		$root: &;
@@ -12,7 +12,7 @@
 			border: 1px solid transparent;
 
 			&--selected {
-				border: 1px solid theming.daff-color($gray);
+				border: 1px solid theming.daff-color($neutral);
 			}
 		}
 

--- a/libs/design/menu/src/menu-theme.scss
+++ b/libs/design/menu/src/menu-theme.scss
@@ -4,7 +4,7 @@
 @mixin daff-menu-theme($theme) {
 	$white: core.daff-map-deep-get($theme, 'core.white');
 	$black: core.daff-map-deep-get($theme, 'core.black');
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$base: core.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 
@@ -19,7 +19,7 @@
 
 		&:hover,
 		&:focus {
-			background: theming.daff-illuminate($base, $gray, 1);
+			background: theming.daff-illuminate($base, $neutral, 1);
 		}
 	}
 }

--- a/libs/design/navbar/src/navbar-theme.scss
+++ b/libs/design/navbar/src/navbar-theme.scss
@@ -11,7 +11,7 @@
 	$primary: map.get($theme, primary);
 	$secondary: map.get($theme, secondary);
 	$tertiary: map.get($theme, tertiary);
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$base: core.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$white: core.daff-map-deep-get($theme, 'core.white');
@@ -19,7 +19,7 @@
 
 	.daff-navbar {
 		@include daff-navbar-theme-variant(
-			theming.daff-illuminate($base, $gray, 1)
+			theming.daff-illuminate($base, $neutral, 1)
 		);
 
 		&--raised {

--- a/libs/design/notification/src/notification-theme.scss
+++ b/libs/design/notification/src/notification-theme.scss
@@ -6,16 +6,16 @@
 	$primary: map.get($theme, primary);
 	$secondary: map.get($theme, secondary);
 	$tertiary: map.get($theme, tertiary);
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$base: core.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$white: core.daff-map-deep-get($theme, 'core.white');
 	$black: core.daff-map-deep-get($theme, 'core.black');
 
 	.daff-notification {
-		background: theming.daff-illuminate($base, $gray, 1);
-		border: 1px solid theming.daff-illuminate($base, $gray, 2);
-		color: theming.daff-text-contrast(theming.daff-illuminate($base, $gray, 1));
+		background: theming.daff-illuminate($base, $neutral, 1);
+		border: 1px solid theming.daff-illuminate($base, $neutral, 2);
+		color: theming.daff-text-contrast(theming.daff-illuminate($base, $neutral, 1));
 
 		&.daff-success {
 			background: theming.daff-color(theming.$daff-green, 10);

--- a/libs/design/paginator/src/paginator-theme.scss
+++ b/libs/design/paginator/src/paginator-theme.scss
@@ -23,7 +23,7 @@
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$white: core.daff-map-deep-get($theme, 'core.white');
 	$black: core.daff-map-deep-get($theme, 'core.black');
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$font-color: core.daff-map-deep-get($theme, 'core.font-color');
 
 	.daff-paginator {
@@ -37,10 +37,10 @@
 
 			&:hover,
 			&.selected {
-				color: daff-text-contrast(theming.daff-illuminate($base, $gray, 2));
+				color: daff-text-contrast(theming.daff-illuminate($base, $neutral, 2));
 
 				&:after {
-					background: theming.daff-illuminate($base, $gray, 2);
+					background: theming.daff-illuminate($base, $neutral, 2);
 				}
 			}
 		}

--- a/libs/design/scss/state/skeleton/_mixins.scss
+++ b/libs/design/scss/state/skeleton/_mixins.scss
@@ -2,13 +2,13 @@
 @use '../../theming';
 
 @mixin daff-skeleton-theme($theme) {
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$base: core.daff-map-deep-get($theme, 'core.base');
 
 	.daff-skeleton {
 		&::before,
 		::before {
-			background: theming.daff-illuminate($base, $gray, 2);
+			background: theming.daff-illuminate($base, $neutral, 2);
 		}
 
 		@keyframes loading {

--- a/libs/design/scss/theming/README.md
+++ b/libs/design/scss/theming/README.md
@@ -54,7 +54,7 @@ $theme-dark: daff-theme.daff-configure-theme($primary-dark, $secondary-dark, $te
 
 $black: daff-theme.daff-map-deep-get($theme, 'core.black');
 $white: daff-theme.daff-map-deep-get($theme, 'core.white');
-$gray: daff-theme.daff-map-deep-get($theme, 'core.gray');
+$neutral: daff-theme.daff-map-deep-get($theme, 'core.neutral');
 ```
 
 ### Setting up the styles file with `@daffodil/design`'s theme

--- a/libs/design/scss/theming/_color-palettes.scss
+++ b/libs/design/scss/theming/_color-palettes.scss
@@ -100,7 +100,7 @@ $daff-green: (
 	100: #07230d,
 );
 
-$daff-gray: (
+$daff-neutral: (
 	0: #ffffff,
 	10: #fafafa,
 	20: #e8e8e8,

--- a/libs/design/scss/theming/_configure-theme.scss
+++ b/libs/design/scss/theming/_configure-theme.scss
@@ -4,21 +4,21 @@
 @use 'get-color';
 
 $daff-light-theme: (
-	'font-color': get-color.daff-color(palette.$daff-gray, 110),
-	'base': get-color.daff-color(palette.$daff-gray, 0),
-	'base-contrast': get-color.daff-color(palette.$daff-gray, 110),
-	'white': get-color.daff-color(palette.$daff-gray, 0),
-	'black': get-color.daff-color(palette.$daff-gray, 110),
-	'gray': configure-palette.daff-configure-palette(palette.$daff-gray, 60),
+	'font-color': get-color.daff-color(palette.$daff-neutral, 110),
+	'base': get-color.daff-color(palette.$daff-neutral, 0),
+	'base-contrast': get-color.daff-color(palette.$daff-neutral, 110),
+	'white': get-color.daff-color(palette.$daff-neutral, 0),
+	'black': get-color.daff-color(palette.$daff-neutral, 110),
+	'neutral': configure-palette.daff-configure-palette(palette.$daff-neutral, 60),
 );
 
 $daff-dark-theme: (
-	'font-color': get-color.daff-color(palette.$daff-gray, 0),
-	'base': get-color.daff-color(palette.$daff-gray, 100),
-	'base-contrast': get-color.daff-color(palette.$daff-gray, 0),
-	'white': get-color.daff-color(palette.$daff-gray, 0),
-	'black': get-color.daff-color(palette.$daff-gray, 110),
-	'gray': configure-palette.daff-configure-palette(palette.$daff-gray, 50),
+	'font-color': get-color.daff-color(palette.$daff-neutral, 0),
+	'base': get-color.daff-color(palette.$daff-neutral, 100),
+	'base-contrast': get-color.daff-color(palette.$daff-neutral, 0),
+	'white': get-color.daff-color(palette.$daff-neutral, 0),
+	'black': get-color.daff-color(palette.$daff-neutral, 110),
+	'neutral': configure-palette.daff-configure-palette(palette.$daff-neutral, 50),
 );
 
 $supported-theme-types: (

--- a/libs/design/scss/theming/_theme-css-variables.scss
+++ b/libs/design/scss/theming/_theme-css-variables.scss
@@ -11,7 +11,7 @@
 	$primary: map.get($theme, primary);
 	$secondary: map.get($theme, secondary);
 	$tertiary: map.get($theme, tertiary);
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$white: core.daff-map-deep-get($theme, 'core.white');
 	$black: core.daff-map-deep-get($theme, 'core.black');
 
@@ -28,7 +28,7 @@
 	--daff-theme-danger: #{theming.daff-color(theming.$daff-red, 60)};
 	--daff-theme-white: #{$white};
 	--daff-theme-black: #{$black};
-	--daff-theme-gray: #{theming.daff-color($gray)};
+	--daff-theme-gray: #{theming.daff-color($neutral)};
 	--daff-base-background: #{$base};
 	--daff-base-text: #{theming.daff-text-contrast($base)};
 }

--- a/libs/design/scss/theming/contrast/text-contrast/text-contrast.scss
+++ b/libs/design/scss/theming/contrast/text-contrast/text-contrast.scss
@@ -19,7 +19,7 @@
 // ```
 @function daff-text-contrast(
 	$color,
-	$black: get-color.daff-color(palette.$daff-gray, 110),
+	$black: get-color.daff-color(palette.$daff-neutral, 110),
 	$white: palette.$daff-white
 ) {
 	$light-contrast: cr.daff-contrast-ratio($color, $white);

--- a/libs/design/src/atoms/form/form-field/form-field/form-field-theme.scss
+++ b/libs/design/src/atoms/form/form-field/form-field/form-field-theme.scss
@@ -8,13 +8,13 @@
 	$tertiary: map.get($theme, tertiary);
 	$base: core.daff-map-deep-get($theme, 'core.base');
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 
 	.daff-form-field {
 		&__control {
 			background: $base;
-			border: 1px solid theming.daff-illuminate($base, $gray, 3);
-			color: theming.daff-illuminate($base-contrast, $gray, 4);
+			border: 1px solid theming.daff-illuminate($base, $neutral, 3);
+			color: theming.daff-illuminate($base-contrast, $neutral, 4);
 
 			&:focus {
 				border: 1px solid $base-contrast;

--- a/libs/design/src/atoms/form/native-select/native-select-theme.scss
+++ b/libs/design/src/atoms/form/native-select/native-select-theme.scss
@@ -3,12 +3,12 @@
 @use '../../../../scss/theming';
 
 @mixin daff-native-select-theme($theme) {
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$black: core.daff-map-deep-get($theme, 'core.black');
 
 	.daff-native-select {
-		color: theming.daff-illuminate($base-contrast, $gray, 4);
+		color: theming.daff-illuminate($base-contrast, $neutral, 4);
 
 		// removes dotted border on in FF
 		&:-moz-focusring {

--- a/libs/design/src/molecules/image-list/image-list.component.scss
+++ b/libs/design/src/molecules/image-list/image-list.component.scss
@@ -28,6 +28,6 @@
 // }
 
 // ::-webkit-scrollbar-thumb {
-// 	box-shadow: inset 0 0 3px c.daff-color(c.$daff-gray, 40);
-// 	-webkit-box-shadow: inset 0 0 3px c.daff-color(c.$daff-gray, 40);
+// 	box-shadow: inset 0 0 3px c.daff-color(c.$daff-neutral, 40);
+// 	-webkit-box-shadow: inset 0 0 3px c.daff-color(c.$daff-neutral, 40);
 // }

--- a/libs/design/tree/src/tree-theme.scss
+++ b/libs/design/tree/src/tree-theme.scss
@@ -10,16 +10,16 @@
 	$base-contrast: core.daff-map-deep-get($theme, 'core.base-contrast');
 	$white: core.daff-map-deep-get($theme, 'core.white');
 	$black: core.daff-map-deep-get($theme, 'core.black');
-	$gray: core.daff-map-deep-get($theme, 'core.gray');
+	$neutral: core.daff-map-deep-get($theme, 'core.neutral');
 
 	.daff-tree-item {
 		$root: &;
 
 		background-color: $base;
-		color: theming.daff-illuminate($base-contrast, $gray, 2);
+		color: theming.daff-illuminate($base-contrast, $neutral, 2);
 
 		&:hover {
-			background-color: theming.daff-illuminate($base, $gray, 2);
+			background-color: theming.daff-illuminate($base, $neutral, 2);
 		}
 
 		&:after {
@@ -27,7 +27,7 @@
 		}
 
 		&.selected {
-			background-color: theming.daff-illuminate($base, $gray, 2);
+			background-color: theming.daff-illuminate($base, $neutral, 2);
 			color: $base-contrast;
 
 			&:before {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Palette is currently named `daff-gray`. The gray wording is confusing because the palette does not just have gray colors. 

Fixes: #1894 


## What is the new behavior?
Update palette name to `daff-neutral` which will allow the palette to be defined with more flexibility.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information