### PR TITLE
fix(design): update the property used to set a default alignment on callout

### DIFF
--- a/libs/design/callout/src/callout/callout.component.ts
+++ b/libs/design/callout/src/callout/callout.component.ts
@@ -43,7 +43,7 @@ import {
 })
 export class DaffCalloutComponent {
   constructor(private textAlignable: DaffTextAlignableDirective) {
-    this.textAlignable.textAlignment = 'left';
+    this.textAlignable.defaultAlignment = 'left';
   }
 
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`textAlignment` is used to set a "default" on callout. `defaultAlignment` is the correct property to use, otherwise text alignment will always be what's set in the callout.

Fixes: #3117 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information