### PR TITLE
feat(core): add new vercel image loader for dynamically resizing asse…

### DIFF
--- a/libs/core/src/image/vercel-image-loader.spec.ts
+++ b/libs/core/src/image/vercel-image-loader.spec.ts
@@ -1,0 +1,195 @@
+import { ImageLoaderConfig } from '@angular/common';
+
+import {
+  createVercelImageLoader,
+  provideVercelImageLoader,
+  VercelAssetsConfig,
+} from './vercel-image-loader';
+
+describe('@daffodil/core | Image | createVercelImageLoader', () => {
+  let domain: string;
+  let configuration: VercelAssetsConfig;
+  let imageLoader: (config: ImageLoaderConfig) => string;
+
+  beforeEach(() => {
+    domain = 'https://assets.daff.io';
+    configuration = {
+      defaultWidth: 256,
+      quality: 75,
+    };
+    imageLoader = createVercelImageLoader(domain, configuration);
+  });
+
+  describe('when src starts with the domain', () => {
+    it('should transform the URL using Vercel image optimization', () => {
+      const config: ImageLoaderConfig = {
+        src: 'https://assets.daff.io/images/test.jpg',
+        width: 400,
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('https://assets.daff.io/_vercel/image?url=%2Fimages%2Ftest.jpg&w=400&q=75');
+    });
+
+    it('should use default width when width is not provided', () => {
+      const config: ImageLoaderConfig = {
+        src: 'https://assets.daff.io/images/test.jpg',
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('https://assets.daff.io/_vercel/image?url=%2Fimages%2Ftest.jpg&w=256&q=75');
+    });
+
+    it('should encode the URL path correctly', () => {
+      const config: ImageLoaderConfig = {
+        src: 'https://assets.daff.io/images/folder with spaces/test.jpg',
+        width: 300,
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('https://assets.daff.io/_vercel/image?url=%2Fimages%2Ffolder%20with%20spaces%2Ftest.jpg&w=300&q=75');
+    });
+
+    it('should handle root level images', () => {
+      const config: ImageLoaderConfig = {
+        src: 'https://assets.daff.io/logo.png',
+        width: 150,
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('https://assets.daff.io/_vercel/image?url=%2Flogo.png&w=150&q=75');
+    });
+
+    it('should use the configured quality setting', () => {
+      const highQualityConfig: VercelAssetsConfig = {
+        defaultWidth: 256,
+        quality: 90,
+      };
+      const highQualityLoader = createVercelImageLoader(domain, highQualityConfig);
+
+      const config: ImageLoaderConfig = {
+        src: 'https://assets.daff.io/images/test.jpg',
+        width: 400,
+      };
+
+      const result = highQualityLoader(config);
+
+      expect(result).toBe('https://assets.daff.io/_vercel/image?url=%2Fimages%2Ftest.jpg&w=400&q=90');
+    });
+  });
+
+  describe('when src does not start with the domain', () => {
+    it('should return the original src unchanged for external URLs', () => {
+      const config: ImageLoaderConfig = {
+        src: 'https://example.com/images/test.jpg',
+        width: 400,
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('https://example.com/images/test.jpg');
+    });
+
+    it('should return the original src unchanged for relative URLs', () => {
+      const config: ImageLoaderConfig = {
+        src: '/local/image.jpg',
+        width: 400,
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('/local/image.jpg');
+    });
+
+    it('should return the original src unchanged for data URLs', () => {
+      const config: ImageLoaderConfig = {
+        src: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+        width: 400,
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==');
+    });
+  });
+
+  describe('with different domain configurations', () => {
+    it('should work with different domain', () => {
+      const customDomain = 'https://cdn.example.com';
+      const customLoader = createVercelImageLoader(customDomain, configuration);
+
+      const config: ImageLoaderConfig = {
+        src: 'https://cdn.example.com/images/test.jpg',
+        width: 400,
+      };
+
+      const result = customLoader(config);
+
+      expect(result).toBe('https://cdn.example.com/_vercel/image?url=%2Fimages%2Ftest.jpg&w=400&q=75');
+    });
+
+    it('should not transform URLs that do not match the exact domain', () => {
+      const config: ImageLoaderConfig = {
+        src: 'https://assets.daff.io.fake.com/images/test.jpg',
+        width: 400,
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('https://assets.daff.io.fake.com/images/test.jpg');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle zero width', () => {
+      const config: ImageLoaderConfig = {
+        src: 'https://assets.daff.io/images/test.jpg',
+        width: 0,
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('https://assets.daff.io/_vercel/image?url=%2Fimages%2Ftest.jpg&w=256&q=75');
+    });
+
+    it('should handle undefined width', () => {
+      const config: ImageLoaderConfig = {
+        src: 'https://assets.daff.io/images/test.jpg',
+        width: undefined,
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('https://assets.daff.io/_vercel/image?url=%2Fimages%2Ftest.jpg&w=256&q=75');
+    });
+
+    it('should handle empty path', () => {
+      const config: ImageLoaderConfig = {
+        src: 'https://assets.daff.io/',
+        width: 400,
+      };
+
+      const result = imageLoader(config);
+
+      expect(result).toBe('https://assets.daff.io/_vercel/image?url=%2F&w=400&q=75');
+    });
+  });
+});
+
+describe('Core | Image | provideVercelImageLoader', () => {
+  it('should provide IMAGE_LOADER with custom domain and configuration', () => {
+    const customDomain = 'https://custom.domain.com';
+    const customConfig: VercelAssetsConfig = {
+      defaultWidth: 512,
+      quality: 90,
+    };
+
+    const providers = provideVercelImageLoader(customDomain, customConfig);
+    expect(providers).toBeDefined();
+    expect(typeof providers).toEqual('object');
+  });
+});

--- a/libs/core/src/image/vercel-image-loader.ts
+++ b/libs/core/src/image/vercel-image-loader.ts
@@ -1,0 +1,57 @@
+
+import {
+  IMAGE_LOADER,
+  ImageLoaderConfig,
+} from '@angular/common';
+import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
+} from '@angular/core';
+
+/**
+ * Configuration interface for Vercel image optimization settings.
+ */
+export interface VercelAssetsConfig {
+  /**
+   * Default width to use when no width is specified in the image config.
+   */
+  defaultWidth: number;
+  /**
+   * Image quality setting (0-100) for Vercel image optimization.
+   */
+  quality: number;
+}
+
+/**
+ * Creates a Vercel image loader function that optimizes images through Vercel's image optimization service.
+ * 
+ * @param domain The domain to match against image URLs for transformation
+ * @param configuration Configuration options for image optimization
+ * @returns An image loader function that transforms URLs for Vercel image optimization
+ */
+export const createVercelImageLoader = (domain: string, configuration: VercelAssetsConfig) =>
+  (config: ImageLoaderConfig): string => {
+    if (!config.src.startsWith(domain + '/')) {
+      return config.src;
+    }
+
+    const baseUrl = domain + '/_vercel/image';
+    const path = config.src.replace(domain, '');
+    const url = encodeURIComponent(path);
+    const width = config.width || configuration.defaultWidth;
+    const quality = configuration.quality;
+
+    return `${baseUrl}?url=${url}&w=${width}&q=${quality}`;
+  };
+
+/**
+ * Provides a Vercel image loader as an Angular environment provider.
+ * 
+ * @param domain The domain to match against image URLs for transformation
+ * @param configuration Configuration options for image optimization
+ * @returns Environment providers array containing the Vercel image loader
+ */
+export const provideVercelImageLoader = (domain: string, configuration: VercelAssetsConfig): EnvironmentProviders => makeEnvironmentProviders([{
+  provide: IMAGE_LOADER,
+  useFactory: () => createVercelImageLoader(domain, configuration),
+}]);

--- a/libs/core/src/image/vercel-image-loader.ts
+++ b/libs/core/src/image/vercel-image-loader.ts
@@ -24,7 +24,7 @@ export interface VercelAssetsConfig {
 
 /**
  * Creates a Vercel image loader function that optimizes images through Vercel's image optimization service.
- * 
+ *
  * @param domain The domain to match against image URLs for transformation
  * @param configuration Configuration options for image optimization
  * @returns An image loader function that transforms URLs for Vercel image optimization
@@ -46,7 +46,7 @@ export const createVercelImageLoader = (domain: string, configuration: VercelAss
 
 /**
  * Provides a Vercel image loader as an Angular environment provider.
- * 
+ *
  * @param domain The domain to match against image URLs for transformation
  * @param configuration Configuration options for image optimization
  * @returns Environment providers array containing the Vercel image loader


### PR DESCRIPTION
…ts via Vercel CDN with NgOptimizedImage

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, assets in the demo are loaded from Vercel at their original size (something like 1024x1024) and image file type (png).

In reality, for performance and CWV, we should be loading these as webp and at the appropriate size for the screen/container size that they are using. 


## What is the new behavior?
I've written a new image loader (`provideVercelImageLoader`) for NgOptimizedImage that provides an extensible way to configure a assets domain (like assets.daff.io) that uses Vercel so that it will resize and reformat these images appropriately.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information