### PR TITLE
feat(demo): load navigation tree on init

### DIFF
--- a/apps/demo/src/app/core/sidebar/containers/sidebar/sidebar.component.spec.ts
+++ b/apps/demo/src/app/core/sidebar/containers/sidebar/sidebar.component.spec.ts
@@ -89,7 +89,7 @@ describe('SidebarContainer', () => {
     it('should dispatch a DaffNavigationTreeLoad', () => {
       spyOn(navFacade, 'dispatch');
       component.ngOnInit();
-      expect(navFacade.dispatch).toHaveBeenCalledWith(new DaffNavigationLoad('2'));
+      expect(navFacade.dispatch).toHaveBeenCalledWith(new DaffNavigationLoad());
     });
   });
 

--- a/apps/demo/src/app/core/sidebar/containers/sidebar/sidebar.component.ts
+++ b/apps/demo/src/app/core/sidebar/containers/sidebar/sidebar.component.ts
@@ -60,7 +60,7 @@ export class SidebarContainer implements OnInit {
     this.tree$ = this.navigationFacade.tree$;
     this.treeLoading$ = this.navigationFacade.loading$;
     this.treeErrors$ = this.navigationFacade.errors$;
-    this.navigationFacade.dispatch(new DaffNavigationLoad('2'));
+    this.navigationFacade.dispatch(new DaffNavigationLoad());
   }
 
   onClose() {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The demo app loads a hardcoded nav ID

## What is the new behavior?
Demo loads the entire nav tree

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information