### PR TITLE
feat(design)!: remove loading property from the button components

### DIFF
--- a/libs/design/button/README.md
+++ b/libs/design/button/README.md
@@ -24,12 +24,12 @@ Button supports five types that change its visual style.
 ### Stroked button
 <design-land-example-viewer-container example="stroked-button"></design-land-example-viewer-container>
 
-> `black`, `white`, and `theme` should be used with caution to ensure that there is sufficient contrast.
+> `dark`, `light`, and `theme` should be used with caution to ensure that there is sufficient contrast.
 
 ### Icon button
 <design-land-example-viewer-container example="icon-button"></design-land-example-viewer-container>
 
-> `black`, `white`, and `theme` should be used with caution to ensure that there is sufficient contrast.
+> `dark`, `light`, and `theme` should be used with caution to ensure that there is sufficient contrast.
 
 ### Underline button
 <design-land-example-viewer-container example="underline-button"></design-land-example-viewer-container>
@@ -87,7 +87,7 @@ Use the `size` property to specify a button size. Setting this property will cha
 ## Colors
 Use the `color` property to change the color of a button. The default color is light gray.
 
-> For select button types, `black` and `white` should be used on a darker background in order to have sufficient contrast.
+> For select button types, `dark` and `light` should be used on a darker background in order to have sufficient contrast.
 
 ## Status indicators
 Buttons with status indicators can be used to distinguish what type of action it performs and its importance compared to other buttons in the same context. Use the `status` property to change the status.

--- a/libs/design/button/examples/src/basic-button/basic-button.component.html
+++ b/libs/design/button/examples/src/basic-button/basic-button.component.html
@@ -9,5 +9,4 @@
 <button daff-button><fa-icon [icon]="faChevronLeft" size="sm" daffPrefix></fa-icon>Button</button>
 <button daff-button><fa-icon [icon]="faChevronRight" size="sm" daffSuffix></fa-icon>Button</button>
 <button daff-button disabled>Disabled</button>
-<button daff-button loading="true">Default</button>
 <a href="#" daff-button>Link</a>

--- a/libs/design/button/examples/src/flat-button/flat-button.component.html
+++ b/libs/design/button/examples/src/flat-button/flat-button.component.html
@@ -9,5 +9,4 @@
 <button daff-flat-button><fa-icon [icon]="faChevronLeft" size="sm" daffPrefix></fa-icon>Button</button>
 <button daff-flat-button><fa-icon [icon]="faChevronRight" size="sm" daffSuffix></fa-icon>Button</button>
 <button daff-flat-button disabled>Disabled</button>
-<button daff-flat-button loading="true">Default</button>
 <a href="#" daff-flat-button>Link</a>

--- a/libs/design/button/examples/src/raised-button/raised-button.component.html
+++ b/libs/design/button/examples/src/raised-button/raised-button.component.html
@@ -9,5 +9,4 @@
 <button daff-raised-button><fa-icon [icon]="faChevronLeft" size="sm" daffPrefix></fa-icon>Button</button>
 <button daff-raised-button><fa-icon [icon]="faChevronRight" size="sm" daffSuffix></fa-icon>Button</button>
 <button daff-raised-button disabled>Disabled</button>
-<button daff-raised-button loading="true">Default</button>
 <a href="#" daff-raised-button>Link</a>

--- a/libs/design/button/examples/src/stroked-button/stroked-button.component.html
+++ b/libs/design/button/examples/src/stroked-button/stroked-button.component.html
@@ -2,12 +2,11 @@
 <button daff-stroked-button color="primary">Primary</button>
 <button daff-stroked-button color="secondary">Secondary</button>
 <button daff-stroked-button color="tertiary">Tertiary</button>
-<button daff-stroked-button color="dark">Black</button>
-<button daff-stroked-button color="light">White</button>
+<button daff-stroked-button color="dark">Dark</button>
+<button daff-stroked-button color="light">Light</button>
 <button daff-stroked-button color="theme">Theme</button>
 <button daff-stroked-button color="theme-contrast">Theme Contrast</button>
 <button daff-stroked-button><fa-icon [icon]="faChevronLeft" size="sm" daffPrefix></fa-icon>Button</button>
 <button daff-stroked-button><fa-icon [icon]="faChevronRight" size="sm" daffSuffix></fa-icon>Button</button>
 <button daff-stroked-button disabled>Disabled</button>
-<button daff-stroked-button loading="true">Default</button>
 <a href="#" daff-stroked-button>Link</a>

--- a/libs/design/button/examples/src/underline-button/underline-button.component.html
+++ b/libs/design/button/examples/src/underline-button/underline-button.component.html
@@ -2,12 +2,11 @@
 <button daff-underline-button color="primary">Primary</button>
 <button daff-underline-button color="secondary">Secondary</button>
 <button daff-underline-button color="tertiary">Tertiary</button>
-<button daff-underline-button color="dark">Black</button>
-<button daff-underline-button color="light">White</button>
+<button daff-underline-button color="dark">Dark</button>
+<button daff-underline-button color="light">Light</button>
 <button daff-underline-button color="theme">Theme</button>
 <button daff-underline-button color="theme-contrast">Theme Contrast</button>
 <button daff-underline-button><fa-icon [icon]="faChevronLeft" size="sm" daffPrefix></fa-icon>Button</button>
 <button daff-underline-button><fa-icon [icon]="faChevronRight" size="sm" daffSuffix></fa-icon>Button</button>
 <button daff-underline-button disabled>Disabled</button>
-<button daff-underline-button loading="true">Default</button>
 <a href="#" daff-underline-button>Link</a>

--- a/libs/design/button/src/button/basic/button.component.scss
+++ b/libs/design/button/src/button/basic/button.component.scss
@@ -6,5 +6,4 @@
 	@include base.daff-button-background(4px);
 	@include base.daff-button-elevated();
 	@include base.daff-button-sizes();
-	min-width: 6rem;
 }

--- a/libs/design/button/src/button/basic/button.component.ts
+++ b/libs/design/button/src/button/basic/button.component.ts
@@ -6,8 +6,6 @@ import {
   Input,
 } from '@angular/core';
 
-import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
-
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
@@ -35,9 +33,6 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
   styleUrl: './button.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    DAFF_LOADING_ICON_COMPONENTS,
-  ],
 })
 export class DaffButtonComponent extends DaffButtonBaseDirective {
   /**

--- a/libs/design/button/src/button/button-base.component.html
+++ b/libs/design/button/src/button/button-base.component.html
@@ -1,11 +1,7 @@
 @if (_prefix) {
   <ng-content select="[daffPrefix]"></ng-content>
 }
-@if (loading) {
-  <daff-loading-icon class="daff-button__loading"></daff-loading-icon>
-} @else {
-  <span class="daff-button__content"><ng-content></ng-content></span>
-}
+<span class="daff-button__content"><ng-content></ng-content></span>
 @if (_suffix) {
   <ng-content select="[daffSuffix]"></ng-content>
 }

--- a/libs/design/button/src/button/button-base.directive.spec.ts
+++ b/libs/design/button/src/button/button-base.directive.spec.ts
@@ -13,17 +13,15 @@ import {
   DaffPalette,
   DaffStatus,
 } from '@daffodil/design';
-import { DaffLoadingIconComponent } from '@daffodil/design/loading-icon';
 
 import { DaffButtonBaseDirective } from './button-base.directive';
 import { DaffButtonSize } from './button-sizable.directive';
 
 @Component({
   template: `
-		<div daffButtonBase [color]="color" [size]="size" [status]="status" [loading]="loading" [tabindex]="tabindex"></div>`,
+		<div daffButtonBase [color]="color" [size]="size" [status]="status" [tabindex]="tabindex"></div>`,
   imports: [
     DaffButtonBaseDirective,
-    DaffLoadingIconComponent,
   ],
 })
 
@@ -31,7 +29,6 @@ class WrapperComponent {
   color: DaffPalette;
   size: DaffButtonSize;
   status: DaffStatus;
-  loading = false;
   tabindex = 0;
 }
 
@@ -104,35 +101,6 @@ describe('@daffodil/design/button | DaffButtonBaseDirective', () => {
   describe('using the tabindex property of a button', () => {
     it('should be able to take `tabindex` as an input', () => {
       expect(directive.tabindex).toEqual(wrapper.tabindex);
-    });
-  });
-
-  describe('using the loading property of a button', () => {
-    it('should be able to take `loading` as an input', () => {
-      expect(directive.loading).toEqual(wrapper.loading);
-    });
-
-    describe('when loading is set to true', () => {
-      beforeEach(() => {
-        wrapper.loading = true;
-        fixture.detectChanges();
-
-      });
-
-      it('should show the <daff-loading-icon>', () => {
-        const loadingIcon = fixture.debugElement.query(By.css('daff-loading-icon'));
-
-        expect(loadingIcon).toBeDefined();
-      });
-    });
-
-    it('should show the `.daff-button__content` when loading is set to false', () => {
-      wrapper.loading = false;
-      fixture.detectChanges();
-
-      const buttonContent = fixture.debugElement.query(By.css('.daff-button__content'));
-
-      expect(buttonContent).toBeDefined();
     });
   });
 

--- a/libs/design/button/src/button/button-base.directive.ts
+++ b/libs/design/button/src/button/button-base.directive.ts
@@ -33,7 +33,6 @@ import { DaffButtonSizableDirective } from './button-sizable.directive';
       inputs: ['color'],
     },
   ],
-  standalone: true,
 })
 export class DaffButtonBaseDirective {
 
@@ -58,8 +57,6 @@ export class DaffButtonBaseDirective {
     return this.disabled;
   }
 
-  @Input() loading = false;
-
   /**
    * Sets the tabindex. Defaults to 0.
    */
@@ -71,7 +68,7 @@ export class DaffButtonBaseDirective {
    * The disabled state of the button.
    */
   @Input() get disabled() {
-    return this._disabled || this.loading;
+    return this._disabled;
   }
   set disabled(value: any) {
     this._disabled = coerceBooleanProperty(value);

--- a/libs/design/button/src/button/button-base.scss
+++ b/libs/design/button/src/button/button-base.scss
@@ -47,12 +47,6 @@
 		z-index: 1;
 	}
 
-	.daff-button__loading {
-		> * {
-			width: 100%;
-		}
-	}
-
 	.daff-button__content {
 		@include t.text-truncate();
 	}
@@ -87,10 +81,6 @@
 		line-height: 2rem;
 		height: 2rem;
 		padding: 0 1rem;
-
-		.daff-button__loading {
-			width: 1rem;
-		}
 	}
 
 	&.daff-md {
@@ -98,10 +88,6 @@
 		line-height: 3rem;
 		height: 3rem;
 		padding: 0 1.5rem;
-
-		.daff-button__loading {
-			width: 1.5rem;
-		}
 	}
 
 	&.daff-lg {
@@ -109,9 +95,5 @@
 		line-height: 3.5rem;
 		height: 3.5rem;
 		padding: 0 1.5rem;
-
-		.daff-button__loading {
-			width: 2rem;
-		}
 	}
 }

--- a/libs/design/button/src/button/flat/flat.component.scss
+++ b/libs/design/button/src/button/flat/flat.component.scss
@@ -4,7 +4,6 @@
 	@include base.daff-button-base();
 	@include base.daff-button-background(4px);
 	@include base.daff-button-sizes();
-	min-width: 6rem;
 	background: none;
 	border: none;
 }

--- a/libs/design/button/src/button/flat/flat.component.ts
+++ b/libs/design/button/src/button/flat/flat.component.ts
@@ -5,8 +5,6 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
-
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
@@ -34,9 +32,6 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
   styleUrl: './flat.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    DAFF_LOADING_ICON_COMPONENTS,
-  ],
 })
 export class DaffFlatButtonComponent
   extends DaffButtonBaseDirective {

--- a/libs/design/button/src/button/icon/icon.component.scss
+++ b/libs/design/button/src/button/icon/icon.component.scss
@@ -12,10 +12,6 @@
 		line-height: 2rem;
 		height: 2rem;
 		width: 2rem;
-
-		.daff-button__loading {
-			width: 2rem;
-		}
 	}
 
 	&.daff-md {
@@ -23,10 +19,6 @@
 		line-height: 3rem;
 		height: 3rem;
 		width: 3rem;
-
-		.daff-button__loading {
-			width: 3rem;
-		}
 	}
 
 	&.daff-lg {
@@ -34,9 +26,5 @@
 		line-height: 3.5rem;
 		height: 3.5rem;
 		width: 3.5rem;
-
-		.daff-button__loading {
-			width: 3.5rem;
-		}
 	}
 }

--- a/libs/design/button/src/button/icon/icon.component.ts
+++ b/libs/design/button/src/button/icon/icon.component.ts
@@ -5,8 +5,6 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
-
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
@@ -30,9 +28,6 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
   styleUrl: './icon.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    DAFF_LOADING_ICON_COMPONENTS,
-  ],
 })
 export class DaffIconButtonComponent
   extends DaffButtonBaseDirective {

--- a/libs/design/button/src/button/raised/raised.component.ts
+++ b/libs/design/button/src/button/raised/raised.component.ts
@@ -5,8 +5,6 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
-
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
@@ -36,9 +34,6 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
   styleUrl: './raised.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    DAFF_LOADING_ICON_COMPONENTS,
-  ],
 })
 export class DaffRaisedButtonComponent
   extends DaffButtonBaseDirective {

--- a/libs/design/button/src/button/stroked/stroked.component.scss
+++ b/libs/design/button/src/button/stroked/stroked.component.scss
@@ -5,5 +5,4 @@
 	@include base.daff-button-background(3px);
 	@include base.daff-button-sizes();
 	@include base.daff-button-elevated();
-	min-width: 6rem;
 }

--- a/libs/design/button/src/button/stroked/stroked.component.ts
+++ b/libs/design/button/src/button/stroked/stroked.component.ts
@@ -6,8 +6,6 @@ import {
   Input,
 } from '@angular/core';
 
-import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
-
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
@@ -35,9 +33,6 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
   styleUrl: './stroked.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    DAFF_LOADING_ICON_COMPONENTS,
-  ],
 })
 export class DaffStrokedButtonComponent
   extends DaffButtonBaseDirective {

--- a/libs/design/button/src/button/underline/underline.component.scss
+++ b/libs/design/button/src/button/underline/underline.component.scss
@@ -48,30 +48,18 @@
 		font-size: t.$small-font-size;
 		height: 1.25rem;
 		padding: 0 0 0.25rem;
-
-		.daff-button__loading {
-			width: 1rem;
-		}
 	}
 
 	&.daff-md {
 		font-size: t.$normal-font-size;
 		height: 1.5rem;
 		padding: 0 0 0.25rem;
-
-		.daff-button__loading {
-			width: 1rem;
-		}
 	}
 
 	&.daff-lg {
 		font-size: t.$medium-font-size;
 		height: 1.75rem;
 		padding: 0 0 0.5rem;
-
-		.daff-button__loading {
-			width: 1.25rem;
-		}
 	}
 }
 

--- a/libs/design/button/src/button/underline/underline.component.ts
+++ b/libs/design/button/src/button/underline/underline.component.ts
@@ -5,8 +5,6 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DAFF_LOADING_ICON_COMPONENTS } from '@daffodil/design/loading-icon';
-
 import { DaffButtonBaseDirective } from '../button-base.directive';
 
 /**
@@ -34,9 +32,6 @@ import { DaffButtonBaseDirective } from '../button-base.directive';
   styleUrl: './underline.component.scss',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    DAFF_LOADING_ICON_COMPONENTS,
-  ],
 })
 export class DaffUnderlineButtonComponent
   extends DaffButtonBaseDirective {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #3765 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

BREAKING CHANGE: The `loading` property and its associated UI has been removed because design components should not have state management UI.

## Other information