### PR TITLE
feat(navigation): add `getTree` method

### DIFF
--- a/libs/navigation/driver/in-memory/src/navigation.service.ts
+++ b/libs/navigation/driver/in-memory/src/navigation.service.ts
@@ -16,6 +16,10 @@ export class DaffInMemoryNavigationService implements DaffNavigationServiceInter
 
   constructor(private http: HttpClient) {}
 
+  getTree(): Observable<DaffNavigationTree> {
+    return this.http.get<DaffNavigationTree>(this.url);
+  }
+
   get(navigationId: DaffNavigationTree['id']): Observable<DaffNavigationTree> {
     return this.http.get<DaffNavigationTree>(this.url + navigationId);
   }

--- a/libs/navigation/driver/magento/src/config/interface.ts
+++ b/libs/navigation/driver/magento/src/config/interface.ts
@@ -8,4 +8,10 @@ export interface MagentoNavigationDriverConfig {
    * Defaults to 3.
    */
   navigationTreeQueryDepth: number;
+
+  /**
+   * The UID of the root category.
+   * While this is optional, setting it will prevent an extra driver call during `getTree`.
+   */
+  rootCategoryId?: string;
 }

--- a/libs/navigation/driver/magento/src/navigation.service.spec.ts
+++ b/libs/navigation/driver/magento/src/navigation.service.spec.ts
@@ -1,10 +1,16 @@
-import { TestBed } from '@angular/core/testing';
+import {
+  TestBed,
+  fakeAsync,
+  flush,
+  tick,
+} from '@angular/core/testing';
 import { InMemoryCache } from '@apollo/client/core';
 import { addTypenameToDocument } from '@apollo/client/utilities';
 import {
   ApolloTestingModule,
   ApolloTestingController,
   APOLLO_TESTING_CACHE,
+  TestOperation,
 } from 'apollo-angular/testing';
 
 import { schema } from '@daffodil/driver/magento';
@@ -18,8 +24,12 @@ import { DaffNavigationTreeFactory } from '@daffodil/navigation/testing';
 
 import { GetCategoryTreeResponse } from './models/public_api';
 import { DaffMagentoNavigationService } from './navigation.service';
+import {
+  MagentoNavgiationGetRootCategoryIdResponse,
+  magentoNavigationGetRootCategoryIdQuery,
+} from './queries/get-root-category-id/public_api';
 
-describe('Driver | Magento | Navigation | NavigationService', () => {
+describe('@daffodil/navigation/driver/magento | DaffMagentoNavigationService', () => {
   let navigationService: DaffMagentoNavigationService;
   let navigationTreeFactory: DaffNavigationTreeFactory;
   let controller: ApolloTestingController;
@@ -78,6 +88,145 @@ describe('Driver | Magento | Navigation | NavigationService', () => {
       };
 
       navigationService.get(navigation.id).subscribe((result) => {
+        expect(result.id).toEqual(navigation.id);
+        expect(result.name).toEqual(navigation.name);
+        expect(result.url).toEqual(`/${navigation.id}.html`);
+        expect(result.total_products).toEqual(navigation.total_products);
+        expect(result.children_count).toEqual(navigation.children_count);
+        done();
+      });
+
+      const op = controller.expectOne(addTypenameToDocument(daffMagentoGetCategoryTree(queryDepth)));
+
+      expect(op.operation.variables.filters).toEqual({ category_uid: { eq: navigation.id }});
+
+      op.flush({
+        data: response,
+      });
+    });
+
+    afterEach(() => {
+      controller.verify();
+    });
+  });
+
+  describe('getTree', () => {
+    it('should return an observable single navigation', fakeAsync(() => {
+      const navigation = navigationTreeFactory.create();
+      const response: GetCategoryTreeResponse = {
+        categoryList: [{
+          __typename: 'CategoryTree',
+          uid: navigation.id,
+          url_path: navigation.id,
+          url_suffix: '.html',
+          name: navigation.name,
+          include_in_menu: true,
+          level: 0,
+          position: 1,
+          product_count: navigation.total_products,
+          children_count: navigation.children_count,
+          children: [],
+          breadcrumbs: [],
+        }],
+      };
+
+      navigationService.getTree().subscribe((result) => {
+        expect(result.id).toEqual(navigation.id);
+        expect(result.name).toEqual(navigation.name);
+        expect(result.url).toEqual(`/${navigation.id}.html`);
+        expect(result.total_products).toEqual(navigation.total_products);
+        expect(result.children_count).toEqual(navigation.children_count);
+      });
+
+      const rootIdOp: TestOperation<MagentoNavgiationGetRootCategoryIdResponse> = controller.expectOne(addTypenameToDocument(magentoNavigationGetRootCategoryIdQuery));
+      rootIdOp.flushData({
+        storeConfig: {
+          root_category_uid: navigation.id,
+        },
+      });
+
+      flush();
+      tick();
+
+      const op = controller.expectOne(addTypenameToDocument(daffMagentoGetCategoryTree(queryDepth)));
+
+      expect(op.operation.variables.filters).toEqual({ category_uid: { eq: navigation.id }});
+
+      op.flush({
+        data: response,
+      });
+      flush();
+    }));
+
+    afterEach(() => {
+      controller.verify();
+    });
+  });
+});
+
+describe('@daffodil/navigation/driver/magento | DaffMagentoNavigationService | with root category ID', () => {
+  let navigationService: DaffMagentoNavigationService;
+  let navigationTreeFactory: DaffNavigationTreeFactory;
+  let controller: ApolloTestingController;
+
+  const queryDepth = 1;
+  const categoryId = 'categoryId';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ApolloTestingModule,
+      ],
+      providers: [
+        DaffMagentoNavigationService,
+        { provide: DaffNavigationTransformer, useExisting: DaffMagentoNavigationTransformerService },
+        provideMagentoNavigationDriverConfig({
+          navigationTreeQueryDepth: queryDepth,
+          rootCategoryId: categoryId,
+        }),
+        {
+          provide: APOLLO_TESTING_CACHE,
+          useValue: new InMemoryCache({
+            addTypename: true,
+            possibleTypes: schema.possibleTypes,
+          }),
+        },
+      ],
+    });
+
+    controller = TestBed.inject(ApolloTestingController);
+
+    navigationService = TestBed.inject(DaffMagentoNavigationService);
+    navigationTreeFactory = TestBed.inject(DaffNavigationTreeFactory);
+  });
+
+  it('should be created', () => {
+    expect(navigationService).toBeTruthy();
+  });
+
+  describe('getTree', () => {
+    it('should return an observable single navigation', done => {
+      const navigation = navigationTreeFactory.create({
+        id: categoryId,
+      });
+      const response: GetCategoryTreeResponse = {
+        categoryList: [{
+          __typename: 'CategoryTree',
+          uid: navigation.id,
+          url_path: navigation.id,
+          url_suffix: '.html',
+          name: navigation.name,
+          include_in_menu: true,
+          level: 0,
+          position: 1,
+          product_count: navigation.total_products,
+          children_count: navigation.children_count,
+          children: [],
+          breadcrumbs: [],
+        }],
+      };
+
+      navigationService.getTree().subscribe((result) => {
         expect(result.id).toEqual(navigation.id);
         expect(result.name).toEqual(navigation.name);
         expect(result.url).toEqual(`/${navigation.id}.html`);

--- a/libs/navigation/driver/magento/src/queries/fragments/category-node.ts
+++ b/libs/navigation/driver/magento/src/queries/fragments/category-node.ts
@@ -2,42 +2,40 @@ import { gql } from 'apollo-angular';
 import { DocumentNode } from 'graphql';
 
 
-/**
- * A category tree fragment with no nested children.
- */
-const categoryNodeFragment = `
-	uid
-  url_path
-  url_suffix
-	level
-	name
-	include_in_menu
-	breadcrumbs {
-		category_uid
-		category_name
-		category_level
-		category_url_path
-	}
-	position
-	product_count
-`;
+const CATEGORY_NODE_FRAGMENT_NAME = 'categoryNode';
 
 /**
  * Generates a category tree fragment with the specified number of nested child category trees.
  *
  * @param depth The maximum depth to which category children should be added to the fragment.
  */
-//todo: use nested fragments when this bug is fixed: https://github.com/magento/magento2/issues/31086
 export function getCategoryNodeFragment(depth: number = 3): DocumentNode {
   const fragmentBody = new Array(depth).fill(null).reduce(acc => `
-    ${categoryNodeFragment}
+    ...${CATEGORY_NODE_FRAGMENT_NAME}
     children_count
     children {
       ${acc}
     }
-  `, categoryNodeFragment);
+  `, `...${CATEGORY_NODE_FRAGMENT_NAME}`);
 
   return gql`
+    fragment ${CATEGORY_NODE_FRAGMENT_NAME} on CategoryTree {
+      uid
+      url_path
+      url_suffix
+      level
+      name
+      include_in_menu
+      breadcrumbs {
+        category_uid
+        category_name
+        category_level
+        category_url_path
+      }
+      position
+      product_count
+    }
+
     fragment recursiveCategoryNode on CategoryTree {
       ${fragmentBody}
     }

--- a/libs/navigation/driver/magento/src/queries/get-root-category-id/public_api.ts
+++ b/libs/navigation/driver/magento/src/queries/get-root-category-id/public_api.ts
@@ -1,0 +1,2 @@
+export * from './query';
+export * from './response.type';

--- a/libs/navigation/driver/magento/src/queries/get-root-category-id/query.ts
+++ b/libs/navigation/driver/magento/src/queries/get-root-category-id/query.ts
@@ -1,0 +1,18 @@
+import { gql } from 'apollo-angular';
+
+import { MagentoNavgiationGetRootCategoryIdResponse } from './response.type';
+
+export const MAGENTO_NAVIGATION_GET_ROOT_CATEGORY_ID_QUERY_NAME = 'MagentoNavigationGetRootCategoryId';
+
+/**
+ * Generates a category tree query with the specified number of nested child category tree fragments.
+ *
+ * @param depth The maximum depth to which category children should be added to the fragment.
+ */
+export const magentoNavigationGetRootCategoryIdQuery = gql<MagentoNavgiationGetRootCategoryIdResponse, null>`
+  query ${MAGENTO_NAVIGATION_GET_ROOT_CATEGORY_ID_QUERY_NAME} {
+    storeConfig {
+      root_category_uid
+    }
+  }
+`;

--- a/libs/navigation/driver/magento/src/queries/get-root-category-id/response.type.ts
+++ b/libs/navigation/driver/magento/src/queries/get-root-category-id/response.type.ts
@@ -1,0 +1,6 @@
+export interface MagentoNavgiationGetRootCategoryIdResponse {
+  __typename: string;
+  storeConfig: {
+    root_category_uid: string;
+  };
+}

--- a/libs/navigation/driver/src/interfaces/navigation-service.interface.ts
+++ b/libs/navigation/driver/src/interfaces/navigation-service.interface.ts
@@ -4,7 +4,15 @@ import { Observable } from 'rxjs';
 import { DaffGenericNavigationTree } from '@daffodil/navigation';
 
 export interface DaffNavigationServiceInterface<T extends DaffGenericNavigationTree<T>> {
-  get(categoryId: T['id']): Observable<T>;
+  /**
+   * Requests a specific navigation item by ID.
+   */
+  get(id: T['id']): Observable<T>;
+
+  /**
+   * Requests the entire top-level navigation tree.
+   */
+  getTree(): Observable<T>;
 }
 
 export const DaffNavigationDriver =

--- a/libs/navigation/driver/testing/src/navigation.service.ts
+++ b/libs/navigation/driver/testing/src/navigation.service.ts
@@ -15,9 +15,13 @@ import { DaffNavigationTreeFactory } from '@daffodil/navigation/testing';
   providedIn: 'root',
 })
 export class DaffTestingNavigationService implements DaffNavigationServiceInterface<DaffNavigationTree> {
-
   constructor(
-    private navigationTreeFactory: DaffNavigationTreeFactory) {}
+    private navigationTreeFactory: DaffNavigationTreeFactory,
+  ) {}
+
+  getTree(): Observable<DaffNavigationTree> {
+    return of(this.navigationTreeFactory.create());
+  }
 
   get(navigationTreeId: string): Observable<DaffNavigationTree> {
     return of(this.navigationTreeFactory.create());

--- a/libs/navigation/state/src/actions/navigation.actions.ts
+++ b/libs/navigation/state/src/actions/navigation.actions.ts
@@ -12,7 +12,7 @@ export enum DaffNavigationActionTypes {
 export class DaffNavigationLoad implements Action {
   readonly type = DaffNavigationActionTypes.NavigationLoadAction;
 
-  constructor(public payload: string) { }
+  constructor(public payload?: string) { }
 }
 
 export class DaffNavigationLoadSuccess<T extends DaffGenericNavigationTree<T>> implements Action {

--- a/libs/navigation/state/src/effects/navigation.effects.ts
+++ b/libs/navigation/state/src/effects/navigation.effects.ts
@@ -35,18 +35,18 @@ import { DAFF_NAVIGATION_ERROR_MATCHER } from '../injection-tokens/public_api';
 
 @Injectable()
 export class DaffNavigationEffects<T extends DaffGenericNavigationTree<T>> {
-
   constructor(
     private actions$: Actions,
     @Inject(DaffNavigationDriver) private driver: DaffNavigationServiceInterface<T>,
     @Inject(DAFF_NAVIGATION_ERROR_MATCHER) private errorMatcher: ErrorTransformer,
   ) {}
 
-
   loadNavigation$: Observable<any> = createEffect(() => this.actions$.pipe(
     ofType(DaffNavigationActionTypes.NavigationLoadAction),
     switchMap((action: DaffNavigationLoad) =>
-      this.driver.get(action.payload)
+      (action.payload
+        ? this.driver.get(action.payload)
+        : this.driver.getTree())
         .pipe(
           map((resp) => new DaffNavigationLoadSuccess(resp)),
           catchError((error: DaffError) => of(new DaffNavigationLoadFailure(this.errorMatcher(error)))),

--- a/libs/navigation/state/src/reducers/navigation-reducers.ts
+++ b/libs/navigation/state/src/reducers/navigation-reducers.ts
@@ -7,4 +7,5 @@ import { DaffNavigationReducersState } from './navigation-reducers.interface';
 
 export const daffNavigationReducers: ActionReducerMap<DaffNavigationReducersState<DaffNavigationTree>> = {
   navigation: daffNavigationReducer,
+  // TODO: add entity state
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
Adds `getTree` driver method for retrieving the root navigation tree, without having to know platform data. An optional config value `MagentoNavigationDriverConfig#rootCategoryId` exists for preventing an additional network request.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information