### PR TITLE
fix(design,dgeni): link tags don't work in child API descriptions

### DIFF
--- a/libs/design/toast/src/interfaces/toast-action.ts
+++ b/libs/design/toast/src/interfaces/toast-action.ts
@@ -6,7 +6,7 @@ import {
 } from '@daffodil/design';
 
 /**
- * An interface for properties of actions, specifically the DaffButtonComponent, placed inside of the toast.
+ * An interface for properties of actions, specifically the {@link DaffButtonComponent}, placed inside of the toast.
  */
 export interface DaffToastAction {
   /**

--- a/tools/dgeni/src/processors/add-api-symbols-to-package.ts
+++ b/tools/dgeni/src/processors/add-api-symbols-to-package.ts
@@ -8,16 +8,17 @@ import {
 } from '@daffodil/docs-utils';
 
 import { CollectLinkableSymbolsProcessor } from './collect-linkable-symbols';
-import { MARKDOWN_CODE_PROCESSOR_NAME } from './markdown';
 import { API_TEMPLATES_PATH } from '../transforms/config';
 import { FilterableProcessor } from '../utils/filterable-processor.type';
 
 export const ADD_API_SYMBOLS_TO_PACKAGES_PROCESSOR_NAME = 'addApiSymbolsToPackages';
 
+const LINK_TAG = /\{@link ([a-zA-Z]+)}/g;
+
 export class AddApiSymbolsToPackagesProcessor implements FilterableProcessor {
   readonly name = ADD_API_SYMBOLS_TO_PACKAGES_PROCESSOR_NAME;
   readonly $runAfter = ['paths-absolutified'];
-  readonly $runBefore = ['rendering-docs', MARKDOWN_CODE_PROCESSOR_NAME];
+  readonly $runBefore = ['rendering-docs'];
 
   docTypes = [];
   lookup = (doc: Document) => doc.id;
@@ -39,7 +40,17 @@ export class AddApiSymbolsToPackagesProcessor implements FilterableProcessor {
       if (this.docTypes.includes(doc.docType)) {
         const exportDocs = CollectLinkableSymbolsProcessor.packages.get(this.lookup(doc));
         doc.symbols = exportDocs?.map((d) => d.slug);
-        doc.api = exportDocs?.map((symbol) => render(this.templateFinder.getFinder()(symbol), { doc: symbol, child: true }));
+        // the inline tag processor runs after doc rendering and
+        // doesn't expose anything besides `$process` so trick it into processing our child docs
+        doc.api = exportDocs?.map((symbol) =>
+          render(
+            this.templateFinder.getFinder()(symbol),
+            { doc: symbol, child: true },
+          ).replaceAll(
+            LINK_TAG,
+            (match, linkableSymbol) => `<a href="${CollectLinkableSymbolsProcessor.symbols.get(linkableSymbol)}"><code>${linkableSymbol}</code></a>`,
+          ),
+        );
         doc.apiToc = exportDocs?.flatMap((symbol: Document & DaffApiDoc): DaffDocTableOfContents => [
           {
             content: symbol.name,
@@ -52,9 +63,6 @@ export class AddApiSymbolsToPackagesProcessor implements FilterableProcessor {
             slug: entry.slug === 'examples' ? `${symbol.slug}-examples` : entry.slug,
           })),
         ]);
-        const match = doc.content.match(/# .*\n+(.*)\n*/);
-        doc.longDescription = match[1];
-        doc.content = doc.content.replace(match[0], '');
       }
       return doc;
     });

--- a/tools/dgeni/src/processors/long-description.ts
+++ b/tools/dgeni/src/processors/long-description.ts
@@ -1,0 +1,33 @@
+import { Document } from 'dgeni';
+
+import { MARKDOWN_CODE_PROCESSOR_NAME } from './markdown';
+import { FilterableProcessor } from '../utils/filterable-processor.type';
+
+export const LONG_DESCRIPTION_PROCESSOR_NAME = 'longDescription';
+
+/**
+ * Pulls the first line of the content out and stores it in the `longDescription` field.
+ */
+export class LongDescriptionProcessor implements FilterableProcessor {
+  readonly name = LONG_DESCRIPTION_PROCESSOR_NAME;
+  readonly $runAfter = ['paths-absolutified'];
+  readonly $runBefore = ['rendering-docs', MARKDOWN_CODE_PROCESSOR_NAME];
+
+  docTypes = [];
+
+  $process(docs: Array<Document>): Array<Document> {
+    return docs.map(doc => {
+      if (this.docTypes.includes(doc.docType)) {
+        const match = doc.content.match(/# .*\n+(.*)\n*/);
+        doc.longDescription = match[1];
+        doc.content = doc.content.replace(match[0], '');
+      }
+      return doc;
+    });
+  }
+};
+
+export const LONG_DESCRIPTION_PROCESSOR_PROVIDER = <const>[
+  LONG_DESCRIPTION_PROCESSOR_NAME,
+  () => new LongDescriptionProcessor(),
+];

--- a/tools/dgeni/src/transforms/daffodil-guides-package/index.ts
+++ b/tools/dgeni/src/transforms/daffodil-guides-package/index.ts
@@ -30,6 +30,10 @@ import {
   GENERATE_NAV_LIST_PROCESSOR_PROVIDER,
   GenerateNavListProcessor,
 } from '../../processors/generateNavList';
+import {
+  LONG_DESCRIPTION_PROCESSOR_PROVIDER,
+  LongDescriptionProcessor,
+} from '../../processors/long-description';
 import { MarkdownCodeProcessor } from '../../processors/markdown';
 import { IdSanitizer } from '../../services/id-sanitizer';
 import { outputPathsConfigurator } from '../../utils/configurator/output';
@@ -131,6 +135,7 @@ export const designDocsPackage = new Package('design-docs', [design])
   .processor(...GENERATE_NAV_LIST_PROCESSOR_PROVIDER)
   .processor(...FILTER_NAV_INDEX_PROCESSOR_PROVIDER)
   .processor(...ADD_API_SYMBOLS_TO_PACKAGES_PROCESSOR_PROVIDER)
+  .processor(...LONG_DESCRIPTION_PROCESSOR_PROVIDER)
   .config((generateNavList: GenerateNavListProcessor) => {
     generateNavList.outputFolder = `${DAFF_DOCS_PATH}/${DAFF_DOCS_DESIGN_PATH}`;
   })
@@ -151,7 +156,8 @@ export const designDocsPackage = new Package('design-docs', [design])
       getAliases: (doc) => [doc.id],
     });
   })
-  .config((addApiSymbolsToPackages: AddApiSymbolsToPackagesProcessor) => {
+  .config((addApiSymbolsToPackages: AddApiSymbolsToPackagesProcessor, longDescription: LongDescriptionProcessor) => {
+    longDescription.docTypes.push('package-guide');
     addApiSymbolsToPackages.docTypes.push('package-guide');
     addApiSymbolsToPackages.lookup = (doc) => doc.id.replace('components/', '');
   })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #3489


## What is the new behavior?

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Unfortunately a robust processing of the child API docs with the inline tag processor is not possible since the link/jsdoc packages don't function well in the guides pipeline. Any post processing must be manually implemented.