### PR TITLE
fix(design): remove overflow style on body on destroy in sidebar component

### DIFF
--- a/libs/design/sidebar/src/sidebar-viewport/sidebar-viewport.component.ts
+++ b/libs/design/sidebar/src/sidebar-viewport/sidebar-viewport.component.ts
@@ -14,6 +14,7 @@ import {
   Inject,
   SkipSelf,
   Optional,
+  OnDestroy,
 } from '@angular/core';
 
 import { hasParentViewport } from './helper/has-parent-viewport';
@@ -74,7 +75,7 @@ import { DaffSidebarComponent } from '../sidebar/sidebar.component';
     { provide: DAFF_SIDEBAR_SCROLL_TOKEN, useFactory: daffSidebarViewportScrollFactory },
   ],
 })
-export class DaffSidebarViewportComponent implements AfterContentChecked {
+export class DaffSidebarViewportComponent implements AfterContentChecked, OnDestroy {
   @HostBinding('class.daff-sidebar-viewport') hostClass = true;
 
   @HostBinding('class') get classes() {
@@ -205,6 +206,14 @@ export class DaffSidebarViewportComponent implements AfterContentChecked {
       this._navPadRight = this.isNavOnSide ? this._contentPadRight : null;
       this.updateAnimationState();
       this.cdRef.markForCheck();
+    }
+  }
+
+  ngOnDestroy() {
+    if(!this.parentViewport && !hasParentViewport(this._elementRef.nativeElement)) {
+      this.bodyScroll.enable();
+    } else {
+      this.scroll.enable();
     }
   }
 

--- a/libs/design/sidebar/src/sidebar-viewport/specs/destroy.spec.ts
+++ b/libs/design/sidebar/src/sidebar-viewport/specs/destroy.spec.ts
@@ -1,0 +1,59 @@
+import { A11yModule } from '@angular/cdk/a11y';
+import { DOCUMENT } from '@angular/common';
+import { Component } from '@angular/core';
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { DaffSidebarViewportComponent } from './../sidebar-viewport.component';
+import { DaffSidebarComponent } from '../../sidebar/sidebar.component';
+
+@Component({
+  template: `
+	<daff-sidebar-viewport>
+		<daff-sidebar side="left" mode="over" [open]="true"></daff-sidebar>
+	</daff-sidebar-viewport>
+	`,
+})
+
+class WrapperOneComponent {}
+
+describe('@daffodil/design/sidebar | DaffSidebarViewportComponent | On Destroy', () => {
+  let fixture: ComponentFixture<WrapperOneComponent>;
+  let component: WrapperOneComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule,
+        A11yModule,
+      ],
+      declarations: [
+        DaffSidebarViewportComponent,
+        DaffSidebarComponent,
+        WrapperOneComponent,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WrapperOneComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should not have `overflow: hidden` on the body when destroyed', () => {
+    fixture.destroy();
+
+    expect((TestBed.inject(DOCUMENT)).body.style.overflow).not.toEqual('hidden');
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
If user navigates to a page without a sidebar through a link inside an open sidebar, the `overflow: hidden;` style on the body does not get removed.

Fixes: N/A


## What is the new behavior?
Add on destroy to remove overflow code from body

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information