### PR TITLE
fix(dgeni): fix Windows path separators and enable sequential execution for Windows

### DIFF
--- a/tools/dgeni/build.ts
+++ b/tools/dgeni/build.ts
@@ -16,37 +16,68 @@ import { daffodilRoutesPackage } from './src/transforms/daffodil-routes-package'
 
 rimraf('../../dist/docs/*', { glob: true }).then(() => {
   new Dgeni([apiDocs]).generate().then(() => {
-    // base docs
-    Promise.all([
-      new Dgeni([packageDocsPackage]).generate().catch((err) => {
-        console.log(err);
-        process.exit(1);
-      }),
-      new Dgeni([guideDocsPackage]).generate().catch((err) => {
-        console.log(err);
-        process.exit(1);
-      }),
-      new Dgeni([explanationDocsPackage]).generate().catch((err) => {
-        console.log(err);
-        process.exit(1);
-      }),
-    ]).then(() => {
+    // base docs 
+    const runBaseDocsSequentially = async () => {
+      if (process.platform === 'win32') {
+        // Sequential execution on Windows
+        try {
+          await new Dgeni([packageDocsPackage]).generate();
+          await new Dgeni([guideDocsPackage]).generate();
+          await new Dgeni([explanationDocsPackage]).generate();
+        } catch (err) {
+          console.log(err);
+          process.exit(1);
+        }
+      } else {
+        // Parallel execution on other platforms
+        await Promise.all([
+          new Dgeni([packageDocsPackage]).generate().catch((err) => {
+            console.log(err);
+            process.exit(1);
+          }),
+          new Dgeni([guideDocsPackage]).generate().catch((err) => {
+            console.log(err);
+            process.exit(1);
+          }),
+          new Dgeni([explanationDocsPackage]).generate().catch((err) => {
+            console.log(err);
+            process.exit(1);
+          }),
+        ]);
+      }
+    };
+    
+    runBaseDocsSequentially().then(() => {
       // design docs
       // run them after base docs so that config between shared processors does not conflict
       // a design flaw of dgeni, it wasn't meant to be run in parallel
-      new Dgeni([designApiPackage]).generate().then(() => {
-        Promise.all([new Dgeni([designDocsPackage]).generate().catch((err) => {
+      new Dgeni([designApiPackage]).generate().then(async () => {
+        const runDesignDocsSequentially = async () => {
+          if (process.platform === 'win32') {
+            try {
+              await new Dgeni([designDocsPackage]).generate();
+              await new Dgeni([designExamplePackage]).generate();
+            } catch (err) {
+              console.log(err);
+              process.exit(1);
+            }
+          } else {
+            await Promise.all([new Dgeni([designDocsPackage]).generate().catch((err) => {
+              console.log(err);
+              process.exit(1);
+            }),
+            new Dgeni([designExamplePackage]).generate().catch((err) => {
+              console.log(err);
+              process.exit(1);
+            })]);
+          }
+        };
+        
+        await runDesignDocsSequentially();
+        
+        new Dgeni([daffodilRoutesPackage]).generate().catch((err) => {
           console.log(err);
           process.exit(1);
-        }),
-        new Dgeni([designExamplePackage]).generate().catch((err) => {
-          console.log(err);
-          process.exit(1);
-        })]).then(() => {
-          new Dgeni([daffodilRoutesPackage]).generate().catch((err) => {
-            console.log(err);
-            process.exit(1);
-          });
         });
       }).catch((err) => {
         console.log(err);

--- a/tools/dgeni/build.ts
+++ b/tools/dgeni/build.ts
@@ -16,7 +16,7 @@ import { daffodilRoutesPackage } from './src/transforms/daffodil-routes-package'
 
 rimraf('../../dist/docs/*', { glob: true }).then(() => {
   new Dgeni([apiDocs]).generate().then(() => {
-    // base docs 
+    // base docs
     const runBaseDocsSequentially = async () => {
       if (process.platform === 'win32') {
         // Sequential execution on Windows
@@ -46,7 +46,7 @@ rimraf('../../dist/docs/*', { glob: true }).then(() => {
         ]);
       }
     };
-    
+
     runBaseDocsSequentially().then(() => {
       // design docs
       // run them after base docs so that config between shared processors does not conflict
@@ -72,9 +72,9 @@ rimraf('../../dist/docs/*', { glob: true }).then(() => {
             })]);
           }
         };
-        
+
         await runDesignDocsSequentially();
-        
+
         new Dgeni([daffodilRoutesPackage]).generate().catch((err) => {
           console.log(err);
           process.exit(1);

--- a/tools/dgeni/src/utils/configurator/output.ts
+++ b/tools/dgeni/src/utils/configurator/output.ts
@@ -1,4 +1,5 @@
 import { Package } from 'dgeni';
+import * as path from 'path';
 
 import {
   DaffDocKind,
@@ -11,7 +12,7 @@ import {
   GENERATE_NAV_LIST_PROCESSOR_PROVIDER,
   GenerateNavListProcessor,
 } from '../../processors/generateNavList';
-import { API_SOURCE_PATH } from '../../transforms/config';
+import { API_SOURCE_PATH, DESIGN_PATH } from '../../transforms/config';
 
 export interface OutputPathsConfig {
   kind: DaffDocKind;
@@ -30,7 +31,13 @@ export const outputPathsConfigurator: Configurator<OutputPathsConfig> = (config:
       {
         docTypes: config.docTypes,
         getPath: (doc) => {
-          doc.moduleFolder = `${config.outputPath}/${DAFF_DOC_KIND_PATH_SEGMENT_MAP[config.kind]}/${doc.id.replace(API_SOURCE_PATH, '')}`;
+          if (config.kind === DaffDocKind.GUIDE || config.kind === DaffDocKind.EXPLANATION) {
+            doc.moduleFolder = `${config.outputPath}/${DAFF_DOC_KIND_PATH_SEGMENT_MAP[config.kind]}/${doc.id}`;
+          } else {
+            const basePath = config.kind === DaffDocKind.COMPONENT ? DESIGN_PATH : API_SOURCE_PATH;
+            const relativePath = path.relative(basePath, doc.id);
+            doc.moduleFolder = `${config.outputPath}/${DAFF_DOC_KIND_PATH_SEGMENT_MAP[config.kind]}/${relativePath}`;
+          }
           return doc.moduleFolder;
         },
         outputPathTemplate: '${moduleFolder}.json',
@@ -38,7 +45,13 @@ export const outputPathsConfigurator: Configurator<OutputPathsConfig> = (config:
       {
         docTypes: ['searchIndex'],
         getPath: (doc) => {
-          doc.moduleFolder = `${config.outputPath}/search-index/${DAFF_DOC_KIND_PATH_SEGMENT_MAP[config.kind]}/${doc.id.replace(API_SOURCE_PATH, '')}`;
+          if (config.kind === DaffDocKind.GUIDE || config.kind === DaffDocKind.EXPLANATION) {
+            doc.moduleFolder = `${config.outputPath}/search-index/${DAFF_DOC_KIND_PATH_SEGMENT_MAP[config.kind]}/${doc.id}`;
+          } else {
+            const basePath = config.kind === DaffDocKind.COMPONENT ? DESIGN_PATH : API_SOURCE_PATH;
+            const relativePath = path.relative(basePath, doc.id);
+            doc.moduleFolder = `${config.outputPath}/search-index/${DAFF_DOC_KIND_PATH_SEGMENT_MAP[config.kind]}/${relativePath}`;
+          }
           return doc.moduleFolder;
         },
         outputPathTemplate: '${moduleFolder}.json',

--- a/tools/dgeni/src/utils/configurator/output.ts
+++ b/tools/dgeni/src/utils/configurator/output.ts
@@ -12,7 +12,10 @@ import {
   GENERATE_NAV_LIST_PROCESSOR_PROVIDER,
   GenerateNavListProcessor,
 } from '../../processors/generateNavList';
-import { API_SOURCE_PATH, DESIGN_PATH } from '../../transforms/config';
+import {
+  API_SOURCE_PATH,
+  DESIGN_PATH,
+} from '../../transforms/config';
 
 export interface OutputPathsConfig {
   kind: DaffDocKind;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Illegal characters in path/invalid path construction issues occur due to improper string replacement, and multiple dgeni processes running in parallel caused Windows file locking errors.


## What is the new behavior?
Dgeni processes now run in sequence on Windows to prevent file locking errors, and path.relative() properly handles Windows vs Unix path differences and absolute path calculations.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```