### PR TITLE
fix(design): fix media gallery a11y role

### DIFF
--- a/libs/design/media-gallery/src/media-gallery/media-gallery.component.html
+++ b/libs/design/media-gallery/src/media-gallery/media-gallery.component.html
@@ -1,6 +1,6 @@
 <ng-content></ng-content>
 
-<div class="daff-media-gallery__thumbnails" #thumbnailsEl>
+<div class="daff-media-gallery__thumbnails" #thumbnailsEl role="tablist">
 	@if(skeleton) {
 		<div class="daff-thumbnail"></div>
 		<div class="daff-thumbnail"></div>

--- a/libs/design/media-gallery/src/media-gallery/media-gallery.component.ts
+++ b/libs/design/media-gallery/src/media-gallery/media-gallery.component.ts
@@ -61,12 +61,6 @@ let uniqueGalleryId = 0;
   ],
 })
 export class DaffMediaGalleryComponent implements DaffMediaGalleryRegistration {
-
-  /**
-   * @docs-private
-   */
-  @HostBinding('attr.role') role = 'tablist';
-
   /**
    * The internal ID of the gallery.
    */

--- a/libs/design/media-gallery/src/media-gallery/specs/default.spec.ts
+++ b/libs/design/media-gallery/src/media-gallery/specs/default.spec.ts
@@ -50,8 +50,4 @@ describe('DaffMediaGalleryComponent | Defaults', () => {
       'daff-media-gallery': true,
     }));
   });
-
-  it('should have a role of tablist', () => {
-    expect(component.role).toBe('tablist');
-  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`role="tablist"` is set on the host of the component, but it needs to be set on the list of thumbnails.

Fixes: #3684 


## What is the new behavior?
Move `role="tablist"` to the `<div class="daff-media-gallery__thumbnails"></div>` container.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information