### PR TITLE
feat(daffio): fix duplicate selector names in docs components

### DIFF
--- a/apps/daffio/src/app/docs/components/doc-article/component.scss
+++ b/apps/daffio/src/app/docs/components/doc-article/component.scss
@@ -22,11 +22,6 @@
 		}
 	}
 
-	&__title {
-		@include daff.headline-xl();
-		margin-bottom: 48px;
-	}
-
 	&__content {
 		flex-grow: 1;
 		display: flex;
@@ -64,9 +59,5 @@
 		@include daff.breakpoint(big-tablet) {
 			display: none;
 		}
-	}
-
-	&__api-section {
-		margin: 48px 0 0;
 	}
 }

--- a/apps/daffio/src/app/docs/guides/components/doc/component.ts
+++ b/apps/daffio/src/app/docs/guides/components/doc/component.ts
@@ -14,7 +14,7 @@ import { DaffioDocArticleModule } from '../../../components/doc-article/module';
 import { DaffioDocComponent } from '../../../components/doc-renderer/component.type';
 
 @Component({
-  selector: 'daffio-api-doc',
+  selector: 'daffio-docs-guides-content',
   templateUrl: './component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
@@ -23,7 +23,7 @@ import { DaffioDocComponent } from '../../../components/doc-renderer/component.t
     DaffioSafeHtmlPipe,
   ],
 })
-export class DaffioDocGuideComponent implements DaffioDocComponent<DaffGuideDoc> {
+export class DaffioDocsGuidesContentComponent implements DaffioDocComponent<DaffGuideDoc> {
   static readonly kind = DaffDocKind.GUIDE;
 
   doc = input<DaffGuideDoc>();

--- a/apps/daffio/src/app/docs/guides/components/doc/provider.ts
+++ b/apps/daffio/src/app/docs/guides/components/doc/provider.ts
@@ -1,4 +1,4 @@
-import { DaffioDocGuideComponent } from './component';
+import { DaffioDocsGuidesContentComponent } from './component';
 import { provideDaffioDocRendererComponents } from '../../../components/doc-renderer/token';
 
-export const daffioDocsGuideComponentProvider = () => provideDaffioDocRendererComponents(DaffioDocGuideComponent);
+export const daffioDocsGuideComponentProvider = () => provideDaffioDocRendererComponents(DaffioDocsGuidesContentComponent);

--- a/apps/daffio/src/app/docs/packages/components/doc/component.ts
+++ b/apps/daffio/src/app/docs/packages/components/doc/component.ts
@@ -2,9 +2,7 @@ import {
   Component,
   ChangeDetectionStrategy,
   input,
-  computed,
 } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
 import { DaffioSafeHtmlPipe } from 'apps/daffio/src/app/core/html-sanitizer/safe.pipe';
 
 import {
@@ -16,7 +14,7 @@ import { DaffioDocArticleModule } from '../../../components/doc-article/module';
 import { DaffioDocComponent } from '../../../components/doc-renderer/component.type';
 
 @Component({
-  selector: 'daffio-api-doc',
+  selector: 'daffio-docs-packages-content',
   templateUrl: './component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
@@ -25,7 +23,7 @@ import { DaffioDocComponent } from '../../../components/doc-renderer/component.t
     DaffioSafeHtmlPipe,
   ],
 })
-export class DaffioDocPackageComponent implements DaffioDocComponent<DaffPackageGuideDoc> {
+export class DaffioDocPackagesContentComponent implements DaffioDocComponent<DaffPackageGuideDoc> {
   static readonly kind = DaffDocKind.PACKAGE;
 
   doc = input<DaffPackageGuideDoc>();

--- a/apps/daffio/src/app/docs/packages/components/doc/provider.ts
+++ b/apps/daffio/src/app/docs/packages/components/doc/provider.ts
@@ -1,4 +1,4 @@
-import { DaffioDocPackageComponent } from './component';
+import { DaffioDocPackagesContentComponent } from './component';
 import { provideDaffioDocRendererComponents } from '../../../components/doc-renderer/token';
 
-export const daffioDocsPackageComponentProvider = () => provideDaffioDocRendererComponents(DaffioDocPackageComponent);
+export const daffioDocsPackageComponentProvider = () => provideDaffioDocRendererComponents(DaffioDocPackagesContentComponent);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/graycoreio/daffodil/pull/3415/files#diff-79596947a4a2f215c971ad944963634b6e9101c81d3ae07b6b9f2b74335073d5

This PR created duplicates of selector name `daffio-api-doc`, in components created for guides and packages. 

The `doc-renderer` interface called `DaffioDocComponent` is also confusing as it's not a component.

Fixes: N/A


## What is the new behavior?
1. Updated duplicate selectors.
2. Renamed `DaffioDocComponent` to `DaffioDocsRenderer`. @griest024 lmk if this makes sense.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information