### PR TITLE
fix(design): tab consumers not notified of tab reset on location change

### DIFF
--- a/libs/design/tabs/src/tabs/tabs.component.spec.ts
+++ b/libs/design/tabs/src/tabs/tabs.component.spec.ts
@@ -56,13 +56,10 @@ import { DAFF_TABS_COMPONENTS } from '../tabs';
   ],
 })
 class WrapperComponent {
-  changed: string | null = null;
   linkModeValue: boolean;
   urlValue: string;
 
-  onTabChange(val: string) {
-    this.changed = val;
-  }
+  onTabChange: (val: string) => void;
 }
 
 describe('@daffodil/design/tabs | DaffTabsComponent', () => {
@@ -104,6 +101,8 @@ describe('@daffodil/design/tabs | DaffTabsComponent', () => {
     fixture = TestBed.createComponent(WrapperComponent);
     wrapper = fixture.componentInstance;
 
+    wrapper.onTabChange = jasmine.createSpy();
+
     de = fixture.debugElement.query(By.css('daff-tabs'));
     component = de.componentInstance;
     fixture.detectChanges();
@@ -136,6 +135,10 @@ describe('@daffodil/design/tabs | DaffTabsComponent', () => {
 
       it('should reset the selected tab', () => {
         expect(component.selectedTab).not.toEqual('tab-2');
+      });
+
+      it('should notify the parent component that the tab changed', () => {
+        expect(wrapper.onTabChange).toHaveBeenCalledWith(component.selectedTab);
       });
     });
 
@@ -182,9 +185,8 @@ describe('@daffodil/design/tabs | DaffTabsComponent', () => {
   it('should emit tabChange when a tab is selected', () => {
     const id = component._tabs.toArray()[1].id;
 
-    wrapper.changed = null;
     component.select(id);
-    expect(wrapper.changed).toEqual(id);
+    expect(wrapper.onTabChange).toHaveBeenCalledWith(id);
   });
 
   it('should focus on the selected tab when select is called', () => {

--- a/libs/design/tabs/src/tabs/tabs.component.ts
+++ b/libs/design/tabs/src/tabs/tabs.component.ts
@@ -168,6 +168,8 @@ export class DaffTabsComponent implements AfterContentInit, OnInit {
     if (!this.selectedTab) {
       this.selectedTab = this._tabs.first.id;
     }
+
+    this.tabChange.emit(this.selectedTab);
   }
 
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #3494 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information