### PR TITLE
fix(core): undefined operation entity from `operationFailed`

### DIFF
--- a/libs/core/state/src/operation/entity/adapter.spec.ts
+++ b/libs/core/state/src/operation/entity/adapter.spec.ts
@@ -190,6 +190,16 @@ describe('@daffodil/core/state | daffCreateOperationEntityStateAdapter', () => {
       result = adapter.operationFailed(entity.id, errors, adapter.list(entities, state));
     });
 
+    describe('when the entity does not exist in state', () => {
+      beforeEach(() => {
+        result = adapter.operationFailed(`not ${entity.id}`, errors, adapter.list(entities, state));
+      });
+
+      it('should not touch state', () => {
+        expect(result.entities[`not ${entity.id}`]).toBeUndefined();
+      });
+    });
+
     it('should indicate that the entity is in an error state', () => {
       expect(result.entities[entity.id].daffState).toEqual(DaffState.Error);
     });

--- a/libs/core/state/src/operation/entity/adapter.ts
+++ b/libs/core/state/src/operation/entity/adapter.ts
@@ -169,11 +169,11 @@ export class DaffOperationEntityStateAdapter<T extends DaffIdentifiable = DaffId
   }
 
   operationFailed<S extends DaffOperationEntityState<T> = DaffOperationEntityState<T>>(key: string, errors: DaffStateError[], state: S): S {
-    return this.adapter.upsertOne({
+    return state.entities[key] ? this.adapter.upsertOne({
       ...state.entities[key],
       daffState: DaffState.Error,
       daffErrors: errors,
-    }, state);
+    }, state) : state;
   }
 
   resetState<S extends DaffOperationEntityState<T> = DaffOperationEntityState<T>>(key: string, state: S): S {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Calling `operationFailed` when the referenced entity does not exist in state causes a bogus entity to be set to the `undefined` key.


## What is the new behavior?
Only entities that are in state will have their error states set.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information