### PR TITLE
feat(design): convert `DaffFormFieldComponent` to standalone

### DIFF
--- a/apps/demo/src/app/checkout/components/forms/address/components/address-form/address-form.component.ts
+++ b/apps/demo/src/app/checkout/components/forms/address/components/address-form/address-form.component.ts
@@ -16,7 +16,7 @@ import {
 import {
   DaffInputComponent,
   DaffNativeSelectModule,
-  DaffFormFieldModule,
+  DAFF_FORM_FIELD_COMPONENTS,
 } from '@daffodil/design';
 import {
   DaffCountry,
@@ -40,7 +40,7 @@ import { DemoCheckoutAddressFormGroup } from '../../models/address-form.type';
     ReactiveFormsModule,
     DaffInputComponent,
     DaffNativeSelectModule,
-    DaffFormFieldModule,
+    DAFF_FORM_FIELD_COMPONENTS,
     DaffGeographyStateModule,
   ],
 })

--- a/apps/demo/src/app/checkout/components/payment/payment-info-form/components/payment-info-form/payment-info-form.component.ts
+++ b/apps/demo/src/app/checkout/components/payment/payment-info-form/components/payment-info-form/payment-info-form.component.ts
@@ -9,7 +9,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import {
   DaffInputComponent,
   DaffNativeSelectModule,
-  DaffFormFieldModule,
+  DAFF_FORM_FIELD_COMPONENTS,
 } from '@daffodil/design';
 
 import { PaymentInfoFormGroup } from '../../models/payment-form.type';
@@ -35,7 +35,7 @@ const currentYear = new Date().getFullYear();
     ReactiveFormsModule,
     DaffInputComponent,
     DaffNativeSelectModule,
-    DaffFormFieldModule,
+    DAFF_FORM_FIELD_COMPONENTS,
   ],
 })
 export class DemoCheckoutPaymentInfoFormComponent {

--- a/libs/design/input/examples/src/input-disabled/input-disabled.component.ts
+++ b/libs/design/input/examples/src/input-disabled/input-disabled.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/forms';
 
 import {
-  DaffFormFieldModule,
+  DAFF_FORM_FIELD_COMPONENTS,
   DaffInputComponent,
 } from '@daffodil/design';
 
@@ -22,11 +22,10 @@ import {
     }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true,
   imports: [
     ReactiveFormsModule,
-    DaffFormFieldModule,
     DaffInputComponent,
+    DAFF_FORM_FIELD_COMPONENTS,
   ],
 })
 export class InputDisabledComponent {

--- a/libs/design/input/examples/src/input-error/input-error.component.ts
+++ b/libs/design/input/examples/src/input-error/input-error.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/forms';
 
 import {
-  DaffFormFieldModule,
+  DAFF_FORM_FIELD_COMPONENTS,
   DaffHintComponent,
   DaffInputComponent,
 } from '@daffodil/design';
@@ -25,7 +25,7 @@ import {
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffFormFieldModule,
+    DAFF_FORM_FIELD_COMPONENTS,
     DaffInputComponent,
     DaffHintComponent,
     ReactiveFormsModule,

--- a/libs/design/input/examples/src/input-hint/input-hint.component.ts
+++ b/libs/design/input/examples/src/input-hint/input-hint.component.ts
@@ -4,7 +4,7 @@ import {
 } from '@angular/core';
 
 import {
-  DaffFormFieldModule,
+  DAFF_FORM_FIELD_COMPONENTS,
   DaffHintComponent,
   DaffInputComponent,
 } from '@daffodil/design';
@@ -19,9 +19,8 @@ import {
     }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true,
   imports: [
-    DaffFormFieldModule,
+    DAFF_FORM_FIELD_COMPONENTS,
     DaffInputComponent,
     DaffHintComponent,
   ],

--- a/libs/design/input/examples/src/input-with-form-field/input-with-form-field.component.ts
+++ b/libs/design/input/examples/src/input-with-form-field/input-with-form-field.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 import {
-  DaffFormFieldModule,
+  DAFF_FORM_FIELD_COMPONENTS,
   DaffInputComponent,
   DaffPrefixSuffixModule,
 } from '@daffodil/design';
@@ -24,9 +24,8 @@ import {
     }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true,
   imports: [
-    DaffFormFieldModule,
+    DAFF_FORM_FIELD_COMPONENTS,
     DaffInputComponent,
     FaIconComponent,
     DaffPrefixSuffixModule,

--- a/libs/design/quantity-field/examples/src/basic-quantity-field/basic-quantity-field.component.ts
+++ b/libs/design/quantity-field/examples/src/basic-quantity-field/basic-quantity-field.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/forms';
 
 import {
-  DaffFormFieldModule,
+  DAFF_FORM_FIELD_COMPONENTS,
   DaffQuantityFieldModule,
 } from '@daffodil/design';
 
@@ -19,7 +19,7 @@ import {
   styleUrls: ['./basic-quantity-field.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffFormFieldModule,
+    DAFF_FORM_FIELD_COMPONENTS,
     DaffQuantityFieldModule,
     ReactiveFormsModule,
   ],

--- a/libs/design/quantity-field/examples/src/custom-range-quantity-field/custom-range-quantity-field.component.ts
+++ b/libs/design/quantity-field/examples/src/custom-range-quantity-field/custom-range-quantity-field.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/forms';
 
 import {
-  DaffFormFieldModule,
+  DAFF_FORM_FIELD_COMPONENTS,
   DaffQuantityFieldModule,
 } from '@daffodil/design';
 
@@ -19,7 +19,7 @@ import {
   styleUrls: ['./custom-range-quantity-field.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffFormFieldModule,
+    DAFF_FORM_FIELD_COMPONENTS,
     DaffQuantityFieldModule,
     ReactiveFormsModule,
   ],

--- a/libs/design/quantity-field/examples/src/disabled-quantity-field/disabled-quantity-field.component.ts
+++ b/libs/design/quantity-field/examples/src/disabled-quantity-field/disabled-quantity-field.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/forms';
 
 import {
-  DaffFormFieldModule,
+  DAFF_FORM_FIELD_COMPONENTS,
   DaffQuantityFieldModule,
 } from '@daffodil/design';
 
@@ -19,7 +19,7 @@ import {
   styleUrls: ['./disabled-quantity-field.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffFormFieldModule,
+    DAFF_FORM_FIELD_COMPONENTS,
     DaffQuantityFieldModule,
     ReactiveFormsModule,
   ],

--- a/libs/design/quantity-field/examples/src/select-max-quantity-field/select-max-quantity-field.component.ts
+++ b/libs/design/quantity-field/examples/src/select-max-quantity-field/select-max-quantity-field.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/forms';
 
 import {
-  DaffFormFieldModule,
+  DAFF_FORM_FIELD_COMPONENTS,
   DaffQuantityFieldModule,
 } from '@daffodil/design';
 
@@ -19,7 +19,7 @@ import {
   styleUrls: ['./select-max-quantity-field.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffFormFieldModule,
+    DAFF_FORM_FIELD_COMPONENTS,
     DaffQuantityFieldModule,
     ReactiveFormsModule,
   ],

--- a/libs/design/src/atoms/form/form-field/README.md
+++ b/libs/design/src/atoms/form/form-field/README.md
@@ -1,38 +1,76 @@
 # Form field
-Form field a wrapping component for form control elements.
+Form field is a wrapping component for form control elements.
 
 ## Overview
 It's used to style certain controls that would otherwise be impossible to style with normal css and organize error messages alongside their associated form controls.
 
 ## Usage
 
+### Within a standalone component
+To use form field in a standalone component, import `DAFF_FORM_FIELD_COMPONENTS` directly into your custom component:
+
+```ts
+import { DAFF_FORM_FIELD_COMPONENTS } from '@daffodil/design';
+
+@Component({
+  selector: 'custom-component',
+  templateUrl: './custom-component.component.html',
+  imports: [
+    DAFF_FORM_FIELD_COMPONENTS,
+  ],
+})
+export class CustomComponent {}
 ```
-<daff-form-field>
-  <input daff-input type="text" placeholder="Email" name="email" />
-  <daff-error-message *ngIf="requiredError">This field is required.</daff-error-message>
-</daff-form-field>
+
+### Within a module (deprecated)
+To use form field in a module, import `DaffFormFieldModule` into your custom module:
+
+```ts
+import { NgModule } from '@angular/core';
+import { DaffFormFieldModule } from '@daffodil/design';
+import { CustomComponent } from './custom.component';
+
+@NgModule({
+	declarations: [
+    CustomComponent,
+  ],
+  exports: [
+    CustomComponent,
+  ],
+  imports: [
+    DaffFormFieldModule,
+  ],
+})
+export class CustomComponentModule { }
 ```
 
-## Creating a custom DaffFormFieldControl that works with DaffFormField
+> This method is deprecated. It's recommended to update all custom components to standalone.
 
-Creating a control that works easily with the form field is fairly straightforward. We've provided the `DaffFormFieldControl` abstract class to allow you to implement the required methods and properties on your control in a consistent manner. Implementing this interface will also ensure that any breaking updates will be caught at build time, instead of runtime.
+## Creating a custom control that works with form field
+Creating a control that works easily with the form field is fairly straightforward. We've provided the `DaffFormFieldControl` abstract class to allow you to implement the required methods and properties on your control in a consistent manner. Implementing this interface will also ensure that any breaking updates will be caught at build time instead of runtime.
 
-To start, your control component must implement the `DaffFormFieldControl` interface. Once implemented, all you have to is provide the appropriate dependency key for the `DaffFormField` to hook into. You can do this by adding the key to the `providers` key of your component definition as follows:
+1. Your control component must implement the `DaffFormFieldControl` interface.
+2. Provide the appropriate dependency key for the `DaffFormFieldComponent` to hook into. You can do this by adding the key to the `providers` key of your component definition as follows:
 
 ```ts
 @Component({
-  selector: 'some-component',
+  selector: 'custom-control-component',
   ...
-  providers: [{provide: DaffFormFieldControl, useExisting: SomeComponent}],
+  providers: [
+    {
+      provide: DaffFormFieldControl,
+      useExisting: CustomControlComponent
+    }
+  ],
 })
-export class SomeComponent implements DaffFormFieldControl<any> {
+export class CustomControlComponent implements DaffFormFieldControl<any> {
   ...
 }
 ```
 
-You can see examples of controls meeting this interface on `DaffInput` and `DaffNativeSelect`. 
+You can see examples of controls meeting this interface in the `DaffInputComponent` and `DaffNativeSelectComponent`. 
 
 ## Troubleshooting
 
 ### Error: A DaffFormFieldComponent must contain a DaffFormFieldControl
-This error appears when your `DaffFormField` is missing a child control. As this component is intended to only be used with a child component that implements `DaffFormFieldControl` this error enforces that constraint at development time. To fix, make sure that your `daff-form-field` has a child component that implements this interface. An example of some components that we've built include: `daff-input` and `daff-native-select`.
+This error appears when the `DaffFormFieldComponent` is missing a child control. As this component is intended to only be used with a child component that implements `DaffFormFieldControl`, this error enforces that constraint at development time. To fix, make sure that the `<daff-form-field>` has a child component that implements this interface. An example of some components that we've built include: `DaffInputComponent` and `DaffNativeSelectComponent`.

--- a/libs/design/src/atoms/form/form-field/form-field.module.ts
+++ b/libs/design/src/atoms/form/form-field/form-field.module.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { DaffFormFieldComponent } from './form-field/form-field.component';
@@ -7,8 +6,7 @@ import { DaffFormLabelModule } from '../form-label/form-label.module';
 
 @NgModule({
   imports: [
-    CommonModule,
-
+    DaffFormFieldComponent,
     DaffErrorMessageModule,
     DaffFormLabelModule,
   ],
@@ -16,9 +14,6 @@ import { DaffFormLabelModule } from '../form-label/form-label.module';
     DaffFormFieldComponent,
     DaffErrorMessageModule,
     DaffFormLabelModule,
-  ],
-  declarations: [
-    DaffFormFieldComponent,
   ],
 })
 export class DaffFormFieldModule { }

--- a/libs/design/src/atoms/form/form-field/form-field.ts
+++ b/libs/design/src/atoms/form/form-field/form-field.ts
@@ -1,0 +1,18 @@
+import { DaffFormFieldComponent } from './form-field/form-field.component';
+import { DaffPrefixDirective } from '../../../core/prefix-suffix/prefix.directive';
+import { DaffSuffixDirective } from '../../../core/prefix-suffix/suffix.directive';
+import { DaffErrorMessageModule } from '../error-message/error-message.module';
+import { DaffFormLabelModule } from '../form-label/form-label.module';
+import { DaffHintComponent } from '../hint/hint.component';
+
+/**
+ * @docs-private
+ */
+export const DAFF_FORM_FIELD_COMPONENTS = <const> [
+  DaffFormFieldComponent,
+  DaffErrorMessageModule,
+  DaffFormLabelModule,
+  DaffHintComponent,
+  DaffPrefixDirective,
+  DaffSuffixDirective,
+];

--- a/libs/design/src/atoms/form/form-field/form-field/form-field.component.spec.ts
+++ b/libs/design/src/atoms/form/form-field/form-field/form-field.component.spec.ts
@@ -10,11 +10,10 @@ import {
   Validators,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import { DaffFormFieldComponent } from './form-field.component';
-import { DaffErrorMessageComponent } from '../../error-message/error-message.component';
 import { DaffInputComponent } from '../../input/input.component';
+import { DAFF_FORM_FIELD_COMPONENTS } from '../form-field';
 import { DaffFormFieldControl } from '../form-field-control';
 import { DaffFormFieldMissingControlMessage } from '../form-field-errors';
 
@@ -23,7 +22,12 @@ import { DaffFormFieldMissingControlMessage } from '../form-field-errors';
     <input daff-input [formControl]="formControl">
     <daff-error-message></daff-error-message>
   </daff-form-field>`,
-standalone: false })
+imports: [
+  DaffFormFieldComponent,
+  DaffInputComponent,
+  ReactiveFormsModule,
+]})
+
 class WrapperComponent {
   formControl = new UntypedFormControl('', Validators.required);
 }
@@ -38,14 +42,7 @@ describe('@daffodil/design | DaffFormFieldComponent | Usage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        ReactiveFormsModule,
-        DaffInputComponent,
-        FontAwesomeModule,
-      ],
-      declarations: [
         WrapperComponent,
-        DaffFormFieldComponent,
-        DaffErrorMessageComponent,
       ],
     })
       .compileComponents();
@@ -121,7 +118,9 @@ describe('@daffodil/design | DaffFormFieldComponent | Usage', () => {
   <daff-form-field>
     <daff-error-message></daff-error-message>
   </daff-form-field>`,
-standalone: false })
+imports: [
+  DAFF_FORM_FIELD_COMPONENTS,
+]})
 
 class WrapperWithoutControlComponent {}
 
@@ -131,12 +130,7 @@ describe('@daffodil/design | DaffFormFieldComponent | Usage Without Control', ()
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        FontAwesomeModule,
-      ],
-      declarations: [
         WrapperWithoutControlComponent,
-        DaffFormFieldComponent,
-        DaffErrorMessageComponent,
       ],
     })
       .compileComponents();

--- a/libs/design/src/atoms/form/form-field/form-field/form-field.component.ts
+++ b/libs/design/src/atoms/form/form-field/form-field/form-field.component.ts
@@ -19,7 +19,6 @@ import { DaffFormFieldMissingControlMessage } from '../form-field-errors';
   templateUrl: './form-field.component.html',
   styleUrls: ['./form-field.component.scss'],
   encapsulation: ViewEncapsulation.None,
-  standalone: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DaffFormFieldComponent implements AfterContentInit, AfterContentChecked {

--- a/libs/design/src/atoms/form/form-field/public_api.ts
+++ b/libs/design/src/atoms/form/form-field/public_api.ts
@@ -1,3 +1,4 @@
 export { DaffFormFieldModule } from './form-field.module';
-export * from './form-field/form-field.component';
+export { DaffFormFieldComponent } from './form-field/form-field.component';
 export { DaffFormFieldControl } from './form-field-control';
+export { DAFF_FORM_FIELD_COMPONENTS } from './form-field';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Part of: #416 


## What is the new behavior?
`DaffFormFieldComponent` has been converted to standalone. Components should still work by using the module, but deprecation notices have been added. `DAFF_FORM_FIELD_COMPONENTS` should be used to ensure all child components related to the form field are imported together.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information