### PR TITLE
refactor(design): remove leading combinator from sidebar viewport styles

### DIFF
--- a/libs/design/sidebar/src/sidebar-viewport/sidebar-viewport.component.scss
+++ b/libs/design/sidebar/src/sidebar-viewport/sidebar-viewport.component.scss
@@ -18,7 +18,7 @@
 			}
 		}
 		
-		+ &.beside {
+		&.beside {
 			.daff-sidebar-viewport__nav {
 				padding-left: 0;
 	
@@ -38,7 +38,7 @@
 			}
 		}
 
-		+ &.beside {
+		&.beside {
 			.daff-sidebar-viewport__nav {
 				padding-right: 0;
 	


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
sidebar viewport styles are currently using invalid combinators that will cause browsers to ignore the style rules.

`+ &.beside {`: the `+` leading combinator is not allowed anymore.

Fixes: #3114

## What is the new behavior?
Remove leading combinator. Style still works as intended.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information