### PR TITLE
Fix DaffShopifyProduct Transformer function

### DIFF
--- a/apps/demo/src/app/drivers/shopify.module.ts
+++ b/apps/demo/src/app/drivers/shopify.module.ts
@@ -6,19 +6,15 @@ import {
 } from 'apollo-angular';
 
 
+import { DaffAuthorizeNetInMemoryDriverModule } from '@daffodil/authorizenet/driver/in-memory';
 import { DaffCartInMemoryDriverModule } from '@daffodil/cart/driver/in-memory';
+import { DaffCategoryInMemoryDriverModule } from '@daffodil/category/driver/in-memory';
 import { DaffInMemoryDriverModule } from '@daffodil/driver/in-memory';
+import { DaffNavigationInMemoryDriverModule } from '@daffodil/navigation/driver/in-memory';
 import { DaffNewsletterInMemoryDriverModule } from '@daffodil/newsletter/driver/in-memory';
 import { createApolloConfig } from '@daffodil/product/driver';
 import { DaffProductShopifyDriverModule } from '@daffodil/product/driver/shopify';
 import { shopifyDriverConfig } from '@daffodil/product/driver/shopify';
-import {
-  DaffNavigationInMemoryDriverModule,
-  DAFF_NAVIGATION_IN_MEMORY_SEED_DATA_PROVIDER,
-} from '@daffodil/navigation/driver/in-memory';
-import { DaffCategoryInMemoryDriverModule } from '@daffodil/category/driver/in-memory';
-
-import { DaffAuthorizeNetInMemoryDriverModule } from '@daffodil/authorizenet/driver/in-memory';
 import {
   DaffDefaultProductFactory,
   provideDaffProductExtraFactoryTypes,
@@ -27,8 +23,6 @@ import {
 
 import { environment } from '../../environments/environment';
 import { ShopifyEnviromentDriverConfiguration } from '../../environments/environment.interface';
-
-const cache = new InMemoryCache();
 
 @NgModule({
   imports: [

--- a/libs/product/driver/shopify/src/product.service.ts
+++ b/libs/product/driver/shopify/src/product.service.ts
@@ -41,6 +41,7 @@ interface ProductNode {
   };
   images: {
     nodes: {
+      id: string;
       url: string;
       altText: string;
     }[];
@@ -67,6 +68,7 @@ export const GetAllProductsQuery = gql`
           description
           images(first: 1) {
             nodes {
+              id
               url
               altText
             }
@@ -86,11 +88,15 @@ export const GetAllProductsQuery = gql`
 
 const DaffShopifyProductTransformer = (node: ProductNode): DaffProduct => ({
   name: node.title,
-  images: [],
+  images: node.images.nodes.map(imageNode => ({
+    id: imageNode.id,
+    url: imageNode.url,
+    label: imageNode.altText,
+  })),
   thumbnail: {
     url: node.images.nodes[0].url,
     label: node.images.nodes[0].altText,
-    id: node.id,
+    id: node.images.nodes[0].id,
   },
   id: node.id,
   url: node.onlineStoreUrl,

--- a/libs/product/driver/shopify/src/product.service.ts
+++ b/libs/product/driver/shopify/src/product.service.ts
@@ -79,6 +79,9 @@ export const GetAllProductsQuery = gql`
   }
 `;
 
+// To be implemented properly later
+export const GetAProduct = GetAllProductsQuery;
+
 /**
  * Transforms a ProductNode into a different object.
  *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [y] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [y] Tests for the changes have been added (for bug fixes / features)
- [y] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Transformer function has a "reads undefined" error on DaffProduct's image.url.

Fixes:
Map images (DaffProduct) to images.nodes instead of images (Shopify product structure)


## What is the new behavior?
The Shopify ProductNode is now correctly mapped to DaffProduct (including image.url).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The code fails unit tests because GetAProduct, getBestSellers, get, and getByURL are not implemented.