### PR TITLE
feat(design)!: remove 0 and 110 from neutral palette and set the colors as `$white` and `$black`

### DIFF
--- a/apps/demo/src/scss/demo-theme.scss
+++ b/apps/demo/src/scss/demo-theme.scss
@@ -9,6 +9,4 @@ $theme: daff-theme.daff-create-theme(
 	('primary': $primary, 'secondary': $secondary, 'tertiary': $tertiary, 'mode': 'light')
 );
 
-$black: daff-theme.daff-map-get($theme, 'core', 'black');
-$white: daff-theme.daff-map-get($theme, 'core', 'white');
 $neutral: daff-theme.daff-map-get($theme, 'core', 'neutral');

--- a/apps/design-land/src/app/foundations/color/color-theme.scss
+++ b/apps/design-land/src/app/foundations/color/color-theme.scss
@@ -1,8 +1,8 @@
 @use 'theme' as daff-theme;
 
 @mixin color-theme($theme) {
-	$white: daff-theme.daff-map-get($theme, 'core', 'white');
-	$black: daff-theme.daff-map-get($theme, 'core', 'black');
+	$white: daff-theme.daff-get-base-color($theme, 'white');
+	$black: daff-theme.daff-get-base-color($theme, 'black');
 
 	.dl-color {
 		&__palette {

--- a/libs/branding/src/scss/branding-theme.scss
+++ b/libs/branding/src/scss/branding-theme.scss
@@ -16,6 +16,3 @@ $tertiary-dark: daff-theme.daff-configure-palette(daff-theme.$daff-turquoise, 50
 $theme-dark: daff-theme.daff-create-theme(
 	('primary': $primary-dark, 'secondary': $secondary-dark, 'tertiary': $tertiary-dark, 'mode': 'dark')
 );
-
-$black: daff-theme.daff-map-get($theme, 'core', 'black');
-$white: daff-theme.daff-map-get($theme, 'core', 'white');

--- a/libs/design/button/src/button/raised/raised-theme.scss
+++ b/libs/design/button/src/button/raised/raised-theme.scss
@@ -9,7 +9,7 @@
 		@error 'Button Hover State: ' + map.get(a11y.$wcag-aa-errors, 'text-contrast');
 	}
 
-	$black: daff-color($daff-neutral, 110);
+	$black: daff-get-base-color($theme, 'black');
 	background-color: $base-color;
 	border: 1px solid $base-color;
 	box-shadow: 0 1px 5px -4px rgba($black, 0.5), 0 4px 8px 0 rgba($black, 0.05);

--- a/libs/design/card/src/card-base-theme.scss
+++ b/libs/design/card/src/card-base-theme.scss
@@ -31,7 +31,6 @@
 	$tertiary: daff-get-palette($theme, tertiary);
 	$base: daff-get-base-color($theme, base);
 	$base-contrast: daff-get-base-color($theme, base-contrast);
-	$black: daff-get-base-color($theme, 'black');
 	$neutral: daff-get-palette($theme, neutral);
 	$mode: daff-get-theme-mode($theme);
 

--- a/libs/design/card/src/card/raised/raised-theme.scss
+++ b/libs/design/card/src/card/raised/raised-theme.scss
@@ -1,14 +1,7 @@
 @use '../../../../scss/theming' as *;
 
 @mixin daff-raised-card-theme($theme) {
-	$primary: daff-get-palette($theme, primary);
-	$secondary: daff-get-palette($theme, secondary);
-	$tertiary: daff-get-palette($theme, tertiary);
-	$base: daff-get-base-color($theme, base);
-	$base-contrast: daff-get-base-color($theme, base-contrast);
-	$white: daff-get-base-color($theme, 'white');
 	$black: daff-get-base-color($theme, 'black');
-	$neutral: daff-get-palette($theme, neutral);
 
 	.daff-raised-card {
 		box-shadow: 0 6px 12px -4px rgba($black, 0.12),

--- a/libs/design/guides/foundations/color.md
+++ b/libs/design/guides/foundations/color.md
@@ -24,7 +24,7 @@ Normal text must have a contrast ratio of at least 4.5:1 to pass AA guidelines a
 
 Large text must have a contrast ratio of at least 3:1 to pass AA guidelines and 4.5:1 to pass AAA guidelines. This is accurate only if your font is **at least 18.66px with bold weight or 24px.**
 
-The `10-50` steps all meet a 4:5:1 contrast ratio or higher against `$daff-neutral, 110 (#070707)` or darker, while the `60-100` steps all meet a 4:5:1 contrast ratio against `$daff-neutral, 10 (#fafafa)`.
+The `10-50` steps all meet a 4:5:1 contrast ratio or higher against `$black (#070707)` or darker, while the `60-100` steps all meet a 4:5:1 contrast ratio against `$daff-neutral, 10 (#fafafa)`.
 
 **As a result, we've ensured that in the palettes that we provide, the following are enforced:**
 

--- a/libs/design/scss/theming/_color-palettes.scss
+++ b/libs/design/scss/theming/_color-palettes.scss
@@ -1,5 +1,7 @@
 // Base colors
-$daff-white: #ffffff;
+$white: #ffffff;
+$black: #070707;
+// need to deprecate
 $error: #dd0000;
 
 // 60 apart passes AAA level for any size text (except for 10/70)
@@ -101,7 +103,6 @@ $daff-green: (
 );
 
 $daff-neutral: (
-	0: #ffffff,
 	10: #fafafa,
 	20: #e8e8e8,
 	30: #d3d3d3,
@@ -111,6 +112,5 @@ $daff-neutral: (
 	70: #5e5e5e,
 	80: #474747,
 	90: #323232,
-	100: #1a1a1a,
-	110: #070707
+	100: #1a1a1a
 );

--- a/libs/design/scss/theming/_configure-theme.scss
+++ b/libs/design/scss/theming/_configure-theme.scss
@@ -5,21 +5,21 @@
 
 $daff-light-theme: (
 	'mode': 'light',
-	'font-color': get-color.daff-color(palette.$daff-neutral, 110),
-	'base': get-color.daff-color(palette.$daff-neutral, 0),
-	'base-contrast': get-color.daff-color(palette.$daff-neutral, 110),
-	'white': get-color.daff-color(palette.$daff-neutral, 0),
-	'black': get-color.daff-color(palette.$daff-neutral, 110),
+	'font-color': palette.$black,
+	'base': palette.$white,
+	'base-contrast': palette.$black,
+	'white': palette.$white,
+	'black': palette.$black,
 	'neutral': configure-palette.daff-configure-palette(palette.$daff-neutral, 60),
 );
 
 $daff-dark-theme: (
 	'mode': 'dark',
-	'font-color': get-color.daff-color(palette.$daff-neutral, 0),
-	'base': get-color.daff-color(palette.$daff-neutral, 100),
-	'base-contrast': get-color.daff-color(palette.$daff-neutral, 0),
-	'white': get-color.daff-color(palette.$daff-neutral, 0),
-	'black': get-color.daff-color(palette.$daff-neutral, 110),
+	'font-color': palette.$white,
+	'base': palette.$black,
+	'base-contrast': palette.$white,
+	'white': palette.$white,
+	'black': palette.$black,
 	'neutral': configure-palette.daff-configure-palette(palette.$daff-neutral, 50),
 );
 

--- a/libs/design/scss/theming/_daff-theme.scss
+++ b/libs/design/scss/theming/_daff-theme.scss
@@ -18,6 +18,3 @@ $tertiary-dark: configure-palette.daff-configure-palette(palette.$daff-turquoise
 $theme-dark: create-theme.daff-create-theme(
 	('primary': $primary-dark, 'secondary': $secondary-dark, 'tertiary': $tertiary-dark, 'mode': 'dark')
 );
-
-$black: core.daff-map-get($theme, 'core', 'black');
-$white: core.daff-map-get($theme, 'core', 'white');

--- a/libs/design/scss/theming/contrast/text-contrast/text-contrast.scss
+++ b/libs/design/scss/theming/contrast/text-contrast/text-contrast.scss
@@ -35,8 +35,8 @@
 	$theme: null
 ) {
 	@if ($theme == null) {
-		$default-black: get-color.daff-color(palette.$daff-neutral, 110);
-		$default-white: get-color.daff-color(palette.$daff-neutral, 0);
+		$default-black: palette.$black;
+		$default-white: palette.$white;
 		@return mc.daff-max-contrast($reference-color, ($default-black, $default-white));
 	}
 	$theme-font-colors: fc.daff-get-font-colors($theme);

--- a/libs/design/scss/theming/contrast/text-contrast/text-contrast.spec.scss
+++ b/libs/design/scss/theming/contrast/text-contrast/text-contrast.spec.scss
@@ -18,8 +18,8 @@
 		'secondary': configure-palette.daff-configure-palette(palette.$daff-purple, 60),
 		'tertiary': configure-palette.daff-configure-palette(palette.$daff-turquoise, 60))
 	);
-	$white: get-color.daff-color(palette.$daff-neutral, 0);
-	$black: get-color.daff-color(palette.$daff-neutral, 110);
+	$white: palette.$white;
+	$black: palette.$black;
 	$dark-gray: get-color.daff-color(palette.$daff-neutral, 80);
 	$light-gray: get-color.daff-color(palette.$daff-neutral, 20);
 	$blue: get-color.daff-color(palette.$daff-blue, 60);

--- a/libs/design/scss/theming/create-theme/_create-theme.scss
+++ b/libs/design/scss/theming/create-theme/_create-theme.scss
@@ -7,18 +7,18 @@
 
 $daff-light-theme: (
 	'mode': 'light',
-	'base': get-color.daff-color(palette.$daff-neutral, 0),
-	'base-contrast': get-color.daff-color(palette.$daff-neutral, 110),
-	'white': get-color.daff-color(palette.$daff-neutral, 0),
-	'black': get-color.daff-color(palette.$daff-neutral, 110),
+	'base': palette.$white,
+	'base-contrast': palette.$black,
+	'white': palette.$white,
+	'black': palette.$black,
 );
 
 $daff-dark-theme: (
 	'mode': 'dark',
 	'base': get-color.daff-color(palette.$daff-neutral, 100),
-	'base-contrast': get-color.daff-color(palette.$daff-neutral, 0),
-	'white': get-color.daff-color(palette.$daff-neutral, 0),
-	'black': get-color.daff-color(palette.$daff-neutral, 110),
+	'base-contrast': palette.$white,
+	'white': palette.$white,
+	'black': palette.$black,
 );
 
 $supported-theme-modes: (
@@ -143,8 +143,8 @@ $supported-theme-modes: (
 	$text-color-default,
 	$text-color-inverse
 ) {
-	$dark: get-color.daff-color(palette.$daff-neutral, 110);
-	$light: get-color.daff-color(palette.$daff-neutral, 0);
+	$dark: palette.$black;
+	$light: palette.$white;
 
 	@if ($text-color-default == null) {
 		$text-color-default: if($mode == 'light', $dark, $light);

--- a/libs/design/scss/theming/create-theme/_create-theme.spec.scss
+++ b/libs/design/scss/theming/create-theme/_create-theme.spec.scss
@@ -19,18 +19,18 @@
 
 	$default-daff-light-theme: (
 		'mode': 'light',
-		'base': get-color.daff-color(palette.$daff-neutral, 0),
-		'base-contrast': get-color.daff-color(palette.$daff-neutral, 110),
-		'white': get-color.daff-color(palette.$daff-neutral, 0),
-		'black': get-color.daff-color(palette.$daff-neutral, 110),
+		'base': palette.$white,
+		'base-contrast': palette.$black,
+		'white': palette.$white,
+		'black': palette.$black,
 		'neutral': configure-palette.daff-configure-palette(palette.$daff-neutral, 60),
 	);
 	$daff-dark-theme: (
 		'mode': 'dark',
 		'base': get-color.daff-color(palette.$daff-neutral, 100),
-		'base-contrast': get-color.daff-color(palette.$daff-neutral, 0),
-		'white': get-color.daff-color(palette.$daff-neutral, 0),
-		'black': get-color.daff-color(palette.$daff-neutral, 110),
+		'base-contrast': palette.$white,
+		'white': palette.$white,
+		'black': palette.$black,
 		'neutral': configure-palette.daff-configure-palette(palette.$daff-neutral, 50),
 	);
 

--- a/libs/design/scss/theming/get-font-colors/_get-font-colors.spec.scss
+++ b/libs/design/scss/theming/get-font-colors/_get-font-colors.spec.scss
@@ -15,10 +15,10 @@
 	$tertiary: configure-palette.daff-configure-palette(palette.$daff-turquoise, 60);
 	$font-light: get-color.daff-color(palette.$daff-neutral, 10);
 	$font-dark: get-color.daff-color(palette.$daff-neutral, 100);
-	$default-dark: get-color.daff-color(palette.$daff-neutral, 110);
-	$default-light: get-color.daff-color(palette.$daff-neutral, 0);
-	$white: get-color.daff-color(palette.$daff-neutral, 0);
-	$black: get-color.daff-color(palette.$daff-neutral, 110);
+	$default-dark: palette.$black;
+	$default-light: palette.$white;
+	$white: palette.$white;
+	$black: palette.$black;
 
 	@include it('returns theme text colors when provided') {
 		$config: (

--- a/libs/design/tag/src/tag-theme.scss
+++ b/libs/design/tag/src/tag-theme.scss
@@ -9,12 +9,14 @@
 	$critical: daff-get-palette($theme, critical);
 	$success: daff-get-palette($theme, success);
 	$neutral: daff-get-palette($theme, neutral);
+	$black: daff-get-base-color($theme, 'black');
+	$white: daff-get-base-color($theme, 'white');
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-tag {
 		@include light($mode) {
 			background: daff-color($neutral, 20);
-			color: daff-color($neutral, 110);
+			color: $black;
 
 			&.daff-primary {
 				background: daff-color($primary, 10);
@@ -42,13 +44,13 @@
 			}
 
 			&.daff-theme {
-				background: daff-color($neutral, 0);
-				color: daff-color($neutral, 110);
+				background: $white;
+				color: $black;
 			}
 
 			&.daff-theme-contrast {
-				background: daff-color($neutral, 110);
-				color: daff-color($neutral, 0);
+				background: $black;
+				color: $white;
 			}
 
 			&.daff-warn {
@@ -102,13 +104,13 @@
 			}
 
 			&.daff-theme {
-				background: daff-color($neutral, 110);
-				color: daff-color($neutral, 0);
+				background: $black;
+				color: $white;
 			}
 
 			&.daff-theme-contrast {
-				background: daff-color($neutral, 0);
-				color: daff-color($neutral, 110);
+				background: $white;
+				color: $black;
 			}
 
 			&.daff-warn {

--- a/libs/design/tree/src/tree-theme.scss
+++ b/libs/design/tree/src/tree-theme.scss
@@ -2,12 +2,8 @@
 
 @mixin daff-tree-theme($theme) {
 	$primary: daff-get-palette($theme, primary);
-	$secondary: daff-get-palette($theme, secondary);
-	$tertiary: daff-get-palette($theme, tertiary);
 	$base: daff-get-base-color($theme, base);
 	$base-contrast: daff-get-base-color($theme, base-contrast);
-	$white: daff-get-base-color($theme, 'white');
-	$black: daff-get-base-color($theme, 'black');
 	$neutral: daff-get-palette($theme, neutral);
 	$mode: daff-get-theme-mode($theme);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #3679


## What is the new behavior?
- Removed `0` and `110` from `$daff-neutral` palette. Hex value from `0` is now set as `$white`. Hex value from `110` is now set as `$black`.

- It's no longer necessary to retrieve `$black` and `$white` from core. You can still do it, but it's extra code that's not needed. This can be removed from your theme mixins.

```
$white: daff-get-base-color($theme, 'white');
$black: daff-get-base-color($theme, 'black');
```

@damienwebdev this change makes me feel like `white` and `black` in `configure-theme.scss` is not really necessary.

```
$daff-light-theme: (
	'mode': 'light',
	'font-color': palette.$black,
	'base': palette.$white,
	'base-contrast': palette.$black,
	'white': palette.$white,
	'black': palette.$black,
	'neutral': configure-palette.daff-configure-palette(palette.$daff-neutral, 60),
);

$daff-dark-theme: (
	'mode': 'dark',
	'font-color': palette.$white,
	'base': palette.$black,
	'base-contrast': palette.$white,
	'white': palette.$white,
	'black': palette.$black,
	'neutral': configure-palette.daff-configure-palette(palette.$daff-neutral, 50),
);
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

BREAKING CHANGE:
The `0` and `110` hues have been removed from the `$daff-neutral` palette.

## Other information