### PR TITLE
fix(driver): correct the paths for ng-package schema entrypoint (hubs…

### DIFF
--- a/libs/driver/hubspot/ng-package.json
+++ b/libs/driver/hubspot/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../node_modules/ng-packagr/ng-entrypoint.schema.json",
+  "$schema": "../../../node_modules/ng-packagr/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "src/index.ts"
   }

--- a/libs/driver/magento/ng-package.json
+++ b/libs/driver/magento/ng-package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../node_modules/ng-packagr/ng-entrypoint.schema.json",
+  "$schema": "../../../node_modules/ng-packagr/ng-entrypoint.schema.json",
   "lib": {
     "entryFile": "src/index.ts"
   }


### PR DESCRIPTION
…pot and magento)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Hubspot and magento in libs/driver have incorrect paths for the ng-package entrypoint (off by 1 layer).

Fixes: path


## What is the new behavior?



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information