### PR TITLE
feat(design)!: remove deprecated `layout` and `size` properties in `DaffCalloutComponent`

### DIFF
--- a/libs/design/callout/src/callout/callout.component.scss
+++ b/libs/design/callout/src/callout/callout.component.scss
@@ -63,32 +63,6 @@
 		}
 	}
 
-	// centered will be deprecated in v1.0.0
-	&--centered {
-		#{$root}__title {
-			margin: 0 auto;
-			text-align: center;
-		}
-
-		#{$root}__subtitle {
-			margin: 10px auto 0;
-			text-align: center;
-
-			@include layout.breakpoint(mobile) {
-				margin: 25px auto 0;
-			}
-		}
-	}
-
-	// compact will be deprecated in v1.0.0
-	&--compact {
-		padding: 25px;
-
-		@include layout.breakpoint(mobile) {
-			padding: 25px 50px;
-		}
-	}
-
 	&.daff-compact {
 		padding: 48px 24px;
 

--- a/libs/design/callout/src/callout/callout.component.spec.ts
+++ b/libs/design/callout/src/callout/callout.component.spec.ts
@@ -14,22 +14,16 @@ import {
   DaffTextAlignment,
 } from '@daffodil/design';
 
-import {
-  DaffCalloutComponent,
-  DaffCalloutLayout,
-  DaffCalloutSize,
-} from './callout.component';
+import { DaffCalloutComponent } from './callout.component';
 
 @Component ({
   template: `
-    <daff-callout [color]="color" [layout]="layout" [size]="size" [textAlignment]="textAlignment" [compact]="compact"></daff-callout>
+    <daff-callout [color]="color" [textAlignment]="textAlignment" [compact]="compact"></daff-callout>
   `,
 })
 
 class WrapperComponent {
   color: DaffPalette;
-  layout: DaffCalloutLayout;
-  size: DaffCalloutSize;
   textAlignment: DaffTextAlignment;
   compact = false;
 }
@@ -78,36 +72,6 @@ describe('@daffodil/design/callout | DaffCalloutComponent', () => {
       fixture.detectChanges();
 
       expect(de.nativeElement.classList.contains('daff-primary')).toEqual(true);
-    });
-  });
-
-  describe('setting the layout', () => {
-    describe('when layout="centered"', () => {
-      it('should add a class of "daff-callout--centered" to the host element', () => {
-        wrapper.layout = 'centered';
-        fixture.detectChanges();
-        expect(de.nativeElement.classList.contains('daff-callout--centered')).toBeTruthy();
-      });
-    });
-
-    it('should not set a default layout', () => {
-      expect(component.layout).toBeFalsy();
-      expect(de.nativeElement.classList.contains('daff-callout--centered')).toBeFalsy();
-    });
-  });
-
-  describe('setting the size', () => {
-    describe('when size="compact"', () => {
-      it('should add a class of "daff-callout--compact" to the host element', () => {
-        wrapper.size = 'compact';
-        fixture.detectChanges();
-        expect(de.nativeElement.classList.contains('daff-callout--compact')).toBeTruthy();
-      });
-    });
-
-    it('should not set a default size', () => {
-      expect(component.size).toBeFalsy();
-      expect(de.nativeElement.classList.contains('daff-callout--compact')).toBeFalsy();
     });
   });
 

--- a/libs/design/callout/src/callout/callout.component.ts
+++ b/libs/design/callout/src/callout/callout.component.ts
@@ -20,22 +20,6 @@ import {
 } from '@daffodil/design';
 
 /**
- * @deprecated See {@link DaffTextAlignable}
- */
-export type DaffCalloutLayout = 'centered' | undefined;
-export enum DaffCalloutLayoutEnum {
-  Centered = 'centered'
-}
-
-/**
- * @deprecated See {@link DaffCompactable}
- */
-export type DaffCalloutSize = 'compact' | undefined;
-export enum DaffCalloutSizeEnum {
-  Compact = 'compact'
-}
-
-/**
  * An _elementRef and an instance of renderer2 are needed for the Colorable mixin
  */
 class DaffCalloutBase {
@@ -58,16 +42,6 @@ const _daffCalloutBase = daffArticleEncapsulatedMixin(daffManageContainerLayoutM
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DaffCalloutComponent extends _daffCalloutBase implements DaffColorable, DaffTextAlignable, DaffCompactable {
-  /**
-   * @deprecated See {@link DaffTextAlignable}
-   */
-  @Input() layout: DaffCalloutLayout;
-
-  /**
-   * @deprecated See {@link DaffCompactable}
-   */
-  @Input() size: DaffCalloutSize;
-
   constructor(private elementRef: ElementRef, private renderer: Renderer2) {
     super(elementRef, renderer);
   }
@@ -76,18 +50,4 @@ export class DaffCalloutComponent extends _daffCalloutBase implements DaffColora
    * @docs-private
    */
   @HostBinding('class.daff-callout') class = true;
-
-  /**
-   * @deprecated See {@link DaffTextAlignable}
-   */
-  @HostBinding('class.daff-callout--centered') get centered() {
-	  return this.layout === DaffCalloutLayoutEnum.Centered;
-  }
-
-  /**
-   * @deprecated See {@link DaffCompactable}
-   */
-  @HostBinding('class.daff-callout--compact') get compactClass() {
-	  return this.size === DaffCalloutSizeEnum.Compact;
-  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`layout` and `size` are deprecated properties that should not remain in the codebase.

Part of: #2853 


## What is the new behavior?
There are no more deprecated properties in `DaffCalloutComponent`

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

Removed `layout` in favor of `DaffTextAlignable` and `size` in favor of `DaffCompactable`

## Other information