### PR TITLE
feat(design)!: remove `color` property from `DaffPaginatorComponent`

### DIFF
--- a/libs/design/paginator/src/paginator-theme.scss
+++ b/libs/design/paginator/src/paginator-theme.scss
@@ -2,19 +2,6 @@
 @use '../../scss/core';
 @use '../../scss/theming';
 
-@mixin daff-paginator-theme-variant($active-color) {
-	color: currentColor;
-
-	&:hover,
-	&.selected { /* stylelint-disable-line selector-class-pattern */
-		color: theming.daff-text-contrast($active-color);
-
-		&:after {
-			background: $active-color;
-		}
-	}
-}
-
 @mixin daff-paginator-theme($theme) {
 	$primary: map.get($theme, primary);
 	$secondary: map.get($theme, secondary);
@@ -42,48 +29,6 @@
 				&:after {
 					background: theming.daff-illuminate($base, $neutral, 2);
 				}
-			}
-		}
-
-		&.daff-primary {
-			.daff-paginator__page-link {
-				@include daff-paginator-theme-variant(theming.daff-color($primary));
-			}
-		}
-
-		&.daff-secondary {
-			.daff-paginator__page-link {
-				@include daff-paginator-theme-variant(theming.daff-color($secondary));
-			}
-		}
-
-		&.daff-tertiary {
-			.daff-paginator__page-link {
-				@include daff-paginator-theme-variant(theming.daff-color($tertiary));
-			}
-		}
-
-		&.daff-theme {
-			.daff-paginator__page-link {
-				@include daff-paginator-theme-variant($base);
-			}
-		}
-
-		&.daff-theme-contrast {
-			.daff-paginator__page-link {
-				@include daff-paginator-theme-variant($base-contrast);
-			}
-		}
-
-		&.daff-black {
-			.daff-paginator__page-link {
-				@include daff-paginator-theme-variant($black);
-			}
-		}
-
-		&.daff-white {
-			.daff-paginator__page-link {
-				@include daff-paginator-theme-variant($white);
 			}
 		}
 	}

--- a/libs/design/paginator/src/paginator/paginator.component.ts
+++ b/libs/design/paginator/src/paginator/paginator.component.ts
@@ -25,18 +25,6 @@ import {
   DaffPaginatorPageOutOfRangeErrorMessage,
 } from '../utils/paginator-errors';
 
-/**
- * An _elementRef and an instance of renderer2 are needed for the Colorable mixin
- */
-class DaffPaginatorBase {
-  constructor(public _elementRef: ElementRef, public _renderer: Renderer2) {}
-}
-
-/**
- * @deprecated in v1.0.0
- */
-const _daffPaginatorBase = daffColorMixin(DaffPaginatorBase);
-
 const visiblePageRange = 2;
 
 /**
@@ -46,12 +34,9 @@ const visiblePageRange = 2;
   selector: 'daff-paginator',
   styleUrls: ['./paginator.component.scss'],
   templateUrl: './paginator.component.html',
-  //todo(damienwebdev): remove once decorators hit stage 3 - https://github.com/microsoft/TypeScript/issues/7342
-  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['color'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChanges, DaffColorable {
+export class DaffPaginatorComponent implements OnChanges {
 
   /**
    * @docs-private
@@ -76,8 +61,7 @@ export class DaffPaginatorComponent extends _daffPaginatorBase implements OnChan
    */
   _paginatorId: string;
 
-  constructor(private elementRef: ElementRef, private renderer: Renderer2) {
-	  super(elementRef, renderer);
+  constructor(private elementRef: ElementRef) {
 	  const ariaLabel = elementRef.nativeElement.attributes['aria-label'];
 	  this._paginatorId = ariaLabel ? ariaLabel.nodeValue : null;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`color` property is deprecated and should not remain in the codebase.

Part of: #2853 


## What is the new behavior?
There are no more deprecated properties in `DaffPaginatorComponent`

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

BREAKING CHANGE: `color` been removed from the codebase. Paginators are no longer themable.

## Other information