### PR TITLE
feat(daffio): set widths on doc viewer grid content

### DIFF
--- a/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.scss
+++ b/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.scss
@@ -10,21 +10,25 @@
 
 		@include daff.breakpoint(small-laptop) {
 			display: flex;
-			justify-content: space-between;
 			gap: 4rem;
 			padding: 3rem;
 		}
 
 		@include daff.breakpoint(desktop) {
 			padding: 3rem 0;
+			gap: 8rem;
 		}
 	}
 
 	&__content {
 		display: flex;
 		flex-direction: column;
-		flex-basis: 100%;
 		gap: 1.5rem;
+		width: 100%;
+
+		@include daff.breakpoint(small-laptop) {
+			min-width: 40rem;
+		}
 	}
 
 	&__table-of-contents {
@@ -32,7 +36,9 @@
 
 		@include daff.breakpoint(small-laptop) {
 			display: block;
-			flex: 1 0 15rem;
+			flex-grow: 1;
+			max-width: 15rem;
+			width: 100%;
 		}
 	}
 

--- a/apps/daffio/src/app/docs/components/table-of-contents/link/link.component.scss
+++ b/apps/daffio/src/app/docs/components/table-of-contents/link/link.component.scss
@@ -22,12 +22,12 @@
 	line-height: 1.25rem;
 	text-decoration: none;
 	position: relative;
-	padding: 0.25rem 0 0.25rem 0.5rem;
+	padding: 0.5rem 0 0.5rem 0.75rem;
 
 	&::before {
 		content: '';
 		position: absolute;
-		top: 0.25rem;
+		top: 0.5rem;
 		bottom: 0;
 		left: 0;
 		width: 0.125rem;
@@ -43,10 +43,10 @@
 	}
 
 	&.level-3 {
-		padding: 0.25rem 0 0.25rem 1.5rem;
+		padding-left: 1.5rem;
 	}
 
 	&.level-4 {
-		padding: 0.25rem 0 0.25rem 2.5rem;
+		padding-left: 2.5rem;
 	}
 }

--- a/apps/daffio/src/app/docs/components/table-of-contents/link/link.component.ts
+++ b/apps/daffio/src/app/docs/components/table-of-contents/link/link.component.ts
@@ -2,7 +2,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  HostBinding,
   Input,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
@@ -17,6 +16,10 @@ import { DaffioActiveHeaderService } from '../../../../core/dynamic-fragment/ser
   templateUrl: './link.component.html',
   styleUrl: 'link.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'daffio-docs-table-of-contents-link',
+    '[class.in-sidebar]': 'inSidebar',
+  },
   imports: [
     LetDirective,
     RouterLink,
@@ -27,7 +30,7 @@ export class DaffioDocsTableOfContentsLinkComponent {
    * The doc to render
    */
   @Input() tableOfContents: DaffDocTableOfContents;
-  @Input() @HostBinding('class.in-sidebar') inSidebar = false;
+  @Input() inSidebar = false;
 
   constructor(
     public activeHeaderService: DaffioActiveHeaderService,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Because there is no min-width set on the content of the doc viewer, it'll stretch as much as it needs, even though there's a width set on the toc sidebar.

Fixes: N/A


## What is the new behavior?
Add min-width to doc viewer content and update how toc sets width. This will help w/ allowing `<pre>` blocks to be scrollable.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information