### PR TITLE
feat(design): update modal API so that the modal service can be used to close a modal with the ESC key

### DIFF
--- a/apps/demo/src/app/cart/components/add-to-cart-notification/effects/add-to-cart-notification.effects.ts
+++ b/apps/demo/src/app/cart/components/add-to-cart-notification/effects/add-to-cart-notification.effects.ts
@@ -13,7 +13,7 @@ import {
 import { DaffCartActionTypes } from '@daffodil/cart/state';
 import {
   DaffModalService,
-  DaffModal,
+  DaffModalComponent,
 } from '@daffodil/design/modal';
 
 import {
@@ -25,7 +25,7 @@ import { AddToCartNotificationComponent } from '../components/add-to-cart-notifi
 
 @Injectable()
 export class AddToCartNotificationEffects {
-  private notification: DaffModal;
+  private notification: DaffModalComponent;
 
   constructor(
     private actions$: Actions,

--- a/libs/design/modal/examples/src/basic-modal/basic-modal.component.ts
+++ b/libs/design/modal/examples/src/basic-modal/basic-modal.component.ts
@@ -3,7 +3,10 @@ import {
   Component,
 } from '@angular/core';
 
-import { DaffModalService } from '@daffodil/design/modal';
+import {
+  DaffModalComponent,
+  DaffModalService,
+} from '@daffodil/design/modal';
 
 import { BasicModalContentComponent } from './modal-content.component';
 
@@ -14,7 +17,7 @@ import { BasicModalContentComponent } from './modal-content.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BasicModalComponent {
-  modal: any;
+  modal: DaffModalComponent;
 
   constructor(private modalService: DaffModalService) {}
 

--- a/libs/design/modal/src/modal.module.ts
+++ b/libs/design/modal/src/modal.module.ts
@@ -8,6 +8,7 @@ import { DaffModalActionsComponent } from './modal-actions/modal-actions.compone
 import { DaffModalContentComponent } from './modal-content/modal-content.component';
 import { DaffModalHeaderComponent } from './modal-header/modal-header.component';
 import { DaffModalTitleDirective } from './modal-title/modal-title.directive';
+import { DaffModalService } from './service/modal.service';
 
 @NgModule({
   imports: [
@@ -27,6 +28,9 @@ import { DaffModalTitleDirective } from './modal-title/modal-title.directive';
     DaffModalTitleDirective,
     DaffModalContentComponent,
     DaffModalActionsComponent,
+  ],
+  providers: [
+    DaffModalService,
   ],
 })
 export class DaffModalModule { }

--- a/libs/design/modal/src/modal/modal.component.spec.ts
+++ b/libs/design/modal/src/modal/modal.component.spec.ts
@@ -11,6 +11,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { DaffModalComponent } from './modal.component';
+import { DaffModalService } from '../service/modal.service';
 
 @Component({ template: `
   <div class="daff-modal-wrapper">
@@ -33,6 +34,9 @@ describe('@daffodil/design/modal | DaffModalComponent', () => {
       declarations: [
         WrapperComponent,
         DaffModalComponent,
+      ],
+      providers: [
+        DaffModalService,
       ],
     })
       .compileComponents();

--- a/libs/design/modal/src/modal/modal.component.ts
+++ b/libs/design/modal/src/modal/modal.component.ts
@@ -18,12 +18,14 @@ import {
   ElementRef,
   AfterContentInit,
   AfterViewInit,
+  Self,
 } from '@angular/core';
 
 import { daffFocusableElementsSelector } from '@daffodil/design';
 
 import { daffFadeAnimations } from '../animations/modal-animation';
 import { getAnimationState } from '../animations/modal-animation-state';
+import { DaffModalService } from '../service/modal.service';
 
 @Component({
   selector: 'daff-modal',
@@ -61,13 +63,17 @@ export class DaffModalComponent implements AfterContentInit, AfterViewInit {
   >();
 
   /**
-   * Event fired when the backdrop is clicked. This is often used to close the modal.
+   * @docs-private
    */
-  hide: EventEmitter<void> = new EventEmitter<void>();
+  @HostListener('keydown.escape')
+  onEscape() {
+    this.modalService.close(this);
+  }
 
   private _focusTrap: ConfigurableFocusTrap;
 
   constructor(
+    private modalService: DaffModalService,
     private _focusTrapFactory: ConfigurableFocusTrapFactory,
     private _elementRef: ElementRef<HTMLElement>,
   ) {

--- a/libs/design/modal/src/specs/animations.spec.ts
+++ b/libs/design/modal/src/specs/animations.spec.ts
@@ -11,6 +11,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { DaffModalComponent } from '../modal/modal.component';
+import { DaffModalService } from '../service/modal.service';
 
 @Component({ template: `
   <div class="daff-modal-wrapper">
@@ -35,6 +36,9 @@ describe('@daffodil/design/modal | DaffModalComponent', () => {
       declarations: [
         WrapperComponent,
         DaffModalComponent,
+      ],
+      providers: [
+        DaffModalService,
       ],
     })
       .compileComponents();

--- a/libs/design/modal/src/specs/dynamic-content.spec.ts
+++ b/libs/design/modal/src/specs/dynamic-content.spec.ts
@@ -16,6 +16,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { DaffModalComponent } from '../modal/modal.component';
+import { DaffModalService } from '../service/modal.service';
 
 @Component({ template: `<daff-modal></daff-modal>` })
 class WrapperComponent {}
@@ -44,6 +45,9 @@ describe('@daffodil/design/modal | DaffModalComponent', () => {
       declarations: [
         WrapperComponent,
         DaffModalComponent,
+      ],
+      providers: [
+        DaffModalService,
       ],
     })
       .compileComponents();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The modal is not closable via the ESC key.

Fixes:

## What is the new behavior?

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

Breaking change: The return type of open and the argument type of close have changed. It now returns DaffModalComponent instead of DaffModal.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information