### PR TITLE
feat(design)!: allow individual list type imports and add a title directive for multiline lists

### DIFF
--- a/apps/daffio/src/app/core/nav/sidebar-body/component.ts
+++ b/apps/daffio/src/app/core/nav/sidebar-body/component.ts
@@ -10,7 +10,7 @@ import {
   Observable,
 } from 'rxjs';
 
-import { DAFF_LIST_COMPONENTS } from '@daffodil/design/list';
+import { DAFF_NAV_LIST_COMPONENTS } from '@daffodil/design/list';
 import { DaffRouterDataService } from '@daffodil/router';
 
 import { DaffioRouteWithNavLinks } from '../link/route.type';
@@ -22,7 +22,7 @@ import { DaffioNavLink } from '../link/type';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AsyncPipe,
-    DAFF_LIST_COMPONENTS,
+    DAFF_NAV_LIST_COMPONENTS,
     RouterLink,
   ],
 })

--- a/apps/daffio/src/app/docs/api/components/nav-list/nav-list.component.ts
+++ b/apps/daffio/src/app/docs/api/components/nav-list/nav-list.component.ts
@@ -8,7 +8,7 @@ import {
   RouterLinkActive,
 } from '@angular/router';
 
-import { DAFF_LIST_COMPONENTS } from '@daffodil/design/list';
+import { DAFF_NAV_LIST_COMPONENTS } from '@daffodil/design/list';
 import { DaffDocsApiNavList } from '@daffodil/docs-utils';
 
 const DEFAULT_ROUTER_LINK_ACTIVE_CONFIG: RouterLinkActive['routerLinkActiveOptions'] = {
@@ -22,7 +22,7 @@ const DEFAULT_ROUTER_LINK_ACTIVE_CONFIG: RouterLinkActive['routerLinkActiveOptio
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     RouterLink,
-    DAFF_LIST_COMPONENTS,
+    DAFF_NAV_LIST_COMPONENTS,
     RouterLinkActive,
   ],
 })

--- a/apps/design-land/src/app/list/list.component.html
+++ b/apps/design-land/src/app/list/list.component.html
@@ -14,5 +14,5 @@
 <design-land-example-viewer-container example="multiline-list"></design-land-example-viewer-container>
 
 <h2>List with Icons</h2>
-<p>To add an icon to a list item, use the <code>daffPrefix</code> or <code>daffSuffix</code> attributes for the appropriate placements.</p>
+<p>To add an icon to a list item, use the <code>daffPrefix</code> attribute.</p>
 <design-land-example-viewer-container example="icon-list"></design-land-example-viewer-container>

--- a/libs/design/list/README.md
+++ b/libs/design/list/README.md
@@ -1,10 +1,22 @@
 # List
-List is a flexible component that can be used to display a series of content. It can be modified to support a range of content types.
+List is a stylized container used to vertically group a series of related content.
+
+## Overview
+List supports two main variants:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `daff-list` | A standard list used for grouping generic content. |
+| `daff-nav-list` | A navigation list intended for use with anchor elements (`<a>`). |
 
 ## Usage
 
 ### Within a standalone component
-To use list in a standalone component, import `DAFF_LIST_COMPONENTS` directly into your custom component:
+To use list in a standalone component, import each list type directly into your custom component.
+
+Available imports:
+- `DAFF_LIST_COMPONENTS`
+- `DAFF_NAV_LIST_COMPONENTS`
 
 ```ts
 import { DAFF_LIST_COMPONENTS } from '@daffodil/design/list';
@@ -43,22 +55,40 @@ export class CustomComponentModule { }
 
 > This method is deprecated. It's recommended to update all custom components to standalone.
 
-## Basic List
-A `<daff-list>` consists of multiple `<daff-list-item>`s.
+## Anatomy
+A list consists of multiple `daff-list-item` elements.
 
-<design-land-example-viewer-container example="basic-list"></design-land-example-viewer-container>
+```html
+<daff-list>
+  <daff-list-item></daff-list-item>
+  <daff-list-item></daff-list-item>
+  <daff-list-item></daff-list-item>
+</daff-list>
+```
 
-## Navigation List
-Use `<daff-nav-list>` for navigation lists. `<daff-list-item>` should be directly added to an anchor tag.
+```html
+<daff-nav-list>
+  <a href="/" daff-list-item></a>
+  <a href="/" daff-list-item></a>
+  <a href="/" daff-list-item></a>
+</daff-nav-list>
+```
 
-<design-land-example-viewer-container example="nav-list"></design-land-example-viewer-container>
+### Icon support
+Use the `[daffPrefix]` directive to display a leading visual icon to a list item.
 
-## Multi-line List
-For lists that have multiple lines per item, wrap each line appropriately with a heading or paragraph tag.
+<design-land-example-viewer-container example="icon-list"></design-land-example-viewer-container>
+
+### Multi-line lists
+For list items that contain multiple lines of text, use the `[daffListItemTitle]` directive to identify the primary title. Additional supporting content can be added using `<div>` or `<p>` elements.
 
 <design-land-example-viewer-container example="multiline-list"></design-land-example-viewer-container>
 
-## List with Icons
-To add an icon to a list item, use the `daffPrefix` or `daffSuffix` attributes for the appropriate placements.
+## Accessibility
+By default, list includes appropriate ARIA roles by default to support screen readers and provide an accessible experience.
 
-<design-land-example-viewer-container example="icon-list"></design-land-example-viewer-container>
+- `<daff-list>` is assigned `role="list"` to identify a list of items.
+- `<daff-list-item>` within a `<daff-list>` is assigned `role="listitem"` to identify a list item contained inside the list.
+- `<daff-nav-list>`is assigned `role="navigation"` to indicate that the list is used for navigation.
+
+> Always provide an accessible label for `<daff-nav-list>` via `aria-label` or `aria-labelledby` to describe its purpose (e.g. `"Footer links"` or `"Sidebar links"`).

--- a/libs/design/list/examples/src/icon-list/icon-list.component.html
+++ b/libs/design/list/examples/src/icon-list/icon-list.component.html
@@ -1,6 +1,9 @@
 <daff-list>
 	<daff-list-item>
-		<fa-icon [icon]="faInfoCircle" daffPrefix></fa-icon>
-		List item with icon
+		<div daffPrefix>
+			<fa-icon [icon]="faInfoCircle"></fa-icon>
+		</div>
+		<div daffListItemTitle>Title</div>
+		<p>List item with icon</p>
 	</daff-list-item>
 </daff-list>

--- a/libs/design/list/examples/src/multiline-list/multiline-list.component.html
+++ b/libs/design/list/examples/src/multiline-list/multiline-list.component.html
@@ -1,11 +1,11 @@
 <daff-list>
 	<daff-list-item>
-		<h5>List item heading</h5>
+		<div daffListItemTitle>List item heading</div>
 		<p>List item description<p>
 		<p>List item description line 2</p>
 	</daff-list-item>
 	<daff-list-item>
-		<h5>List item heading</h5>
+		<div daffListItemTitle>List item heading</div>
 		<p>List item description</p>
 	</daff-list-item>
 </daff-list>

--- a/libs/design/list/examples/src/multiline-list/multiline-list.component.ts
+++ b/libs/design/list/examples/src/multiline-list/multiline-list.component.ts
@@ -2,6 +2,8 @@ import {
   ChangeDetectionStrategy,
   Component,
 } from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
 import { DAFF_LIST_COMPONENTS } from '@daffodil/design/list';
 
@@ -12,6 +14,9 @@ import { DAFF_LIST_COMPONENTS } from '@daffodil/design/list';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_LIST_COMPONENTS,
+    FaIconComponent,
   ],
 })
-export class MultilineListComponent {}
+export class MultilineListComponent {
+  faInfoCircle = faInfoCircle;
+}

--- a/libs/design/list/examples/src/nav-list/nav-list.component.html
+++ b/libs/design/list/examples/src/nav-list/nav-list.component.html
@@ -1,12 +1,11 @@
 <daff-nav-list>
 	<a href="#" daff-list-item>
-			Navigation list item 1
-			<fa-icon [icon]="faChevronRight" daffSuffix></fa-icon>
+		Navigation list item 1
 	</a>
 	<a href="#" daff-list-item>
-			Navigation list item 2
+		Navigation list item 2
 	</a>
 	<a href="#" daff-list-item>
-			Navigation list item 3
+		Navigation list item 3
 	</a>
 </daff-nav-list>

--- a/libs/design/list/examples/src/nav-list/nav-list.component.ts
+++ b/libs/design/list/examples/src/nav-list/nav-list.component.ts
@@ -5,7 +5,7 @@ import {
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 
-import { DAFF_LIST_COMPONENTS } from '@daffodil/design/list';
+import { DAFF_NAV_LIST_COMPONENTS } from '@daffodil/design/list';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -13,7 +13,7 @@ import { DAFF_LIST_COMPONENTS } from '@daffodil/design/list';
   templateUrl: './nav-list.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DAFF_LIST_COMPONENTS,
+    DAFF_NAV_LIST_COMPONENTS,
     FaIconComponent,
   ],
 })

--- a/libs/design/list/src/list-base.scss
+++ b/libs/design/list/src/list-base.scss
@@ -30,11 +30,11 @@
 			padding: 0;
 		}
 
-		.daff-prefix,
-		.daff-suffix {
+		.daff-prefix {
 			display: flex;
 			align-items: center;
-			z-index: 2;
+			height: 1.5rem;
+			width: 1.5rem;
 		}
 	}
 }

--- a/libs/design/list/src/list-base.scss
+++ b/libs/design/list/src/list-base.scss
@@ -34,7 +34,7 @@
 			display: flex;
 			align-items: center;
 			height: 1.5rem;
-			width: 1.5rem;
+			width: auto;
 		}
 	}
 }

--- a/libs/design/list/src/list-item-base.scss
+++ b/libs/design/list/src/list-item-base.scss
@@ -1,0 +1,40 @@
+@use '../../scss/typography' as t;
+
+@mixin daff-list-base() {
+	$root: &;
+	display: block;
+	margin: 0;
+	padding: 0;
+
+	.daff-list-item {
+		$root: &;
+		display: flex;
+		gap: 1rem;
+		padding: 0.75rem 1rem;
+
+		&__content {
+			font-size: t.$normal-font-size;
+			flex-grow: 1;
+
+			> * {
+				margin: 0;
+				padding: 0;
+			}
+		}
+
+		&__title {
+			font-size: t.$normal-font-size;
+			font-weight: 600;
+			line-height: 1.5rem;
+			margin: 0;
+			padding: 0;
+		}
+
+		.daff-prefix,
+		.daff-suffix {
+			display: flex;
+			align-items: center;
+			z-index: 2;
+		}
+	}
+}

--- a/libs/design/list/src/list-item-title/list-item-title.directive.spec.ts
+++ b/libs/design/list/src/list-item-title/list-item-title.directive.spec.ts
@@ -1,0 +1,54 @@
+import {
+  Component,
+  DebugElement,
+} from '@angular/core';
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { DaffListItemTitleDirective } from './list-item-title.directive';
+
+@Component({
+  template: `<div daffListItemTitle>Title</div>`,
+  imports: [
+    DaffListItemTitleDirective,
+  ],
+})
+class WrapperComponent {}
+
+describe('DaffListItemTitleDirective', () => {
+  let fixture: ComponentFixture<WrapperComponent>;
+  let de: DebugElement;
+  let wrapper: WrapperComponent;
+  let component: DaffListItemTitleDirective;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        WrapperComponent,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WrapperComponent);
+    wrapper = fixture.componentInstance;
+    de = fixture.debugElement.query(By.css('[daffListItemTitle]'));
+    component = de.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(wrapper).toBeTruthy();
+  });
+
+  it('should add a class of "daff-list-item__title" to the host element', () => {
+    expect(de.classes).toEqual(jasmine.objectContaining({
+      'daff-list-item__title': true,
+    }));
+  });
+});

--- a/libs/design/list/src/list-item-title/list-item-title.directive.ts
+++ b/libs/design/list/src/list-item-title/list-item-title.directive.ts
@@ -1,0 +1,11 @@
+import { Directive } from '@angular/core';
+
+/* eslint-disable quote-props */
+@Directive({
+  selector: '[daffListItemTitle]',
+  host: {
+    'class': 'daff-list-item__title',
+  },
+})
+
+export class DaffListItemTitleDirective {}

--- a/libs/design/list/src/list-item-title/list-item-title.directive.ts
+++ b/libs/design/list/src/list-item-title/list-item-title.directive.ts
@@ -1,6 +1,14 @@
 import { Directive } from '@angular/core';
 
 /* eslint-disable quote-props */
+/**
+ * Used to identify the primary title of a list item within a multi-line list.
+ *
+ * @example
+ * ```html
+ * <div daffListItemTitle>Title</div>
+ * ```
+ */
 @Directive({
   selector: '[daffListItemTitle]',
   host: {

--- a/libs/design/list/src/list-item/list-item.component.html
+++ b/libs/design/list/src/list-item/list-item.component.html
@@ -4,6 +4,3 @@
 <div class="daff-list-item__content">
   <ng-content></ng-content>
 </div>
-@if(_suffix) {
-  <ng-content select="[daffSuffix]"></ng-content>
-}

--- a/libs/design/list/src/list-item/list-item.component.html
+++ b/libs/design/list/src/list-item/list-item.component.html
@@ -1,9 +1,9 @@
-<ng-container *ngIf="_prefix">
+@if(_prefix) {
   <ng-content select="[daffPrefix]"></ng-content>
-</ng-container>
+}
 <div class="daff-list-item__content">
   <ng-content></ng-content>
 </div>
-<ng-container *ngIf="_suffix">
+@if(_suffix) {
   <ng-content select="[daffSuffix]"></ng-content>
-</ng-container>
+}

--- a/libs/design/list/src/list-item/list-item.component.spec.ts
+++ b/libs/design/list/src/list-item/list-item.component.spec.ts
@@ -24,12 +24,9 @@ class WrapperComponent {}
 
 describe('@daffodil/design/list | DaffListItemComponent', () => {
   let wrapper: WrapperComponent;
-  let de: DebugElement;
-  let fixture: ComponentFixture<WrapperComponent>;
   let itemDE: DebugElement;
+  let fixture: ComponentFixture<WrapperComponent>;
   let anchorDE: DebugElement;
-  let listItem: DaffListItemComponent;
-  let anchorListItem: DaffListItemComponent;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -42,8 +39,9 @@ describe('@daffodil/design/list | DaffListItemComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);
-    de = fixture.debugElement.query(By.css('daff-list-item'));
-    wrapper = de.componentInstance;
+    itemDE = fixture.debugElement.query(By.css('daff-list-item'));
+    wrapper = itemDE.componentInstance;
+    anchorDE = fixture.debugElement.query(By.css('a[daff-list-item]'));
     fixture.detectChanges();
   });
 
@@ -51,34 +49,21 @@ describe('@daffodil/design/list | DaffListItemComponent', () => {
     expect(wrapper).toBeTruthy();
   });
 
-  describe('<daff-list-item>', () => {
-    beforeEach(() => {
-      itemDE = fixture.debugElement.query(By.css('daff-list-item'));
-      anchorDE = fixture.debugElement.query(By.css('a[daff-list-item]'));
-      listItem = itemDE.componentInstance;
-      anchorListItem = anchorDE.componentInstance;
-    });
+  it('should add a class of "daff-list-item" to the host element', () => {
+    expect(itemDE.classes).toEqual(jasmine.objectContaining({
+      'daff-list-item': true,
+    }));
 
-    it('should add a class of "daff-list-item" to the host element', () => {
-      expect(itemDE.classes).toEqual(jasmine.objectContaining({
-        'daff-list-item': true,
-      }));
+    expect(anchorDE.classes).toEqual(jasmine.objectContaining({
+      'daff-list-item': true,
+    }));
+  });
 
-      expect(anchorDE.classes).toEqual(jasmine.objectContaining({
-        'daff-list-item': true,
-      }));
-    });
+  it('should have a role of listitem if it is used without an anchor element', () => {
+    expect(itemDE.nativeElement.role).toBe('listitem');
+  });
 
-    describe('if it is used without an anchor element', () => {
-      it('should have a role of listitem', () => {
-        expect(listItem.role).toBe('listitem');
-      });
-    });
-
-    describe('if it is used with an anchor element', () => {
-      it('should not have a role applied', () => {
-        expect(anchorListItem.role).toBe(null);
-      });
-    });
+  it('should not have a role applied if it is used with an anchor element', () => {
+    expect(anchorDE.nativeElement.role).toBe(null);
   });
 });

--- a/libs/design/list/src/list-item/list-item.component.ts
+++ b/libs/design/list/src/list-item/list-item.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   ChangeDetectionStrategy,
-  HostBinding,
   ContentChild,
   ElementRef,
   Input,
@@ -18,13 +17,14 @@ import { DaffPrefixDirective } from '@daffodil/design';
   host: {
     'class': 'daff-list-item',
     '[class.active]': 'active',
+    '[attr.role]': 'this._isAnchor ? null : "listitem"',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 
 export class DaffListItemComponent {
-  /** Whether or not the header item is active */
-  @Input() @HostBinding('class.active') active = false;
+  /** Whether an item in a `<daff-nav-list>` is the currently active item. */
+  @Input() active = false;
 
   /**
    * @docs-private
@@ -32,15 +32,6 @@ export class DaffListItemComponent {
   @ContentChild(DaffPrefixDirective) _prefix: DaffPrefixDirective;
 
   constructor(private elementRef: ElementRef) {}
-
-  /**
-   * Sets the role for a regular `<daff-list-item>` to listitem and an `a[daff-list-item]` to navigation.
-   *
-   * @docs-private
-   */
-  @HostBinding('attr.role') get role() {
-    return this._isAnchor ? null : 'listitem';
-  };
 
   private get _isAnchor() {
     return this.elementRef.nativeElement.nodeName.toLowerCase() === 'a';

--- a/libs/design/list/src/list-item/list-item.component.ts
+++ b/libs/design/list/src/list-item/list-item.component.ts
@@ -1,4 +1,3 @@
-import { NgIf } from '@angular/common';
 import {
   Component,
   ChangeDetectionStrategy,
@@ -10,28 +9,22 @@ import {
 
 import {
   DaffPrefixDirective,
-  DaffPrefixSuffixModule,
   DaffSuffixDirective,
 } from '@daffodil/design';
 
+/* eslint-disable quote-props */
 @Component({
-  selector: 'daff-list-item' + ',' +
-        'a[daff-list-item]',
+  selector:
+    'daff-list-item' + ',' +
+    'a[daff-list-item]',
   templateUrl: './list-item.component.html',
+  host: {
+    'class': 'daff-list-item',
+  },
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    NgIf,
-    DaffPrefixSuffixModule,
-  ],
 })
 
 export class DaffListItemComponent {
-
-  /**
-   * @docs-private
-   */
-  @HostBinding('class.daff-list-item') class = true;
-
   /** Whether or not the header item is active */
   @Input() @HostBinding('class.active') active = false;
 
@@ -47,20 +40,15 @@ export class DaffListItemComponent {
   constructor(private elementRef: ElementRef) {}
 
   /**
-   * Sets the role for a regular `<daff-list-item>` to listitem.
+   * Sets the role for a regular `<daff-list-item>` to listitem and an `a[daff-list-item]` to navigation.
    *
    * @docs-private
    */
   @HostBinding('attr.role') get role() {
-    return this._isAnchor() ? null : 'listitem';
+    return this._isAnchor ? 'navigation' : 'listitem';
   };
 
-  private _getHostElement() {
-    return this.elementRef.nativeElement;
-  }
-
-  /** Gets whether a list item has one of the given attributes. */
-  private _isAnchor() {
-    return this.elementRef.nativeElement.localName === 'a';
+  private get _isAnchor() {
+    return this.elementRef.nativeElement.nodeName.toLowerCase() === 'a';
   }
 }

--- a/libs/design/list/src/list-item/list-item.component.ts
+++ b/libs/design/list/src/list-item/list-item.component.ts
@@ -7,10 +7,7 @@ import {
   Input,
 } from '@angular/core';
 
-import {
-  DaffPrefixDirective,
-  DaffSuffixDirective,
-} from '@daffodil/design';
+import { DaffPrefixDirective } from '@daffodil/design';
 
 /* eslint-disable quote-props */
 @Component({
@@ -33,10 +30,6 @@ export class DaffListItemComponent {
    * @docs-private
    */
   @ContentChild(DaffPrefixDirective) _prefix: DaffPrefixDirective;
-  /**
-   * @docs-private
-   */
-  @ContentChild(DaffSuffixDirective) _suffix: DaffSuffixDirective;
 
   constructor(private elementRef: ElementRef) {}
 
@@ -46,7 +39,7 @@ export class DaffListItemComponent {
    * @docs-private
    */
   @HostBinding('attr.role') get role() {
-    return this._isAnchor ? 'navigation' : 'listitem';
+    return this._isAnchor ? null : 'listitem';
   };
 
   private get _isAnchor() {

--- a/libs/design/list/src/list-item/list-item.component.ts
+++ b/libs/design/list/src/list-item/list-item.component.ts
@@ -9,6 +9,15 @@ import {
 import { DaffPrefixDirective } from '@daffodil/design';
 
 /* eslint-disable quote-props */
+/**
+ * Individual items within a list.
+ *
+ * @example
+ * ```html
+ * <daff-list-item>Standard list item</daff-list-item>
+ * <a href="/" daff-list-item> Linked list item</a>
+ * ```
+ */
 @Component({
   selector:
     'daff-list-item' + ',' +

--- a/libs/design/list/src/list-item/list-item.component.ts
+++ b/libs/design/list/src/list-item/list-item.component.ts
@@ -20,6 +20,7 @@ import {
   templateUrl: './list-item.component.html',
   host: {
     'class': 'daff-list-item',
+    '[class.active]': 'active',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/libs/design/list/src/list-theme.scss
+++ b/libs/design/list/src/list-theme.scss
@@ -7,6 +7,11 @@
 	$base-contrast: daff-get-base-color($theme, base-contrast);
 	$mode: daff-get-theme-mode($theme);
 
+	.daff-list,
+	.daff-nav-list {
+		color: $base-contrast;
+	}
+
 	.daff-nav-list {
 		.daff-list-item {
 			&::after {

--- a/libs/design/list/src/list.module.ts
+++ b/libs/design/list/src/list.module.ts
@@ -5,6 +5,7 @@ import { DaffPrefixSuffixModule } from '@daffodil/design';
 
 import { DaffListComponent } from './list/list.component';
 import { DaffListItemComponent } from './list-item/list-item.component';
+import { DaffNavListComponent } from './nav-list/nav-list.component';
 
 /**
  * @deprecated in favor of {@link DAFF_LIST_COMPONENTS}. Deprecated in version 0.78.0. Will be removed in version 1.0.0.
@@ -13,10 +14,12 @@ import { DaffListItemComponent } from './list-item/list-item.component';
   imports: [
     CommonModule,
     DaffListComponent,
+    DaffNavListComponent,
     DaffListItemComponent,
   ],
   exports: [
     DaffListComponent,
+    DaffNavListComponent,
     DaffListItemComponent,
     DaffPrefixSuffixModule,
   ],

--- a/libs/design/list/src/list.ts
+++ b/libs/design/list/src/list.ts
@@ -1,7 +1,12 @@
-import { DaffPrefixSuffixModule } from '@daffodil/design';
+import {
+  DaffPrefixDirective,
+  DaffSuffixDirective,
+} from '@daffodil/design';
 
 import { DaffListComponent } from './list/list.component';
 import { DaffListItemComponent } from './list-item/list-item.component';
+import { DaffListItemTitleDirective } from './list-item-title/list-item-title.directive';
+import { DaffNavListComponent } from './nav-list/nav-list.component';
 
 /**
  * @docs-private
@@ -9,5 +14,18 @@ import { DaffListItemComponent } from './list-item/list-item.component';
 export const DAFF_LIST_COMPONENTS = <const> [
   DaffListComponent,
   DaffListItemComponent,
-  DaffPrefixSuffixModule,
+  DaffListItemTitleDirective,
+  DaffPrefixDirective,
+  DaffSuffixDirective,
+];
+
+/**
+ * @docs-private
+ */
+export const DAFF_NAV_LIST_COMPONENTS = <const> [
+  DaffNavListComponent,
+  DaffListItemComponent,
+  DaffListItemTitleDirective,
+  DaffPrefixDirective,
+  DaffSuffixDirective,
 ];

--- a/libs/design/list/src/list.ts
+++ b/libs/design/list/src/list.ts
@@ -1,7 +1,4 @@
-import {
-  DaffPrefixDirective,
-  DaffSuffixDirective,
-} from '@daffodil/design';
+import { DaffPrefixDirective } from '@daffodil/design';
 
 import { DaffListComponent } from './list/list.component';
 import { DaffListItemComponent } from './list-item/list-item.component';
@@ -16,7 +13,6 @@ export const DAFF_LIST_COMPONENTS = <const> [
   DaffListItemComponent,
   DaffListItemTitleDirective,
   DaffPrefixDirective,
-  DaffSuffixDirective,
 ];
 
 /**
@@ -27,5 +23,4 @@ export const DAFF_NAV_LIST_COMPONENTS = <const> [
   DaffListItemComponent,
   DaffListItemTitleDirective,
   DaffPrefixDirective,
-  DaffSuffixDirective,
 ];

--- a/libs/design/list/src/list/list.component.scss
+++ b/libs/design/list/src/list/list.component.scss
@@ -1,81 +1,8 @@
 @use '../../../scss/typography' as t;
 @use '../../../scss/interactions';
 @use '../../../scss/layout';
-
-// styleline-disable selector-class-pattern
-@mixin daff-list() {
-	$root: &;
-	display: block;
-	margin: 0;
-	padding: 0;
-
-	.daff-list-item {
-		$root: &;
-		display: flex;
-		gap: 16px;
-		padding: 12px 16px;
-
-		&__content {
-			flex-grow: 1;
-
-			*:nth-child(1) { // stylelint-disable-line scss/selector-nest-combinators
-				font-size: t.$normal-font-size;
-				font-weight: bold;
-				line-height: 1.5em;
-				margin: 0;
-				padding: 0;
-			}
-
-			*:nth-child(n + 2) { // stylelint-disable-line scss/selector-nest-combinators
-				font-size: t.$normal-font-size;
-				margin: 0;
-				padding: 0;
-			}
-		}
-
-		.daff-prefix,
-		.daff-suffix {
-			display: flex;
-			align-items: center;
-			z-index: 2;
-		}
-	}
-}
+@use '../list-item-base' as base;
 
 .daff-list {
-	@include daff-list();
-}
-
-.daff-nav-list {
-	@include daff-list();
-
-	.daff-list-item {
-		@include interactions.clickable();
-		outline: none;
-		text-decoration: none;
-		position: relative;
-
-		&__content {
-			z-index: 2;
-		}
-
-		&::after {
-			content: '';
-			position: absolute;
-			height: 100%;
-			width: 100%;
-			top: 0;
-			left: 0;
-			opacity: 0;
-			transition: opacity 300ms;
-			z-index: 1;
-		}
-
-		&:hover,
-		&.active {
-			&::after {
-				opacity: 1;
-			}
-		}
-	}
+	@include base.daff-list-base();
 }

--- a/libs/design/list/src/list/list.component.scss
+++ b/libs/design/list/src/list/list.component.scss
@@ -1,7 +1,7 @@
 @use '../../../scss/typography' as t;
 @use '../../../scss/interactions';
 @use '../../../scss/layout';
-@use '../list-item-base' as base;
+@use '../list-base' as base;
 
 .daff-list {
 	@include base.daff-list-base();

--- a/libs/design/list/src/list/list.component.scss
+++ b/libs/design/list/src/list/list.component.scss
@@ -1,6 +1,3 @@
-@use '../../../scss/typography' as t;
-@use '../../../scss/interactions';
-@use '../../../scss/layout';
 @use '../list-base' as base;
 
 .daff-list {

--- a/libs/design/list/src/list/list.component.spec.ts
+++ b/libs/design/list/src/list/list.component.spec.ts
@@ -13,8 +13,7 @@ import { DaffListComponent } from './list.component';
 
 @Component({
   template: `
-    <daff-list [mode]="mode"></daff-list>
-    <daff-nav-list></daff-nav-list>
+    <daff-list></daff-list>
   `,
   imports: [
     DaffListComponent,
@@ -27,8 +26,6 @@ describe('@daffodil/design/list | DaffListComponent', () => {
   let component: DaffListComponent;
   let de: DebugElement;
   let fixture: ComponentFixture<WrapperComponent>;
-  let navDE: DebugElement;
-  let navList: DaffListComponent;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -51,28 +48,11 @@ describe('@daffodil/design/list | DaffListComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('<daff-list>', () => {
-    it('should add a class of "daff-list" to the host element', () => {
-      expect(de.nativeElement.classList.contains('daff-list')).toBeTruthy();
-    });
-
-    it('should have a role of list', () => {
-      expect(component.role).toBe('list');
-    });
+  it('should add a class of "daff-list" to the host element', () => {
+    expect(de.nativeElement.classList.contains('daff-list')).toBeTruthy();
   });
 
-  describe('<daff-nav-list>', () => {
-    beforeEach(() => {
-      navDE = fixture.debugElement.query(By.css('daff-nav-list'));
-      navList = navDE.componentInstance;
-    });
-
-    it('should add a class of "daff-nav-list" to the host element', () => {
-      expect(navDE.nativeElement.classList.contains('daff-nav-list')).toBeTruthy();
-    });
-
-    it('should have a role of navigation', () => {
-      expect(navList.role).toBe('navigation');
-    });
+  it('should have a role of list', () => {
+    expect(de.nativeElement.getAttribute('role')).toBe('list');
   });
 });

--- a/libs/design/list/src/list/list.component.ts
+++ b/libs/design/list/src/list/list.component.ts
@@ -7,6 +7,17 @@ import {
 import { DaffArticleEncapsulatedDirective } from '@daffodil/design';
 
 /* eslint-disable quote-props */
+/**
+ * A standard list used for grouping generic content.
+ *
+ * @example
+ * ```html
+ * <daff-list>
+ *  <daff-list-item>List item</daff-list-item>
+ *  <daff-list-item>List item</daff-list-item>
+ * </daff-list>
+ * ```
+ */
 @Component({
   selector: 'daff-list',
   template: '<ng-content></ng-content>',

--- a/libs/design/list/src/nav-list/nav-list.component.scss
+++ b/libs/design/list/src/nav-list/nav-list.component.scss
@@ -1,7 +1,7 @@
 @use '../../../scss/typography' as t;
 @use '../../../scss/interactions';
 @use '../../../scss/layout';
-@use '../list-item-base' as base;
+@use '../list-base' as base;
 
 .daff-nav-list {
 	@include base.daff-list-base();

--- a/libs/design/list/src/nav-list/nav-list.component.scss
+++ b/libs/design/list/src/nav-list/nav-list.component.scss
@@ -1,0 +1,37 @@
+@use '../../../scss/typography' as t;
+@use '../../../scss/interactions';
+@use '../../../scss/layout';
+@use '../list-item-base' as base;
+
+.daff-nav-list {
+	@include base.daff-list-base();
+
+	.daff-list-item {
+		@include interactions.clickable();
+		text-decoration: none;
+		position: relative;
+
+		&__content {
+			z-index: 2;
+		}
+
+		&::after {
+			content: '';
+			position: absolute;
+			height: 100%;
+			width: 100%;
+			top: 0;
+			left: 0;
+			opacity: 0;
+			transition: opacity 300ms;
+			z-index: 1;
+		}
+
+		&:hover,
+		&.active {
+			&::after {
+				opacity: 1;
+			}
+		}
+	}
+}

--- a/libs/design/list/src/nav-list/nav-list.component.scss
+++ b/libs/design/list/src/nav-list/nav-list.component.scss
@@ -1,6 +1,4 @@
-@use '../../../scss/typography' as t;
 @use '../../../scss/interactions';
-@use '../../../scss/layout';
 @use '../list-base' as base;
 
 .daff-nav-list {

--- a/libs/design/list/src/nav-list/nav-list.component.spec.ts
+++ b/libs/design/list/src/nav-list/nav-list.component.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffListComponent } from './list.component';
+import { DaffNavListComponent } from './nav-list.component';
 
 @Component({
   template: `
@@ -17,18 +17,16 @@ import { DaffListComponent } from './list.component';
     <daff-nav-list></daff-nav-list>
   `,
   imports: [
-    DaffListComponent,
+    DaffNavListComponent,
   ],
 })
 class WrapperComponent {}
 
-describe('@daffodil/design/list | DaffListComponent', () => {
+describe('@daffodil/design/list | DaffNavListComponent', () => {
   let wrapper: WrapperComponent;
-  let component: DaffListComponent;
+  let component: DaffNavListComponent;
   let de: DebugElement;
   let fixture: ComponentFixture<WrapperComponent>;
-  let navDE: DebugElement;
-  let navList: DaffListComponent;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -42,7 +40,7 @@ describe('@daffodil/design/list | DaffListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);
     wrapper = fixture.debugElement.componentInstance;
-    de = fixture.debugElement.query(By.css('daff-list'));
+    de = fixture.debugElement.query(By.css('daff-nav-list'));
     component = de.componentInstance;
     fixture.detectChanges();
   });
@@ -51,28 +49,11 @@ describe('@daffodil/design/list | DaffListComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('<daff-list>', () => {
-    it('should add a class of "daff-list" to the host element', () => {
-      expect(de.nativeElement.classList.contains('daff-list')).toBeTruthy();
-    });
-
-    it('should have a role of list', () => {
-      expect(component.role).toBe('list');
-    });
+  it('should add a class of "daff-nav-list" to the host element', () => {
+    expect(de.nativeElement.classList.contains('daff-nav-list')).toBeTruthy();
   });
 
-  describe('<daff-nav-list>', () => {
-    beforeEach(() => {
-      navDE = fixture.debugElement.query(By.css('daff-nav-list'));
-      navList = navDE.componentInstance;
-    });
-
-    it('should add a class of "daff-nav-list" to the host element', () => {
-      expect(navDE.nativeElement.classList.contains('daff-nav-list')).toBeTruthy();
-    });
-
-    it('should have a role of navigation', () => {
-      expect(navList.role).toBe('navigation');
-    });
+  it('should have a role of navigation', () => {
+    expect(de.nativeElement.getAttribute('role')).toBe('navigation');
   });
 });

--- a/libs/design/list/src/nav-list/nav-list.component.spec.ts
+++ b/libs/design/list/src/nav-list/nav-list.component.spec.ts
@@ -1,0 +1,78 @@
+import {
+  Component,
+  DebugElement,
+} from '@angular/core';
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { DaffListComponent } from './list.component';
+
+@Component({
+  template: `
+    <daff-list [mode]="mode"></daff-list>
+    <daff-nav-list></daff-nav-list>
+  `,
+  imports: [
+    DaffListComponent,
+  ],
+})
+class WrapperComponent {}
+
+describe('@daffodil/design/list | DaffListComponent', () => {
+  let wrapper: WrapperComponent;
+  let component: DaffListComponent;
+  let de: DebugElement;
+  let fixture: ComponentFixture<WrapperComponent>;
+  let navDE: DebugElement;
+  let navList: DaffListComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        WrapperComponent,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WrapperComponent);
+    wrapper = fixture.debugElement.componentInstance;
+    de = fixture.debugElement.query(By.css('daff-list'));
+    component = de.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('<daff-list>', () => {
+    it('should add a class of "daff-list" to the host element', () => {
+      expect(de.nativeElement.classList.contains('daff-list')).toBeTruthy();
+    });
+
+    it('should have a role of list', () => {
+      expect(component.role).toBe('list');
+    });
+  });
+
+  describe('<daff-nav-list>', () => {
+    beforeEach(() => {
+      navDE = fixture.debugElement.query(By.css('daff-nav-list'));
+      navList = navDE.componentInstance;
+    });
+
+    it('should add a class of "daff-nav-list" to the host element', () => {
+      expect(navDE.nativeElement.classList.contains('daff-nav-list')).toBeTruthy();
+    });
+
+    it('should have a role of navigation', () => {
+      expect(navList.role).toBe('navigation');
+    });
+  });
+});

--- a/libs/design/list/src/nav-list/nav-list.component.ts
+++ b/libs/design/list/src/nav-list/nav-list.component.ts
@@ -7,6 +7,17 @@ import {
 import { DaffArticleEncapsulatedDirective } from '@daffodil/design';
 
 /* eslint-disable quote-props */
+/**
+ * A navigation list intended for use with anchor elements (`<a>`).
+ *
+ * @example
+ * ```html
+ * <daff-nav-list aria-label="Sidebar links">
+ *  <a href="/" daff-list-item></a>
+ *  <a href="/" daff-list-item></a>
+ * </daff-nav-list>
+ * ```
+ */
 @Component({
   selector: 'daff-nav-list',
   template: '<ng-content></ng-content>',

--- a/libs/design/list/src/nav-list/nav-list.component.ts
+++ b/libs/design/list/src/nav-list/nav-list.component.ts
@@ -8,18 +8,20 @@ import { DaffArticleEncapsulatedDirective } from '@daffodil/design';
 
 /* eslint-disable quote-props */
 @Component({
-  selector: 'daff-list',
+  selector: 'daff-nav-list',
   template: '<ng-content></ng-content>',
-  styleUrls: ['./list.component.scss'],
+  styleUrl: './nav-list.component.scss',
   host: {
-    'class': 'daff-list',
-    'role': 'list',
+    'class': 'daff-nav-list',
+    'role': 'navigation',
   },
-  hostDirectives: [{
-    directive: DaffArticleEncapsulatedDirective,
-  }],
+  hostDirectives: [
+    {
+      directive: DaffArticleEncapsulatedDirective,
+    },
+  ],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 
-export class DaffListComponent { }
+export class DaffNavListComponent {}

--- a/libs/design/list/src/public_api.ts
+++ b/libs/design/list/src/public_api.ts
@@ -1,4 +1,7 @@
 export { DaffListModule } from './list.module';
 export { DAFF_LIST_COMPONENTS } from './list';
-export * from './list/list.component';
-export * from './list-item/list-item.component';
+export { DAFF_NAV_LIST_COMPONENTS } from './list';
+export { DaffListComponent } from './list/list.component';
+export { DaffNavListComponent } from './nav-list/nav-list.component';
+export { DaffListItemComponent } from './list-item/list-item.component';
+export { DaffListItemTitleDirective } from './list-item-title/list-item-title.directive';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #3507
Part of: #3771 


## What is the new behavior?
1. Split apart `daff-list` and `daff-nav-list`. Imports are now separate (`DAFF_LIST_COMPONENTS` and `DAFF_NAV_LIST_COMPONENTS`.
2. Created a `DaffListItemTitleDirective` to display a title UI to multiline lists.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

BREAKING CHANGE: Regular and nav lists have been split up. The `DAFF_LIST_COMPONENTS` array now only exports the `DaffListComponent`. To use `DaffNavListComponent`, use the `DAFF_NAV_LIST_COMPONENTS` array. There is no longer default styling for multiline lists, use the `[daffListItemTitle]` selector instead.


## Other information