### PR TITLE
feat(design): update root status tokens to use value retrieved from daff-map-get function

### DIFF
--- a/libs/design/scss/theming/_theme-css-variables.scss
+++ b/libs/design/scss/theming/_theme-css-variables.scss
@@ -12,6 +12,9 @@
 	$primary: core.daff-map-get($theme, primary);
 	$secondary: core.daff-map-get($theme, secondary);
 	$tertiary: core.daff-map-get($theme, tertiary);
+	$warn: core.daff-map-get($theme, warn);
+	$success: core.daff-map-get($theme, success);
+	$critical: core.daff-map-get($theme, critical);
 	$neutral: core.daff-map-get($theme, 'core', 'neutral');
 	$white: core.daff-map-get($theme, 'core', 'white');
 	$black: core.daff-map-get($theme, 'core', 'black');
@@ -24,9 +27,9 @@
 	--daff-theme-primary: #{theming.daff-color($primary)};
 	--daff-theme-secondary: #{theming.daff-color($secondary)};
 	--daff-theme-tertiary: #{theming.daff-color($tertiary)};
-	--daff-theme-warn: #{theming.daff-color(theming.$daff-bronze, 60)};
-	--daff-theme-success: #{theming.daff-color(theming.$daff-green, 60)};
-	--daff-theme-critical: #{theming.daff-color(theming.$daff-red, 60)};
+	--daff-theme-warn: #{theming.daff-color($warn)};
+	--daff-theme-success: #{theming.daff-color($success)};
+	--daff-theme-critical: #{theming.daff-color($critical)};
 	--daff-theme-white: #{$white};
 	--daff-theme-black: #{$black};
 	--daff-theme-gray: #{theming.daff-color($neutral)};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
```
--daff-theme-warn: #{theming.daff-color(theming.$daff-bronze, 60)};
--daff-theme-success: #{theming.daff-color(theming.$daff-green, 60)};
--daff-theme-critical: #{theming.daff-color(theming.$daff-red, 60)};
```

These values are using fixed values retrieved directly from palette names. This means they're not variable depending on light or dark theme.

## What is the new behavior?
Added variables that retrieves the color based on the configure theme status function.

```
$warn: core.daff-map-get($theme, warn);
$success: core.daff-map-get($theme, success);
$critical: core.daff-map-get($theme, critical);
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information