### PR TITLE
feat((design-land): update they way open is set for the design land sidebar

### DIFF
--- a/apps/design-land/src/app/core/sidebar-viewport/sidebar-viewport.component.ts
+++ b/apps/design-land/src/app/core/sidebar-viewport/sidebar-viewport.component.ts
@@ -30,9 +30,16 @@ export class DesignLandSidebarViewportComponent {
   public open = false;
 
   constructor(private breakpoint: BreakpointObserver) {
-    this.open = this.breakpoint.isMatched(DaffBreakpoints.BIG_TABLET);
     this.mode$ = this.breakpoint.observe(DaffBreakpoints.BIG_TABLET).pipe(
-      map((match) => match.matches ? DaffSidebarModeEnum.SideFixed : DaffSidebarModeEnum.Under),
+      map((match) => {
+        if (match.matches) {
+          this.open = true;
+          return DaffSidebarModeEnum.SideFixed;
+				 } else {
+          this.open = false;
+          return DaffSidebarModeEnum.Over;
+        }
+      }),
     );
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The design land sidebar would automatically open when viewport changes to tablet or mobile.

Fixes: #2836 


## What is the new behavior?
Design land sidebar remains hidden when viewport changes to tablet or mobile unless user clicks on the hamburger icon to open it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information