### PR TITLE
fix(daffio): reconfigure how docs are loaded for ssr

### DIFF
--- a/apps/daffio/src/app/core/router/route.type.ts
+++ b/apps/daffio/src/app/core/router/route.type.ts
@@ -16,6 +16,5 @@ export interface DaffioRoute extends Route {
   & DaffioRouteWithSidebars['data']
   & {
     docKind?: DaffDocKind;
-    docPrefix?: string;
   };
 }

--- a/apps/daffio/src/app/docs/design/design-routing.module.ts
+++ b/apps/daffio/src/app/docs/design/design-routing.module.ts
@@ -28,7 +28,6 @@ export const docsDesignRoutes: Routes = [
       index: daffioDocsDesignIndexResolver,
     },
     data: {
-      docPrefix: `${DAFF_DOCS_PATH}/${DAFF_DOCS_DESIGN_PATH}`,
       daffioSidebars: {
         [DAFFIO_DOCS_DESIGN_LIST_SIDEBAR_REGISTRATION.id]: DAFFIO_DOCS_DESIGN_LIST_SIDEBAR_REGISTRATION,
       },

--- a/apps/daffio/src/app/docs/design/design-routing.module.ts
+++ b/apps/daffio/src/app/docs/design/design-routing.module.ts
@@ -7,8 +7,6 @@ import {
 import { DaffSidebarModeEnum } from '@daffodil/design/sidebar';
 import {
   DAFF_DOC_KIND_PATH_SEGMENT_MAP,
-  DAFF_DOCS_DESIGN_PATH,
-  DAFF_DOCS_PATH,
   DaffDocKind,
 } from '@daffodil/docs-utils';
 

--- a/apps/daffio/src/app/docs/design/services/index.service.spec.ts
+++ b/apps/daffio/src/app/docs/design/services/index.service.spec.ts
@@ -47,7 +47,7 @@ describe('DaffioDocsDesignIndexService', () => {
 
     service.getList().subscribe((guides) => {
       expect(guides).toEqual(mockGuideList);
-      expect(fetchAssetServiceSpy.fetch).toHaveBeenCalledWith('/assets/daffio//docs/design/index.json', `${DAFF_DOCS_DESIGN_PATH}/index`);
+      expect(fetchAssetServiceSpy.fetch).toHaveBeenCalledWith('/assets/daffio/docs/design/index.json', `design/index`);
       done();
     });
   });

--- a/apps/daffio/src/app/docs/design/services/index.service.spec.ts
+++ b/apps/daffio/src/app/docs/design/services/index.service.spec.ts
@@ -1,10 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 
-import {
-  DAFF_DOCS_DESIGN_PATH,
-  DaffDoc,
-} from '@daffodil/docs-utils';
+import { DaffDoc } from '@daffodil/docs-utils';
 
 import { DaffioDocsDesignIndexService } from './index.service';
 import {

--- a/apps/daffio/src/app/docs/design/services/index.service.ts
+++ b/apps/daffio/src/app/docs/design/services/index.service.ts
@@ -4,7 +4,10 @@ import {
 } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { DaffDocsDesignGuideNavList } from '@daffodil/docs-utils';
+import {
+  DAFF_DOCS_DESIGN_PATH,
+  DaffDocsDesignGuideNavList,
+} from '@daffodil/docs-utils';
 
 import {
   DaffioAssetFetchService,

--- a/apps/daffio/src/app/docs/design/services/index.service.ts
+++ b/apps/daffio/src/app/docs/design/services/index.service.ts
@@ -26,6 +26,6 @@ export class DaffioDocsDesignIndexService<T extends DaffDocsDesignGuideNavList =
   ) {}
 
   getList(): Observable<T> {
-    return this.fetchAsset.fetch<T>(`${this.docsPath}/${DAFF_DOCS_PATH}/${DAFF_DOCS_DESIGN_PATH}/index.json`, this._key);
+    return this.fetchAsset.fetch<T>(`${this.docsPath}/${DAFF_DOCS_DESIGN_PATH}/index.json`, this._key);
   }
 }

--- a/apps/daffio/src/app/docs/design/services/index.service.ts
+++ b/apps/daffio/src/app/docs/design/services/index.service.ts
@@ -4,11 +4,7 @@ import {
 } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import {
-  DAFF_DOCS_DESIGN_PATH,
-  DAFF_DOCS_PATH,
-  DaffDocsDesignGuideNavList,
-} from '@daffodil/docs-utils';
+import { DaffDocsDesignGuideNavList } from '@daffodil/docs-utils';
 
 import {
   DaffioAssetFetchService,

--- a/apps/daffio/src/app/docs/index/index.service.spec.ts
+++ b/apps/daffio/src/app/docs/index/index.service.spec.ts
@@ -6,8 +6,6 @@ import {
 } from 'rxjs';
 
 import {
-  DAFF_DOC_KIND_PATH_SEGMENT_MAP,
-  DAFF_DOCS_PATH,
   DaffDoc,
   DaffDocKind,
 } from '@daffodil/docs-utils';

--- a/apps/daffio/src/app/docs/index/index.service.spec.ts
+++ b/apps/daffio/src/app/docs/index/index.service.spec.ts
@@ -61,7 +61,7 @@ describe('DaffioDocsIndexService', () => {
 
     service.getListForKind(DaffDocKind.PACKAGE).subscribe((guides) => {
       expect(guides).toEqual(mockGuideList);
-      expect(fetchAssetServiceSpy.fetch).toHaveBeenCalledWith('/assets/daffio//docs/packages/index.json', `${DAFF_DOCS_PATH}/${DAFF_DOC_KIND_PATH_SEGMENT_MAP[DaffDocKind.PACKAGE]}/index`);
+      expect(fetchAssetServiceSpy.fetch).toHaveBeenCalledWith('/assets/daffio/docs/packages/index.json', `packages/index`);
       done();
     });
   });

--- a/apps/daffio/src/app/docs/index/index.service.ts
+++ b/apps/daffio/src/app/docs/index/index.service.ts
@@ -5,7 +5,6 @@ import {
 
 import {
   DAFF_DOC_KIND_PATH_SEGMENT_MAP,
-  DAFF_DOCS_PATH,
   DaffDocKind,
   DaffDocsNavList,
 } from '@daffodil/docs-utils';
@@ -24,8 +23,8 @@ export class DaffioDocsIndexService<T extends DaffDocsNavList = DaffDocsNavList>
     @Inject(DAFFIO_DOCS_PATH_TOKEN) private docsPath: string,
   ) {}
 
-  getListForKind(kind: DaffDocKind, prefix = DAFF_DOCS_PATH) {
-    const path = `${prefix}/${DAFF_DOC_KIND_PATH_SEGMENT_MAP[kind]}/index`;
+  getListForKind(kind: DaffDocKind) {
+    const path = `${DAFF_DOC_KIND_PATH_SEGMENT_MAP[kind]}/index`;
     return this.fetchAsset.fetch<T>(`${this.docsPath}/${path}.json`, path);
   }
 }

--- a/apps/daffio/src/app/docs/index/resolver.ts
+++ b/apps/daffio/src/app/docs/index/resolver.ts
@@ -10,4 +10,4 @@ import { DaffioDocsIndexService } from './index.service';
 import { DaffioRoute } from '../../core/router/route.type';
 
 export const daffioDocsIndexResolver: ResolveFn<DaffDocsNavList> = (route: ActivatedRouteSnapshot) =>
-  inject(DaffioDocsIndexService).getListForKind((<DaffioRoute['data']>route.data).docKind, (<DaffioRoute['data']>route.data).docPrefix);
+  inject(DaffioDocsIndexService).getListForKind((<DaffioRoute['data']>route.data).docKind);

--- a/apps/daffio/src/app/docs/services/docs-path-server.ts
+++ b/apps/daffio/src/app/docs/services/docs-path-server.ts
@@ -16,7 +16,6 @@ export const findProjectRoot = (fileUrl: string = import.meta.url) => {
   while(current !== dirname(current)) {
     const angularCacheFolder = join(dirname(current),'.angular');
     if(angularCacheFolder === current) {
-      console.log(dirname(current));
       return dirname(current);
     }
 

--- a/apps/daffio/src/app/docs/services/docs-path-server.ts
+++ b/apps/daffio/src/app/docs/services/docs-path-server.ts
@@ -1,30 +1,30 @@
-import { isPlatformServer } from '@angular/common';
+import { Provider } from '@angular/core';
 import {
-  inject,
-  PLATFORM_ID,
-  Provider,
-  REQUEST,
-} from '@angular/core';
-import { resolve } from 'path';
+  resolve,
+  dirname,
+  join,
+} from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { DAFFIO_DOCS_PATH_TOKEN } from './docs-path.token';
-import { environment } from '../../../environments/environment';
 
-/**
- * The path on the server to the docs folder.
- */
-const daffioDocsPathServerFactory = () =>
-  // the SSR runs from the daffio directory and doesn't use dotenv so we rely on cwd
-  // devs should have the DAFF_ROOT env var set in their .env
-  resolve(!process.env.DAFF_ROOT ? process.cwd() : resolve(process.env.DAFF_ROOT, 'dist/apps/daffio'), environment.docsPath);
+export const isAngularDevServer = () => import.meta.url.includes('.angular');
 
-/**
- * The path on the compile machine to the docs folder.
- */
-const daffioDocsPathPrerenderFactory = () =>
-  // the SSR runs from the daffio directory and doesn't use dotenv so we rely on cwd
-  // devs should have the DAFF_ROOT env var set in their .env
-  !process.env.DAFF_ROOT ? resolve(process.cwd(), '../../dist') : resolve(process.env.DAFF_ROOT, 'dist');
+export const findProjectRoot = (fileUrl: string = import.meta.url) => {
+  let current = dirname(fileURLToPath(fileUrl));
+
+  while(current !== dirname(current)) {
+    const angularCacheFolder = join(dirname(current),'.angular');
+    if(angularCacheFolder === current) {
+      console.log(dirname(current));
+      return dirname(current);
+    }
+
+    current = dirname(current);
+  }
+
+  throw new Error('No project root found, does the .angular folder exist');
+};
 
 /**
  * A provider for the docs path for the server.
@@ -33,10 +33,12 @@ export function provideServerDocsPath(): Provider {
   return {
     provide: DAFFIO_DOCS_PATH_TOKEN,
     useFactory: () => {
-      // if we're on the server but we don't have access to the SSR request
-      // then we must be in prerender
-      const isPrerender = isPlatformServer(inject(PLATFORM_ID)) && !inject(REQUEST);
-      return isPrerender ? daffioDocsPathPrerenderFactory() : daffioDocsPathServerFactory();
+      if(isAngularDevServer()) {
+        return resolve(findProjectRoot(import.meta.url), 'dist/docs');
+      }
+      //This works so long as chunks are located in the same folder as the default Angular `server.mjs`.
+      //If these move, we'll get missing files.
+      return resolve(dirname(fileURLToPath(import.meta.url)), '../browser/assets/daffio/docs');
     },
   };
 };

--- a/apps/daffio/src/app/docs/services/docs-path.token.ts
+++ b/apps/daffio/src/app/docs/services/docs-path.token.ts
@@ -6,4 +6,4 @@ export const {
    * Provider function for {@link DAFFIO_DOCS_PATH_TOKEN}.
    */
   provider: provideDaffioDocsPath,
-} = createSingleInjectionToken<string>('DAFFIO_DOCS_PATH_TOKEN', { factory: () => '/assets/daffio/' });
+} = createSingleInjectionToken<string>('DAFFIO_DOCS_PATH_TOKEN', { factory: () => '/assets/daffio/docs' });

--- a/apps/daffio/src/app/docs/services/docs.service.spec.ts
+++ b/apps/daffio/src/app/docs/services/docs.service.spec.ts
@@ -43,7 +43,7 @@ describe('DaffioDocsService', () => {
 
     service.get('docs/my/path').subscribe((apiDoc) => {
       expect(apiDoc).toEqual(doc);
-      expect(fetchAssetServiceSpy.fetch).toHaveBeenCalledWith('/assets/daffio//docs/my/path.json', 'docs/my/path');
+      expect(fetchAssetServiceSpy.fetch).toHaveBeenCalledWith('/assets/daffio/docs/my/path.json', 'my/path');
       done();
     });
   });

--- a/apps/daffio/src/app/docs/services/docs.service.ts
+++ b/apps/daffio/src/app/docs/services/docs.service.ts
@@ -11,6 +11,7 @@ import {
 
 import { DAFFIO_DOCS_PATH_TOKEN } from './docs-path.token';
 import { DaffioDocsServiceInterface } from './docs-service.interface';
+import { getSafePath } from './safe-path';
 import {
   DaffioAssetFetchService,
   DaffioAssetFetchServiceInterface,
@@ -26,6 +27,7 @@ export class DaffioDocsService implements DaffioDocsServiceInterface {
   ) {}
 
   get<T extends DaffDoc = DaffDoc>(path: string): Observable<T> {
+    path = getSafePath(path);
     return this.fetchAsset.fetch<T>(`${this.docsPath}/${crossOsFilename(path)}.json`, path);
   }
 }

--- a/apps/daffio/src/app/docs/services/safe-path.ts
+++ b/apps/daffio/src/app/docs/services/safe-path.ts
@@ -1,0 +1,6 @@
+export const getSafePath = (path: string): string => {
+  if(!path.startsWith('docs/')) {
+    throw new Error('Unsafe file access attempt.');
+  }
+  return path.substring(5);
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Previously, both @xelaint and I have errors at run time while working locally (and at serve when using a local ssr dev server) as a result of various usages of process.cwd().

Fixes: N/A


## What is the new behavior?
Now, we no longer rely on process.cwd() instead, we determine whether or not we're using the Angular dev server and decide how to long assets from there. In addition, when running locally with a ssr server (not vite) we know grab the assets from the built browser folder.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information