### PR TITLE
fix(external-router): extract daff paths ignoring full path

### DIFF
--- a/libs/external-router/src/util/extract-daff-path-data.spec.ts
+++ b/libs/external-router/src/util/extract-daff-path-data.spec.ts
@@ -1,0 +1,45 @@
+import { ActivatedRouteSnapshot } from '@angular/router';
+
+import { daffExtractDaffPathData } from './extract-daff-path-data';
+
+describe('@daffodil/external-router | daffExtractDaffPathData', () => {
+  let snapshot: ActivatedRouteSnapshot;
+
+  beforeEach(() => {
+    snapshot = <ActivatedRouteSnapshot><unknown>{
+      data: {
+        daffPaths: {
+          '00/01/02/10/11/12': {
+            test: 'test',
+          },
+        },
+      },
+      pathFromRoot: [
+        {
+          url: [],
+        },
+        {
+          url: [
+            { path: '00' },
+            { path: '01' },
+            { path: '02' },
+          ],
+        },
+        {
+          url: [
+            { path: '10' },
+            { path: '11' },
+            { path: '12' },
+          ],
+        },
+        {
+          url: [],
+        },
+      ],
+    };
+  });
+
+  it('should return the correct data', () => {
+    expect(daffExtractDaffPathData(snapshot, 'test')).toEqual('test');
+  });
+});

--- a/libs/external-router/src/util/extract-daff-path-data.ts
+++ b/libs/external-router/src/util/extract-daff-path-data.ts
@@ -8,6 +8,6 @@ import {
  * RouteSnapshot.
  */
 export const daffExtractDaffPathData = <T extends Data = Data, K extends keyof T = keyof T>(snapshot: ActivatedRouteSnapshot, key: K): T[K] => {
-  const pathFromRoot = snapshot.pathFromRoot[snapshot.pathFromRoot.length - 1].url.map((seg) => seg.path).join('/');
+  const pathFromRoot = snapshot.pathFromRoot.flatMap((route) => route.url).map((seg) => seg.path).join('/');
   return snapshot.data?.daffPaths?.[pathFromRoot]?.[key] ?? null;
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`daffExtractDaffPathData` ignores all routes in the path except the last, incorrectly building the path when the last route is an empty path route.

## What is the new behavior?
`daffExtractDaffPathData` computes the path from all routes in the path from root.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information