### PR TITLE
fix(design-land): add missing provideDaffToast provider in root

### DIFF
--- a/apps/design-land/src/app/app.module.ts
+++ b/apps/design-land/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { DaffButtonModule } from '@daffodil/design/button';
 import { DaffLinkSetModule } from '@daffodil/design/link-set';
 import { DaffNavbarModule } from '@daffodil/design/navbar';
 import { DaffSidebarModule } from '@daffodil/design/sidebar';
+import { provideDaffToast } from '@daffodil/design/toast';
 import { DaffThemeSwitchButtonModule } from '@daffodil/theme-switch';
 
 import { DesignLandAppRoutingModule } from './app-routing.module';
@@ -46,6 +47,7 @@ import { DesignLandSwitchModule } from './switch/switch.module';
   providers: [
     DAFF_THEME_INITIALIZER,
     provideHttpClient(withInterceptorsFromDi()),
+    provideDaffToast(),
   ],
 })
 export class AppModule { }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Error in console on the toast page of design-land because it's missing the `daffProvideToast` provider that was removed in #3143 

Fixes: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information