### PR TITLE
feat(dgeni): ensure unique slug in heading IDs

### DIFF
--- a/tools/dgeni/src/processors/markdown.ts
+++ b/tools/dgeni/src/processors/markdown.ts
@@ -28,6 +28,11 @@ hljs.registerLanguage('gql', graphql);
 export const MARKDOWN_CODE_PROCESSOR_NAME = 'markdown';
 
 export class MarkdownCodeProcessor implements FilterableProcessor {
+  /**
+   * Stores a list of headings for the current document.
+   * Needed so that `slugify` can generate unique slugs.
+   */
+  private headingList: Array<string> = [];
   private marked = new Marked(
     markedHighlight({
       highlight: (code, lang, info) => {
@@ -49,8 +54,11 @@ export class MarkdownCodeProcessor implements FilterableProcessor {
         }
       },
       renderer: {
-        heading: (text: string, level: number, raw: string) =>
-          `<h${level} id="${slugify(raw)}">${text}</h${level}>`,
+        heading: (text: string, level: number, raw: string) => {
+          const count = this.headingList.filter((heading) => heading === raw).length;
+          this.headingList.push(raw);
+          return `<h${level} id="${slugify(raw, count > 0 ? { num: count } : undefined)}">${text}</h${level}>`;
+        },
         codespan: (text: string): string | false =>
           `<code>${linkSymbols(text)}</code>`,
       },
@@ -90,6 +98,7 @@ export class MarkdownCodeProcessor implements FilterableProcessor {
   }
 
   parse(text: string): string {
+    this.headingList = [];
     return <string>this.marked.parse(text);
   }
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #3534


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Turns out it was not necessary to prefix parent slugs as `markdown-toc` already appends numbers to ensure slugs are unique. Aligning header `id` slug generation with this behavior is sufficient to fix the issue.