### PR TITLE
feat(core): replace mutating with updating

### DIFF
--- a/libs/core/state/src/states/state.enum.ts
+++ b/libs/core/state/src/states/state.enum.ts
@@ -28,19 +28,31 @@ export const enum DaffState {
   Added = 'Added',
 
   /**
-   * The 'Mutating' state describes when an object that currently exists in state
+   * The 'Updating' state describes when an object that currently exists in state
    * is being changed in some way.
    *
    * Disambiguation: This has nothing to do with immutability.
    */
-  Mutating = 'Mutating',
+  Updating = 'Updating',
 
   /**
    * The 'Mutated' state describes when an object has recently been modified in
    * state. This state is typically associated with a subsequent decay into a
    * 'Stable' state.
    */
-  Mutated = 'Mutated',
+  Updated = 'Updated',
+
+  /**
+   * @deprecated in favor of {@link DaffState.Updating}
+   */
+  // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
+  Mutating = 'Updating',
+
+  /**
+   * @deprecated in favor of {@link DaffState.Updated}
+   */
+  // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
+  Mutated = 'Updated',
 
   /**
    * The "Deleting" state occurs when an object is in the process of being


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
While mutating is a valuable concept, having it treated as a distinct state alongside `Adding` and `Deleting` causes confusion.  Adding and deleting are also mutable operation states, though the concept of an `enum` indicates that they are distinct. Aligning `DaffState` more closely with CRUD distinctions presents a more familiar and predicatable operation state model.

The concept of mutating will still be supported at a state layer as an OR of adding, updating, or deleting.

The only possible concern here is the inability to determine the exact role of an operation as it pertains to the CRUD paradigm and therefore being unable to make a good choice as to the `DaffState` to represent the operation. `Mutating` and `Mutated` are, for this reason, left in a deprecated state (rather than removed) to further evaluate the use cases.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information