### PR TITLE
docs(all): remove code blocks from npm and yarn in readme headings

### DIFF
--- a/libs/cart/guides/installation.md
+++ b/libs/cart/guides/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-## Installing with `npm`
+## Installing with npm
 
 To install the cart library and its dependencies, use the following command in the terminal.
 
@@ -8,7 +8,7 @@ To install the cart library and its dependencies, use the following command in t
 npm install @daffodil/cart @daffodil/core @ngrx/store @ngrx/effects --save
 ```
 
-## Installing with `yarn`
+## Installing with yarn
 
 To install the cart library and its dependencies, use the following command in the terminal.
 

--- a/libs/contact/guides/installation.md
+++ b/libs/contact/guides/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-## Installing with `npm`
+## Installing with npm
 
 To install the contact library and its dependencies, use the following command in your terminal.
 
@@ -10,7 +10,7 @@ npm install @daffodil/contact @daffodil/core @ngrx/store @ngrx/effects --save
 
 After installing, an ecommerce platform driver needs to be set-up. We highly recommend installing the In-Memory-Web-API for fast, out-of-the-box development.
 
-## Installing with `yarn`
+## Installing with yarn
 
 To install the contact library and its dependencies, use the following command in your terminal.
 

--- a/libs/geography/guides/installation.md
+++ b/libs/geography/guides/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-## Installing with `npm`
+## Installing with npm
 
 To install the `@daffodil/geography` library and its dependencies, use the following command in your terminal.
 
@@ -8,7 +8,7 @@ To install the `@daffodil/geography` library and its dependencies, use the follo
 npm install @daffodil/geography @daffodil/core
 ```
 
-## Installing with `yarn`
+## Installing with yarn
 
 To install the `@daffodil/geography` library and its dependencies, use the following command in your terminal.
 

--- a/libs/newsletter/guides/installation.md
+++ b/libs/newsletter/guides/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-## Installing with `npm`
+## Installing with npm
 
 To install the newsletter library and its dependencies, use the following command in your terminal.
 
@@ -10,7 +10,7 @@ npm install @daffodil/newsletter @daffodil/core @ngrx/store @ngrx/effects --save
 
 After installing, an ecommerce platform driver needs to be set-up, we highly recommend installing the [In-Memory-Web-API](#in-memory-web-api) for fast, out-of-the-box development.
 
-## Installing with `yarn`
+## Installing with yarn
 
 To install the newsletter library and its dependencies, use the following command in your terminal.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Some `installation.md` files use code ticks in headings for `npm` and `yarn`. 

Fixes: #2846 

## What is the new behavior?
Code blocks removed from `npm` and `yarn` in readme headings as it's not necessary to denote them as code.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information