### PR TITLE
fix(design): fix sticky element positioning by updating sidebar viewport overflow for opened over/under sidebars

### DIFF
--- a/libs/design/sidebar/src/sidebar-viewport/sidebar-viewport.component.ts
+++ b/libs/design/sidebar/src/sidebar-viewport/sidebar-viewport.component.ts
@@ -103,7 +103,7 @@ export class DaffSidebarViewportComponent implements AfterContentChecked, OnDest
 
   onContentAnimationStart(e: AnimationEvent) {
     if(e.toState === 'open') {
-      this._elementRef.nativeElement.style.overflow = 'hidden';
+      this._elementRef.nativeElement.style.overflow = 'clip';
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Sticky elements within the viewport are not positioned correctly when a sidebar is opened. 
Fixes: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information