### PR TITLE
fix(daffio): trailing slash missing from docs path

### DIFF
--- a/apps/daffio/src/app/core/assets/fetch/browser.service.spec.ts
+++ b/apps/daffio/src/app/core/assets/fetch/browser.service.spec.ts
@@ -31,7 +31,7 @@ describe('DaffioAssetFetchBrowserService', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('getApiList', () => {
+  describe('fetch', () => {
     it('should make a get request', () => {
       service.fetch('path').subscribe((docsList) => {
         expect(docsList).toEqual([]);
@@ -43,4 +43,16 @@ describe('DaffioAssetFetchBrowserService', () => {
       req.flush([]);
     });
   });
+
+  it('should remove double slashes', () => {
+    service.fetch('path//path').subscribe((docsList) => {
+      expect(docsList).toEqual([]);
+    });
+    const req = httpTestingController.expectOne('path/path');
+
+    expect(req.request.method).toEqual('GET');
+
+    req.flush([]);
+  });
+});
 });

--- a/apps/daffio/src/app/core/assets/fetch/browser.service.spec.ts
+++ b/apps/daffio/src/app/core/assets/fetch/browser.service.spec.ts
@@ -55,4 +55,3 @@ describe('DaffioAssetFetchBrowserService', () => {
     req.flush([]);
   });
 });
-});

--- a/apps/daffio/src/app/core/assets/fetch/browser.service.ts
+++ b/apps/daffio/src/app/core/assets/fetch/browser.service.ts
@@ -11,6 +11,6 @@ export class DaffioAssetFetchBrowserService implements DaffioAssetFetchServiceIn
   ) {}
 
   fetch<T = unknown>(path: string): Observable<T> {
-    return this.http.get<T>(path);
+    return this.http.get<T>(path.replaceAll('//', '/'));
   }
 }

--- a/apps/daffio/src/app/docs/services/docs.service.spec.ts
+++ b/apps/daffio/src/app/docs/services/docs.service.spec.ts
@@ -43,7 +43,7 @@ describe('DaffioDocsService', () => {
 
     service.get('docs/my/path').subscribe((apiDoc) => {
       expect(apiDoc).toEqual(doc);
-      expect(fetchAssetServiceSpy.fetch).toHaveBeenCalledWith('/assets/daffio/docs/my/path.json');
+      expect(fetchAssetServiceSpy.fetch).toHaveBeenCalledWith('/assets/daffio//docs/my/path.json');
       done();
     });
   });
@@ -53,7 +53,7 @@ describe('DaffioDocsService', () => {
 
     service.getPackageList().subscribe((guides) => {
       expect(guides).toEqual(mockGuideList);
-      expect(fetchAssetServiceSpy.fetch).toHaveBeenCalledWith('/assets/daffio/docs/packages/index.json');
+      expect(fetchAssetServiceSpy.fetch).toHaveBeenCalledWith('/assets/daffio//docs/packages/index.json');
       done();
     });
   });

--- a/apps/daffio/src/app/docs/services/docs.service.ts
+++ b/apps/daffio/src/app/docs/services/docs.service.ts
@@ -26,14 +26,14 @@ export class DaffioDocsService<T extends DaffioDoc = DaffioDoc, V extends Daffio
   ) {}
 
   get(path: string): Observable<T> {
-    return this.fetchAsset.fetch<T>(`${this.docsPath}${crossOsFilename(path)}.json`);
+    return this.fetchAsset.fetch<T>(`${this.docsPath}/${crossOsFilename(path)}.json`);
   }
 
   getPackageList(): Observable<V> {
-    return this.fetchAsset.fetch<V>(`${this.docsPath}docs/packages/index.json`);
+    return this.fetchAsset.fetch<V>(`${this.docsPath}/docs/packages/index.json`);
   }
 
   getGuidesList(): Observable<V> {
-    return this.fetchAsset.fetch<V>(`${this.docsPath}docs/guides/index.json`);
+    return this.fetchAsset.fetch<V>(`${this.docsPath}/docs/guides/index.json`);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is ambiguity in whether the docs path has a trailing `/`. A missing trailing slash will cause an exception.

## What is the new behavior?
The resolver always adds an extra `/` and removes any double slashes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information