### PR TITLE
fix(external-router): `meta_description` missing from magento categories

### DIFF
--- a/libs/external-router/driver/magento/2.4.3/src/graphql/queries/resolve.ts
+++ b/libs/external-router/driver/magento/2.4.3/src/graphql/queries/resolve.ts
@@ -16,6 +16,7 @@ export const MagentoResolveUrlv243 = gql`
 				uid
 				name
 				meta_title
+				meta_description
 				canonical_url
 				products {
 					items {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The magento driver does not request the `meta_description` field from the backend.


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information