### PR TITLE
feat(design): remove deprecated tag on `onBackdropClicked` in `DaffSidebarViewportBackdropComponent`

### DIFF
--- a/libs/design/sidebar/src/sidebar-viewport-backdrop/sidebar-viewport-backdrop.component.ts
+++ b/libs/design/sidebar/src/sidebar-viewport-backdrop/sidebar-viewport-backdrop.component.ts
@@ -71,10 +71,6 @@ export class DaffSidebarViewportBackdropComponent implements OnInit {
 	  }
   }
 
-  /**
-   * @deprecated
-   * Backdrop event that triggers when the backdrop element is clicked.
-   */
   @HostListener('click')
   onBackdropClicked(): void {
 	  this.backdropClicked.emit();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is a deprecated tag on `onBackdropClicked` in `DaffSidebarViewportBackdropComponent`

Part of: #2853 


## What is the new behavior?
Remove the deprecated tag on `onBackdropClicked` because it's necessary.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information