### PR TITLE
feat(cart): set shipping method `id` in magento driver

### DIFF
--- a/libs/cart/driver/magento/src/transforms/outputs/cart-shipping-rate.service.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-shipping-rate.service.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
+import { DaffCartShippingRate } from '@daffodil/cart';
+import { MagentoCartShippingMethod } from '@daffodil/cart/driver/magento';
 import { MagentoCartShippingMethodFactory } from '@daffodil/cart/driver/magento/testing';
 
 import { DaffMagentoCartShippingRateTransformer } from './cart-shipping-rate.service';
@@ -9,7 +11,7 @@ describe('@daffodil/cart/driver/magento | Transformer | MagentoCartShippingRate'
 
   let magentoShippingMethodFactory: MagentoCartShippingMethodFactory;
 
-  let mockMagentoShippingMethod;
+  let mockMagentoShippingMethod: MagentoCartShippingMethod;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -30,7 +32,7 @@ describe('@daffodil/cart/driver/magento | Transformer | MagentoCartShippingRate'
   });
 
   describe('transform | transforming a cart shipping rate', () => {
-    let transformedCartShippingRate;
+    let transformedCartShippingRate: DaffCartShippingRate;
     let carrier;
     let price;
 
@@ -47,6 +49,7 @@ describe('@daffodil/cart/driver/magento | Transformer | MagentoCartShippingRate'
     it('should return an object with the correct values', () => {
       expect(transformedCartShippingRate.carrier).toEqual(carrier);
       expect(transformedCartShippingRate.price).toEqual(price);
+      expect(transformedCartShippingRate.id).toEqual(mockMagentoShippingMethod.method_code);
     });
 
     describe('when the argument is null', () => {

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-shipping-rate.service.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-shipping-rate.service.ts
@@ -23,9 +23,9 @@ export class DaffMagentoCartShippingRateTransformer {
       price: shippingMethod.amount.value,
       method_code: shippingMethod.method_code,
       method_title: shippingMethod.method_title,
+      id: shippingMethod.method_code,
 
       // TODO: implement
-      id: null,
       method_description: null,
     } : null;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
Magento sets shipping method IDs to be the `method_code`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information