### PR TITLE
feat(design, daffio): deprecate `daff-illuminate` function and replace usage with light and dark mixins

### DIFF
--- a/apps/daffio/src/app/core/footer/docs-footer/docs-footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/docs-footer/docs-footer-theme.scss
@@ -2,23 +2,40 @@
 
 @mixin daffio-docs-footer-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);
-	$base: daff-get-base-color($theme, base);
 	$base-contrast: daff-get-base-color($theme, base-contrast);
 	$primary: daff-get-palette($theme, primary);
+	$mode: daff-get-theme-mode($theme);
 
 	.daffio-docs-footer {
-		border-top: 1px solid daff-illuminate($base, $neutral, 2);
+		@include light($mode) {
+			border-top: 1px solid daff-color($neutral, 20);
 
-		&__copyright {
-			color: daff-illuminate($base-contrast, $neutral, 4);
+			&__copyright {
+				color: daff-color($neutral, 70);
+			}
+
+			&__link {
+				color: $base-contrast;
+
+				&:hover {
+					color: daff-color($primary);
+				}
+			}
 		}
 
-		&__link {
-			color: daff-text-contrast($base);
-			transition: color 300ms;
+		@include dark($mode) {
+			border-top: 1px solid daff-color($neutral, 80);
 
-			&:hover {
-				color: daff-color($primary);
+			&__copyright {
+				color: daff-color($neutral, 30);
+			}
+
+			&__link {
+				color: $base-contrast;
+
+				&:hover {
+					color: daff-color($primary, 40);
+				}
 			}
 		}
 	}

--- a/apps/daffio/src/app/core/footer/docs-footer/docs-footer.component.scss
+++ b/apps/daffio/src/app/core/footer/docs-footer/docs-footer.component.scss
@@ -64,6 +64,7 @@
 		gap: 0.5rem;
 		font-weight: 500;
 		text-decoration: none;
+		transition: color 300ms;
 	}
 
 	&__link,

--- a/apps/daffio/src/app/core/footer/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/footer/footer-theme.scss
@@ -1,26 +1,42 @@
-@use 'theme' as daff-theme;
+@use 'theme' as *;
 @use 'sass:map';
 
 @mixin daffio-footer-theme($theme) {
-	$neutral: daff-theme.daff-get-palette($theme, neutral);
-	$base: daff-theme.daff-get-base-color($theme, base);
-	$base-contrast: daff-theme.daff-get-base-color($theme, base-contrast);
-	$secondary: daff-theme.daff-get-palette($theme, secondary);
+	$neutral: daff-get-palette($theme, neutral);
+	$base-contrast: daff-get-base-color($theme, base-contrast);
+	$primary: daff-get-palette($theme, primary);
+	$mode: daff-get-theme-mode($theme);
 
 	.daffio-footer {
-		border-top: 1px solid daff-theme.daff-illuminate($base, $neutral, 2);
+		@include light($mode) {
+			border-top: 1px solid daff-color($neutral, 20);
 
-		&__copyright {
-			color: daff-theme.daff-illuminate($base-contrast, $neutral, 3);
+			&__copyright {
+				color: daff-color($neutral, 70);
+			}
+
+			&__link {
+				color: $base-contrast;
+
+				&:hover {
+					color: daff-color($primary);
+				}
+			}
 		}
 
-		&__link,
-		&__social-link {
-			color: daff-theme.daff-text-contrast($base);
-			transition: color 300ms;
+		@include dark($mode) {
+			border-top: 1px solid daff-color($neutral, 80);
 
-			&:hover {
-				color: daff-theme.daff-illuminate($base-contrast, $neutral, 3);
+			&__copyright {
+				color: daff-color($neutral, 30);
+			}
+
+			&__link {
+				color: $base-contrast;
+
+				&:hover {
+					color: daff-color($primary, 40);
+				}
 			}
 		}
 	}

--- a/apps/daffio/src/app/core/footer/footer/footer.component.scss
+++ b/apps/daffio/src/app/core/footer/footer/footer.component.scss
@@ -69,9 +69,8 @@
 		display: flex;
 		align-items: center;
 		gap: 8px;
-		font-weight: bold;
+		font-weight: 500;
 		text-decoration: none;
-		text-transform: uppercase;
 	}
 
 	&__copyright {

--- a/apps/daffio/src/app/core/footer/simple-footer/simple-footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/simple-footer/simple-footer-theme.scss
@@ -1,23 +1,41 @@
-@use 'theme' as daff-theme;
+@use 'theme' as *;
 
 @mixin daffio-simple-footer-theme($theme) {
-	$neutral: daff-theme.daff-get-palette($theme, neutral);
-	$base: daff-theme.daff-get-base-color($theme, base);
-	$base-contrast: daff-theme.daff-get-base-color($theme, base-contrast);
+	$neutral: daff-get-palette($theme, neutral);
+	$base-contrast: daff-get-base-color($theme, base-contrast);
+	$primary: daff-get-palette($theme, primary);
+	$mode: daff-get-theme-mode($theme);
 
 	.daffio-simple-footer {
-		border-top: 1px solid daff-theme.daff-illuminate($base, $neutral, 2);
+		@include light($mode) {
+			border-top: 1px solid daff-color($neutral, 20);
 
-		&__copyright {
-			color: daff-theme.daff-illuminate($base-contrast, $neutral, 4);
+			&__copyright {
+				color: daff-color($neutral, 70);
+			}
+
+			&__link {
+				color: $base-contrast;
+
+				&:hover {
+					color: daff-color($primary);
+				}
+			}
 		}
 
-		&__link {
-			color: daff-theme.daff-text-contrast($base);
-			transition: color 300ms;
+		@include dark($mode) {
+			border-top: 1px solid daff-color($neutral, 80);
 
-			&:hover {
-				color: daff-theme.daff-illuminate($base-contrast, $neutral, 3);
+			&__copyright {
+				color: daff-color($neutral, 30);
+			}
+
+			&__link {
+				color: $base-contrast;
+
+				&:hover {
+					color: daff-color($primary, 40);
+				}
 			}
 		}
 	}

--- a/apps/daffio/src/app/core/header/components/header/header-theme.scss
+++ b/apps/daffio/src/app/core/header/components/header/header-theme.scss
@@ -1,22 +1,42 @@
 @use 'sass:map';
 @use 'theme' as *;
 
+// stylelint-disable selector-class-pattern
 @mixin daffio-header-theme($theme) {
 	$primary: daff-get-palette($theme, primary);
 	$neutral: daff-get-palette($theme, neutral);
 	$base: daff-get-base-color($theme, base);
+	$mode: daff-get-theme-mode($theme);
 
-	.daffio-header {
-		// stylelint-disable selector-class-pattern
-		&.bordered {
-			.daffio-header__navbar {
-				border-bottom: 1px solid daff-illuminate($base, $neutral, 2);
+	@include light($mode) {
+		.daffio-header {
+			&.bordered {
+				.daffio-header__navbar {
+					border-bottom: 1px solid daff-color($neutral, 20);
+				}
+			}
+		}
+
+		.daffio-header-item {
+			&.active {
+				color: daff-color($primary);
 			}
 		}
 	}
-	.daffio-header-item {
-		&.active {
-			color: daff-color($primary);
+
+	@include dark($mode) {
+		.daffio-header {
+			&.bordered {
+				.daffio-header__navbar {
+					border-bottom: 1px solid daff-color($neutral, 90);
+				}
+			}
+		}
+
+		.daffio-header-item {
+			&.active {
+				color: daff-color($primary, 40);
+			}
 		}
 	}
 }

--- a/apps/daffio/src/app/core/sidebar/components/docs/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/sidebar/components/docs/footer/footer-theme.scss
@@ -1,15 +1,25 @@
 @use 'sass:map';
-@use 'theme' as daff-theme;
+@use 'theme' as *;
 
 @mixin daffio-docs-sidebar-footer-theme($theme) {
-	$neutral: daff-theme.daff-get-palette($theme, neutral);
-	$base: daff-theme.daff-get-base-color($theme, base);
+	$neutral: daff-get-palette($theme, neutral);
+	$mode: daff-get-theme-mode($theme);
 
 	.daffio-docs-sidebar-footer {
-		border-top: 1px solid daff-theme.daff-illuminate($base, $neutral, 2);
+		@include light($mode) {
+			border-top: 1px solid daff-color($neutral, 20);
 
-		&::after {
-			background: daff-theme.daff-illuminate($base, $neutral, 2);
+			&::after {
+				background: daff-color($neutral, 20);
+			}
+		}
+
+		@include dark($mode) {
+			border-top: 1px solid daff-color($neutral, 90);
+
+			&::after {
+				background: daff-color($neutral, 90);
+			}
 		}
 	}
 }

--- a/apps/daffio/src/app/core/sidebar/components/marketing/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/sidebar/components/marketing/footer/footer-theme.scss
@@ -3,15 +3,23 @@
 
 @mixin daffio-marketing-sidebar-footer-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);
-	$base: daff-get-base-color($theme, base);
-	$base-contrast: daff-get-base-color($theme, base-contrast);
-	$primary: daff-get-palette($theme, primary);
+	$mode: daff-get-theme-mode($theme);
 
 	.daffio-marketing-sidebar-footer {
-		background: daff-illuminate($base, $neutral, 2);
+		@include light($mode) {
+			background: daff-color($neutral, 20);
 
-		&:hover {
-			background: daff-illuminate($base, $neutral, 3);
+			&:hover {
+				background: daff-color($neutral, 30);
+			}
+		}
+
+		@include dark($mode) {
+			background: daff-color($neutral, 90);
+
+			&:hover {
+				background: daff-color($neutral, 80);
+			}
 		}
 	}
 }

--- a/apps/daffio/src/app/docs/api/components/api-list-section/api-list-section-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-list-section/api-list-section-theme.scss
@@ -2,26 +2,41 @@
 
 @mixin daffio-api-list-section-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);
-	$base: daff-get-base-color($theme, base);
 	$base-contrast: daff-get-base-color($theme, base-contrast);
+	$mode: daff-get-theme-mode($theme);
 
 	.daffio-api-list-section {
 		&__item {
 			color: $base-contrast;
 
 			&:focus {
-				box-shadow: 0 0 0 4px rgba($base-contrast, 0.1);
+				box-shadow: 0 0 0 0.25rem rgba($base-contrast, 0.1);
 				outline: none;
 			}
 
 			&::after {
-				background: daff-illuminate($base, $neutral, 2);
 				opacity: 0;
 			}
 
 			&:hover {
 				&::after {
 					opacity: 1;
+				}
+			}
+		}
+
+		@include light($mode) {
+			&__item {
+				&::after {
+					background: rgba(daff-color($neutral, 20), 0.5);
+				}
+			}
+		}
+
+		@include dark($mode) {
+			&__item {
+				&::after {
+					background: rgba(daff-color($neutral, 80), 0.5);
 				}
 			}
 		}

--- a/apps/daffio/src/app/docs/api/components/api-list/api-list-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-list/api-list-theme.scss
@@ -2,21 +2,37 @@
 
 @mixin daffio-api-list-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);
-	$base: daff-get-base-color($theme, base);
 	$base-contrast: daff-get-base-color($theme, base-contrast);
+	$mode: daff-get-theme-mode($theme);
 
 	.daffio-api-list {
 		&__package-name {
-			> * {
+			a {
 				&:focus {
-					border-radius: 4px;
-					box-shadow: 0 0 0 4px rgba($base-contrast, 0.1);
+					border-radius: 0.25rem;
+					box-shadow: 0 0 0 0.25rem rgba($base-contrast, 0.1);
 					outline: none;
 				}
 			}
+		}
 
-			&:hover {
-				color: daff-illuminate($base-contrast, $neutral, 3);
+		@include light($mode) {
+			&__package-name {
+				a {
+					&:hover {
+						color: daff-color($neutral, 80);
+					}
+				}
+			}
+		}
+
+		@include dark($mode) {
+			&__package-name {
+				a {
+					&:hover {
+						color: daff-color($neutral, 20);
+					}
+				}
 			}
 		}
 	}

--- a/apps/daffio/src/app/docs/api/components/api-package/api-package-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-package/api-package-theme.scss
@@ -2,21 +2,37 @@
 
 @mixin daffio-api-package-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);
-	$base: daff-get-base-color($theme, base);
 	$base-contrast: daff-get-base-color($theme, base-contrast);
+	$mode: daff-get-theme-mode($theme);
 
 	.daffio-api-package {
 		&__subpackage-name {
-			> * {
+			a {
 				&:focus {
-					border-radius: 4px;
-					box-shadow: 0 0 0 4px rgba($base-contrast, 0.1);
+					border-radius: 0.25rem;
+					box-shadow: 0 0 0 0.25rem rgba($base-contrast, 0.1);
 					outline: none;
 				}
 			}
 
-			&:hover {
-				color: daff-illuminate($base-contrast, $neutral, 3);
+			@include light($mode) {
+				&__subpackage-name {
+					a {
+						&:hover {
+							color: daff-color($neutral, 80);
+						}
+					}
+				}
+			}
+
+			@include dark($mode) {
+				&__subpackage-name {
+					a {
+						&:hover {
+							color: daff-color($neutral, 20);
+						}
+					}
+				}
 			}
 		}
 	}

--- a/apps/design-land/src/app/core/code-preview/component/code-preview-theme.scss
+++ b/apps/design-land/src/app/core/code-preview/component/code-preview-theme.scss
@@ -1,26 +1,42 @@
 @use 'sass:map';
 @use 'theme' as daff-theme;
 
+// stylelint-disable selector-class-pattern
 @mixin code-preview-theme($theme) {
-	$neutral: daff-theme.daff-map-get($theme, 'core', 'neutral');
-	$base: daff-theme.daff-map-get($theme, 'core', 'base');
-	$primary: daff-theme.daff-map-get(daff-theme.$theme, primary);
-	$font-color: daff-theme.daff-map-get($theme, 'core', 'font-color');
-	$border: 1px solid daff-theme.daff-illuminate($base, $neutral, 2);
+	$neutral: daff-theme.daff-get-palette($theme, neutral);
+	$base-contrast: daff-theme.daff-get-base-color($theme, base-contrast);
+	$primary: daff-theme.daff-get-palette($theme, primary);
+	$mode: daff-theme.daff-get-theme-mode($theme);
+	$border-light: 1px solid daff-theme.daff-color($neutral, 20);
+	$border-dark: 1px solid daff-theme.daff-color($neutral, 80);
 
 	.design-land-code-preview {
-		&__content {
-			border: $border;
-			border-bottom: 0;
+		@include daff-theme.light($mode) {
+			&__content {
+				border: $border-light;
+				border-bottom: 0;
+			}
+
+			&__tab-wrapper {
+				border-left: $border-light;
+				border-right: $border-light;
+			}
 		}
 
-		&__tab-wrapper {
-			border-left: $border;
-			border-right: $border;
+		@include daff-theme.dark($mode) {
+			&__content {
+				border: $border-dark;
+				border-bottom: 0;
+			}
+
+			&__tab-wrapper {
+				border-left: $border-dark;
+				border-right: $border-dark;
+			}
 		}
 
 		&__tab {
-			color: $font-color;
+			color: $base-contrast;
 
 			&.selected {
 				border-bottom: 2px solid daff-theme.daff-color($primary);

--- a/apps/design-land/src/app/core/sidebar-viewport/sidebar-viewport-theme.scss
+++ b/apps/design-land/src/app/core/sidebar-viewport/sidebar-viewport-theme.scss
@@ -1,22 +1,39 @@
 @use 'sass:map';
 @use 'theme' as daff-theme;
 
+// stylelint-disable selector-class-pattern
 @mixin sidebar-viewport-theme($theme) {
-	$neutral: daff-theme.daff-map-get($theme, 'core', 'neutral');
-	$base: daff-theme.daff-map-get($theme, 'core', 'base');
-	$base-contrast: daff-theme.daff-map-get($theme, 'core', 'base-contrast');
-	$primary: daff-theme.daff-map-get($theme, primary);
+	$neutral: daff-theme.daff-get-palette($theme, neutral);
+	$base: daff-theme.daff-get-base-color($theme, base);
+	$base-contrast: daff-theme.daff-get-base-color($theme, base-contrast);
+	$mode: daff-theme.daff-get-theme-mode($theme);
 
 	.design-land-sidebar-viewport {
-		&__sidebar {
-			border-right: 1px solid daff-theme.daff-illuminate($base, $neutral, 2);
+		@include daff-theme.light($mode) {
+			&__sidebar {
+				border-right: 1px solid daff-theme.daff-color($neutral, 20);
+			}
+
+			&__get-started-button {
+				background: daff-theme.daff-color($neutral, 10);
+
+				&:hover {
+					background: daff-theme.daff-color($neutral, 20);
+				}
+			}
 		}
 
-		&__get-started-button {
-			background: daff-theme.daff-illuminate($base, $neutral, 1);
+		@include daff-theme.dark($mode) {
+			&__sidebar {
+				border-right: 1px solid daff-theme.daff-color($neutral, 80);
+			}
 
-			&:hover {
-				background: daff-theme.daff-illuminate($base, $neutral, 2);
+			&__get-started-button {
+				background: daff-theme.daff-color($neutral, 90);
+
+				&:hover {
+					background: daff-theme.daff-color($neutral, 80);
+				}
 			}
 		}
 

--- a/libs/branding/src/lib/logo/logo-theme.scss
+++ b/libs/branding/src/lib/logo/logo-theme.scss
@@ -1,16 +1,16 @@
 @use '../../scss/branding-theme';
-@use 'theme' as *;
+@use 'theme' as daff-theme;
 
 @mixin daff-logo-theme($theme) {
-	$neutral: daff-get-palette($theme, neutral);
-	$mode: daff-get-theme-mode($theme);
+	$neutral: daff-theme.daff-get-palette($theme, neutral);
+	$mode: daff-theme.daff-get-theme-mode($theme);
 
 	.daff-branding-logo {
-		@include light($mode) {
+		@include daff-theme.light($mode) {
 			fill: daff-theme.daff-color($neutral, 90);
 		}
 
-		@include dark($mode) {
+		@include daff-theme.dark($mode) {
 			fill: daff-theme.daff-color($neutral, 10);
 		}
 	}

--- a/libs/branding/src/lib/logo/logo-theme.scss
+++ b/libs/branding/src/lib/logo/logo-theme.scss
@@ -1,12 +1,17 @@
 @use '../../scss/branding-theme';
-@use 'theme' as daff-theme;
+@use 'theme' as *;
 
 @mixin daff-logo-theme($theme) {
-	$neutral: daff-theme.daff-map-get($theme, 'core', 'neutral');
-	$base: branding-theme.daff-map-get($theme, 'core', 'base');
-	$base-contrast: branding-theme.daff-map-get($theme, 'core', 'base-contrast');
+	$neutral: daff-get-palette($theme, neutral);
+	$mode: daff-get-theme-mode($theme);
 
 	.daff-branding-logo {
-		fill: daff-theme.daff-illuminate($base-contrast, $neutral, 1);
+		@include light($mode) {
+			fill: daff-theme.daff-color($neutral, 90);
+		}
+
+		@include dark($mode) {
+			fill: daff-theme.daff-color($neutral, 10);
+		}
 	}
 }

--- a/libs/design/button/src/button/raised/raised-theme.scss
+++ b/libs/design/button/src/button/raised/raised-theme.scss
@@ -42,7 +42,7 @@
 
 	.daff-raised-button {
 		@include daff-raised-button-theme-variant(
-			daff-illuminate($base, $neutral, 2)
+			daff-color($neutral, 20)
 		);
 
 		&.daff-primary {
@@ -76,9 +76,9 @@
 		&[disabled],
 		&.disabled {
 			@include daff-raised-button-theme-variant(
-				daff-illuminate($base, $neutral, 3)
+				daff-color($neutral, 30)
 			);
-			color: daff-illuminate($base, $neutral, 5);
+			color: daff-color($neutral, 50);
 
 			&::after {
 				box-shadow: none;

--- a/libs/design/scss/theming/illuminate/illuminate.scss
+++ b/libs/design/scss/theming/illuminate/illuminate.scss
@@ -4,6 +4,8 @@
 @use 'sass:meta';
 @use '../contrast/luminance/luminance';
 
+// @deprecated Deprecated in version 0.87.0. Will be removed in version 0.90.0.
+//
 // @docs
 // Take a numeric map and sort it.
 //

--- a/libs/design/select/src/select-theme.scss
+++ b/libs/design/select/src/select-theme.scss
@@ -1,21 +1,66 @@
 @use 'sass:map';
-@use '../../scss/theming';
+@use '../../scss/theming' as *;
 @use '../../scss/core';
 
 // stylelint-disable selector-class-pattern
 @mixin daff-select-theme($theme) {
-	$base: core.daff-map-get($theme, 'core', 'base');
-	$base-contrast: core.daff-map-get($theme, 'core', 'base-contrast');
-	$neutral: core.daff-map-get($theme, 'core', 'neutral');
-
-	$border-color: theming.daff-illuminate($base, $neutral, 3);
+	$base: daff-get-base-color($theme, base);
+	$base-contrast: daff-get-base-color($theme, base-contrast);
+	$neutral: daff-get-palette($theme, neutral);
+	$mode: daff-get-theme-mode($theme);
+	$border-color-light: daff-color($neutral, 30);
+	$border-color-dark: daff-color($neutral, 70);
 
 	.daff-select {
 		$root: '.daff-select';
 
-		&.disabled {
-			#{$root}__field {
-				color: theming.daff-illuminate($base, $neutral, 5);
+		@include light($mode) {
+			&.disabled {
+				#{$root}__field {
+					color: daff-color($neutral, 50);
+				}
+			}
+
+			&__option {
+				background-color: $base;
+				border-bottom: 1px solid $border-color-light;
+				border-left: 1px solid $border-color-light;
+				border-right: 1px solid $border-color-light;
+				color: $base-contrast;
+
+				&:first-of-type {
+					border-top: 1px solid $border-color-light;
+				}
+
+				&:hover,
+				&.highlighted {
+					background-color: daff-color($neutral, 10);
+				}
+			}
+		}
+
+		@include dark($mode) {
+			&.disabled {
+				#{$root}__field {
+					color: daff-color($neutral, 70);
+				}
+			}
+
+			&__option {
+				background-color: $base;
+				border-bottom: 1px solid $border-color-dark;
+				border-left: 1px solid $border-color-dark;
+				border-right: 1px solid $border-color-dark;
+				color: $base-contrast;
+
+				&:first-of-type {
+					border-top: 1px solid $border-color-dark;
+				}
+
+				&:hover,
+				&.highlighted {
+					background-color: daff-color($neutral, 90);
+				}
 			}
 		}
 
@@ -23,24 +68,7 @@
 			color: $base-contrast;
 
 			&::after {
-				border-color: theming.daff-color($neutral);
-			}
-		}
-
-		&__option {
-			background-color: $base;
-			border-bottom: 1px solid $border-color;
-			border-left: 1px solid $border-color;
-			border-right: 1px solid $border-color;
-			color: $base-contrast;
-
-			&:first-of-type {
-				border-top: 1px solid $border-color;
-			}
-
-			&:hover,
-			&.highlighted {
-				background-color: theming.daff-illuminate($base, $neutral, 1);
+				border-color: daff-color($neutral);
 			}
 		}
 	}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #3772 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

BREAKING CHANGE: The `daff-illuminate` function has been deprecated and will be removed in version 0.90.0. Update usage of the function with the `light` and `dark` mixins.

## Other information