### PR TITLE
feat(design): allow the whole typography subpackaged to be exported and allow body-font-family variable to be assignable

### DIFF
--- a/apps/design-land/src/app/typography/typography.component.html
+++ b/apps/design-land/src/app/typography/typography.component.html
@@ -2,7 +2,7 @@
 <p>We use typography to establish hierarchy, organize information, and guide our users through a product or experience.</p>
 
 <h2>Type scale</h2>
-<p>The Design Land typopgrahic scale is designed with visual distinctions to help our users better understand content and UI. Text sizes, styles, and layouts were selected to maintain logical hierarchies and drive consistency throughout an application.</p>
+<p>The typopgrahic scale is designed with visual distinctions to help our users better understand content and UI. Text sizes, styles, and layouts were selected to maintain logical hierarchies and drive consistency throughout an application.</p>
 
 <h3>8px system</h3>
 <p>Our type scale is based on an 8px system, where the type is largely divisible by 8. For smaller sizes, the system allows for the scale to be divisble by 4.</p>

--- a/libs/design/package.json
+++ b/libs/design/package.json
@@ -60,8 +60,8 @@
     "./scss/utilities": {
       "sass": "./scss/utilities.scss"
     },
-    "./scss/typography/classes": {
-      "sass": "./scss/typography/_classes.scss"
+    "./scss/typography": {
+      "sass": "./scss/typography/_index.scss"
     }
   }
 }

--- a/libs/design/scss/typography/README.md
+++ b/libs/design/scss/typography/README.md
@@ -1,30 +1,38 @@
 # Typography
-Daffodil uses typography to establish hierarchy and create clear visual patterns to guide users through a product or experience.
+Daffodil uses typography to establish hierarchy, organize information, and guide our users through a product or experience.
 
 ## Usage
-To include typography in your project, you can add the following in your Sass file:
+To include typography in your project, you can include the following in your Sass file:
 
 ```scss
-@use '@daffodil/design/scss/utilities';
+@use '@daffodil/design/scss/typography';
 ```
 
 ## Type Scale
-`@daffodil/design`'s typographic scale is designed with visual distinctions to help users better understand content and UI. Text sizes, styles, and layouts have been chosen to maintain logical hierarchies and drive consistency throughout an application.
+The typographic scale is designed with visual distinctions to help users better understand content and UI. Text sizes, styles, and layouts have been chosen to maintain logical hierarchies and drive consistency throughout an application.
 
 ### 8px System
 Our type scale is based on an 8px system, where the type is largely divisible by 8. For smaller sizes, the system allows for the scale to be divisible by 4. Font sizes are typically smaller on mobile and scaled up at the `tablet` breakpoint to be larger on desktop.
 
-## Font Stack
-Daffodil uses a system font stack to maximize on performance, legibility, and accessibility. System fonts play into the improvement of today's rich displays Additionally, system fonts provides a seamless experience for users because the application feel more like it blends in with their device's OS.
+## Default Font Stack
+By default, Daffodil uses a system font stack to maximize on performance, legibility, and accessibility. System fonts play into the improvement of today's rich displays Additionally, system fonts provides a seamless experience for users because the application feel more like it blends in with their device's OS.
 
 ```scss
-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+&dollar;font-family-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 ```
 
 * `-apple-system` and `BlinkMacSystemFont` targets default fonts in Safari, Firefox, and Chrome on macOS and iOS.
 * `Segoe UI` is the system font for Windows.
 * `Helvetica` and `Arial` are added as fallbacks.
 * `Apple Color Emoji`, `Segoe UI Emoji`, and `Segoe UI Symbol` are included so that emojis are rendered correctly in macOS and Windows.
+
+To customize your project's font stack, you can pass the `$font-family-base` variable to the typography module in your `style.scss` file:
+
+```scss
+@use '@daffodil/design/scss/typography' with (
+	$font-family-base: 'Arial',
+);
+```
 
 ## Typography Mixins
 Typography mixins are used to keep typography consistent with logical hierarchies. Utilizing the mixin ensures that content within the UI are clear and easily recognizable. Mixins are available for headlines, body, subheading, and caption. They are used within the `@daffodil/design` components and can also be used within custom CSS.
@@ -46,10 +54,10 @@ The headline mixins are responsive and will adjust at the `tablet` breakpoint.
 
 **Example:**
 ```scss
-@use '@daffodil/design/scss/utilities';
+@use '@daffodil/design/scss/typography';
 
 .title {
-	@include utilities.headline-xl;
+	@include typography.headline-xl();
 }
 ```
 
@@ -67,13 +75,13 @@ The headline mixins are responsive and will adjust at the `tablet` breakpoint.
 You can include the typography utility classes in your project by writing the following in your Sass file:
 
 ```scss
-@use '@daffodil/design/scss/typography/classes';
+@use '@daffodil/design/scss/typography';
 ```
 
 Otherwise, you can use the mixins in your project by using the following module in your Sass file:
 
 ```scss
-@use '@daffodil/design/scss/utilities';
+@use '@daffodil/design/scss/typography';
 ```
 
 ## Typography Variables

--- a/libs/design/scss/typography/_index.scss
+++ b/libs/design/scss/typography/_index.scss
@@ -1,4 +1,4 @@
+@forward 'utilities';
 @forward 'mixins/font-weight';
 @forward 'mixins/sizes';
 @forward 'mixins/text-truncate';
-@forward 'utilities';

--- a/libs/design/scss/typography/utilities/_variables.scss
+++ b/libs/design/scss/typography/utilities/_variables.scss
@@ -1,9 +1,19 @@
-$body-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
-	Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
-$base-font-family: $body-font-family;
-$monospace-font-family: ui-monospace, 'SFMono-Regular', SF Mono, Menlo, Consolas,
-	'Liberation Mono', monospace;
+$font-family-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
+	Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji' !default;
+$font-family-mono: ui-monospace, 'SFMono-Regular', SF Mono, Menlo, Consolas,
+	'Liberation Mono', monospace !default;
 
+// these three variables will be deprecated in v1.0.0 in favor of more consistent naming
+$body-font-family: $font-family-base;
+$base-font-family: $body-font-family;
+$monospace-font-family: $font-family-mono;
+
+$font-size-sm: 0.875rem;
+$font-size-base: 1rem;
+$font-size-md: 1.25rem;
+$font-size-lg: 1.5rem;
+
+// these variables will be deprecated in v1.0.0 in favor of more consistent naming
 $large-font-size: 1.5rem;
 $medium-font-size: 1.25rem;
 $normal-font-size: 1rem;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `body-font-family` variable can't be customized by a user.

Part of: #1880 


## What is the new behavior?
Add a `!default` flag to `$font-family-base` and `$font-family-mono` so that it's set as default but can be overridden by a Daffodil user.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information