### PR TITLE
fix(core): allow shuffle to return first element in first index

### DIFF
--- a/libs/core/src/utils/shuffle.spec.ts
+++ b/libs/core/src/utils/shuffle.spec.ts
@@ -11,4 +11,16 @@ describe('Core | Utils | shuffle', () => {
     });
     expect(initialArray).not.toEqual(result);
   });
+
+  it('should return array containing the same single element if input contains one element', () => {
+    const initialArray = [1];
+    const result = shuffle(initialArray);
+    expect(initialArray).toEqual(result);
+  });
+
+  it('should return an empty array if input is an empty array', () => {
+    const initialArray = [];
+    const result = shuffle(initialArray);
+    expect(initialArray).toEqual(result);
+  });
 });

--- a/libs/core/src/utils/shuffle.ts
+++ b/libs/core/src/utils/shuffle.ts
@@ -5,7 +5,7 @@
 export const shuffle = <T>(array: T[]): T[] => {
   const result = [];
   array.forEach((el, i) => {
-    const s = Math.floor(Math.random() * i);
+    const s = Math.floor(Math.random() * (i + 1));
     if( s !== i ){
       result[i] = result[s];
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
``randomSubset`` with length 1 never returns the first element. This is because ``shuffle`` makes it impossible for the first element of the shuffled array to be the same as the first element of the original array, and ``randomSubset`` slices the shuffled array up to ``length`` to return the subset.

Fixes: #1780


## What is the new behavior?

``shuffle`` can now potentially return an array with the first element being the first element of the original array, so calling ``randomSubset`` with length 1 can return the first element.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information