### PR TITLE
feat(dgeni,docs-utils): centralize paths for different doc kinds

### DIFF
--- a/libs/docs-utils/src/kind/enum.ts
+++ b/libs/docs-utils/src/kind/enum.ts
@@ -1,0 +1,6 @@
+export enum DaffDocKind {
+  GUIDE = 'GUIDE',
+  EXPLANATION = 'EXPLANATION',
+  PACKAGE = 'PACKAGE',
+  API = 'API',
+}

--- a/libs/docs-utils/src/kind/path-segment-map.ts
+++ b/libs/docs-utils/src/kind/path-segment-map.ts
@@ -1,0 +1,8 @@
+import { DaffDocKind } from './enum';
+
+export const DAFF_DOC_KIND_PATH_SEGMENT_MAP = <const>{
+  [DaffDocKind.GUIDE]: 'guides',
+  [DaffDocKind.EXPLANATION]: 'explanations',
+  [DaffDocKind.PACKAGE]: 'packages',
+  [DaffDocKind.API]: 'api',
+};

--- a/libs/docs-utils/src/kind/public_api.ts
+++ b/libs/docs-utils/src/kind/public_api.ts
@@ -1,0 +1,2 @@
+export * from './enum';
+export * from './path-segment-map';

--- a/libs/docs-utils/src/public_api.ts
+++ b/libs/docs-utils/src/public_api.ts
@@ -1,1 +1,2 @@
 export { crossOsFilename } from './cross-os-filename';
+export * from './kind/public_api';

--- a/tools/dgeni/src/processors/markdown.ts
+++ b/tools/dgeni/src/processors/markdown.ts
@@ -12,6 +12,11 @@ import { slugify } from 'markdown-toc';
 import { marked } from 'marked';
 import { markedHighlight } from 'marked-highlight';
 
+import {
+  DAFF_DOC_KIND_PATH_SEGMENT_MAP,
+  DaffDocKind,
+} from '@daffodil/docs-utils';
+
 hljs.registerLanguage('typescript', typescript);
 hljs.registerLanguage('ts', typescript);
 hljs.registerLanguage('xml', xml);
@@ -20,17 +25,11 @@ hljs.registerLanguage('bash', bash);
 hljs.registerLanguage('graphql', graphql);
 hljs.registerLanguage('gql', graphql);
 
-enum DocKind {
-  GUIDE = 'GUIDE',
-  EXPLANATION = 'EXPLANATION',
-  PACKAGE = 'PACKAGE',
-  API = 'API',
-}
 const DOC_KIND_REGEX = {
-  [DocKind.GUIDE]: /\/docs\/guides\/(?<path>.+)\.md/,
-  [DocKind.EXPLANATION]: /\/docs\/explanations\/(?<path>.+)\.md/,
-  [DocKind.PACKAGE]: /\/libs\/(?<path>.+)\.md/,
-  [DocKind.API]: /\/libs\/(?<path>.+)\.ts/,
+  [DaffDocKind.GUIDE]: /\/docs\/guides\/(?<path>.+)\.md/,
+  [DaffDocKind.EXPLANATION]: /\/docs\/explanations\/(?<path>.+)\.md/,
+  [DaffDocKind.PACKAGE]: /\/libs\/(?<path>.+)\.md/,
+  [DaffDocKind.API]: /\/libs\/(?<path>.+)\.ts/,
 };
 const getLinkUrl = (path: string): string => {
   const kind = (<Array<keyof typeof DOC_KIND_REGEX>>Object.keys(DOC_KIND_REGEX)).find((k) => DOC_KIND_REGEX[k].test(path));
@@ -41,17 +40,13 @@ const getLinkUrl = (path: string): string => {
   }
 
   switch (kind) {
-    case DocKind.GUIDE:
-      return `/docs/guides/${match.groups.path}`;
+    case DaffDocKind.GUIDE:
+    case DaffDocKind.EXPLANATION:
+    case DaffDocKind.API:
+      return `/docs/${DAFF_DOC_KIND_PATH_SEGMENT_MAP[kind]}/${match.groups.path}`;
 
-    case DocKind.EXPLANATION:
-      return `/docs/explanations/${match.groups.path}`;
-
-    case DocKind.PACKAGE:
+    case DaffDocKind.PACKAGE:
       return `/docs/packages/${match.groups.path}`.replaceAll(/\/(?:readme|src|guides)/gi, '');
-
-    case DocKind.API:
-      return `/docs/api/${match.groups.path}`;
 
     default:
       return path;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
dgeni hardcodes doc paths

## What is the new behavior?
doc paths are stored in a central location, preventing the need to duplicate brittle hardcoded paths in multiple places

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information