### PR TITLE
feat(driver,product): add initial medusa base driver and sample product driver

### DIFF
--- a/libs/driver/medusa/README.md
+++ b/libs/driver/medusa/README.md
@@ -1,0 +1,36 @@
+# @daffodil/driver/medusa
+
+A Daffodil product driver for integrating with [Medusa](https://medusajs.com/) e-commerce platform.
+
+## Overview
+
+This driver provides integration between Daffodil's product interfaces and Medusa's product API. It transforms Medusa product data into Daffodil's standardized product format.
+
+## Installation
+
+```bash
+npm install @daffodil/driver --save
+```
+
+## Configuration
+
+Configure the driver by providing a `DaffMedusaConfig` object:
+
+```ts
+import { provideHttpClient } from '@angular/common/http';
+import {
+	provideDaffProductMedusaDriver,
+	DaffMedusaConfig,
+} from '@daffodil/driver/medusa';
+
+const medusaConfig: DaffMedusaConfig = {
+	api_url: 'https://your-medusa-api/store',
+	publishableApiKey: 'your-publishable-api-key',
+};
+
+// In your app module or standalone bootstrap
+providers: [
+  provideHttpClient(),
+  provideDaffProductMedusaDriver(medusaConfig)
+];
+```

--- a/libs/driver/medusa/ng-package.json
+++ b/libs/driver/medusa/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/ng-entrypoint.schema.json",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/driver/medusa/src/config-provider.ts
+++ b/libs/driver/medusa/src/config-provider.ts
@@ -1,0 +1,20 @@
+import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
+} from '@angular/core';
+
+import {
+  DAFF_MEDUSA_CONFIG,
+  DaffMedusaConfig,
+} from './config';
+
+/**
+ * Provides the Medusa configuration for the driver.
+ *
+ * @param config - The Medusa configuration object
+ * @returns Array of Angular providers for the configuration
+ */
+export const provideMedusaDriver = (config: DaffMedusaConfig): EnvironmentProviders => makeEnvironmentProviders([{
+  provide: DAFF_MEDUSA_CONFIG,
+  useValue: config,
+}]);

--- a/libs/driver/medusa/src/config.ts
+++ b/libs/driver/medusa/src/config.ts
@@ -1,0 +1,17 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Configuration interface for the Medusa product driver.
+ */
+export interface DaffMedusaConfig {
+  /** Base URL of the Medusa storefront API */
+  api_url: string;
+  /** Medusa publishable API key for authentication */
+  publishableApiKey: string;
+}
+
+/**
+ * Injection token for Medusa configuration.
+ * Used to provide DaffMedusaConfig throughout the driver.
+ */
+export const DAFF_MEDUSA_CONFIG = new InjectionToken<DaffMedusaConfig>('DAFF_MEDUSA_CONFIG');

--- a/libs/driver/medusa/src/index.ts
+++ b/libs/driver/medusa/src/index.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/libs/driver/medusa/src/public_api.ts
+++ b/libs/driver/medusa/src/public_api.ts
@@ -1,2 +1,3 @@
 export { provideMedusaDriver } from './config-provider';
+export { DAFF_MEDUSA_CONFIG } from './config';
 export { DaffMedusaConfig } from './config';

--- a/libs/driver/medusa/src/public_api.ts
+++ b/libs/driver/medusa/src/public_api.ts
@@ -1,0 +1,3 @@
+export { provideDaffProductMedusaDriver } from './provider';
+export { DaffProductMedusaService } from './product-driver.service';
+export { DaffMedusaConfig } from './config';

--- a/libs/driver/medusa/src/public_api.ts
+++ b/libs/driver/medusa/src/public_api.ts
@@ -1,3 +1,2 @@
-export { provideDaffProductMedusaDriver } from './provider';
-export { DaffProductMedusaService } from './product-driver.service';
+export { provideMedusaDriver } from './config-provider';
 export { DaffMedusaConfig } from './config';

--- a/libs/product/driver/medusa/ng-package.json
+++ b/libs/product/driver/medusa/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/ng-entrypoint.schema.json",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/product/driver/medusa/src/index.ts
+++ b/libs/product/driver/medusa/src/index.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/libs/product/driver/medusa/src/product-driver.service.ts
+++ b/libs/product/driver/medusa/src/product-driver.service.ts
@@ -1,0 +1,81 @@
+import {
+  HttpClient,
+  HttpHeaders,
+} from '@angular/common/http';
+import {
+  Inject,
+  Injectable,
+} from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import {
+  DAFF_MEDUSA_CONFIG,
+  DaffMedusaConfig,
+} from '@daffodil/driver/medusa';
+import { DaffProduct } from '@daffodil/product';
+import {
+  DaffProductDriverResponse,
+  DaffProductServiceInterface,
+} from '@daffodil/product/driver';
+
+import { transformMedusaProduct } from './transform';
+import { MedusaProduct } from './types/medusa-product';
+
+/**
+ * Angular service that implements DaffProductServiceInterface for Medusa.
+ * Provides methods to fetch product data from Medusa API.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class DaffProductMedusaService implements DaffProductServiceInterface {
+  /** HTTP headers used for Medusa API requests */
+  private readonly headers: HttpHeaders;
+
+  /**
+   * @param client - Angular HTTP client for API requests
+   * @param config - Medusa configuration injected via DAFF_MEDUSA_CONFIG token
+   */
+  constructor(
+    private client: HttpClient,
+    @Inject(DAFF_MEDUSA_CONFIG) private config: DaffMedusaConfig,
+  ) {
+    this.headers = new HttpHeaders({
+      'x-publishable-api-key': this.config.publishableApiKey,
+    });
+  }
+
+  /**
+   * Fetches all products from the Medusa API.
+   * @returns Observable of DaffProduct array
+   */
+  getAll(): Observable<DaffProduct[]> {
+    return this.client.get<{ products: MedusaProduct[] }>(
+      this.config.api_url + '/products',
+      { headers: this.headers },
+    ).pipe(
+      map((response): DaffProduct[] => response.products.map(transformMedusaProduct)),
+    );
+  }
+
+  /**
+   * Gets a single product by ID.
+   * @param productId - The product ID to fetch
+   * @returns Observable of DaffProductDriverResponse
+   * @throws Error - Method not implemented
+   */
+  get(productId: string): Observable<DaffProductDriverResponse<DaffProduct>> {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Gets a product by its URL.
+   * @param url - The product URL to fetch
+   * @returns Observable of DaffProductDriverResponse
+   * @throws Error - Method not implemented
+   */
+  getByUrl(url: string): Observable<DaffProductDriverResponse<DaffProduct>> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/libs/product/driver/medusa/src/provider.ts
+++ b/libs/product/driver/medusa/src/provider.ts
@@ -1,0 +1,15 @@
+import { Provider } from '@angular/core';
+
+import { provideDaffProductDriver } from '@daffodil/product/driver';
+
+import { DaffProductMedusaService } from './product-driver.service';
+
+/**
+ * Provides the complete Medusa product driver with configuration.
+ *
+ * @param config - The Medusa configuration object
+ * @returns Array of Angular providers for the Medusa driver
+ */
+export const provideDaffProductMedusaDriver = (): Provider[] => [
+  provideDaffProductDriver(DaffProductMedusaService),
+];

--- a/libs/product/driver/medusa/src/public_api.ts
+++ b/libs/product/driver/medusa/src/public_api.ts
@@ -1,4 +1,2 @@
 export { provideDaffProductMedusaDriver } from './provider';
-export { provideDaffMedusaConfig } from './config-provider';
 export { DaffProductMedusaService } from './product-driver.service';
-export { DaffMedusaConfig, DAFF_MEDUSA_CONFIG } from './config';

--- a/libs/product/driver/medusa/src/public_api.ts
+++ b/libs/product/driver/medusa/src/public_api.ts
@@ -1,0 +1,4 @@
+export { provideDaffProductMedusaDriver } from './provider';
+export { provideDaffMedusaConfig } from './config-provider';
+export { DaffProductMedusaService } from './product-driver.service';
+export { DaffMedusaConfig, DAFF_MEDUSA_CONFIG } from './config';

--- a/libs/product/driver/medusa/src/transform.ts
+++ b/libs/product/driver/medusa/src/transform.ts
@@ -1,0 +1,41 @@
+import {
+  DaffProduct,
+  DaffProductTypeEnum,
+} from '@daffodil/product';
+
+import { MedusaProduct } from './types/medusa-product';
+
+/**
+ * Transforms a MedusaProduct into a DaffProduct.
+ *
+ * @param medusaProduct - The Medusa product to transform
+ * @returns A DaffProduct with standardized format
+ */
+export const transformMedusaProduct = (medusaProduct: MedusaProduct): DaffProduct => ({
+  id: medusaProduct.id,
+  type: DaffProductTypeEnum.Simple,
+  name: medusaProduct.title,
+  url: medusaProduct.handle || '',
+  price: medusaProduct.variants?.[0]?.prices?.[0]?.amount || 0,
+  discount: {
+    amount: 0,
+    percent: 0,
+  },
+  images: medusaProduct.images?.map(image => ({
+    id: image.id,
+    url: image.url,
+    label: medusaProduct.title,
+  })) || [],
+  thumbnail: {
+    id: 'thumbnail',
+    url: medusaProduct?.thumbnail ?? '',
+    label: medusaProduct.title,
+  },
+  description: medusaProduct.description || '',
+  short_description: medusaProduct.description?.substring(0, 100) || '',
+  meta_title: medusaProduct.title,
+  meta_description: medusaProduct.description || '',
+  in_stock: medusaProduct.variants?.some(variant =>
+    variant.inventory_quantity === undefined || variant.inventory_quantity > 0,
+  ) ?? true,
+});

--- a/libs/product/driver/medusa/src/types/medusa-product.ts
+++ b/libs/product/driver/medusa/src/types/medusa-product.ts
@@ -1,0 +1,147 @@
+/**
+ * Represents a product from the Medusa e-commerce platform.
+ */
+export interface MedusaProduct {
+  /** Unique identifier for the product */
+  id: string;
+  /** Display name of the product */
+  title: string;
+  /** URL-friendly identifier for the product */
+  handle: string;
+  /** Product description */
+  description?: string;
+  /** URL of the product's thumbnail image */
+  thumbnail?: string;
+  /** Array of product images */
+  images?: MedusaProductImage[];
+  /** Product status (draft, published, etc.) */
+  status: string;
+  /** ISO timestamp when the product was created */
+  created_at: string;
+  /** ISO timestamp when the product was last updated */
+  updated_at: string;
+  /** Product variants with different pricing and options */
+  variants?: MedusaProductVariant[];
+  /** Available product options (size, color, etc.) */
+  options?: MedusaProductOption[];
+  /** Tags associated with the product */
+  tags?: MedusaProductTag[];
+  /** Product type classification */
+  type?: MedusaProductType;
+  /** Collection this product belongs to */
+  collection?: MedusaProductCollection;
+  /** Additional metadata as key-value pairs */
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Represents an image associated with a Medusa product.
+ */
+export interface MedusaProductImage {
+  /** Unique identifier for the image */
+  id: string;
+  /** URL of the image */
+  url: string;
+  /** Additional metadata for the image */
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Represents a product variant with specific pricing and inventory.
+ */
+export interface MedusaProductVariant {
+  /** Unique identifier for the variant */
+  id: string;
+  /** Display name of the variant */
+  title: string;
+  /** Pricing information for different regions/currencies */
+  prices: MedusaProductPrice[];
+  /** Stock keeping unit identifier */
+  sku?: string;
+  /** Barcode for the variant */
+  barcode?: string;
+  /** European Article Number */
+  ean?: string;
+  /** Universal Product Code */
+  upc?: string;
+  /** Available inventory quantity */
+  inventory_quantity?: number;
+  /** Whether backorders are allowed when out of stock */
+  allow_backorder?: boolean;
+  /** Whether inventory is managed for this variant */
+  manage_inventory?: boolean;
+  /** Additional metadata for the variant */
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Represents pricing information for a product variant.
+ */
+export interface MedusaProductPrice {
+  /** Unique identifier for the price */
+  id: string;
+  /** Currency code (USD, EUR, etc.) */
+  currency_code: string;
+  /** Price amount in the smallest currency unit (cents) */
+  amount: number;
+  /** Region this price applies to */
+  region_id?: string;
+  /** Price list this price belongs to */
+  price_list_id?: string;
+}
+
+/**
+ * Represents a product option (like size, color) with possible values.
+ */
+export interface MedusaProductOption {
+  /** Unique identifier for the option */
+  id: string;
+  /** Display name of the option (Size, Color, etc.) */
+  title: string;
+  /** Available values for this option */
+  values: MedusaProductOptionValue[];
+}
+
+/**
+ * Represents a specific value for a product option.
+ */
+export interface MedusaProductOptionValue {
+  /** Unique identifier for the option value */
+  id: string;
+  /** The actual value (Small, Red, etc.) */
+  value: string;
+  /** ID of the option this value belongs to */
+  option_id: string;
+}
+
+/**
+ * Represents a tag associated with a product.
+ */
+export interface MedusaProductTag {
+  /** Unique identifier for the tag */
+  id: string;
+  /** Tag value/name */
+  value: string;
+}
+
+/**
+ * Represents a product type classification.
+ */
+export interface MedusaProductType {
+  /** Unique identifier for the product type */
+  id: string;
+  /** Type name/value */
+  value: string;
+}
+
+/**
+ * Represents a product collection grouping.
+ */
+export interface MedusaProductCollection {
+  /** Unique identifier for the collection */
+  id: string;
+  /** Display name of the collection */
+  title: string;
+  /** URL-friendly identifier for the collection */
+  handle: string;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, there's no support for Medusa across anything in Daffodil. 

## What is the new behavior?

This adds very basic support for Medusa.

You can now render medusa products using the `getAll()` method of the product driver (the other implementations of the driver features are still todo) by importing the providers and calling the driver:

```ts
export const appConfig: ApplicationConfig = {
  providers: [
    ...
    provideHttpClient(),
    provideMedusaDriver(),
    provideDaffProductMedusaDriver({
      api_url: 'http://localhost:9000/store',
      publishableApiKey: 'pk_429f0b1f3acb8a318702b19335e624c2fbb2fa7c2dc13634b04e2dd305e9f4a4'
    }),
};
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```