### PR TITLE
feat(dgeni,docs-utils)!: extract out ToC type

### DIFF
--- a/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.html
+++ b/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.html
@@ -31,7 +31,7 @@
   @if (isGuideDoc) {
     <daffio-docs-table-of-contents
       class="daffio-doc-viewer__table-of-contents"
-      [tableOfContents]="doc.tableOfContents.json">
+      [tableOfContents]="doc.tableOfContents">
     </daffio-docs-table-of-contents>
   }
 </div>

--- a/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents.component.spec.ts
+++ b/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents.component.spec.ts
@@ -32,7 +32,7 @@ describe('DaffioDocsTableOfContentsComponent', () => {
     fixture = TestBed.createComponent(DaffioDocsTableOfContentsComponent);
     component = fixture.componentInstance;
     stubDaffioDoc = new DaffioDocsFactory().create();
-    component.tableOfContents = stubDaffioDoc.tableOfContents.json;
+    component.tableOfContents = stubDaffioDoc.tableOfContents;
     fixture.detectChanges();
   });
 
@@ -42,15 +42,15 @@ describe('DaffioDocsTableOfContentsComponent', () => {
 
   it('should render a .daffio-docs-table-of-contents__item for each entry in the table of contents', () => {
     const tocItems = fixture.debugElement.queryAll(By.css('.daffio-docs-table-of-contents__item'));
-    expect(tocItems.length).toEqual(stubDaffioDoc.tableOfContents.json.length);
+    expect(tocItems.length).toEqual(stubDaffioDoc.tableOfContents.length);
   });
 
   it('should label each item with an indent level based on its toc level', () => {
     const tocLevel1 = fixture.debugElement.queryAll(By.css('.daffio-docs-table-of-contents__item--level-1'));
     const tocLevel2 = fixture.debugElement.queryAll(By.css('.daffio-docs-table-of-contents__item--level-2'));
     const tocLevel3 = fixture.debugElement.queryAll(By.css('.daffio-docs-table-of-contents__item--level-3'));
-    expect(tocLevel1.length).toEqual(stubDaffioDoc.tableOfContents.json.filter(content => content.lvl === 1).length);
-    expect(tocLevel2.length).toEqual(stubDaffioDoc.tableOfContents.json.filter(content => content.lvl === 2).length);
-    expect(tocLevel3.length).toEqual(stubDaffioDoc.tableOfContents.json.filter(content => content.lvl === 3).length);
+    expect(tocLevel1.length).toEqual(stubDaffioDoc.tableOfContents.filter(content => content.lvl === 1).length);
+    expect(tocLevel2.length).toEqual(stubDaffioDoc.tableOfContents.filter(content => content.lvl === 2).length);
+    expect(tocLevel3.length).toEqual(stubDaffioDoc.tableOfContents.filter(content => content.lvl === 3).length);
   });
 });

--- a/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents.component.ts
+++ b/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents.component.ts
@@ -4,7 +4,7 @@ import {
   Input,
 } from '@angular/core';
 
-import { DaffGuideDoc } from '@daffodil/docs-utils';
+import { DaffDocTableOfContents } from '@daffodil/docs-utils';
 
 @Component({
   selector: 'daffio-docs-table-of-contents',
@@ -16,5 +16,5 @@ export class DaffioDocsTableOfContentsComponent {
   /**
    * The doc to render
    */
-  @Input() tableOfContents: DaffGuideDoc['tableOfContents']['json'];
+  @Input() tableOfContents: DaffDocTableOfContents;
 }

--- a/apps/daffio/src/app/docs/testing/factories/docs.factory.spec.ts
+++ b/apps/daffio/src/app/docs/testing/factories/docs.factory.spec.ts
@@ -17,8 +17,8 @@ describe('DaffioDocsFactory', () => {
     expect(Object.keys(doc)).toContain('id');
     expect(Object.keys(doc)).toContain('title');
     expect(Object.keys(doc)).toContain('contents');
-    expect(Object.keys(doc.tableOfContents.json[0])).toContain('content');
-    expect(Object.keys(doc.tableOfContents.json[0])).toContain('lvl');
-    expect(Object.keys(doc.tableOfContents.json[0])).toContain('slug');
+    expect(Object.keys(doc.tableOfContents[0])).toContain('content');
+    expect(Object.keys(doc.tableOfContents[0])).toContain('lvl');
+    expect(Object.keys(doc.tableOfContents[0])).toContain('slug');
   });
 });

--- a/apps/daffio/src/app/docs/testing/factories/docs.factory.ts
+++ b/apps/daffio/src/app/docs/testing/factories/docs.factory.ts
@@ -10,15 +10,13 @@ export class MockDoc implements DaffGuideDoc {
   contents = faker.lorem.paragraph();
   // TODO: implement child models
   breadcrumbs = [];
-  tableOfContents = {
-    json: [
-      {
-        content: faker.lorem.paragraph(),
-        lvl: faker.datatype.number(),
-        slug: faker.random.alphaNumeric(),
-      },
-    ],
-  };
+  tableOfContents = [
+    {
+      content: faker.lorem.paragraph(),
+      lvl: faker.datatype.number(),
+      slug: faker.random.alphaNumeric(),
+    },
+  ];
 };
 
 @Injectable({

--- a/libs/docs-utils/src/doc/guide.type.ts
+++ b/libs/docs-utils/src/doc/guide.type.ts
@@ -1,14 +1,9 @@
+import { DaffDocTableOfContents } from './toc.type';
 import { DaffDoc } from './type';
 
 /**
  * A guide doc. Includes a table of contents.
  */
 export interface DaffGuideDoc extends DaffDoc {
-  tableOfContents: {
-    json: Array<{
-      content: string;
-      lvl: number;
-      slug: string;
-    }>;
-  };
+  tableOfContents: DaffDocTableOfContents;
 }

--- a/libs/docs-utils/src/doc/public_api.ts
+++ b/libs/docs-utils/src/doc/public_api.ts
@@ -1,4 +1,5 @@
 export * from './api.type';
 export * from './example.type';
 export * from './guide.type';
+export * from './toc.type';
 export * from './type';

--- a/libs/docs-utils/src/doc/toc.type.ts
+++ b/libs/docs-utils/src/doc/toc.type.ts
@@ -1,0 +1,7 @@
+export interface DaffDocTableOfContentsEntry {
+  content: string;
+  lvl: number;
+  slug: string;
+}
+
+export type DaffDocTableOfContents = Array<DaffDocTableOfContentsEntry>;

--- a/tools/dgeni/src/transforms/daffodil-guides-package/reader/guide-file.reader.ts
+++ b/tools/dgeni/src/transforms/daffodil-guides-package/reader/guide-file.reader.ts
@@ -35,7 +35,7 @@ export function guideFileReaderFactory() {
     getDocs: (fileInfo) => fileInfo.content ? [{
       docType: 'guide',
       title: extractTitle(fileInfo),
-      tableOfContents: toc(fileInfo.content),
+      tableOfContents: toc(fileInfo.content).json,
       content: fileInfo.content,
     }] : [],
   };


### PR DESCRIPTION
BREAKING CHANGE: the ToC types have been trimmed up to only have fields used

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```


## What is the new behavior?
- extract ToC into its own type
- remove an unnecessary nesting of ToC data
- remove a *lot* of unused data from JSON documents

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
`DaffGuideDoc.tableOfContents` has a different type, the `json` nesting has been removed.

## Other information