### PR TITLE
build(docs-utils): expose types from built package

### DIFF
--- a/libs/docs-utils/.eslintrc.js
+++ b/libs/docs-utils/.eslintrc.js
@@ -1,0 +1,26 @@
+module.exports = {
+  extends: '../../.eslintrc.js',
+  ignorePatterns: [
+    '!**/*'
+  ],
+  overrides: [
+    {
+      files: [
+        '*.ts'
+      ],
+      parserOptions: {
+        project: [
+          'tsconfig.json',
+          'tsconfig.spec.json'
+        ],
+        createDefaultProgram: true
+      },
+    },
+    {
+      files: [
+        '*.html'
+      ],
+      rules: {}
+    }
+  ]
+}

--- a/libs/docs-utils/package.json
+++ b/libs/docs-utils/package.json
@@ -3,7 +3,9 @@
   "nx": {
     "targets": {
       "build": {
-        "outputs": ["{workspaceRoot}/dist/docs-utils"]
+        "outputs": [
+          "{workspaceRoot}/dist/docs-utils"
+        ]
       }
     }
   },
@@ -14,7 +16,7 @@
     "build": "npm run clean && npm run build:bundle && npm run build:types && npm run build:copy-static",
     "build:types": "npx tsc --emitDeclarationOnly --declaration --project tsconfig.json",
     "build:bundle": "esbuild --outfile=../../dist/docs-utils/index.js --platform=node --bundle src/index.ts",
-    "build:copy-static":"shx cp package.json README.md ../../dist/docs-utils",
+    "build:copy-static": "shx cp package.json README.md ../../dist/docs-utils && shx cp -R ../../dist/docs-utils/src/* ../../dist/docs-utils",
     "clean": "rimraf ../../dist/docs-utils",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Consumers of `@daffodil/docs-utils` will not have access to typescript types

## What is the new behavior?
they will

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information