### PR TITLE
fix(dgeni): API search indices don't get `id` set to `path`

### DIFF
--- a/tools/dgeni/src/transforms/daffodil-api-package/processors/role.ts
+++ b/tools/dgeni/src/transforms/daffodil-api-package/processors/role.ts
@@ -33,6 +33,7 @@ import {
 } from '@daffodil/docs-utils';
 
 import { InlineTagProcessor } from './inline-tag-processor';
+import { defaultIndexer } from '../../../processors/convertToJson';
 import {
   MARKDOWN_CODE_PROCESSOR_NAME,
   MarkdownCodeProcessor,
@@ -96,9 +97,6 @@ export class RoleProcessor implements FilterableProcessor {
 
   readonly baseSearchIndexer = indexerFactory<DaffApiDocBase>(
     [
-      'id',
-      'title',
-      'kind',
       'docType',
       'role',
       'examples',
@@ -106,9 +104,10 @@ export class RoleProcessor implements FilterableProcessor {
       'name',
       'description',
     ],
-    // {
-    //   examples: extraIndexer(this.examplesSearchIndexer),
-    // },
+    {},
+    [
+      defaultIndexer,
+    ],
   );
 
   readonly decoratorSerialize = serializeFactory<DaffDocsApiDecorator>(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information