### PR TITLE
feat(design): remove DaffPrefixSuffixModule import from DaffMenuItemComponent

### DIFF
--- a/libs/design/menu/src/menu-item/menu-item.component.html
+++ b/libs/design/menu/src/menu-item/menu-item.component.html
@@ -1,6 +1,6 @@
-<ng-container *ngIf="_prefix">
+@if (_prefix) {
   <ng-content select="[daffPrefix]"></ng-content>
-</ng-container>
+}
 <div class="daff-menu-item__content">
   <ng-content></ng-content>
 </div>

--- a/libs/design/menu/src/menu-item/menu-item.component.ts
+++ b/libs/design/menu/src/menu-item/menu-item.component.ts
@@ -1,4 +1,3 @@
-import { NgIf } from '@angular/common';
 import {
   Component,
   ChangeDetectionStrategy,
@@ -6,10 +5,7 @@ import {
   ContentChild,
 } from '@angular/core';
 
-import {
-  DaffPrefixDirective,
-  DaffPrefixSuffixModule,
-} from '@daffodil/design';
+import { DaffPrefixDirective } from '@daffodil/design';
 
 @Component({
   selector: 'a[daff-menu-item]' + ',' +
@@ -17,10 +13,6 @@ import {
   templateUrl: './menu-item.component.html',
   styleUrls: ['./menu-item.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    NgIf,
-    DaffPrefixSuffixModule,
-  ],
 })
 
 export class DaffMenuItemComponent {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `DaffMenuItemComponent` imports the `DaffPrefixSuffixModule`. The import doesn't do anything as the module isn't actively used in the component.

## What is the new behavior?
`DaffPrefixSuffixModule` has been removed as an import. This doesn't cause a breaking change because the module isn't actively used in the component, and you would still need to import it in the usage component.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information