### PR TITLE
feat(design)!: remove DaffPrefixSuffixModule imports from button components and update usage docs

### DIFF
--- a/libs/design/button/README.md
+++ b/libs/design/button/README.md
@@ -8,6 +8,7 @@ Native `<button>` or `<a>` elements are always used in order to provide an easy,
 
 ## Types
 - `daff-button` - Rectangular contained button with background color
+- `daff-flat-button` - Rectangular contained button with no outline or background color
 - `daff-icon-button` - Icon button used with icon fonts
 - `daff-raised-button` - Rectangular contained button with background color and elevation
 - `daff-stroked-button` - Rectangular outlined button with no background color
@@ -15,20 +16,23 @@ Native `<button>` or `<a>` elements are always used in order to provide an easy,
 ### Basic Button
 <design-land-example-viewer-container example="basic-button"></design-land-example-viewer-container>
 
-### Stroked Button
+### Flat Button
+<design-land-example-viewer-container example="flat-button"></design-land-example-viewer-container>
+
+### Stroked button
 <design-land-example-viewer-container example="stroked-button"></design-land-example-viewer-container>
 
 > `black`, `white`, and `theme` should be used with caution to ensure that there is sufficient contrast.
 
-### Raised Button
+### Raised button
 <design-land-example-viewer-container example="raised-button"></design-land-example-viewer-container>
 
-### Icon Button
+### Icon button
 <design-land-example-viewer-container example="icon-button"></design-land-example-viewer-container>
 
 > `black`, `white`, and `theme` should be used with caution to ensure that there is sufficient contrast.
 
-### Underline Button
+### Underline button
 <design-land-example-viewer-container example="underline-button"></design-land-example-viewer-container>
 
 ## Usage
@@ -37,10 +41,11 @@ Native `<button>` or `<a>` elements are always used in order to provide an easy,
 To use button in a standalone component, import it directly into your custom component. Buttons can be imported individually or all together by using `DAFF_BUTTON_COMPONENTS`:
 
 ```ts
+import { DaffButtonComponent } from '@daffodil/design/button';
+
 @Component({
   selector: 'custom-component',
   templateUrl: './custom-component.component.html',
-  standalone: true,
   imports: [
     DaffButtonComponent,
   ],
@@ -86,7 +91,7 @@ Supported colors: `primary | secondary | tertiary | black | white | theme | them
 
 > For select button types, `black` and `white` should be used on a darker background in order to have sufficient contrast.
 
-## Status Indicators
+## Status indicators
 Buttons with status indicators can be used to distinguish what type of action it performs and its importance compared to other buttons in the same context.
 
 Supported statuses: `warn | critical | success`

--- a/libs/design/button/examples/src/basic-button/basic-button.component.ts
+++ b/libs/design/button/examples/src/basic-button/basic-button.component.ts
@@ -8,6 +8,7 @@ import {
   faChevronRight,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DaffButtonComponent } from '@daffodil/design/button';
 
 @Component({
@@ -25,6 +26,7 @@ import { DaffButtonComponent } from '@daffodil/design/button';
   imports: [
     DaffButtonComponent,
     FaIconComponent,
+    DaffPrefixSuffixModule,
   ],
 })
 export class BasicButtonComponent {

--- a/libs/design/button/examples/src/flat-button/flat-button.component.ts
+++ b/libs/design/button/examples/src/flat-button/flat-button.component.ts
@@ -8,6 +8,7 @@ import {
   faChevronRight,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DaffFlatButtonComponent } from '@daffodil/design/button';
 
 @Component({
@@ -25,6 +26,7 @@ import { DaffFlatButtonComponent } from '@daffodil/design/button';
   imports: [
     DaffFlatButtonComponent,
     FaIconComponent,
+    DaffPrefixSuffixModule,
   ],
 })
 export class FlatButtonComponent {

--- a/libs/design/button/examples/src/raised-button/raised-button.component.ts
+++ b/libs/design/button/examples/src/raised-button/raised-button.component.ts
@@ -8,6 +8,7 @@ import {
   faChevronRight,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DaffRaisedButtonComponent } from '@daffodil/design/button';
 
 @Component({
@@ -25,6 +26,7 @@ import { DaffRaisedButtonComponent } from '@daffodil/design/button';
   imports: [
     DaffRaisedButtonComponent,
     FaIconComponent,
+    DaffPrefixSuffixModule,
   ],
 })
 export class RaisedButtonComponent {

--- a/libs/design/button/examples/src/stroked-button/stroked-button.component.ts
+++ b/libs/design/button/examples/src/stroked-button/stroked-button.component.ts
@@ -8,6 +8,7 @@ import {
   faChevronRight,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DaffStrokedButtonComponent } from '@daffodil/design/button';
 
 @Component({
@@ -25,6 +26,7 @@ import { DaffStrokedButtonComponent } from '@daffodil/design/button';
   imports: [
     DaffStrokedButtonComponent,
     FaIconComponent,
+    DaffPrefixSuffixModule,
   ],
 })
 export class StrokedButtonComponent {

--- a/libs/design/button/examples/src/underline-button/underline-button.component.ts
+++ b/libs/design/button/examples/src/underline-button/underline-button.component.ts
@@ -8,6 +8,7 @@ import {
   faChevronRight,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DaffUnderlineButtonComponent } from '@daffodil/design/button';
 
 @Component({
@@ -25,6 +26,7 @@ import { DaffUnderlineButtonComponent } from '@daffodil/design/button';
   imports: [
     DaffUnderlineButtonComponent,
     FaIconComponent,
+    DaffPrefixSuffixModule,
   ],
 })
 export class UnderlineButtonComponent {

--- a/libs/design/button/src/button.module.ts
+++ b/libs/design/button/src/button.module.ts
@@ -30,7 +30,6 @@ import { DaffUnderlineButtonComponent } from './button/underline/underline.compo
     DaffRaisedButtonComponent,
     DaffStrokedButtonComponent,
     DaffUnderlineButtonComponent,
-    DaffPrefixSuffixModule,
   ],
 })
 export class DaffButtonModule { }

--- a/libs/design/button/src/button.ts
+++ b/libs/design/button/src/button.ts
@@ -7,9 +7,14 @@ import { DaffRaisedButtonComponent } from './button/raised/raised.component';
 import { DaffStrokedButtonComponent } from './button/stroked/stroked.component';
 import { DaffUnderlineButtonComponent } from './button/underline/underline.component';
 
+/**
+ * `DAFF_BUTTON_COMPONENTS` imports all the available button types.
+ * ```ts
+ * import { DAFF_BUTTON_COMPONENTS } from '@daffodil/design/button';
+ * ```
+ */
 export const DAFF_BUTTON_COMPONENTS = <const> [
   DaffButtonComponent,
-  DaffPrefixSuffixModule,
   DaffFlatButtonComponent,
   DaffIconButtonComponent,
   DaffRaisedButtonComponent,

--- a/libs/design/button/src/button/basic/button.component.ts
+++ b/libs/design/button/src/button/basic/button.component.ts
@@ -5,13 +5,16 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
 
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
  * DaffButtonComponent is a rectangular contained button with background color.
+ *
+ * ```ts
+ * import { DaffButtonComponent } from '@daffodil/design/button';
+ * ```
  *
  * @example Basic button
  * ```html
@@ -30,15 +33,12 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
  */
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
-  selector: '' +
-        'button[daff-button]' + ',' +
-        'a[daff-button]',
+  selector: 'button[daff-button]' + ',' + 'a[daff-button]',
   templateUrl: '../button-base.component.html',
   styleUrl: './button.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffPrefixSuffixModule,
     DAFF_LOADING_ICON_COMPONENTS,
   ],
 })

--- a/libs/design/button/src/button/button-base.directive.ts
+++ b/libs/design/button/src/button/button-base.directive.ts
@@ -74,11 +74,11 @@ export class DaffButtonBaseDirective
   @Input() loading = false;
 
   /**
-   * Set the `tabindex` to 0.
+   * Sets the tabindex. Defaults to 0.
    */
   @Input() tabindex = 0;
 
-  _disabled = false;
+  private _disabled = false;
 
   /**
    * The disabled state of the button.
@@ -90,18 +90,26 @@ export class DaffButtonBaseDirective
     this._disabled = coerceBooleanProperty(value);
   }
 
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.disabled') get disabledAttribute() {
     return this.disabled ? true : null;
   }
 
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.aria-disabled') get ariaDisabled() {
     return this.disabled ? true : null;
   }
 
   /**
+   * @docs-private
+   *
    * Set the `tabindex` to -1 if the button is disabled.
    */
-  @HostBinding('attr.tabindex') get disabledTabIndex() {
+  @HostBinding('attr.tabindex') get tabIndexAttribute() {
     return this.disabled ? -1 : this.tabindex;
   }
 }

--- a/libs/design/button/src/button/flat/flat.component.ts
+++ b/libs/design/button/src/button/flat/flat.component.ts
@@ -5,13 +5,16 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
 
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
  * DaffFlatButtonComponent is a rectangular contained button no background.
+ *
+ * ```ts
+ * import { DaffFlatButton } from '@daffodil/design/button';
+ * ```
  *
  * @example Flat button
  * ```html
@@ -30,15 +33,12 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
  */
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
-  selector: '' +
-        'button[daff-flat-button]' + ',' +
-        'a[daff-flat-button]',
+  selector: 'button[daff-flat-button]' + ',' + 'a[daff-flat-button]',
   templateUrl: '../button-base.component.html',
   styleUrl: './flat.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffPrefixSuffixModule,
     DAFF_LOADING_ICON_COMPONENTS,
   ],
 })

--- a/libs/design/button/src/button/icon/icon.component.ts
+++ b/libs/design/button/src/button/icon/icon.component.ts
@@ -5,13 +5,16 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
 
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
  * DaffIconButtonComponent is an icon button used with icon fonts.
+ *
+ * ```ts
+ * import { DaffIconButtonComponent } from '@daffodil/design/button';
+ * ```
  *
  * @example Icon button
  * ```html
@@ -26,15 +29,12 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
  */
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
-  selector: '' +
-        'button[daff-icon-button]' + ',' +
-        'a[daff-icon-button]',
+  selector: 'button[daff-icon-button]' + ',' + 'a[daff-icon-button]',
   templateUrl: '../button-base.component.html',
   styleUrl: './icon.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffPrefixSuffixModule,
     DAFF_LOADING_ICON_COMPONENTS,
   ],
 })

--- a/libs/design/button/src/button/raised/raised.component.ts
+++ b/libs/design/button/src/button/raised/raised.component.ts
@@ -5,13 +5,16 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
 
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
  * DaffRaisedButtonComponent is a rectangular contained button with background color and elevation.
+ *
+ * ```ts
+ * import { DaffRaisedButtonComponent } from '@daffodil/design/button';
+ * ```
  *
  * @example Raised button
  * ```html
@@ -30,15 +33,12 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
  */
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
-  selector: '' +
-        'button[daff-raised-button]' + ',' +
-        'a[daff-raised-button]',
+  selector: 'button[daff-raised-button]' + ',' + 'a[daff-raised-button]',
   templateUrl: '../button-base.component.html',
   styleUrl: './raised.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffPrefixSuffixModule,
     DAFF_LOADING_ICON_COMPONENTS,
   ],
 })

--- a/libs/design/button/src/button/stroked/stroked.component.ts
+++ b/libs/design/button/src/button/stroked/stroked.component.ts
@@ -6,13 +6,16 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
 
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
  * DaffStrokedButtonComponent is a rectangular outlined button with no background color.
+ *
+ * ```ts
+ * import { DaffStrokedButtonComponent } from '@daffodil/design/button';
+ * ```
  *
  * @example Stroked button
  * ```html
@@ -31,15 +34,12 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
  */
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
-  selector: '' +
-        'button[daff-stroked-button]' + ',' +
-        'a[daff-stroked-button]',
+  selector: 'button[daff-stroked-button]' + ',' + 'a[daff-stroked-button]',
   templateUrl: '../button-base.component.html',
   styleUrl: './stroked.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffPrefixSuffixModule,
     DAFF_LOADING_ICON_COMPONENTS,
   ],
 })

--- a/libs/design/button/src/button/underline/underline.component.ts
+++ b/libs/design/button/src/button/underline/underline.component.ts
@@ -6,13 +6,16 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
 
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
  * DaffUnderlineButtonComponent is a borderless button with a custom underline style.
+ *
+ * ```ts
+ * import { DaffUnderlineButtonComponent } from '@daffodil/design/button';
+ * ```
  *
  * @example Underline button
  * ```html
@@ -31,15 +34,12 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
  */
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
-  selector: '' +
-        'button[daff-underline-button]' + ',' +
-        'a[daff-underline-button]',
+  selector: 'button[daff-underline-button]' + ',' + 'a[daff-underline-button]',
   templateUrl: '../button-base.component.html',
   styleUrl: './underline.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffPrefixSuffixModule,
     DAFF_LOADING_ICON_COMPONENTS,
   ],
 })

--- a/libs/design/button/src/public_api.ts
+++ b/libs/design/button/src/public_api.ts
@@ -2,7 +2,6 @@ export { DaffButtonModule } from './button.module';
 export { DAFF_BUTTON_COMPONENTS } from './button';
 
 export { DaffButtonComponent } from './button/basic/button.component';
-export { DaffButtonSizableDirective } from './button/button-sizable.directive';
 export { DaffFlatButtonComponent } from './button/flat/flat.component';
 export { DaffRaisedButtonComponent } from './button/raised/raised.component';
 export { DaffStrokedButtonComponent } from './button/stroked/stroked.component';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

BREAKING CHANGE: `DaffPrefixSuffixModule` is no longer exported through `DAFF_BUTTON_COMPONENTS`. If you are using a button with a prefix or suffix, make sure to import `DaffPrefixSuffixModule` in your usage component.

## Other information