### PR TITLE
feat(design)!: throw error when `DaffFormFieldComponent` is not used with `DaffSelectComponent`

### DIFF
--- a/libs/design/select/src/select/select.component.ts
+++ b/libs/design/select/src/select/select.component.ts
@@ -170,9 +170,13 @@ export class DaffSelectComponent<T = unknown> extends DaffFormFieldControl<strin
     @Optional() @Self() public ngControl: NgControl,
     private overlay: Overlay,
     private openDirective: DaffOpenableDirective,
-    private formField: DaffFormFieldComponent,
+    @Optional() private formField: DaffFormFieldComponent,
   ) {
     super(ngControl);
+
+    if(!this.formField) {
+      throw new Error('DaffSelectComponent needs to be used with the DaffFormFieldComponent.');
+    }
 
     this.ariaLabelledBy = this.formField.id;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

BREAKING CHANGE: `DaffSelectComponent` is required to be used with the `DaffFormFieldComponent`.

## Other information