### PR TITLE
feat(design): configure defaults for status themes and add a new function that can be used to customize it

### DIFF
--- a/libs/design/scss/theming/_configure-theme.scss
+++ b/libs/design/scss/theming/_configure-theme.scss
@@ -26,13 +26,20 @@ $supported-theme-types: (
 	'dark': $daff-dark-theme
 );
 
+
 // @docs
 //
-// Create a theme object given some initial settings
+// Create a theme object given some initial settings.
+// Sets light and dark mode defaults for `$info`, `$warn`, `$critical`, and `$success`
+// that can be overriden by using the `daff-configure-theme-status` function.
 //
 // @usage
 // ```
-// daff-configure-theme($daff-yellow, $daff-blue, $daff-purple)
+// $primary: configure-palette.daff-configure-palette(palette.$daff-blue, 60);
+// $secondary: configure-palette.daff-configure-palette(palette.$daff-purple, 60);
+// $tertiary: configure-palette.daff-configure-palette(palette.$daff-turquoise, 60);
+// 
+// $theme: daff-configure-theme($primary, $secondary, $tertiary)
 // ```
 @function daff-configure-theme(
 	$primary,
@@ -40,12 +47,63 @@ $supported-theme-types: (
 	$tertiary,
 	$type: 'light'
 ) {
+	$info: null;
+	$warn: null;
+	$critical: null;
+	$success: null;
+
+	@if($type == 'dark') {
+		$info: configure-palette.daff-configure-palette(palette.$daff-neutral, 50);
+		$warn: configure-palette.daff-configure-palette(palette.$daff-bronze, 50);
+		$critical: configure-palette.daff-configure-palette(palette.$daff-red, 50);
+		$success: configure-palette.daff-configure-palette(palette.$daff-green, 50);
+	}
+	@if($type == 'light') {
+		$info: configure-palette.daff-configure-palette(palette.$daff-neutral, 60);
+		$warn: configure-palette.daff-configure-palette(palette.$daff-bronze, 60);
+		$critical: configure-palette.daff-configure-palette(palette.$daff-red, 60);
+		$success: configure-palette.daff-configure-palette(palette.$daff-green, 60);
+	}
+
 	@return (
 		'primary': $primary,
 		'secondary': $secondary,
 		'tertiary': $tertiary,
+		'informational': $info,
+		'warn':  $warn,
+		'critical': $critical,
+		'success': $success,
 		'core': daff-build-theme-core($type)
 	);
+}
+
+// @docs
+//
+// Create a status theme object given some initial settings.
+//
+// @usage
+// ```
+// $info: configure-palette.daff-configure-palette(palette.$daff-blue, 60);
+// $warn: configure-palette.daff-configure-palette(palette.$daff-bronze, 60);
+// $critical: configure-palette.daff-configure-palette(palette.$daff-red, 60);
+// $success: configure-palette.daff-configure-palette(palette.$daff-green, 60);
+// 
+// $theme: daff-configure-theme-status($info, $warn, $critical, $success);
+// ```
+@function daff-configure-theme-status(
+	$theme,
+	$warn,
+	$critical,
+	$success,
+	$info,
+) {
+	@debug $theme;
+	@return map.merge($theme, (
+		'warn':  $warn,
+		'critical': $critical,
+		'success': $success,
+		'informational': $info,
+	));
 }
 
 //


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Statusable components are currently directly referencing palettes to set the colors. This causes issues for theme switching as well as inconsistencies in color for statuses. 

Fixes: #3287 


## What is the new behavior?
Added status defaults to `daff-configure-theme` and created a new function called `daff-configure-theme-status` for users to customize their own status themes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information