### PR TITLE
feat(design)!: remove DaffPrefixSuffixModule import from tabs and update docs

### DIFF
--- a/libs/design/tabs/README.md
+++ b/libs/design/tabs/README.md
@@ -22,11 +22,26 @@ import { DAFF_TABS_COMPONENTS } from '@daffodil/design/tabs';
 export class CustomComponent {}
 ```
 
+## Properties
+
+### Link Mode
+Tabs in link mode replaces the tab buttons with anchors. This allows the selected tab to be connected to a URL. By default, the current URL and `tab` query param will be used. These can be overriden with the `url` and `queryParam` inputs respectively.
+
+```html
+<daff-tabs [linkMode]="true">
+</daff-tabs>
+```
+
 ## Accessbility
 Tabs follow the [ARIA Tabs design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/). Tabs compose of `tablist`, `tab`, and `tabpanel` elements,  each with its appropriate role and integrated keyboard interactions.
 
 ### Label
 A meaningful `aria-label` should be set on `<daff-tabs>` by using the `aria-label` property. This will set the `aria-label` on the `tablist` element.
+
+```html
+<daff-tabs aria-label="Custom aria label">
+</daff-tabs>
+```
 
 ### Keyboard Interactions
 | Key | Action |
@@ -35,6 +50,3 @@ A meaningful `aria-label` should be set on `<daff-tabs>` by using the `aria-labe
 | Right Arrow |  Moves focus and activates next tab. If focus is on the last tab, moves focus to the first tab. |
 | Home |  Moves focus and activates first tab. |
 | End |  Moves focus and activates last tab. |
-
-### Link Mode
-Tabs can operate in "link mode" which replaces the tab buttons with anchors. This allows the selected tab to be connected to the URL. To use this mode, set `linkMode` to `true` on the tabs component. By default, the current URL and `tab` query param will be used. These can be overriden with the `url` and `queryParam` inputs respectively.

--- a/libs/design/tabs/examples/src/basic-tabs/basic-tabs.component.ts
+++ b/libs/design/tabs/examples/src/basic-tabs/basic-tabs.component.ts
@@ -5,6 +5,7 @@ import {
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DAFF_TABS_COMPONENTS } from '@daffodil/design/tabs';
 
 @Component({
@@ -15,6 +16,7 @@ import { DAFF_TABS_COMPONENTS } from '@daffodil/design/tabs';
   imports: [
     DAFF_TABS_COMPONENTS,
     FaIconComponent,
+    DaffPrefixSuffixModule,
   ],
 })
 export class BasicTabsComponent {

--- a/libs/design/tabs/examples/src/custom-select-tabs/custom-select-tabs.component.ts
+++ b/libs/design/tabs/examples/src/custom-select-tabs/custom-select-tabs.component.ts
@@ -6,6 +6,7 @@ import {
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DaffButtonComponent } from '@daffodil/design/button';
 import {
   DAFF_TABS_COMPONENTS,
@@ -22,6 +23,7 @@ import {
     DAFF_TABS_COMPONENTS,
     DaffButtonComponent,
     FaIconComponent,
+    DaffPrefixSuffixModule,
   ],
 })
 export class CustomSelectTabsComponent {

--- a/libs/design/tabs/examples/src/disabled-tabs/disabled-tabs.component.ts
+++ b/libs/design/tabs/examples/src/disabled-tabs/disabled-tabs.component.ts
@@ -5,6 +5,7 @@ import {
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DAFF_TABS_COMPONENTS } from '@daffodil/design/tabs';
 
 @Component({
@@ -15,6 +16,7 @@ import { DAFF_TABS_COMPONENTS } from '@daffodil/design/tabs';
   imports: [
     DAFF_TABS_COMPONENTS,
     FaIconComponent,
+    DaffPrefixSuffixModule,
   ],
 })
 export class DisabledTabsComponent {

--- a/libs/design/tabs/examples/src/initially-select-tab/initially-select-tab.component.ts
+++ b/libs/design/tabs/examples/src/initially-select-tab/initially-select-tab.component.ts
@@ -5,6 +5,7 @@ import {
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DAFF_TABS_COMPONENTS } from '@daffodil/design/tabs';
 
 @Component({
@@ -15,6 +16,7 @@ import { DAFF_TABS_COMPONENTS } from '@daffodil/design/tabs';
   imports: [
     DAFF_TABS_COMPONENTS,
     FaIconComponent,
+    DaffPrefixSuffixModule,
   ],
 })
 export class InitiallySelectTabComponent {

--- a/libs/design/tabs/examples/src/link-tabs/link-tabs.component.html
+++ b/libs/design/tabs/examples/src/link-tabs/link-tabs.component.html
@@ -1,7 +1,6 @@
 <daff-tabs
 	aria-label="List of tabs"
-	[linkMode]="true"
->
+	[linkMode]="true">
 	<daff-tab>
 		<daff-tab-label>
 			<fa-icon [icon]="faInfoCircle" daffPrefix></fa-icon>

--- a/libs/design/tabs/examples/src/link-tabs/link-tabs.component.ts
+++ b/libs/design/tabs/examples/src/link-tabs/link-tabs.component.ts
@@ -5,6 +5,7 @@ import {
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixSuffixModule } from '@daffodil/design';
 import { DAFF_TABS_COMPONENTS } from '@daffodil/design/tabs';
 
 @Component({
@@ -15,6 +16,7 @@ import { DAFF_TABS_COMPONENTS } from '@daffodil/design/tabs';
   imports: [
     DAFF_TABS_COMPONENTS,
     FaIconComponent,
+    DaffPrefixSuffixModule,
   ],
 })
 export class LinkTabsComponent {

--- a/libs/design/tabs/src/tabs.ts
+++ b/libs/design/tabs/src/tabs.ts
@@ -1,14 +1,16 @@
-import { DaffPrefixSuffixModule } from '@daffodil/design';
-
 import { DaffTabComponent } from './tabs/tab/tab.component';
 import { DaffTabLabelComponent } from './tabs/tab-label/tab-label.component';
 import { DaffTabPanelComponent } from './tabs/tab-panel/tab-panel.component';
 import { DaffTabsComponent } from './tabs/tabs.component';
 
-export const DAFF_TABS_COMPONENTS = <const>[
+/**
+ * ```ts
+ * import { DAFF_TABS_COMPONENTS } from '@daffodil/design/tabs';
+ * ```
+ */
+export const DAFF_TABS_COMPONENTS = <const> [
   DaffTabsComponent,
   DaffTabLabelComponent,
   DaffTabPanelComponent,
-  DaffPrefixSuffixModule,
   DaffTabComponent,
 ];

--- a/libs/design/tabs/src/tabs/tab-activator/tab-activator.component.ts
+++ b/libs/design/tabs/src/tabs/tab-activator/tab-activator.component.ts
@@ -11,7 +11,6 @@ import {
 import { DaffSelectableDirective } from '@daffodil/design';
 
 @Component({
-  standalone: true,
   selector: '' +
     'button[daff-tab-activator]' + ',' +
     'a[daff-tab-activator]',

--- a/libs/design/tabs/src/tabs/tab-label/tab-label.component.ts
+++ b/libs/design/tabs/src/tabs/tab-label/tab-label.component.ts
@@ -36,6 +36,13 @@ import {
   ],
 })
 export class DaffTabLabelComponent implements DaffPrefixable, DaffSuffixable {
+  /**
+   * @docs-private
+   */
   @ContentChild(DaffPrefixDirective) _prefix: DaffPrefixDirective;
+
+  /**
+   * @docs-private
+   */
   @ContentChild(DaffSuffixDirective) _suffix: DaffSuffixDirective;
 }

--- a/libs/design/tabs/src/tabs/tab-panel/tab-panel.component.ts
+++ b/libs/design/tabs/src/tabs/tab-panel/tab-panel.component.ts
@@ -17,7 +17,6 @@ import { DaffTabComponent } from '../tab/tab.component';
  * ```
  */
 @Component({
-  standalone: true,
   selector: 'daff-tab-panel',
   template: `<ng-content></ng-content>`,
   styleUrl: './tab-panel.component.scss',
@@ -30,16 +29,22 @@ export class DaffTabPanelComponent {
   @HostBinding('class.daff-tab-panel') private class = true;
 
   /**
+   * @docs-private
+   *
    * Sets the `role` to tabpanel.
    */
   @HostBinding('attr.role') role = 'tabpanel';
 
   /**
+   * @docs-private
+   *
    * `aria-labelledby` for the tab.
    */
   @HostBinding('attr.aria-labelledby') ariaLabelledBy = '';
 
   /**
+   * @docs-private
+   *
    * Sets the `tabindex` to 0.
    */
   @HostBinding('attr.tabindex') tabIndex = '0';
@@ -47,6 +52,8 @@ export class DaffTabPanelComponent {
   private _id = '';
 
   /**
+   * @docs-private
+   *
    * Dynamically binds the tab panel's id to a unique value generated from the associated tab's panelId.
    */
   @HostBinding('attr.id') get tabPanelId() {

--- a/libs/design/tabs/src/tabs/tab/tab.component.ts
+++ b/libs/design/tabs/src/tabs/tab/tab.component.ts
@@ -11,7 +11,7 @@ let tabId = 1;
 /**
  * `DaffTabComponet` is an element in the tab list that is used as a content container to group the label of a tab panel and the tab panel together.
  *
- * A `<daff-tab>` should include the {@link DaffTabLabelComponent} and {@link DaffTabPanelComponent} components in order to properly structure the UI.
+ * A `<daff-tab>` should include the DaffTabLabelComponent and DaffTabPanelComponent components in order to properly structure the UI.
  *
  * @example Basic structure of tab
  * ```html
@@ -27,7 +27,6 @@ let tabId = 1;
  * ```
  */
 @Component({
-  standalone: true,
   selector: 'daff-tab',
   template: `
       <ng-template #label>

--- a/libs/design/tabs/src/tabs/tabs.component.ts
+++ b/libs/design/tabs/src/tabs/tabs.component.ts
@@ -75,27 +75,30 @@ export class DaffTabsComponent implements AfterContentInit, OnInit {
   @HostBinding('class.daff-tabs') private class = true;
 
   /**
+   * @docs-private
+   *
    * The currently selected tab. This property is dynamically updated when a user selects a tab.
    */
   selectedTab: string;
 
   /**
-   * The tab that is initially selected on initial load. If it's not used, the first tab in the tablist will be selected by default.
+   * The tab that is selected on initial load. If it's not used, the first tab in the tablist will be selected by default.
    */
   @Input() initiallySelected: string = null;
 
   /**
-   * @docs-private
+   * aria-label for the tab.
    */
   @HostBinding('attr.aria-label') private externalAriaLabel = null;
 
   /**
-   * aria-label for the tab.
+   * @docs-private
+   *
    */
   @Input('aria-label') ariaLabel = '';
 
   /**
-   * Replace the tab buttons with links.
+   * Replace the tab buttons as links.
    */
   @Input() linkMode = false;
 
@@ -130,6 +133,9 @@ export class DaffTabsComponent implements AfterContentInit, OnInit {
    */
   @ViewChildren(DaffTabActivatorComponent) _tabActivators: QueryList<DaffTabActivatorComponent>;
 
+  /**
+   * @docs-private
+   */
   get currentPath(): string {
     return this.location.path();
   }
@@ -165,6 +171,8 @@ export class DaffTabsComponent implements AfterContentInit, OnInit {
   }
 
   /**
+   * @docs-private
+   *
    * Selects a tab and sets focus on the selected tab.
    */
   select(tabId: string) {
@@ -210,6 +218,8 @@ export class DaffTabsComponent implements AfterContentInit, OnInit {
   }
 
   /**
+   * @docs-private
+   *
    * Selects the previous tab and wraps around to the last tab if the first tab is currently selected.
    */
   previous() {
@@ -217,6 +227,8 @@ export class DaffTabsComponent implements AfterContentInit, OnInit {
   }
 
   /**
+   * @docs-private
+   *
    * Selects the next tab and wraps around to the first tab if the last tab is currently selected.
    */
   next() {
@@ -224,6 +236,8 @@ export class DaffTabsComponent implements AfterContentInit, OnInit {
   }
 
   /**
+   * @docs-private
+   *
    * Selects the first tab.
    */
   selectFirst(event: KeyboardEvent | null) {
@@ -232,6 +246,8 @@ export class DaffTabsComponent implements AfterContentInit, OnInit {
   }
 
   /**
+   * @docs-private
+   *
    * Selects the last tab.
    */
   selectLast(event: KeyboardEvent | null) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

BREAKING CHANGE: `DaffPrefixSuffixModule` is no longer exported through `DAFF_TABS_COMPONENTS`. If you are using tabs with a prefix or suffix, make sure to import `DaffPrefixSuffixModule` in your usage component.

## Other information