### PR TITLE
feat(design)!: remove `DaffPrefixDirective` import from `DaffNotificationComponent` and update usage docs

### DIFF
--- a/libs/design/notification/README.md
+++ b/libs/design/notification/README.md
@@ -52,27 +52,24 @@ export class CustomComponentModule { }
 ## Supported Content Types
 
 ### Icon
-An icon can be used to give a user a brief overview of what the nofication is about. It can be added before the title and subtitle by using the <code>daffPrefix</code> selector.
+An icon can be used to provide users with a quick visual cue about the purpose of a notification. Place the icon before the title and subtitle using the `[daffPrefix]` selector. Make sure to import the `DaffPrefixDirective` for the selector to function correctly.
 
 ### Title
-Title gives a quick overview of what the notification is about. It can be added by using the `daffNotificationTitle` selector.
+The title provides a quick overview of what the notification's content. Add it using the `[daffNotificationTitle]` selector.
 
 ### Subtitle
-Subtitle provides additional details about the notification that should be limited to one or two sentences. It can be added by using the `daffNotificationSubtitle` selector.
+The subtitle provides additional details about the notification. It should be limited to one or two sentences. Add it using the `[daffNotificationSubtitle]` selector.
 
 ### Actions
-Buttons can be included in notifications to resolve the notification or navigate them to a page with more information. It can be added by using the `daffNotificationActions` selector.
+Buttons can be included in notifications to dismiss them or navigate them to a page with more information. Use the `[daffNotificationActions]` selector to include these actions.
 
 <design-land-example-viewer-container example="notification-with-actions"></design-land-example-viewer-container>
 
 ## Properties
 
-### Statuses
-The status color of a notification can be updated by using the `status` property.
+### Status
+The status property is used to visually distinguish between different notification types. Use the `status` property to set the status.
 
-Supported statuses: `warn | critical | success`
-
-#### Notification with statuses
 <design-land-example-viewer-container example="notification-status"></design-land-example-viewer-container>
 
 ### Orientation
@@ -81,11 +78,13 @@ Orientation dictates how a notification's content is stacked — `vertical` or `
 <design-land-example-viewer-container example="notification-orientations"></design-land-example-viewer-container>
 
 ### Dismissing a notification
-Notifications are not dismissible by default. They typically persist on the page until a user takes action that resolves the notification.
+By default, notifications are not dismissible and remain visible until the user takes an action to resolve them.
 
-The close button is hidden by default but can be visible by setting the `dismissible` property to `true`. It should remain hidden if a notification has critical information for a user to read or interact with.
+To show a close button, set the `dismissible` property to `true`. Avoid making critical notifications dismissible to ensure users can read or interact with the necessary information.
 
 <design-land-example-viewer-container example="dismissible-notification"></design-land-example-viewer-container>
 
 ## Accessibility
-Notifications with a `critical` or `warn` status have a `role="alert"` so that it can be announced by assistive technologies. See [live region roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#4._live_region_roles) for more information. All other notifications have a `role="status"`. Notifications have a `tabindex="0"` so users can discover them while tabbing through a page.
+Notifications with a `critical` or `warn` status have a `role="alert"` so that it can be announced by assistive technologies. See [live region roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#4._live_region_roles) for more information. All other notifications have a `role="status"`.
+
+Notifications have a `tabindex="0"` so users can discover them while tabbing through a page.

--- a/libs/design/notification/examples/src/default-notification/default-notification.component.ts
+++ b/libs/design/notification/examples/src/default-notification/default-notification.component.ts
@@ -1,4 +1,3 @@
-import { NgIf } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -6,6 +5,7 @@ import {
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixDirective } from '@daffodil/design';
 import { DAFF_NOTIFICATION_COMPONENTS } from '@daffodil/design/notification';
 
 @Component({
@@ -16,8 +16,8 @@ import { DAFF_NOTIFICATION_COMPONENTS } from '@daffodil/design/notification';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_NOTIFICATION_COMPONENTS,
+    DaffPrefixDirective,
     FaIconComponent,
-    NgIf,
   ],
 })
 export class DefaultNotificationComponent {

--- a/libs/design/notification/examples/src/dismissible-notification/dismissible-notification.component.ts
+++ b/libs/design/notification/examples/src/dismissible-notification/dismissible-notification.component.ts
@@ -6,6 +6,7 @@ import {
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixDirective } from '@daffodil/design';
 import { DAFF_NOTIFICATION_COMPONENTS } from '@daffodil/design/notification';
 
 @Component({
@@ -23,6 +24,7 @@ import { DAFF_NOTIFICATION_COMPONENTS } from '@daffodil/design/notification';
     DAFF_NOTIFICATION_COMPONENTS,
     FaIconComponent,
     NgIf,
+    DaffPrefixDirective,
   ],
 })
 export class DismissibleNotificationComponent {

--- a/libs/design/notification/examples/src/notification-orientations/notification-orientations.component.ts
+++ b/libs/design/notification/examples/src/notification-orientations/notification-orientations.component.ts
@@ -13,6 +13,7 @@ import {
   faInfoCircle,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixDirective } from '@daffodil/design';
 import { DAFF_NOTIFICATION_COMPONENTS } from '@daffodil/design/notification';
 
 @Component({
@@ -25,6 +26,7 @@ import { DAFF_NOTIFICATION_COMPONENTS } from '@daffodil/design/notification';
     DAFF_NOTIFICATION_COMPONENTS,
     FaIconComponent,
     ReactiveFormsModule,
+    DaffPrefixDirective,
   ],
 })
 export class NotificationOrientationsComponent {

--- a/libs/design/notification/examples/src/notification-status/notification-status.component.ts
+++ b/libs/design/notification/examples/src/notification-status/notification-status.component.ts
@@ -14,6 +14,7 @@ import {
   faInfoCircle,
 } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixDirective } from '@daffodil/design';
 import { DAFF_NOTIFICATION_COMPONENTS } from '@daffodil/design/notification';
 
 @Component({
@@ -27,6 +28,7 @@ import { DAFF_NOTIFICATION_COMPONENTS } from '@daffodil/design/notification';
     NgIf,
     FaIconComponent,
     ReactiveFormsModule,
+    DaffPrefixDirective,
   ],
 })
 export class NotificationStatusComponent {

--- a/libs/design/notification/examples/src/notification-with-actions/notification-with-actions.component.ts
+++ b/libs/design/notification/examples/src/notification-with-actions/notification-with-actions.component.ts
@@ -2,9 +2,10 @@ import {
   ChangeDetectionStrategy,
   Component,
 } from '@angular/core';
-import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 
+import { DaffPrefixDirective } from '@daffodil/design';
 import {
   DaffButtonComponent,
   DaffFlatButtonComponent,
@@ -26,9 +27,10 @@ import { DAFF_NOTIFICATION_COMPONENTS } from '@daffodil/design/notification';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_NOTIFICATION_COMPONENTS,
-    FontAwesomeModule,
+    FaIconComponent,
     DaffButtonComponent,
     DaffFlatButtonComponent,
+    DaffPrefixDirective,
   ],
 })
 export class NotificationWithActionsComponent {

--- a/libs/design/notification/src/notification.ts
+++ b/libs/design/notification/src/notification.ts
@@ -1,5 +1,3 @@
-import { DaffPrefixDirective } from '@daffodil/design';
-
 import { DaffNotificationComponent } from './notification/notification.component';
 import { DaffNotificationActionsDirective } from './notification-actions/notification-actions.directive';
 import { DaffNotificationMessageDirective } from './notification-message/notification-message.directive';
@@ -15,5 +13,4 @@ export const DAFF_NOTIFICATION_COMPONENTS = <const> [
   DaffNotificationMessageDirective,
   DaffNotificationTitleDirective,
   DaffNotificationSubtitleDirective,
-  DaffPrefixDirective,
 ];

--- a/libs/design/notification/src/notification/notification.component.ts
+++ b/libs/design/notification/src/notification/notification.component.ts
@@ -48,7 +48,6 @@ enum DaffNotificationOrientationEnum {
   imports: [
     NgIf,
     FaIconComponent,
-    DaffPrefixDirective,
   ],
 })
 export class DaffNotificationComponent {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`DaffPrefixDirective` is imported in the `DAFF_NOTIFICATION_COMPONENTS` const. It should not be part of the notification component and should be imported as needed by the end user.

Fixes: N/A


## What is the new behavior?
Remove `DaffPrefixDirective` as part of the export const of `DAFF_NOTIFICATION_COMPONENTS`.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

BREAKING CHANGE: `DaffPrefixDirective` has been removed from the `DAFF_NOTIFICATION_COMPONENTS` array. To continue using the `daffPrefix` selector for displaying icons, you must now import `DaffPrefixDirective` directly into your custom component.

## Other information