### PR TITLE
feat(dgeni,docs-utils): store API docs and symbols on package guides

### DIFF
--- a/libs/docs-utils/src/doc/package-guide.type.ts
+++ b/libs/docs-utils/src/doc/package-guide.type.ts
@@ -1,0 +1,17 @@
+import { DaffApiDoc } from '@daffodil/docs-utils';
+
+import { DaffGuideDoc } from './guide.type';
+
+/**
+ * A guide doc for a package.
+ */
+export interface DaffPackageGuideDoc extends DaffGuideDoc {
+  /**
+   * A list of symbol paths exported from the package.
+   */
+  symbols?: Array<string>;
+  /**
+   * A list of API docs for symbols exported from this package.
+   */
+  api?: Array<DaffApiDoc>;
+}

--- a/libs/docs-utils/src/doc/public_api.ts
+++ b/libs/docs-utils/src/doc/public_api.ts
@@ -1,5 +1,6 @@
 export * from './api.type';
 export * from './example.type';
 export * from './guide.type';
+export * from './package-guide.type';
 export * from './toc.type';
 export * from './type';

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "@types/jasmine": "~3.6.0",
         "@types/jasminewd2": "~2.0.8",
         "@types/node": "^20.17.0",
+        "@types/nunjucks": "^3.2.6",
         "@types/through2": "^2.0.41",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
@@ -8657,6 +8658,13 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
+    },
+    "node_modules/@types/nunjucks": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
+      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/picomatch": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.8",
     "@types/node": "^20.17.0",
+    "@types/nunjucks": "^3.2.6",
     "@types/through2": "^2.0.41",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",

--- a/tools/dgeni/src/processors/add-api-symbols-to-package.ts
+++ b/tools/dgeni/src/processors/add-api-symbols-to-package.ts
@@ -1,0 +1,47 @@
+import { Document } from 'dgeni';
+import type { Environment } from 'nunjucks';
+
+import { CollectLinkableSymbolsProcessor } from './collect-linkable-symbols';
+import { API_TEMPLATES_PATH } from '../transforms/config';
+import { FilterableProcessor } from '../utils/filterable-processor.type';
+
+export const ADD_API_SYMBOLS_TO_PACKAGES_PROCESSOR_NAME = 'addApiSymbolsToPackages';
+
+export class AddApiSymbolsToPackagesProcessor implements FilterableProcessor {
+  readonly name = ADD_API_SYMBOLS_TO_PACKAGES_PROCESSOR_NAME;
+  readonly $runAfter = ['paths-absolutified'];
+  readonly $runBefore = ['rendering-docs'];
+
+  docTypes = [];
+  lookup = (doc: Document) => doc.id;
+
+  constructor(
+    private templateEngine,
+    private templateFinder,
+  ) {}
+
+  $process(docs: Array<Document>): Array<Document> {
+    const templates = this.templateFinder.templateFolders;
+    this.templateFinder.templateFolders = [
+      API_TEMPLATES_PATH,
+      ...templates,
+    ];
+    const render: Environment['render'] = this.templateEngine.getRenderer();
+
+    const ret = docs.map(doc => {
+      if (this.docTypes.includes(doc.docType)) {
+        doc.symbols = CollectLinkableSymbolsProcessor.packages.get(this.lookup(doc))?.map((d) => d.path);
+        doc.api = CollectLinkableSymbolsProcessor.packages.get(this.lookup(doc))?.map((symbol) => render(this.templateFinder.getFinder()(symbol), { doc: symbol, child: true }));
+      }
+      return doc;
+    });
+
+    this.templateFinder.templateFolders = templates;
+    return ret;
+  }
+};
+
+export const ADD_API_SYMBOLS_TO_PACKAGES_PROCESSOR_PROVIDER = <const>[
+  ADD_API_SYMBOLS_TO_PACKAGES_PROCESSOR_NAME,
+  (templateEngine, templateFinder) => new AddApiSymbolsToPackagesProcessor(templateEngine, templateFinder),
+];

--- a/tools/dgeni/src/processors/collect-linkable-symbols.ts
+++ b/tools/dgeni/src/processors/collect-linkable-symbols.ts
@@ -10,9 +10,14 @@ export const COLLECT_LINKABLE_SYMBOLS_PROCESSOR_NAME = 'collectLinkableSymbols';
  */
 export class CollectLinkableSymbolsProcessor implements Processor {
   private static readonly _symbols = new Map<string, string>();
+  private static readonly _packages = new Map<string, Array<string>>();
 
   public static get symbols(): ReadonlyMap<string, string> {
     return this._symbols;
+  }
+
+  public static get packages(): ReadonlyMap<string, Array<Document>> {
+    return this._packages;
   }
 
   name = COLLECT_LINKABLE_SYMBOLS_PROCESSOR_NAME;
@@ -27,6 +32,13 @@ export class CollectLinkableSymbolsProcessor implements Processor {
         this.log.warn(this.createDocMessage(`Linkable symbol collision for name ${doc.name}. Existing path: ${CollectLinkableSymbolsProcessor._symbols.get(doc.name)}, new path: ${doc.path}`));
       }
       CollectLinkableSymbolsProcessor._symbols.set(doc.name, doc.path);
+      if (doc.docType !== 'package') {
+        const packageName = doc.id.match(/(.*)\/src/)[1];
+        if (!CollectLinkableSymbolsProcessor._packages.get(packageName)) {
+          CollectLinkableSymbolsProcessor._packages.set(packageName, []);
+        }
+        CollectLinkableSymbolsProcessor._packages.get(packageName).push(doc);
+      }
     });
 
     return docs;

--- a/tools/dgeni/src/templates/api/base.template.html
+++ b/tools/dgeni/src/templates/api/base.template.html
@@ -1,5 +1,5 @@
 {% block header %}
-<h1>{$ doc.name $}</h1>
+{$'<h3>' if child else '<h1>'$}{$ doc.name $}{$'</h3>' if child else '</h1>'$}
 {% endblock %}
 <p>{$ doc.description $}</p>
 

--- a/tools/dgeni/src/templates/api/class.template.html
+++ b/tools/dgeni/src/templates/api/class.template.html
@@ -10,7 +10,7 @@
 <span class="selectors__name"><code>{$ doc.decorators[0].argumentInfo[0].selector $}</code></span>
 {% endif %}
 
-<h2>Properties</h2>
+{$'<h4>' if child else '<h2>'$}Properties{$'<h4>' if child else '<h2>'$}
 <table>
   <thead>
     <tr>

--- a/tools/dgeni/src/transforms/daffodil-guides-package/index.ts
+++ b/tools/dgeni/src/transforms/daffodil-guides-package/index.ts
@@ -18,6 +18,10 @@ import {
 } from './reader/guide-file.reader';
 import { DAFF_DGENI_EXCLUDED_PACKAGES_REGEX } from '../../constants/excluded-packages';
 import { AbsolutifyPathsProcessor } from '../../processors/absolutify-paths';
+import {
+  ADD_API_SYMBOLS_TO_PACKAGES_PROCESSOR_PROVIDER,
+  AddApiSymbolsToPackagesProcessor,
+} from '../../processors/add-api-symbols-to-package';
 import { AddKindProcessor } from '../../processors/add-kind';
 import { BreadcrumbProcessor } from '../../processors/breadcrumb';
 import { ConvertToJsonProcessor } from '../../processors/convertToJson';
@@ -80,6 +84,9 @@ const base = new Package('daffodil-guides-base', [daffodilBasePackage])
   })
   .config((generateNavList: GenerateNavListProcessor) => {
     generateNavList.transform = (docs) => generateNavigationTrieFromDocuments(docs.map(transformGuideDoc), { id: '', title: '', path: '' });
+  })
+  .config((convertToJson: ConvertToJsonProcessor) => {
+    convertToJson.extraFields.push('api');
   });
 
 // global
@@ -123,6 +130,7 @@ const design = new Package('design-base', [base])
 export const designDocsPackage = new Package('design-docs', [design])
   .processor(...GENERATE_NAV_LIST_PROCESSOR_PROVIDER)
   .processor(...FILTER_NAV_INDEX_PROCESSOR_PROVIDER)
+  .processor(...ADD_API_SYMBOLS_TO_PACKAGES_PROCESSOR_PROVIDER)
   .config((generateNavList: GenerateNavListProcessor) => {
     generateNavList.outputFolder = `${DAFF_DOCS_PATH}/${DAFF_DOCS_DESIGN_PATH}`;
   })
@@ -143,6 +151,10 @@ export const designDocsPackage = new Package('design-docs', [design])
       getAliases: (doc) => [doc.id],
     });
   })
+  .config((addApiSymbolsToPackages: AddApiSymbolsToPackagesProcessor) => {
+    addApiSymbolsToPackages.docTypes.push('package-guide');
+    addApiSymbolsToPackages.lookup = (doc) => doc.id.replace('components/', '');
+  })
   .config((readFilesProcessor) => {
     readFilesProcessor.basePath = DESIGN_PATH;
     readFilesProcessor.sourceFiles = [
@@ -150,7 +162,7 @@ export const designDocsPackage = new Package('design-docs', [design])
     ];
   })
   .config((convertToJson: ConvertToJsonProcessor) => {
-    convertToJson.extraFields.push('description');
+    convertToJson.extraFields.push('description', 'symbols');
   })
   .config((absolutifyPaths: AbsolutifyPathsProcessor) => {
     absolutifyPaths.docTypes = docTypes;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- Package guides store a list of API symbol paths
- Package guides store a list of API docs rendered in "child" mode

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information