### PR TITLE
fix(design): only add the aria expanded attribute when tree item has children

### DIFF
--- a/libs/design/tree/src/tree-item/tree-item.directive.ts
+++ b/libs/design/tree/src/tree-item/tree-item.directive.ts
@@ -101,10 +101,13 @@ export class DaffTreeItemDirective {
   set node(val: DaffTreeFlatNode) {
     this._node = val;
     this.id = 'tree-' + this._node.id;
-    this.ariaExpanded = this._node._treeRef.open ? 'true' : 'false';
     this.depth = this._node.level;
     this.classParent = this._node.hasChildren;
     this.openClass = this._node._treeRef.open;
+
+    if(this._node.hasChildren) {
+      this.ariaExpanded = this._node._treeRef.open ? 'true' : 'false';
+    }
   }
 
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`aria-expanded` is set on all tree items, even when it's not expandable (does not have child tree items)

Fixes: #2855 


## What is the new behavior?
`aria-expanded` is now only set if tree item has children.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information