### PR TITLE
feat(navigation): widen the magento transform type

### DIFF
--- a/libs/navigation/driver/magento/src/transforms/type.ts
+++ b/libs/navigation/driver/magento/src/transforms/type.ts
@@ -6,4 +6,4 @@ import { CategoryNode } from '../models/public_api';
  * A transform for the Magento driver that can add extra fields or otherwise modify the navigation driver response.
  */
 export type MagentoNavigationTreeTransform<T extends CategoryNode = CategoryNode, V extends DaffNavigationTree = DaffNavigationTree> =
-  (daffTree: DaffNavigationTree, magentoCategoryNode: T) => V;
+  (daffTree: DaffNavigationTree & Pick<V, 'children'>, magentoCategoryNode: T) => V;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`children` in extra transforms are always typed as the base daff model even though the extra transforms have been run on that data


## What is the new behavior?
`children` in extra transforms are now typed correctly

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information