### PR TITLE
chore(design): add `docs-private-hostbinding-lifecycle` linting rule

### DIFF
--- a/libs/design/.eslintrc.js
+++ b/libs/design/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
             style: 'camelCase'
           }
         ],
+        'custom-rules/docs-private-hostbinding-lifecycle': 'error',
       }
     },
     {

--- a/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
+++ b/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
@@ -47,6 +47,9 @@ export class DaffBreadcrumbComponent implements AfterContentInit {
    */
   @ContentChildren(DaffBreadcrumbItemDirective) breadcrumbItems!: QueryList<DaffBreadcrumbItemDirective>;
 
+  /**
+   * @docs-private
+   */
   ngAfterContentInit() {
     this.updateActiveState();
 

--- a/libs/design/card/src/card/basic/basic.component.ts
+++ b/libs/design/card/src/card/basic/basic.component.ts
@@ -18,5 +18,8 @@ import { DaffCardBaseDirective } from '../../card-base.directive';
 })
 
 export class DaffCardComponent extends DaffCardBaseDirective {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-card') class = true;
 }

--- a/libs/design/card/src/card/raised/raised.component.ts
+++ b/libs/design/card/src/card/raised/raised.component.ts
@@ -18,5 +18,8 @@ import { DaffCardBaseDirective } from '../../card-base.directive';
 })
 
 export class DaffRaisedCardComponent extends DaffCardBaseDirective {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-raised-card') class = true;
 }

--- a/libs/design/card/src/card/stroked/stroked.component.ts
+++ b/libs/design/card/src/card/stroked/stroked.component.ts
@@ -18,5 +18,8 @@ import { DaffCardBaseDirective } from '../../card-base.directive';
 })
 
 export class DaffStrokedCardComponent extends DaffCardBaseDirective {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-stroked-card') class = true;
 }

--- a/libs/design/checkbox/examples/src/basic-checkbox/basic-checkbox.component.ts
+++ b/libs/design/checkbox/examples/src/basic-checkbox/basic-checkbox.component.ts
@@ -25,6 +25,9 @@ import { DaffButtonComponent } from '@daffodil/design/button';
 export class BasicCheckboxComponent implements OnInit {
   checkboxExample = new UntypedFormControl();
 
+  /**
+   * @docs-private
+   */
   ngOnInit() {
     this.checkboxExample.setValue(true);
   }

--- a/libs/design/checkbox/examples/src/checkbox-set/checkbox-set.component.ts
+++ b/libs/design/checkbox/examples/src/checkbox-set/checkbox-set.component.ts
@@ -34,6 +34,9 @@ export class CheckboxSetComponent implements OnInit {
   checkboxArray = new UntypedFormArray([new UntypedFormControl(), new UntypedFormControl(), new UntypedFormControl()]);
   selectedValues = [];
 
+  /**
+   * @docs-private
+   */
   ngOnInit() {
     this.checkboxArray.setValue([false, false, false]);
   }

--- a/libs/design/menu/src/menu-activator/menu-activator.component.ts
+++ b/libs/design/menu/src/menu-activator/menu-activator.component.ts
@@ -25,6 +25,9 @@ export class DaffMenuActivatorDirective implements OnDestroy {
   private _destroyed$ = new Subject<boolean>();
   private _open: boolean;
 
+  /**
+   * @docs-private
+   */
   @HostBinding('class.open') get openClass() {
     return this._open;
   }

--- a/libs/design/menu/src/menu/menu.component.ts
+++ b/libs/design/menu/src/menu/menu.component.ts
@@ -31,8 +31,17 @@ import { DaffMenuService } from '../services/menu.service';
   ],
 })
 export class DaffMenuComponent implements AfterContentInit, AfterViewInit {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-menu') class = true;
+  /**
+   * @docs-private
+   */
   @HostBinding('tabindex') tabindex = 0;
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.role') role = 'menu';
 
   private _focusTrap: ConfigurableFocusTrap;
@@ -62,12 +71,18 @@ export class DaffMenuComponent implements AfterContentInit, AfterViewInit {
     });
   }
 
+  /**
+   * @docs-private
+   */
   ngAfterContentInit() {
     this._focusTrap = this._focusTrapFactory.create(
       this._elementRef.nativeElement,
     );
   }
 
+  /**
+   * @docs-private
+   */
   ngAfterViewInit() {
     const focusableChild = (<HTMLElement>this._elementRef.nativeElement.querySelector(
       daffFocusableElementsSelector)

--- a/libs/design/modal/src/modal-actions/modal-actions.component.ts
+++ b/libs/design/modal/src/modal-actions/modal-actions.component.ts
@@ -11,5 +11,8 @@ import {
   standalone: true,
 })
 export class DaffModalActionsComponent {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-modal-actions') class = true;
 }

--- a/libs/design/modal/src/modal-close/modal-close.directive.ts
+++ b/libs/design/modal/src/modal-close/modal-close.directive.ts
@@ -38,5 +38,8 @@ export class DaffModalCloseDirective {
   /**
    * Sets the button type attribute to button.
    */
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.type') typeAttribute = 'button';
 }

--- a/libs/design/modal/src/modal-content/modal-content.component.ts
+++ b/libs/design/modal/src/modal-content/modal-content.component.ts
@@ -11,5 +11,8 @@ import {
   standalone: true,
 })
 export class DaffModalContentComponent {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-modal-content') class = true;
 }

--- a/libs/design/modal/src/modal-title/modal-title.directive.ts
+++ b/libs/design/modal/src/modal-title/modal-title.directive.ts
@@ -27,6 +27,9 @@ export class DaffModalTitleDirective {
   /**
    * The html `id` of the modal title.
    */
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.id') get uniqueId() {
     return this._id;
   }

--- a/libs/design/modal/src/modal/modal.component.ts
+++ b/libs/design/modal/src/modal/modal.component.ts
@@ -52,15 +52,24 @@ export class DaffModalComponent implements AfterContentInit, AfterViewInit, Daff
   /**
    * Sets a class of .daff-modal to the host element.
    */
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-modal') modalClass = true;
 
   /**
    * Sets the role to dialog.
    */
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.role') role = 'dialog';
 
   /**
    * Sets aria-modal to true.
+   */
+  /**
+   * @docs-private
    */
   @HostBinding('attr.aria-modal') ariaModal = true;
 
@@ -70,6 +79,9 @@ export class DaffModalComponent implements AfterContentInit, AfterViewInit, Daff
    * The aria-labelledby for the modal. This is set by the id of
    * {@link DaffModalTitleDirective} when it is used.
    *
+   */
+  /**
+   * @docs-private
    */
   @HostBinding('attr.aria-labelledby') get ariaLabelledBy() {
     return this._ariaLabelledBy;
@@ -113,12 +125,18 @@ export class DaffModalComponent implements AfterContentInit, AfterViewInit, Daff
     this.openDirective.stateless = false;
   }
 
+  /**
+   * @docs-private
+   */
   ngAfterContentInit() {
     this._focusTrap = this._focusTrapFactory.create(
       this.elementRef.nativeElement,
     );
   }
 
+  /**
+   * @docs-private
+   */
   ngAfterViewInit() {
     const focusableChild = (<HTMLElement>this.elementRef.nativeElement.querySelector(
       daffFocusableElementsSelector)
@@ -151,6 +169,9 @@ export class DaffModalComponent implements AfterContentInit, AfterViewInit, Daff
   }
 
   /** Animation hook that controls the entrance and exit animations of the modal. */
+  /**
+   * @docs-private
+   */
   @HostBinding('@fade') get fadeState(): string {
     return getAnimationState(this.openDirective.open);
   }

--- a/libs/design/notification/src/notification-actions/notification-actions.directive.ts
+++ b/libs/design/notification/src/notification-actions/notification-actions.directive.ts
@@ -10,5 +10,8 @@ import {
 
 export class DaffNotificationActionsDirective {
 
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-notification__actions') class = true;
 }

--- a/libs/design/notification/src/notification-message/notification-message.directive.ts
+++ b/libs/design/notification/src/notification-message/notification-message.directive.ts
@@ -10,5 +10,8 @@ import {
 
 export class DaffNotificationMessageDirective {
 
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-notification__message') class = true;
 }

--- a/libs/design/notification/src/notification-subtitle/notification-subtitle.directive.ts
+++ b/libs/design/notification/src/notification-subtitle/notification-subtitle.directive.ts
@@ -10,5 +10,8 @@ import {
 
 export class DaffNotificationSubtitleDirective {
 
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-notification__subtitle') class = true;
 }

--- a/libs/design/notification/src/notification-title/notification-title.directive.ts
+++ b/libs/design/notification/src/notification-title/notification-title.directive.ts
@@ -10,5 +10,8 @@ import {
 
 export class DaffNotificationTitleDirective {
 
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-notification__title') class = true;
 }

--- a/libs/design/notification/src/notification/notification.component.ts
+++ b/libs/design/notification/src/notification/notification.component.ts
@@ -58,22 +58,37 @@ export class DaffNotificationComponent {
 
   @ContentChild(DaffNotificationActionsDirective) _actions: DaffNotificationActionsDirective;
 
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-notification') class = true;
 
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.tabindex') tabindex = '0';
 
   /**
    * Sets role to alert when `status="warn"` or `status="critical"`.
    * Sets role to status on all other instances.
    */
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.role') get role() {
     return this.statusDirective.status === DaffStatusEnum.Warn || this.statusDirective.status === DaffStatusEnum.Critical ? 'alert' : 'status';
   };
 
+  /**
+   * @docs-private
+   */
   @HostBinding('class.vertical') get verticalOrientation() {
     return this.orientation === DaffNotificationOrientationEnum.Vertical;
   }
 
+  /**
+   * @docs-private
+   */
   @HostBinding('class.horizontal') get horizontalOrientation() {
     return this.orientation === DaffNotificationOrientationEnum.Horizontal;
   }

--- a/libs/design/progress-bar/src/progress-bar-label/progress-bar-label.directive.ts
+++ b/libs/design/progress-bar/src/progress-bar-label/progress-bar-label.directive.ts
@@ -8,5 +8,8 @@ import {
   standalone: true,
 })
 export class DaffProgressBarLabelDirective {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-progress-bar__label') class = true;
 }

--- a/libs/design/progress-bar/src/progress-bar.component.ts
+++ b/libs/design/progress-bar/src/progress-bar.component.ts
@@ -49,16 +49,31 @@ export class DaffProgressBarComponent {
     return this._indeterminate;
   }
 
+  /**
+   * @docs-private
+   */
   @HostBinding('role') get role() {
     return 'progressbar';
   }
 
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.aria-label') get ariaLabel() {
     return this._indeterminate ? 'loading' : null;
   }
 
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.aria-valuemin') ariaValueMin = '0';
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.aria-valuemax') ariaValueMax = '100';
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.aria-valuenow') get ariaValueNow() {
     return this.percentage;
   }

--- a/libs/design/src/atoms/form/checkbox-set/checkbox-set.component.spec.ts
+++ b/libs/design/src/atoms/form/checkbox-set/checkbox-set.component.spec.ts
@@ -37,6 +37,9 @@ class CheckboxEmbeddedComponent implements OnInit {
 
   selectedValues = [];
 
+  /**
+   * @docs-private
+   */
   ngOnInit() {
     this.checkboxArray.setValue([false, true, true]);
   }

--- a/libs/design/src/atoms/form/checkbox/cva/checkbox-cva.directive.ts
+++ b/libs/design/src/atoms/form/checkbox/cva/checkbox-cva.directive.ts
@@ -47,6 +47,9 @@ export class DaffCheckboxControlValueAccessorDirective implements OnInit, Contro
   /**
    * A lifecycle method called when the directive is initialized.
    */
+  /**
+   * @docs-private
+   */
   ngOnInit(): void {
     // See the note about `writeValue` usage.
     this.writeValue(this._control.value);

--- a/libs/design/src/atoms/form/error-message/error-message.component.ts
+++ b/libs/design/src/atoms/form/error-message/error-message.component.ts
@@ -12,5 +12,8 @@ import {
   standalone: false,
 })
 export class DaffErrorMessageComponent {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-error-message') class = true;
 }

--- a/libs/design/src/atoms/form/form-label/form-label.directive.ts
+++ b/libs/design/src/atoms/form/form-label/form-label.directive.ts
@@ -8,5 +8,8 @@ import {
   standalone: false,
 })
 export class DaffFormLabelDirective {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-form-label') class = true;
 }

--- a/libs/design/src/atoms/form/hint/hint.component.ts
+++ b/libs/design/src/atoms/form/hint/hint.component.ts
@@ -12,5 +12,8 @@ import {
   standalone: true,
 })
 export class DaffHintComponent {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-hint') class = true;
 }

--- a/libs/design/src/atoms/form/input/input.component.ts
+++ b/libs/design/src/atoms/form/input/input.component.ts
@@ -63,6 +63,7 @@ export class DaffInputComponent extends DaffFormFieldControl<string> implements 
     super(ngControl);
   }
 
+  /** @docs-private */
   ngOnInit() {
     this.stateChanges = merge(
       this._stateChanges.asObservable(),

--- a/libs/design/src/atoms/form/quantity-field/quantity-input/quantity-input.component.ts
+++ b/libs/design/src/atoms/form/quantity-field/quantity-input/quantity-input.component.ts
@@ -71,6 +71,9 @@ export class DaffQuantityInputComponent implements OnInit, OnDestroy {
     private changeDetectorRef: ChangeDetectorRef,
   ) {}
 
+  /**
+   * @docs-private
+   */
   ngOnInit() {
     this._inputControl.patchValue(this.ngControl.control.value);
     this.setInputDisabled();

--- a/libs/design/src/atoms/form/radio/cva/radio-cva.directive.ts
+++ b/libs/design/src/atoms/form/radio/cva/radio-cva.directive.ts
@@ -45,6 +45,9 @@ export class DaffRadioControlValueAccessorDirective implements OnInit, ControlVa
     }
   }
 
+  /**
+   * @docs-private
+   */
   ngOnInit(): void {
     this.writeValue(this._control.value);
     this._registry.add(this._control, this);

--- a/libs/design/src/core/article-encapsulated/article-encapsulated.directive.ts
+++ b/libs/design/src/core/article-encapsulated/article-encapsulated.directive.ts
@@ -32,5 +32,8 @@ import {
   standalone: true,
 })
 export class DaffArticleEncapsulatedDirective {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-ae') class = true;
 }

--- a/libs/design/src/core/colorable/colorable.directive.ts
+++ b/libs/design/src/core/colorable/colorable.directive.ts
@@ -119,12 +119,18 @@ export class DaffColorableDirective implements DaffColorable, OnChanges, OnInit 
    */
   defaultColor: DaffPalette;
 
+  /**
+   * @docs-private
+   */
   ngOnChanges(changes: SimpleChanges) {
     if (!changes.color.currentValue) {
       this.color = this.defaultColor;
     }
   }
 
+  /**
+   * @docs-private
+   */
   ngOnInit() {
     validateColor(this.color);
     if (!this.color) {

--- a/libs/design/src/core/manage-container-layout/manage-container-layout.directive.ts
+++ b/libs/design/src/core/manage-container-layout/manage-container-layout.directive.ts
@@ -67,5 +67,8 @@ import {
   standalone: true,
 })
 export class DaffManageContainerLayoutDirective {
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-manage-container-layout') class = true;
 }

--- a/libs/design/src/core/openable/openable.directive.ts
+++ b/libs/design/src/core/openable/openable.directive.ts
@@ -117,6 +117,9 @@ export class DaffOpenableDirective implements DaffOpenable, OnChanges {
     this.toggled.emit(state);
   }
 
+  /**
+   * @docs-private
+   */
   ngOnChanges(changes: SimpleChanges) {
     /**
      * Throw an error if open is set in a component that is not stateless

--- a/libs/design/src/core/prefix-suffix/prefix.directive.ts
+++ b/libs/design/src/core/prefix-suffix/prefix.directive.ts
@@ -13,5 +13,8 @@ import {
 })
 export class DaffPrefixDirective {
 
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-prefix') class = true;
 }

--- a/libs/design/src/core/prefix-suffix/suffix.directive.ts
+++ b/libs/design/src/core/prefix-suffix/suffix.directive.ts
@@ -13,5 +13,8 @@ import {
 })
 export class DaffSuffixDirective {
 
+  /**
+   * @docs-private
+   */
   @HostBinding('class.daff-suffix') class = true;
 }

--- a/libs/design/src/core/sizable/sizable.directive.ts
+++ b/libs/design/src/core/sizable/sizable.directive.ts
@@ -94,12 +94,18 @@ export class DaffSizableDirective<T extends DaffSizeAllType> implements DaffSiza
    */
   public defaultSize: T;
 
+  /**
+   * @docs-private
+   */
   ngOnChanges(changes: SimpleChanges) {
     if(!changes.size?.currentValue) {
       this.size = this.defaultSize;
     }
   }
 
+  /**
+   * @docs-private
+   */
   ngOnInit() {
     if(!this.size) {
       this.size = this.defaultSize;

--- a/libs/design/src/core/text-alignable/text-alignable.directive.ts
+++ b/libs/design/src/core/text-alignable/text-alignable.directive.ts
@@ -87,6 +87,9 @@ export class DaffTextAlignableDirective implements DaffTextAlignable, OnChanges 
    */
   public defaultAlignment: DaffTextAlignment;
 
+  /**
+   * @docs-private
+   */
   ngOnChanges(changes: SimpleChanges) {
     if (!changes.textAlignment?.currentValue) {
       this.textAlignment = this.defaultAlignment;

--- a/libs/design/tabs/src/tabs/tab-activator/tab-activator.component.ts
+++ b/libs/design/tabs/src/tabs/tab-activator/tab-activator.component.ts
@@ -34,10 +34,16 @@ export class DaffTabActivatorComponent implements OnInit {
   /**
    * Sets the `role` to tab.
    */
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.role') role = 'tab';
 
   /**
    * Sets `aria-selected` to true if the component is selected and false if it's not selected.
+   */
+  /**
+   * @docs-private
    */
   @HostBinding('attr.aria-selected') get ariaSelected() {
     return this.selectableDirective.selected ? true :  false;
@@ -46,10 +52,16 @@ export class DaffTabActivatorComponent implements OnInit {
   /**
    * Sets `tabindex` to `0` if the component is selected and `-1` if it's not selected.
    */
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.tabindex') get tabIndex() {
     return this.selectableDirective.selected ? '0' :  '-1';
   }
 
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.aria-controls') ariaControls = '';
 
   constructor(
@@ -65,6 +77,9 @@ export class DaffTabActivatorComponent implements OnInit {
 
   @Input() panelId = '';
 
+  /**
+   * @docs-private
+   */
   ngOnInit() {
     /**
      * Sets the value of `panelId` to the `ariaControls` property

--- a/libs/design/tabs/src/tabs/tabs.component.ts
+++ b/libs/design/tabs/src/tabs/tabs.component.ts
@@ -89,6 +89,9 @@ export class DaffTabsComponent implements AfterContentInit, OnInit {
   /**
    * aria-label for the tab.
    */
+  /**
+   * @docs-private
+   */
   @HostBinding('attr.aria-label') private externalAriaLabel = null;
 
   /**

--- a/libs/design/toast/examples/src/default-toast/default-toast.component.ts
+++ b/libs/design/toast/examples/src/default-toast/default-toast.component.ts
@@ -42,6 +42,9 @@ export class DefaultToastComponent implements OnInit {
     });
   }
 
+  /**
+   * @docs-private
+   */
   ngOnInit() {
     this.update.subscribe(() => {
       console.log('test');

--- a/libs/design/toast/examples/src/toast-positions/toast-positions.component.ts
+++ b/libs/design/toast/examples/src/toast-positions/toast-positions.component.ts
@@ -58,6 +58,9 @@ export class ToastPositionsComponent implements OnInit {
   horizontalControl: FormControl = new FormControl('right');
   verticalControl: FormControl = new FormControl('top');
 
+  /**
+   * @docs-private
+   */
   ngOnInit() {
     combineLatest([
       this.horizontalControl.valueChanges,

--- a/libs/design/tree/src/tree-item/tree-item.directive.ts
+++ b/libs/design/tree/src/tree-item/tree-item.directive.ts
@@ -70,10 +70,16 @@ export class DaffTreeItemDirective {
    * You can use this to style your templates if you want to
    * use different designs at different depths.
    */
+  /**
+   * @docs-private
+   */
   @HostBinding('style.--depth') depth: number;
 
   /**
    * The CSS class indicating whether or not the tree is `selected`.
+   */
+  /**
+   * @docs-private
    */
   @HostBinding('class.selected') get selectedClass() {
     return this.selected;
@@ -81,6 +87,9 @@ export class DaffTreeItemDirective {
 
   /**
    * The CSS class indicating whether or not the tree is `open`.
+   */
+  /**
+   * @docs-private
    */
   @HostBinding('class.open') openClass = false;
 

--- a/libs/design/tree/src/tree/tree.component.ts
+++ b/libs/design/tree/src/tree/tree.component.ts
@@ -117,6 +117,9 @@ export class DaffTreeComponent implements OnInit, OnChanges {
 
   constructor(private notifier: DaffTreeNotifierService) {}
 
+  /**
+   * @docs-private
+   */
   ngOnChanges(changes: SimpleChanges): void {
     if(!changes.tree.currentValue) {
       this._tree = undefined;

--- a/libs/design/youtube-player/src/youtube-player.component.ts
+++ b/libs/design/youtube-player/src/youtube-player.component.ts
@@ -77,6 +77,9 @@ export class DaffYoutubePlayerComponent implements OnInit {
     return this.sanitizer.bypassSecurityTrustStyle(this.width + ' / ' + this.height);
   }
 
+  /**
+   * @docs-private
+   */
   @HostBinding('style.max-width') get maxWidth(): string {
     return this.width + 'px';
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "dotenv": "^16.4.5",
         "esbuild": "^0.24.0",
         "eslint": "^8.57.0",
+        "eslint-plugin-custom-rules": "file:tools/eslint/custom-rules",
         "eslint-plugin-import": "^2.30.0",
         "eslint-plugin-jasmine": "^4.2.1",
         "eslint-plugin-jest": "^28.8.3",
@@ -16983,6 +16984,10 @@
       "dependencies": {
         "ms": "^2.1.1"
       }
+    },
+    "node_modules/eslint-plugin-custom-rules": {
+      "resolved": "tools/eslint/custom-rules",
+      "link": true
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.31.0",
@@ -37820,6 +37825,21 @@
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
       "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==",
       "license": "MIT"
+    },
+    "tools/eslint/custom-rules": {
+      "name": "eslint-plugin-custom-rules",
+      "version": "0.0.0",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "tools/eslint/custom-rules/docs-private-hostbinding-lifecycle": {
+      "version": "0.0.0",
+      "extraneous": true,
+      "peerDependencies": {
+        "eslint": "*"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "eslint-plugin-modules-newlines": "^0.0.7",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-unused-imports": "^4.1.4",
+    "eslint-plugin-custom-rules": "file:tools/eslint/custom-rules",
     "gulp": "^4.0.2",
     "gulp-execa": "^1.1.0",
     "gulp-reduce-async": "^1.0.0",

--- a/tools/eslint/config/index.js
+++ b/tools/eslint/config/index.js
@@ -7,7 +7,8 @@ module.exports = {
     "eslint-plugin-jsdoc",
     "eslint-plugin-prefer-arrow",
     "@stylistic",
-    "eslint-plugin-unused-imports"
+    "eslint-plugin-unused-imports",
+    "custom-rules",
   ],
   extends: [
     "plugin:@typescript-eslint/recommended",
@@ -343,6 +344,6 @@ module.exports = {
         "message": "Inject `DOCUMENT` from `@angular/common` and access `window` via `document.defaultView`."
       },
     ],
-    "unused-imports/no-unused-imports": "error"
+    "unused-imports/no-unused-imports": "error",
   }
 }

--- a/tools/eslint/custom-rules/.eslintrc.js
+++ b/tools/eslint/custom-rules/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    es6: true,
+  },
+};

--- a/tools/eslint/custom-rules/docs-private-hostbinding-lifecycle.js
+++ b/tools/eslint/custom-rules/docs-private-hostbinding-lifecycle.js
@@ -1,0 +1,114 @@
+/**
+ * docs-private-hostbinding-lifecycle.js
+ *
+ * Inserts and enforces
+ *
+ *   /**
+ *    * @docs-private
+ *    *\/
+ *
+ * above every @HostBinding() member and Angular lifecycle method.
+ */
+'use strict';
+
+const LIFECYCLE_HOOKS = new Set([
+  'ngOnChanges', 'ngOnInit', 'ngDoCheck',
+  'ngAfterContentInit', 'ngAfterContentChecked',
+  'ngAfterViewInit', 'ngAfterViewChecked',
+]);
+
+/**
+ * Returns true if any leading block comment on `node` already has @docs-private 
+ */
+function hasDocsPrivate(src, node) {
+  return src
+    .getCommentsBefore(node)
+    .some((c) => c.type === 'Block' && /@docs-private\b/i.test(c.value));
+}
+
+/**
+ * Returns (`indent`, `eol`) for the line where `node` starts
+ * - indenting should be irrelevant as there are existing eslint rules that can resolve indenting issues
+*/
+function indentAndEol(src, node) {
+  const full = src.getText();
+  const start = node.range[0];
+
+  const eol = /\r\n/.test(full.slice(0, start)) ? '\r\n' : '\n';
+
+  const indent = ' '.repeat(node.loc.start.column);
+
+  return { indent, eol };
+}
+
+/**
+ * Returns true if the decorators array contains a @HostBinding() decorator.
+ */
+function isHostBinding(decorators = []) {
+  if (decorators.length === 0) return false;
+  return decorators.every(
+    (d) =>
+      d.expression.type === 'CallExpression' &&
+      d.expression.callee.type === 'Identifier' &&
+      d.expression.callee.name === 'HostBinding'
+  );
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Require /** @docs-private */ above HostBinding members and Angular lifecycle hooks',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      missing:
+        '`{{id}}` must be preceded by a JSDoc block containing @docs-private',
+    },
+  },
+
+  create(context) {
+    const src = context.getSourceCode();
+
+    function ensure(node, id) {
+      if (hasDocsPrivate(src, node)) return;
+
+      context.report({
+        node,
+        messageId: 'missing',
+        data: { id },
+        fix(fixer) {
+          const { indent, eol } = indentAndEol(src, node);
+
+          const block =
+            `${indent}/**${eol}` +
+            `${indent} * @docs-private${eol}` +
+            `${indent} */${eol}`;
+
+          return fixer.insertTextBefore(node, block);
+        },
+      });
+    }
+
+    const selector =
+      'PropertyDefinition, ClassProperty, MethodDefinition';
+
+    return {
+      [selector](node) {
+        if (isHostBinding(node.decorators)) {
+          ensure(node, '@HostBinding member');
+        }
+
+        if (
+          node.type === 'MethodDefinition' &&
+          node.key.type === 'Identifier' &&
+          LIFECYCLE_HOOKS.has(node.key.name)
+        ) {
+          ensure(node, node.key.name);
+        }
+      },
+    };
+  },
+};

--- a/tools/eslint/custom-rules/index.js
+++ b/tools/eslint/custom-rules/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports.rules = {
+  "docs-private-hostbinding-lifecycle": require("./docs-private-hostbinding-lifecycle"),
+};

--- a/tools/eslint/custom-rules/package.json
+++ b/tools/eslint/custom-rules/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "eslint-plugin-custom-rules",
+  "version": "0.0.0",
+  "main": "index.js",
+  "private": true,
+  "peerDependencies": { "eslint": "*" }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
No existing linting rule for @docs-private tag for HostBinding and Lifecycle methods.

Fixes: #3487


## What is the new behavior?
Added linting rule, and added @docs-private tag to hostbinding and lifecycle methods.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


Notes:

- The non-typescript files are the files that involve changes that aren't purely linting
- The changes to the typescript files are only to add the @docs-private tag to satisfy lerna run lint
- To apply the linting changes, I ran eslint --fix for the necessary packages, since I couldn't find documentation to do it through lerna (not sure if this is the right approach)
- The rule current applies to the entire repository
- To apply the rule only to design, remove custom-rules from tools/config and directly import it as a plugin to libs/design/.eslintrc.js
- CodeClimate errors for function length and code complexity
- It may be worth it to later abstract away some of the custom eslint rule functions in **tools/eslint/custom-rules/docs-private-hostbinding-lifecycle.js** (e.g. hasDocsPrivate could be abstracted to hasTag if we need to frequently check for specific JSDoc annotations/block tags)
- However, since we only have 1 custom rule currently, I decided to keep them all in the same file for now