### PR TITLE
feat(design): update toast docs and import paths in specs

### DIFF
--- a/apps/design-land/src/app/toast/toast.component.html
+++ b/apps/design-land/src/app/toast/toast.component.html
@@ -46,10 +46,10 @@ The following configurations are available in the <code>DaffToastService</code>:
 <table>
 	<thead>
 		<tr>
-			<td>Property</td>
-			<Td>Type</Td>
-			<td>Description</td>
-			<td>Default</td>
+			<th>Property</th>
+			<th>Type</th>
+			<th>Description</th>
+			<th>Default</th>
 		</tr>
 	</thead>
 	<tbody>

--- a/libs/design/toast/src/service/toast.service.spec.ts
+++ b/libs/design/toast/src/service/toast.service.spec.ts
@@ -14,10 +14,10 @@ import {
   DaffPrefixSuffixModule,
 } from '@daffodil/design';
 import { DaffButtonModule } from '@daffodil/design/button';
-import { DaffToast } from '@daffodil/design/toast';
 
 import { DaffToastPositionService } from './position.service';
 import { DaffToastService } from './toast.service';
+import { DaffToast } from '../interfaces/toast';
 import { DaffToastTemplateComponent } from '../toast/toast-template.component';
 import { DaffToastComponent } from '../toast/toast.component';
 import { DaffToastActionsDirective } from '../toast-actions/toast-actions.directive';

--- a/libs/design/toast/src/toast/toast.component.spec.ts
+++ b/libs/design/toast/src/toast/toast.component.spec.ts
@@ -14,9 +14,9 @@ import {
   DaffStatus,
   DaffStatusEnum,
 } from '@daffodil/design';
-import { DaffToast } from '@daffodil/design/toast';
 
 import { DaffToastComponent } from './toast.component';
+import { DaffToast } from '../interfaces/toast';
 
 @Component ({
   template: `


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
One of the table headers in docs is using the wrong tag. `DaffToast` is being imported from `@daffodil/design/toast` in the specs instead of using relative path.

Fixes: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information