### PR TITLE
feat(dgeni): render interface and type inherited members

### DIFF
--- a/tools/dgeni/src/processors/addInheritedDocsContent.spec.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.spec.ts
@@ -8,9 +8,10 @@ describe('AddInheritedDocsContentProcessor', () => {
     stubInterfaceMemberDescription = 'some member description';
   });
 
-  it('should copy member descriptions from inherited docs', () => {
+  it('should copy member descriptions from inherited docs for class docs', () => {
     const docs = [
       {
+        docType: 'class',
         tags: {
           tags: [{
             tagName: 'inheritdoc',

--- a/tools/dgeni/src/processors/addInheritedDocsContent.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.ts
@@ -3,13 +3,13 @@ import {
   Document,
 } from 'dgeni';
 
-interface DocumentWithParents extends Document {
-  parents: Array<Document>;
+interface DocumentWithAncestors extends Document {
+  ancestors: Array<Document>;
 }
 
-const guardDocumentWithParents = (doc: Document | DocumentWithParents): doc is DocumentWithParents => {
-  if (!('parents' in doc)) {
-    doc.parents = [];
+const guardDocumentWithAncestors = (doc: Document | DocumentWithAncestors): doc is DocumentWithAncestors => {
+  if (!('ancestors' in doc)) {
+    doc.ancestors = [];
   }
 
   return true;
@@ -57,7 +57,7 @@ export class AddInheritedDocsContentProcessor implements Processor {
 
         case 'type':
         case 'interface':
-          if (guardDocumentWithParents(doc)) {
+          if (guardDocumentWithAncestors(doc)) {
             doc.extendsClauses.map(i => {
               if (!i.doc) {
                 return i;
@@ -70,7 +70,7 @@ export class AddInheritedDocsContentProcessor implements Processor {
                     : member.description;
                 } else {
                   if (i.doc) {
-                    doc.parents = getAncestors(doc);
+                    doc.ancestors = getAncestors(doc);
                   }
                 }
               });

--- a/tools/dgeni/src/processors/addInheritedDocsContent.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.ts
@@ -36,7 +36,7 @@ export class AddInheritedDocsContentProcessor implements Processor {
 	      return doc;
 	    }
 
-      doc.content = doc.content.replaceAll('@inheritdoc', '');
+      doc.content = doc.content?.replaceAll('@inheritdoc', '');
 
       switch (doc.docType) {
         case 'class':

--- a/tools/dgeni/src/processors/addInheritedDocsContent.ts
+++ b/tools/dgeni/src/processors/addInheritedDocsContent.ts
@@ -19,17 +19,21 @@ export class AddInheritedDocsContentProcessor implements Processor {
 	      return doc;
 	    }
 
-	    doc.implementsClauses.map(i => {
+      doc.content = doc.content.replaceAll('@inheritdoc', '');
+
+	    [...doc.implementsClauses, ...doc.extendsClauses].map(i => {
 	      if(!i.doc) {
 	        return i;
 	      }
 	      i.doc.members.map(member => {
 	        const matchedMember = doc.members.find(m => m.name === member.name);
 	        if(matchedMember) {
-	          matchedMember.description = matchedMember.description ?
-	            `${member.description} ${matchedMember.description}`:
-	            member.description;
-	        }
+	          matchedMember.description = matchedMember.description
+              ? `${member.description} ${matchedMember.description}`
+              : member.description;
+	        } else if (doc.docType === 'interface' || doc.docType === 'type') {
+            doc.members.push(member);
+          }
 	      });
 	    });
 

--- a/tools/dgeni/src/templates/api/class.template.html
+++ b/tools/dgeni/src/templates/api/class.template.html
@@ -10,6 +10,7 @@
 <span class="selectors__name"><code>{$ doc.decorators[0].argumentInfo[0].selector $}</code></span>
 {% endif %}
 
+{% if doc.members.length > 0 %}
 <h2>Properties</h2>
 <table>
   <thead>
@@ -23,4 +24,5 @@
     {$ member(doc.members[i]) $}
   {% endfor -%}
 </table>
+{% endif %}
 {% endblock %}

--- a/tools/dgeni/src/templates/api/interface.template.html
+++ b/tools/dgeni/src/templates/api/interface.template.html
@@ -10,7 +10,8 @@
 <span class="selectors__name"><code>{$ doc.decorators[0].argumentInfo[0].selector $}</code></span>
 {% endif %}
 
-<h2>Properties</h2>
+{% if doc.members.length > 0 %}
+<h2>Own Properties</h2>
 <table>
   <thead>
     <tr>
@@ -19,8 +20,28 @@
       <th>Description</th>
     </tr>
   </thead>
-  {%- for i in range(0, doc.members.length) %}
-    {$ member(doc.members[i]) $}
+  {%- for m in doc.members %}
+    {$ member(m) $}
   {% endfor -%}
 </table>
+{% endif %}
+
+{% if doc.parents.length > 0 -%}
+  <h2>Inherited Properties</h2>
+  {%- for parent in doc.parents -%}
+    <h3><code><a href="{$ parent.path $}">{$ parent.name $}</a></code></h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      {%- for m in parent.members -%}
+        {$ member(m) $}
+      {%- endfor -%}
+    </table>
+  {%- endfor -%}
+{% endif %}
 {% endblock %}

--- a/tools/dgeni/src/templates/api/interface.template.html
+++ b/tools/dgeni/src/templates/api/interface.template.html
@@ -26,10 +26,10 @@
 </table>
 {% endif %}
 
-{% if doc.parents.length > 0 -%}
+{% if doc.ancestors.length > 0 -%}
   <h2>Inherited Properties</h2>
-  {%- for parent in doc.parents -%}
-    <h3><code><a href="{$ parent.path $}">{$ parent.name $}</a></code></h3>
+  {%- for ancestor in doc.ancestors -%}
+    <h3><code><a href="{$ ancestor.path $}">{$ ancestor.name $}</a></code></h3>
     <table>
       <thead>
         <tr>
@@ -38,7 +38,7 @@
           <th>Description</th>
         </tr>
       </thead>
-      {%- for m in parent.members -%}
+      {%- for m in ancestor.members -%}
         {$ member(m) $}
       {%- endfor -%}
     </table>

--- a/tools/dgeni/src/templates/api/member.template.html
+++ b/tools/dgeni/src/templates/api/member.template.html
@@ -1,17 +1,17 @@
-{% if member.decorators[0].name === 'Input' %}
 <tbody>
-	<tr>
-		<td>@Input() {$ member.name $}</td>
-		<td>{$ member.type $}</td>
-		<td>{$ member.description $}</td>
-		{% elif member.decorators[0].name === 'Output' %}
-		<td>@Output() {$ member.name $}</td>
-		<td>{$ member.type $}</td>
-		<td>{$ member.description $}</td>
-		{% else %}
-		<td>{$ member.name $}</td>
-		<td>{$ member.type $}</td>
-		<td>{$ member.description $}</td>
+  <tr>
+    {% if member.decorators[0].name === 'Input' %}
+      <td>@Input() {$ member.name $}</td>
+      <td>{$ member.type $}</td>
+      <td>{$ member.description $}</td>
+    {% elif member.decorators[0].name === 'Output' %}
+      <td>@Output() {$ member.name $}</td>
+      <td>{$ member.type $}</td>
+      <td>{$ member.description $}</td>
+    {% else %}
+      <td>{$ member.name $}</td>
+      <td>{$ member.type $}</td>
+      <td>{$ member.description $}</td>
+    {% endif %}
 	</tr>
 </tbody>
-{% endif %}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #3048

## What is the new behavior?
- types and interfaces get full list of ancestors set on doc
- all ancestors get rendered for types and interfaces

an example of what this looks like (once `@inheritdoc` is added):
![image](https://github.com/user-attachments/assets/5c753f6c-98c0-48c8-ba8c-d0072b2ffa8e)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information