### PR TITLE
fix(search): SSR gets stuck in resolver when query is empty

### DIFF
--- a/libs/search/routing/src/resolvers/search/search.resolver.spec.ts
+++ b/libs/search/routing/src/resolvers/search/search.resolver.spec.ts
@@ -78,44 +78,68 @@ describe('@daffodil/search/routing | DaffSearchPageResolver', () => {
       spyOn(store, 'dispatch');
     }));
 
-    it('should dispatch a DaffSearchLoad action with the correct search query', () => {
-      searchResolver.resolve(<ActivatedRouteSnapshot><unknown>{
-        ...route.snapshot,
-        queryParams: {
-          query,
-        },
-      }).subscribe();
-      expect(store.dispatch).toHaveBeenCalledWith(
-        new DaffSearchLoad(query, options),
-      );
-    });
+    describe('when the query is defined', () => {
+      let snapshot: ActivatedRouteSnapshot;
 
-    it('should resolve when DaffSearchLoadSuccess is dispatched', done => {
-      searchResolver.resolve(route.snapshot).subscribe(value => {
-        expect(value).toEqual(true);
-        done();
+      beforeEach(() => {
+        snapshot = <ActivatedRouteSnapshot><unknown>{
+          ...route.snapshot,
+          queryParams: {
+            query,
+          },
+        };
       });
 
-      actions$.next(new DaffSearchLoadSuccess({
-        collection: {},
-        metadata: {},
-      }));
-    });
-
-    it('should resolve when DaffCartLoadFailure is dispatched', done => {
-      searchResolver.resolve(route.snapshot).subscribe(value => {
-        expect(value).toEqual(true);
-        done();
+      it('should dispatch a DaffSearchLoad action with the correct search query', () => {
+        searchResolver.resolve(snapshot).subscribe();
+        expect(store.dispatch).toHaveBeenCalledWith(
+          new DaffSearchLoad(query, options),
+        );
       });
 
-      actions$.next(new DaffSearchLoadFailure(null));
+      it('should resolve when DaffSearchLoadSuccess is dispatched', done => {
+        searchResolver.resolve(snapshot).subscribe(value => {
+          expect(value).toEqual(true);
+          done();
+        });
+
+        actions$.next(new DaffSearchLoadSuccess({
+          collection: {},
+          metadata: {},
+        }));
+      });
+
+      it('should resolve when DaffCartLoadFailure is dispatched', done => {
+        searchResolver.resolve(snapshot).subscribe(value => {
+          expect(value).toEqual(true);
+          done();
+        });
+
+        actions$.next(new DaffSearchLoadFailure(null));
+      });
+
+      it('should not resolve without a search load success or failure', () => {
+        searchResolver.resolve(snapshot).subscribe(() => {
+          fail();
+        });
+        expect(true).toBeTruthy();
+      });
     });
 
-    it('should not resolve without a search load success or failure', () => {
-      searchResolver.resolve(route.snapshot).subscribe(() => {
-        fail();
+    describe('when the query is not defined', () => {
+      it('should return true immediately', (done) => {
+        searchResolver.resolve(route.snapshot).subscribe((res) => {
+          expect(res).toBeTrue();
+          done();
+        });
       });
-      expect(true).toBeTruthy();
+
+      it('should not initiate a search', (done) => {
+        searchResolver.resolve(route.snapshot).subscribe((res) => {
+          expect(store.dispatch).not.toHaveBeenCalled();
+          done();
+        });
+      });
     });
   });
 

--- a/libs/search/routing/src/resolvers/search/search.resolver.ts
+++ b/libs/search/routing/src/resolvers/search/search.resolver.ts
@@ -50,15 +50,17 @@ export class DaffSearchPageResolver  {
     const query = getQuery(route);
     if (query) {
       this.store.dispatch(new DaffSearchLoad(query, this.builder(route)));
+
+      return isPlatformBrowser(this.platformId) ? of(true) : this.dispatcher.pipe(
+        ofType(
+          DaffSearchActionTypes.SearchLoadSuccessAction,
+          DaffSearchActionTypes.SearchLoadFailureAction,
+        ),
+        map(() => true),
+        take(1),
+      );
     }
 
-    return isPlatformBrowser(this.platformId) ? of(true) : this.dispatcher.pipe(
-      ofType(
-        DaffSearchActionTypes.SearchLoadSuccessAction,
-        DaffSearchActionTypes.SearchLoadFailureAction,
-      ),
-      map(() => true),
-      take(1),
-    );
+    return of(true);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In SSR when the search query is empty, the resolver will wait forever and the page will never load.

## What is the new behavior?
When the query is empty, the resolver will essentially do nothing and just proceed with navigation.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information