### PR TITLE
fix(driver): allow undefined extensions key in Magento graphql responses

### DIFF
--- a/libs/driver/magento/src/errors/transform-graphql.spec.ts
+++ b/libs/driver/magento/src/errors/transform-graphql.spec.ts
@@ -1,5 +1,3 @@
-import { ApolloError } from '@apollo/client/core';
-
 import {
   DaffError,
   DaffErrorCodeMap,
@@ -60,6 +58,12 @@ describe('@daffodil/driver/magento | daffMagentoTransformGraphQlError', () => {
   });
 
   it('should not crash if the extension is not defined', () => {
+    const { extensions, ...error } = unhandledGraphQlError;
+    expect(() => daffMagentoTransformGraphQlError(error, map)).not.toThrow();
+    expect(daffMagentoTransformGraphQlError(error, map)).toEqual(new DaffDriverMagentoError('An error we don\'t handle'));
+  });
+
+  it('should not crash if there are no extensions defined', () => {
     const error = { ...unhandledGraphQlError, extensions: {}};
     expect(() => daffMagentoTransformGraphQlError(error, map)).not.toThrow();
   });

--- a/libs/driver/magento/src/errors/transform-graphql.ts
+++ b/libs/driver/magento/src/errors/transform-graphql.ts
@@ -11,7 +11,7 @@ export function daffMagentoTransformGraphQlError<T extends DaffErrorCodeMap>(
   error: GraphQLError,
   map: T,
 ): DaffError {
-  const ErrorClass = map[error.extensions.category] || DaffDriverMagentoError;
+  const ErrorClass = map[error?.extensions?.category] || DaffDriverMagentoError;
 
   return new ErrorClass(error.message) ;
 };


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Once you upgrade to v2.4.6 you will see errors like `Cannot read properties of undefined (reading 'category')` when Magento throws certain kinds of error.

Fixes: N/A


## What is the new behavior?
In Magento versions that support GraphQl prior to v2.4.6 there was a key errors called "extensions" that contained an error code indicating what kind of error you received. For whatever reason, in v2.4.6 they removed this. This PR allows this `extensions` key to not exist when it used to always exist.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information