### PR TITLE
fix(router): old route data is replayed for new routes

### DIFF
--- a/libs/router/src/activated-route/service.spec.ts
+++ b/libs/router/src/activated-route/service.spec.ts
@@ -4,6 +4,7 @@ import {
   provideRouter,
   Router,
 } from '@angular/router';
+import { tap } from 'rxjs';
 
 import { DaffRouterActivatedRoute } from './service';
 
@@ -36,6 +37,13 @@ describe('@daffodil/router | DaffRouterActivatedRoute', () => {
                   },
                 ],
               },
+              {
+                path: 'other',
+                data: {
+                  test: 'other',
+                },
+                component: TestComponent,
+              },
             ],
           },
         ]),
@@ -57,5 +65,20 @@ describe('@daffodil/router | DaffRouterActivatedRoute', () => {
       done();
     });
     router.initialNavigation();
+  });
+
+  it('should only emit the last value when the stream is subscribed to late', async (done) => {
+    const spy = jasmine.createSpy();
+    service.route$.subscribe();
+    router.initialNavigation();
+    await router.navigateByUrl('/');
+    await router.navigateByUrl('/other');
+    service.route$.pipe(
+      tap(spy),
+    ).subscribe((route) => {
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(route.snapshot.data['test']).toEqual('other');
+      done();
+    });
   });
 });

--- a/libs/router/src/activated-route/service.ts
+++ b/libs/router/src/activated-route/service.ts
@@ -26,7 +26,7 @@ const getActivatedRoute = (routerState: RouterState): ActivatedRoute => {
  *
  * Note that this service operates by listening to router events. It is therefore recommended to
  * inject this service in the root and subscribe to `route$` on app init so that all routing events are captured.
- * The consumer can then subscribe at any later time (after all navigations) and the emission stream will be replayed.
+ * The consumer can then subscribe at any later time (after all navigations) and the last emitted value will be replayed.
  * {@link provideDaffRouterActivatedRoute} is the recommended way to do this.
  */
 @Injectable({
@@ -36,7 +36,7 @@ export class DaffRouterActivatedRoute {
   route$: Observable<ActivatedRoute> = this.router.events.pipe(
     filter((event) => event instanceof NavigationEnd),
     map(() => getActivatedRoute(this.router.routerState)),
-    shareReplay(),
+    shareReplay(1),
   );
 
   constructor(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The route service replays the entire emission stream, giving components on new routes old and incorrect data. This is also likely a performance issue.

fixes: #3347 

## What is the new behavior?
Only the last value is replayed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information