### PR TITLE
feat(eslint-config): restrict `window` global access

### DIFF
--- a/libs/authorizenet/src/services/accept-js-loading.service.spec.ts
+++ b/libs/authorizenet/src/services/accept-js-loading.service.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 import { TestBed } from '@angular/core/testing';
 
 import { DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION } from '@daffodil/authorizenet';

--- a/libs/core/src/base64/server/server.service.spec.ts
+++ b/libs/core/src/base64/server/server.service.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 import {
   ɵPLATFORM_SERVER_ID,
   ɵPLATFORM_BROWSER_ID,

--- a/libs/paypal/routing/src/effects/express-redirect.effects.spec.ts
+++ b/libs/paypal/routing/src/effects/express-redirect.effects.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import {

--- a/libs/seo/integration-tests/state/provided-canonical-updates.spec.ts
+++ b/libs/seo/integration-tests/state/provided-canonical-updates.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 import { DOCUMENT } from '@angular/common';
 import {
   Injectable,

--- a/tools/eslint/config/index.js
+++ b/tools/eslint/config/index.js
@@ -324,5 +324,12 @@ module.exports = {
     'jasmine/no-suite-dupes': ['warn', 'branch'],
     'jasmine/no-spec-dupes': ['warn', 'branch'],
     'jasmine/new-line-before-expect': 'off',
+    "no-restricted-globals": [
+      "error",
+      {
+        "name": "window",
+        "message": "Inject `DOCUMENT` from `@angular/common` and access `window` via `document.defaultView`."
+      },
+    ]
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Its easy to write SSR unsafe code.

## What is the new behavior?
The linter throws if `window` is accessed via the global.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information