### PR TITLE
feat(core): add error to `DaffState`

### DIFF
--- a/libs/core/state/src/states/state.enum.ts
+++ b/libs/core/state/src/states/state.enum.ts
@@ -55,5 +55,10 @@ export const enum DaffState {
    * Use DaffState.Stable instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
-  Complete = 'Stable'
+  Complete = 'Stable',
+
+  /**
+   * Indicates that the most recent operation specififc to this entity has failed.
+   */
+  Error = 'Error'
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
Adds an error state to `DaffState`. While we initially decided that this was redundant beacuse an app dev can check the `daffErrors` property to determine if the state is an error, the DX of this actually sucks. For example, consider binding the status of a toast to the state of an entity. Without this, it requires all sorts of unnecessary code and logic.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information