### PR TITLE
fix(dgeni): correctly prefix API doc link paths

### DIFF
--- a/tools/dgeni/src/transforms/daffodil-api-package/index.ts
+++ b/tools/dgeni/src/transforms/daffodil-api-package/index.ts
@@ -1,5 +1,10 @@
 import { Package } from 'dgeni';
 
+import {
+  DAFF_DOC_KIND_PATH_SEGMENT_MAP,
+  DaffDocKind,
+} from '@daffodil/docs-utils';
+
 import { DAFF_DGENI_EXCLUDED_PACKAGES_REGEX } from '../../constants/excluded-packages';
 import { AddInheritedDocsContentProcessor } from '../../processors/addInheritedDocsContent';
 import { AddLinkTagToDaffodilReferencesProcessor } from '../../processors/addLinkTagToDaffodilReferences';
@@ -19,7 +24,7 @@ import { daffodilBasePackage } from '../daffodil-base-package';
 const linksPackage = require('dgeni-packages/links');
 const typescriptPackage = require('dgeni-packages/typescript');
 
-export const apiDocs =  new Package('checkout', [
+export const apiDocs = new Package('daffodil-api', [
   daffodilBasePackage,
   typescriptPackage,
   linksPackage,
@@ -56,7 +61,7 @@ export const apiDocs =  new Package('checkout', [
   })
   .config((computePathsProcessor, EXPORT_DOC_TYPES, generateApiList) => {
 
-    const API_SEGMENT = 'api';
+    const API_SEGMENT = DAFF_DOC_KIND_PATH_SEGMENT_MAP[DaffDocKind.API];
 
     generateApiList.outputFolder = API_SEGMENT;
 
@@ -70,7 +75,7 @@ export const apiDocs =  new Package('checkout', [
     });
     computePathsProcessor.pathTemplates.push({
       docTypes: EXPORT_DOC_TYPES,
-      pathTemplate: '${moduleDoc.moduleFolder}/${name}',
+      pathTemplate: 'docs/${moduleDoc.moduleFolder}/${name}',
       outputPathTemplate: '${moduleDoc.moduleFolder}/${safeName}.json',
     });
   })

--- a/tools/dgeni/src/transforms/daffodil-base-package/index.ts
+++ b/tools/dgeni/src/transforms/daffodil-base-package/index.ts
@@ -33,6 +33,8 @@ export const daffodilBasePackage = new Package('daffodil-base', [
 
 // Where do we write the output files?
   .config((writeFilesProcessor) => {
+    // TODO: consider changing this to the parent so that the doc paths automatically include `docs/`
+    // we would avoid having to do things like https://github.com/graycoreio/daffodil/blob/db026e91c2e46b6ac895da86003f2f612800d917/tools/dgeni/src/transforms/daffodil-guides-package/processors/generateGuideList.ts#L15
     writeFilesProcessor.outputFolder = DOCS_OUTPUT_PATH;
   })
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Links in API doc descriptions (https://next.daff.io/docs/api/analytics/DaffAnalyticsModule) are broken, as they are missing the `docs/` prefix.

## What is the new behavior?
The prefix is added to API doc links.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I think we should change the way we compute paths so that we don't have to manually add `docs/` to match the routing organization of daffio.