### PR TITLE
feat(design)!: update breadcrumb active state implementation

### DIFF
--- a/apps/daffio/src/app/docs/components/doc-article/component.html
+++ b/apps/daffio/src/app/docs/components/doc-article/component.html
@@ -9,7 +9,7 @@
         <nav aria-label="Breadcrumb">
           <ol daff-breadcrumb>
             @for (breadcrumb of breadcrumbs; track $index) {
-              <li daffBreadcrumbItem [active]="$last">
+              <li daffBreadcrumbItem>
                 @if ($last) {
                   {{breadcrumb.label}}
                 } @else {

--- a/libs/design/breadcrumb/README.md
+++ b/libs/design/breadcrumb/README.md
@@ -2,16 +2,21 @@
 Breadcrumbs are a secondary navigation that displays a user's location within a website or application.
 
 ## Overview
-Breadcrumbs are a visual representation of the site's navigational hierarchy. They indicate the current page's location and allows users to easily move up to a parent level. It's required for breadcrumbs to be used with the native HTML `<ol>` element, and for each item to be an `<li>`. This offers additional context for assistive technology.
+Breadcrumbs are a visual representation of the site's navigational hierarchy. They indicate the current page's location and allows users to easily move up to a parent level.
 
-## Basic Breadcrumb
+## Requirements
+- `[daff-breadcrumb]` is required to be used with the native HTML `<ol>` element.
+- Each `[daffBreadcrumbItem]` needs to be a `<li>` element.
+
+## Structure
+Breadcrumbs are built using `[daff-breadcrumb]` and `[daffBreadCrumbItem]`.
+
+- **`[daff-breadcrumb]`**: a wrapper for grouping breadcrumb items.
+- **`[daffBreacrumbItem]`**: used to display each breadcrumb item.
+
 <design-land-example-viewer-container example="basic-breadcrumb"></design-land-example-viewer-container>
 
 ## Usage
-
-## Within a standalone component
-To use breadcrumb in a standalone component, import it directly into your custom component:
-
 ```ts
 import { DAFF_BREADCRUMB_COMPONENTS } from '@daffodil/design/breadcrumb';
 
@@ -25,29 +30,33 @@ import { DAFF_BREADCRUMB_COMPONENTS } from '@daffodil/design/breadcrumb';
 export class CustomComponent {}
 ```
 
-## Within a module (deprecated)
-To use breadcrumb in a module, import `DaffBreadcrumbModule` into your custom module:
-
-```ts
-import { NgModule } from '@angular/core';
-import { DaffBreadcrumbModule } from '@daffodil/design/breadcrumb';
-import { CustomComponent } from './custom.component';
-
-@NgModule({
-	declarations: [
-    CustomComponent,
-  ],
-  exports: [
-    CustomComponent,
-  ],
-  imports: [
-    DaffBreadcrumbModule,
-  ],
-})
-export class CustomComponentModule { }
+```html
+<ol daff-breadcrumb>
+  <li daffBreadcrumbItem>
+    <a routerLink="/link">Link</a>
+  </li>
+  <li daffBreadcrumbItem>
+    <a routerLink="/link">Link</a>
+  </li>
+  <li daffBreacrumbItem>
+    <span>Active Link</span>
+  </li>
+</ol>
 ```
 
-> This method is deprecated. It's recommended to update all custom components to standalone.
-
 ## Accessibility
-Breadcrumbs should be wrapped in a native HTML `<nav>` element so that assistive technologies can present the breadcrumbs as a navigational element on the page. Use `aria-label="Breadcrumbs"` on the `nav` element to provide more context. `aria-current="page"` is added to a breadcrumb item when it's the current page, and `aria-current="false"` on all other items.
+Breadcrumb follows the [Breadcrumb WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/).
+
+- `aria-current="page"` is automatically applied to the last item to indicate that it represents the current page.
+
+In order to fully comply with the WAI-ARIA design pattern:
+
+- Breadcrumbs should be wrapped in a native HTML `<nav>` element so that assistive technologies can present the breadcrumbs as a navigational element on the page.
+- Use `aria-label="Breadcrumb"` on the `nav` element to provide more context into what kind of navigation it is.
+
+```html
+<nav aria-label="breadcrumb">
+  <ol daff-breadcrumb>
+  </ol>
+</nav>
+```

--- a/libs/design/breadcrumb/examples/src/basic-breadcrumb/basic-breadcrumb.component.html
+++ b/libs/design/breadcrumb/examples/src/basic-breadcrumb/basic-breadcrumb.component.html
@@ -3,6 +3,6 @@
 		<li daffBreadcrumbItem>
 			<a routerLink="/link">Link</a>
 		</li>
-		<li daffBreadcrumbItem [active]="true">Active Link</li>
+		<li daffBreadcrumbItem>Link</li>
 	</ol>
 </nav>

--- a/libs/design/breadcrumb/examples/src/iterated-breadcrumb/iterated-breadcrumb.component.html
+++ b/libs/design/breadcrumb/examples/src/iterated-breadcrumb/iterated-breadcrumb.component.html
@@ -1,0 +1,13 @@
+<nav aria-label="Breadcrumb">
+	<ol daff-breadcrumb>
+		@for (breadcrumb of breadcrumbs; track breadcrumb) {
+			<li daffBreadcrumbItem>
+				@if ($last) {
+					<div>{{breadcrumb.label}}</div>
+				} @else {
+					<a [routerLink]="breadcrumb.path">{{breadcrumb.label}}</a>
+				}
+			</li>
+		}
+	</ol>
+</nav>

--- a/libs/design/breadcrumb/examples/src/iterated-breadcrumb/iterated-breadcrumb.component.ts
+++ b/libs/design/breadcrumb/examples/src/iterated-breadcrumb/iterated-breadcrumb.component.ts
@@ -1,0 +1,24 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { DAFF_BREADCRUMB_COMPONENTS } from '@daffodil/design/breadcrumb';
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'iterated-breadcrumb',
+  templateUrl: './iterated-breadcrumb.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DAFF_BREADCRUMB_COMPONENTS,
+    RouterLink,
+  ],
+})
+export class IteratedBreadcrumbComponent {
+  breadcrumbs: any[] = [
+    { path: '/link', label: 'link' },
+    { path: '/link-2', label: 'active link' },
+  ];
+}

--- a/libs/design/breadcrumb/examples/src/public_api.ts
+++ b/libs/design/breadcrumb/examples/src/public_api.ts
@@ -1,5 +1,7 @@
 import { BasicBreadcrumbComponent } from './basic-breadcrumb/basic-breadcrumb.component';
+import { IteratedBreadcrumbComponent } from './iterated-breadcrumb/iterated-breadcrumb.component';
 
 export const BREADCRUMB_EXAMPLES = [
   BasicBreadcrumbComponent,
+  IteratedBreadcrumbComponent,
 ];

--- a/libs/design/breadcrumb/src/breadcrumb-item/breadcrumb-item.directive.spec.ts
+++ b/libs/design/breadcrumb/src/breadcrumb-item/breadcrumb-item.directive.spec.ts
@@ -12,14 +12,12 @@ import { By } from '@angular/platform-browser';
 import { DaffBreadcrumbItemDirective } from './breadcrumb-item.directive';
 
 @Component({
-  template: `<li daffBreadcrumbItem [active]="active">Breadcrumb Item</li>`,
+  template: `<li daffBreadcrumbItem>Breadcrumb Item</li>`,
   imports: [
     DaffBreadcrumbItemDirective,
   ],
 })
-class WrapperComponent {
-  active = false;
-}
+class WrapperComponent {}
 
 describe('@daffodil/design/breadcrumb | DaffBreadcrumbItemDirective', () => {
   let wrapper: WrapperComponent;
@@ -54,19 +52,5 @@ describe('@daffodil/design/breadcrumb | DaffBreadcrumbItemDirective', () => {
         'daff-breadcrumb__item': true,
       }));
     });
-  });
-
-  it('should set the `aria-current` to page if it`s the active breadcrumb', () => {
-    wrapper.active = true;
-    fixture.detectChanges();
-
-    expect(de.nativeElement.ariaCurrent).toEqual('page');
-  });
-
-  it('should set the `aria-current` to false if it`s not the active breadcrumb', () => {
-    wrapper.active = false;
-    fixture.detectChanges();
-
-    expect(de.nativeElement.ariaCurrent).toEqual('false');
   });
 });

--- a/libs/design/breadcrumb/src/breadcrumb-item/breadcrumb-item.directive.ts
+++ b/libs/design/breadcrumb/src/breadcrumb-item/breadcrumb-item.directive.ts
@@ -1,8 +1,7 @@
 import {
+  ChangeDetectorRef,
   Directive,
-  ElementRef,
   HostBinding,
-  Renderer2,
 } from '@angular/core';
 
 @Directive({
@@ -14,21 +13,28 @@ export class DaffBreadcrumbItemDirective {
    */
   @HostBinding('class.daff-breadcrumb__item') class = true;
 
+  /**
+   * @docs-private
+   */
+  @HostBinding('class.active') get activeClass() {
+    return this._active;
+  }
+
+  /**
+   * @docs-private
+   */
+  @HostBinding('attr.aria-current') get ariaCurrent() {
+    return this._active ? 'page' : null;
+  }
+
   private _active = false;
 
-  constructor(
-    private elementRef: ElementRef,
-    private renderer: Renderer2,
-  ) {}
+  constructor( private cdRef: ChangeDetectorRef ) {}
 
   /** Called by the DaffBreadcrumbComponent to set the active state */
   setActive(value: boolean) {
     this._active = value;
-    if (value) {
-      this.renderer.addClass(this.elementRef.nativeElement, 'active');
-      this.renderer.setAttribute(this.elementRef.nativeElement, 'aria-current', 'page');
-    } else {
-      this.renderer.removeClass(this.elementRef.nativeElement, 'active');
-    }
+
+    this.cdRef.detectChanges();
   }
 }

--- a/libs/design/breadcrumb/src/breadcrumb-item/breadcrumb-item.directive.ts
+++ b/libs/design/breadcrumb/src/breadcrumb-item/breadcrumb-item.directive.ts
@@ -1,21 +1,34 @@
 import {
   Directive,
+  ElementRef,
   HostBinding,
-  Input,
+  Renderer2,
 } from '@angular/core';
 
 @Directive({
   selector: 'li[daffBreadcrumbItem]',
-  standalone: true,
 })
 export class DaffBreadcrumbItemDirective {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-breadcrumb__item') class = true;
 
-  @HostBinding('attr.aria-current') get ariaCurrent() {
-    return this.active ? 'page' : 'false';
+  private _active = false;
+
+  constructor(
+    private elementRef: ElementRef,
+    private renderer: Renderer2,
+  ) {}
+
+  /** Called by the DaffBreadcrumbComponent to set the active state */
+  setActive(value: boolean) {
+    this._active = value;
+    if (value) {
+      this.renderer.addClass(this.elementRef.nativeElement, 'active');
+      this.renderer.setAttribute(this.elementRef.nativeElement, 'aria-current', 'page');
+    } else {
+      this.renderer.removeClass(this.elementRef.nativeElement, 'active');
+    }
   }
-
-  /** Whether or not the breadcrumb item is active */
-  @Input() @HostBinding('class.active') active = false;
-
 }

--- a/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
+++ b/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
@@ -6,16 +6,15 @@ import {
   ContentChildren,
   QueryList,
   AfterContentInit,
+  DestroyRef,
 } from '@angular/core';
-import {
-  Subject,
-  takeUntil,
-} from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import {
   DaffArticleEncapsulatedDirective,
   DaffSkeletonableDirective,
 } from '@daffodil/design';
+
 
 import { DaffBreadcrumbItemDirective } from '../breadcrumb-item/breadcrumb-item.directive';
 
@@ -36,6 +35,8 @@ import { DaffBreadcrumbItemDirective } from '../breadcrumb-item/breadcrumb-item.
 })
 
 export class DaffBreadcrumbComponent implements AfterContentInit {
+
+  constructor(private destroyRef: DestroyRef) {}
   /**
    * @docs-private
    */
@@ -46,13 +47,11 @@ export class DaffBreadcrumbComponent implements AfterContentInit {
    */
   @ContentChildren(DaffBreadcrumbItemDirective) breadcrumbItems!: QueryList<DaffBreadcrumbItemDirective>;
 
-  private _destroyed$ = new Subject<boolean>();
-
   ngAfterContentInit() {
     this.updateActiveState();
 
     this.breadcrumbItems.changes
-      .pipe(takeUntil(this._destroyed$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.updateActiveState());
   }
 

--- a/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
+++ b/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
@@ -3,6 +3,9 @@ import {
   ChangeDetectionStrategy,
   HostBinding,
   ViewEncapsulation,
+  ContentChildren,
+  QueryList,
+  AfterContentInit,
 } from '@angular/core';
 
 import {
@@ -10,11 +13,13 @@ import {
   DaffSkeletonableDirective,
 } from '@daffodil/design';
 
+import { DaffBreadcrumbItemDirective } from '../breadcrumb-item/breadcrumb-item.directive';
+
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'ol[daff-breadcrumb]',
   templateUrl: './breadcrumb.component.html',
-  styleUrls: ['./breadcrumb.component.scss'],
+  styleUrl: './breadcrumb.component.scss',
   hostDirectives: [
     { directive: DaffArticleEncapsulatedDirective },
     {
@@ -24,9 +29,35 @@ import {
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
 })
 
-export class DaffBreadcrumbComponent {
+export class DaffBreadcrumbComponent implements AfterContentInit {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-breadcrumb') class = true;
+
+  /**
+   * @docs-private
+   */
+  @ContentChildren(DaffBreadcrumbItemDirective) breadcrumbItems!: QueryList<DaffBreadcrumbItemDirective>;
+
+  /**
+   * @docs-private
+   */
+  ngAfterContentInit() {
+    this.updateActiveState();
+    this.breadcrumbItems.changes.subscribe(() => this.updateActiveState());
+  }
+
+  private updateActiveState() {
+    if (!this.breadcrumbItems.length) {
+      return;
+    }
+
+    // Sets only the last breadcrumb item as active
+    this.breadcrumbItems.forEach((item, index) => {
+      item.setActive(index === this.breadcrumbItems.length - 1);
+    });
+  }
 }

--- a/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
+++ b/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
@@ -7,6 +7,10 @@ import {
   QueryList,
   AfterContentInit,
 } from '@angular/core';
+import {
+  Subject,
+  takeUntil,
+} from 'rxjs';
 
 import {
   DaffArticleEncapsulatedDirective,
@@ -42,12 +46,14 @@ export class DaffBreadcrumbComponent implements AfterContentInit {
    */
   @ContentChildren(DaffBreadcrumbItemDirective) breadcrumbItems!: QueryList<DaffBreadcrumbItemDirective>;
 
-  /**
-   * @docs-private
-   */
+  private _destroyed$ = new Subject<boolean>();
+
   ngAfterContentInit() {
     this.updateActiveState();
-    this.breadcrumbItems.changes.subscribe(() => this.updateActiveState());
+
+    this.breadcrumbItems.changes
+      .pipe(takeUntil(this._destroyed$))
+      .subscribe(() => this.updateActiveState());
   }
 
   private updateActiveState() {
@@ -55,9 +61,9 @@ export class DaffBreadcrumbComponent implements AfterContentInit {
       return;
     }
 
+    this.breadcrumbItems.forEach(item => item.setActive(false));
+
     // Sets only the last breadcrumb item as active
-    this.breadcrumbItems.forEach((item, index) => {
-      item.setActive(index === this.breadcrumbItems.length - 1);
-    });
+    this.breadcrumbItems.last.setActive(true);
   }
 }

--- a/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
+++ b/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
@@ -62,7 +62,6 @@ export class DaffBreadcrumbComponent implements AfterContentInit {
 
     this.breadcrumbItems.forEach(item => item.setActive(false));
 
-    // Sets only the last breadcrumb item as active
     this.breadcrumbItems.last.setActive(true);
   }
 }

--- a/libs/design/breadcrumb/src/public_api.ts
+++ b/libs/design/breadcrumb/src/public_api.ts
@@ -1,4 +1,4 @@
-export * from './breadcrumb/breadcrumb.component';
-export * from './breadcrumb-item/breadcrumb-item.directive';
+export { DaffBreadcrumbComponent } from './breadcrumb/breadcrumb.component';
+export { DaffBreadcrumbItemDirective } from './breadcrumb-item/breadcrumb-item.directive';
 export { DAFF_BREADCRUMB_COMPONENTS } from './breadcrumb';
 export { DaffBreadcrumbModule } from './breadcrumb.module';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Enduser is allowed to use the `active` property, but it should just default to the last breadcrumb item.

Fixes: #3514 


## What is the new behavior?
The active state is automatically set to the last breadcrumb item in a list of breadcrumbs.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

BREAKING CHANGE: T `active` property is no longer available to use. The last breadcrumb item will automatically be set to the active state.


## Other information