### PR TITLE
feat(docs-utils,dgeni): pull examples out of content and store in doc

### DIFF
--- a/libs/docs-utils/src/doc/api.type.ts
+++ b/libs/docs-utils/src/doc/api.type.ts
@@ -1,3 +1,4 @@
+import { DaffDocExample } from './example.type';
 import { DaffDoc } from './type';
 
 /**
@@ -5,4 +6,5 @@ import { DaffDoc } from './type';
  */
 export interface DaffApiDoc extends DaffDoc {
   docType: string;
+  example: Array<DaffDocExample>;
 }

--- a/libs/docs-utils/src/doc/api.type.ts
+++ b/libs/docs-utils/src/doc/api.type.ts
@@ -6,5 +6,5 @@ import { DaffDoc } from './type';
  */
 export interface DaffApiDoc extends DaffDoc {
   docType: string;
-  example: Array<DaffDocExample>;
+  examples: Array<DaffDocExample>;
 }

--- a/libs/docs-utils/src/doc/example.type.ts
+++ b/libs/docs-utils/src/doc/example.type.ts
@@ -1,0 +1,15 @@
+/**
+ * A usage example.
+ */
+export interface DaffDocExample {
+  /**
+   * The short caption describing the example.
+   * This should be just plain text.
+   */
+  caption: string;
+  /**
+   * The body of the example.
+   * Can be HTML and should be rendered as such.
+   */
+  body: string;
+}

--- a/libs/docs-utils/src/doc/public_api.ts
+++ b/libs/docs-utils/src/doc/public_api.ts
@@ -1,3 +1,4 @@
 export * from './api.type';
+export * from './example.type';
 export * from './guide.type';
 export * from './type';

--- a/tools/dgeni/src/processors/markdown.ts
+++ b/tools/dgeni/src/processors/markdown.ts
@@ -10,6 +10,7 @@ import { Marked } from 'marked';
 import { markedHighlight } from 'marked-highlight';
 
 import {
+  DaffDocExample,
   DaffDocKind,
   daffDocsGetLinkUrl,
 } from '@daffodil/docs-utils';
@@ -80,9 +81,15 @@ export class MarkdownCodeProcessor implements FilterableProcessor {
   $process(docs: Document[]) {
     const ret = docs.map((doc) => {
       if (this.docTypes.includes(doc.docType)) {
-        doc[this.contentKey] = this.marked.parse(doc.content);
+        doc[this.contentKey] = this.marked.parse(typeof doc.description === 'undefined' ? doc.content : doc.description);
         if (doc.kind === DaffDocKind.PACKAGE || doc.kind === DaffDocKind.COMPONENT) {
           doc.description = this.docDescription;
+        }
+        if (doc.examples) {
+          doc.examples = (<Array<DaffDocExample>>doc.examples).map((example) => ({
+            ...example,
+            body: this.marked.parse(example.body),
+          }));
         }
         this.docDescription = null;
       };

--- a/tools/dgeni/src/transforms/daffodil-api-package/processors/examples.ts
+++ b/tools/dgeni/src/transforms/daffodil-api-package/processors/examples.ts
@@ -1,0 +1,36 @@
+import { Document } from 'dgeni';
+
+import { DaffDocExample } from '@daffodil/docs-utils';
+
+import { MARKDOWN_CODE_PROCESSOR_NAME } from '../../../processors/markdown';
+import { FilterableProcessor } from '../../../utils/filterable-processor.type';
+
+export const EXAMPLES_PROCESSOR_NAME = 'examples';
+
+/**
+ * Adds subpackage entry point docs to the containing package doc.
+ */
+export class ExamplesProcessor implements FilterableProcessor {
+  readonly name = EXAMPLES_PROCESSOR_NAME;
+  readonly $runAfter = ['docs-processed'];
+  readonly $runBefore = ['rendering-docs', MARKDOWN_CODE_PROCESSOR_NAME];
+
+  docTypes = [];
+
+  $process(docs: Array<Document>): Array<Document> {
+    return docs.map((doc) => {
+      if (this.docTypes.includes(doc.docType)) {
+        doc.examples = doc.tags.tagsByName.get('example')?.map((example): DaffDocExample => ({
+          caption: example.caption,
+          body: example.body,
+        })) || [];
+      }
+      return doc;
+    });
+  }
+}
+
+export const EXAMPLES_PROCESSOR_PROVIDER = <const>[
+  EXAMPLES_PROCESSOR_NAME,
+  () => new ExamplesProcessor(),
+];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #3388 


## What is the new behavior?
- Transforms example content and stores it on the doc object
- Main doc content excludes tagged content (like `@deprecated`)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information