### PR TITLE
refactor(core): specify function params in single token factory

### DIFF
--- a/libs/core/src/injection-tokens/single.factory.ts
+++ b/libs/core/src/injection-tokens/single.factory.ts
@@ -1,14 +1,21 @@
 import { InjectionToken } from '@angular/core';
 
 import { DaffSingleInjectionToken } from './single.type';
+import {
+  TokenDesc,
+  TokenOptions,
+} from './token-constuctor-params.type';
 
 /**
  * Creates an injection token/provider pair for a single valued DI token.
  *
  * See {@link DaffSingleInjectionToken}.
  */
-export const createSingleInjectionToken = <T = unknown>(...args: ConstructorParameters<typeof InjectionToken<T>>): DaffSingleInjectionToken<T> => {
-  const token = new InjectionToken<T>(...args);
+export const createSingleInjectionToken = <T = unknown>(
+  desc: TokenDesc<T>,
+  options?: TokenOptions<T>,
+): DaffSingleInjectionToken<T> => {
+  const token = new InjectionToken<T>(desc, options);
   const provider = <R extends T = T>(value: R) => ({
     provide: token,
     useValue: value,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
For reasons that I cannot figure out, the way this function is declared causes the API docsgen to pick up an `unknown` export: https://next.daff.io/docs/api/core/unknown

## What is the new behavior?
There is no longer an `unknown` API symbol

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information