### PR TITLE
feat(tools-dgeni): clean up API templates

### DIFF
--- a/apps/daffio/src/app/docs/design/components/component-content/component-content.component.html
+++ b/apps/daffio/src/app/docs/design/components/component-content/component-content.component.html
@@ -6,6 +6,7 @@
 		[linkMode]="true"
 		[url]="doc().id"
 		(tabChange)="setTab($event)"
+		aria-label="Documentation sections"
 	>
 		<daff-tab [id]="USAGE_TAB_ID">
 			<daff-tab-label>
@@ -25,6 +26,7 @@
 			<daff-tab-panel>
 				@for (apiDoc of doc().api; track $index) {
 					<section [innerHtml]="apiDoc | safe"></section>
+					<hr>
 				}
 			</daff-tab-panel>
 		</daff-tab>

--- a/tools/dgeni/src/templates/api/base.template.html
+++ b/tools/dgeni/src/templates/api/base.template.html
@@ -1,8 +1,7 @@
 {% block header %}
 {$'<h3 id="' + doc.slug + '">' if child else '<h1>'$}{$ doc.name $}{$'</h3>' if child else '</h1>'$}
 {% endblock %}
-<p>{$ doc.description $}</p>
-<h2>API</h2>
-<p>{$ doc.sourceApiBlock $}</p>
+{$ doc.description $}
+{$ doc.sourceApiBlock $}
 
 {% block body %}{% endblock %}

--- a/tools/dgeni/src/templates/api/class.template.html
+++ b/tools/dgeni/src/templates/api/class.template.html
@@ -6,8 +6,10 @@
 
 {% block body %}
 {% if doc.decorators[0].argumentInfo[0].selector %}
-<span class="selectors__label">Selector:</span>
-<span class="selectors__name"><code>{$ doc.decorators[0].argumentInfo[0].selector $}</code></span>
+<div class="selectors__wrapper">
+	<span class="selectors__label">Selector:</span>
+	<span class="selectors__name"><code>{$ doc.decorators[0].argumentInfo[0].selector $}</code></span>
+</div>
 {% endif %}
 
 {% if doc.members.length > 0 %}

--- a/tools/dgeni/src/templates/api/member.template.html
+++ b/tools/dgeni/src/templates/api/member.template.html
@@ -4,11 +4,15 @@
 		<td>@Input() {$ member.name $}</td>
 		<td>{$ member.type | linkSymbols $}</td>
 		<td>{$ member.description | linkSymbols $}</td>
-		{% elif member.decorators[0].name === 'Output' %}
+	</tr>
+	{% elif member.decorators[0].name === 'Output' %}
+	<tr>
 		<td>@Output() {$ member.name $}</td>
 		<td>{$ member.type | linkSymbols $}</td>
 		<td>{$ member.description | linkSymbols $}</td>
-		{% else %}
+	</tr>
+	{% else %}
+	<tr>
 		<td>{$ member.name $}</td>
 		<td>{$ member.type | linkSymbols $}</td>
 		<td>{$ member.description | linkSymbols $}</td>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
1. Extra empty `<p>` are being rendered after each block.
2. Outputs are displayed on the same table row
3. 
<img width="303" alt="Screen Shot 2025-02-12 at 4 04 51 PM" src="https://github.com/user-attachments/assets/2f21c970-348d-405c-922d-6cb0dc33fea2" />

Fixes: N/A


## What is the new behavior?
1. Remove extra `<p>` tags
2. Move outputs to its own table row


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information