### PR TITLE
feat(design): allow `aria-labelledby` to be set by the `DaffModalService`

### DIFF
--- a/libs/design/modal/README.md
+++ b/libs/design/modal/README.md
@@ -26,7 +26,20 @@ Buttons can be added to a modal by using `<daff-modal-actions>`. This container 
 A modal can be dismissed via the close button or the `ESC` key. The close button is shown by default but can be hidden by setting the `dismissible` property to `false` on `<daff-modal-header>`. Additionally, the `[daffModalClose]` directive can be added to a `<button>` HTML element.
 
 ## Accessibility
-Modal works with the ARIA `role="dialog"` and `aria-modal="true"` attributes to provide an accessible experience. `aria-labelledby` is assigned the `[daffModalTitle]` string. When a modal is opened, the first tabbable element within it will receive focus.
+Modal works with the ARIA `role="dialog"` and `aria-modal="true"` attributes to provide an accessible experience. The first tabbable element will receive focus when a modal is opened.
+
+`aria-labelledby` is assigned the `[daffModalTitle]` string when it's used. If there is no title, `aria-labelledby` should be set in the configurations through the `DaffModalService`.
+
+```ts
+constructor(private modalService: DaffModalService) {}
+
+showModal() {
+	this.modal = this.modalService.open(
+		BasicModalContentComponent,
+		{ ariaLabelledBy: 'Modal Title' },
+	);
+}
+```
 
 ### Keyboard Interactions
 A modal can be closed by choosing one of the actions buttons, the close button in the header, or it can be dismissed by pressing the `ESC` key.

--- a/libs/design/modal/examples/src/basic-modal/basic-modal.component.ts
+++ b/libs/design/modal/examples/src/basic-modal/basic-modal.component.ts
@@ -23,6 +23,9 @@ export class BasicModalComponent {
   constructor(private modalService: DaffModalService) {}
 
   showModal() {
-    this.modal = this.modalService.open(BasicModalContentComponent);
+    this.modal = this.modalService.open(
+      BasicModalContentComponent,
+      { ariaLabelledBy: 'Modal Title' },
+    );
   }
 }

--- a/libs/design/modal/src/modal/modal-config.ts
+++ b/libs/design/modal/src/modal/modal-config.ts
@@ -5,5 +5,6 @@ export interface DaffModalConfiguration {
    */
   onBackdropClicked?: () => void;
 
+  /** Sets the `aria-labelledby` property on the modal */
   ariaLabelledBy?: string;
 }

--- a/libs/design/modal/src/modal/modal-config.ts
+++ b/libs/design/modal/src/modal/modal-config.ts
@@ -4,4 +4,6 @@ export interface DaffModalConfiguration {
    * DaffModalComponent is interacted with.
    */
   onBackdropClicked?: () => void;
+
+  ariaLabelledBy?: string;
 }

--- a/libs/design/modal/src/service/modal.service.ts
+++ b/libs/design/modal/src/service/modal.service.ts
@@ -79,6 +79,10 @@ export class DaffModalService {
 	  const _modal = this._attachModal(_ref);
 	  const _attachedModal = this._attachModalContent(component, _modal);
 
+    if(configuration?.ariaLabelledBy) {
+      _modal.instance.ariaLabelledBy = configuration.ariaLabelledBy;
+    }
+
 	  const modal: DaffModal = {
 	    modal: _modal,
 	    overlay: _ref,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`aria-labelledby` is currently determined by the `daffModalTitle`. If a title is not set, there is no `aria-labelledby` on the modal.

Fixes: #2915


## What is the new behavior?
Provide option for user to set a custom `aria-labelledby` in the `DaffModalService`. If one is set by the title and a user sets it in the service, it will override what's set by the title.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information