### PR TITLE
feat(design): convert `DaffErrorMessageComponent` to standalone

### DIFF
--- a/libs/design/src/atoms/form/error-message/error-message.component.spec.ts
+++ b/libs/design/src/atoms/form/error-message/error-message.component.spec.ts
@@ -12,7 +12,7 @@ describe('@daffodil/design | DaffErrorMessageComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [
+      imports: [
         DaffErrorMessageComponent,
       ],
     })

--- a/libs/design/src/atoms/form/error-message/error-message.component.ts
+++ b/libs/design/src/atoms/form/error-message/error-message.component.ts
@@ -9,7 +9,6 @@ import {
   template: '<ng-content></ng-content>',
   styleUrls: ['./error-message.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: false,
 })
 export class DaffErrorMessageComponent {
   /**

--- a/libs/design/src/atoms/form/error-message/error-message.module.ts
+++ b/libs/design/src/atoms/form/error-message/error-message.module.ts
@@ -2,11 +2,14 @@ import { NgModule } from '@angular/core';
 
 import { DaffErrorMessageComponent } from './error-message.component';
 
+/**
+ * @deprecated in favor of standalone components. Deprecated in version 0.83.0. Will be removed in version 1.0.0.
+ */
 @NgModule({
   exports: [
     DaffErrorMessageComponent,
   ],
-  declarations: [
+  imports: [
     DaffErrorMessageComponent,
   ],
 })

--- a/libs/design/src/atoms/form/form-field/form-field.module.ts
+++ b/libs/design/src/atoms/form/form-field/form-field.module.ts
@@ -4,6 +4,9 @@ import { DaffFormFieldComponent } from './form-field/form-field.component';
 import { DaffErrorMessageModule } from '../error-message/error-message.module';
 import { DaffFormLabelModule } from '../form-label/form-label.module';
 
+/**
+ * @deprecated in favor of standalone components. Deprecated in version 0.83.0. Will be removed in version 1.0.0.
+ */
 @NgModule({
   imports: [
     DaffFormFieldComponent,

--- a/libs/design/src/atoms/form/form-field/form-field.ts
+++ b/libs/design/src/atoms/form/form-field/form-field.ts
@@ -1,7 +1,7 @@
 import { DaffFormFieldComponent } from './form-field/form-field.component';
 import { DaffPrefixDirective } from '../../../core/prefix-suffix/prefix.directive';
 import { DaffSuffixDirective } from '../../../core/prefix-suffix/suffix.directive';
-import { DaffErrorMessageModule } from '../error-message/error-message.module';
+import { DaffErrorMessageComponent } from '../error-message/error-message.component';
 import { DaffFormLabelModule } from '../form-label/form-label.module';
 import { DaffHintComponent } from '../hint/hint.component';
 
@@ -10,7 +10,7 @@ import { DaffHintComponent } from '../hint/hint.component';
  */
 export const DAFF_FORM_FIELD_COMPONENTS = <const> [
   DaffFormFieldComponent,
-  DaffErrorMessageModule,
+  DaffErrorMessageComponent,
   DaffFormLabelModule,
   DaffHintComponent,
   DaffPrefixDirective,

--- a/libs/design/switch/src/switch.ts
+++ b/libs/design/switch/src/switch.ts
@@ -1,4 +1,4 @@
-import { DaffErrorMessageModule } from '@daffodil/design';
+import { DaffErrorMessageComponent } from '@daffodil/design';
 
 import { DaffSwitchComponent } from './switch/switch.component';
 
@@ -7,5 +7,5 @@ import { DaffSwitchComponent } from './switch/switch.component';
  */
 export const DAFF_SWITCH_COMPONENTS = <const> [
   DaffSwitchComponent,
-  DaffErrorMessageModule,
+  DaffErrorMessageComponent,
 ];

--- a/libs/design/switch/src/switch/switch.component.ts
+++ b/libs/design/switch/src/switch/switch.component.ts
@@ -9,7 +9,6 @@ import {
   Output,
 } from '@angular/core';
 
-import { DaffErrorMessageModule } from '@daffodil/design';
 import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
 
 import {
@@ -35,7 +34,6 @@ let switchUniqueId = 0;
   styleUrls: ['./switch.component.scss'],
   imports: [
     DAFF_LOADING_ICON_COMPONENTS,
-    DaffErrorMessageModule,
   ],
 })
 export class DaffSwitchComponent {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Part of: #416 


## What is the new behavior?
`DaffErrorMessageComponent` has been converted to standalone. Components should still work by using the module, but deprecation notices have been added.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information