### PR TITLE
feat(shopify,product)!: use named apollo client

### DIFF
--- a/libs/driver/shopify/src/graphql/client-name.ts
+++ b/libs/driver/shopify/src/graphql/client-name.ts
@@ -1,0 +1,5 @@
+/**
+ * Apollo GraphQL client name identifier for the Shopify driver.
+ * Used to distinguish this client instance from other Apollo clients in the application.
+ */
+export const APOLLO_CLIENT_NAME = 'shopify';

--- a/libs/driver/shopify/src/graphql/provide-shopify-apollo-driver.ts
+++ b/libs/driver/shopify/src/graphql/provide-shopify-apollo-driver.ts
@@ -1,12 +1,13 @@
 import { InMemoryCache } from '@apollo/client/cache';
 import { from } from '@apollo/client/core';
-import { provideApollo } from 'apollo-angular';
+import { provideNamedApollo } from 'apollo-angular';
 
 import {
   createErrorLink,
   createAuthLink,
   createHttpLink,
 } from './apollo-links/public_api';
+import { APOLLO_CLIENT_NAME } from './client-name';
 
 /**
  * Provides an Apollo client configuration for Shopify's Storefront API.
@@ -19,13 +20,15 @@ import {
  */
 export function provideShopifyApolloDriver(domain: string, accessToken: string) {
   const shopifyStorefrontAPIEndpoint = `${domain}/api/2025-01/graphql.json`;
-  return provideApollo(() => ({
-    link: from([
-      createErrorLink(),
-      createAuthLink(accessToken),
-      createHttpLink(shopifyStorefrontAPIEndpoint),
-    ]),
-    cache: new InMemoryCache(),
+  return provideNamedApollo(() => ({
+    [APOLLO_CLIENT_NAME]: {
+      link: from([
+        createErrorLink(),
+        createAuthLink(accessToken),
+        createHttpLink(shopifyStorefrontAPIEndpoint),
+      ]),
+      cache: new InMemoryCache(),
+    },
   }));
 
 }

--- a/libs/driver/shopify/src/graphql/public_api.ts
+++ b/libs/driver/shopify/src/graphql/public_api.ts
@@ -1,1 +1,2 @@
 export { provideShopifyApolloDriver } from './provide-shopify-apollo-driver';
+export { APOLLO_CLIENT_NAME } from './client-name';

--- a/libs/product/driver/shopify/src/product.service.spec.ts
+++ b/libs/product/driver/shopify/src/product.service.spec.ts
@@ -4,9 +4,11 @@ import {
   ApolloTestingController,
 } from 'apollo-angular/testing';
 
-import { shopifyUrlTransformer } from '@daffodil/driver/shopify';
+import {
+  APOLLO_CLIENT_NAME,
+  shopifyUrlTransformer,
+} from '@daffodil/driver/shopify';
 import { DaffProductFactory } from '@daffodil/product/testing';
-
 
 import { DaffShopifyProductService } from './product.service';
 import {
@@ -23,7 +25,7 @@ describe('Driver | Shopify | Product | ProductService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        ApolloTestingModule,
+        ApolloTestingModule.withClients([APOLLO_CLIENT_NAME]),
       ],
       providers: [
         DaffShopifyProductService,

--- a/libs/product/driver/shopify/src/product.service.ts
+++ b/libs/product/driver/shopify/src/product.service.ts
@@ -6,6 +6,7 @@ import { map } from 'rxjs/operators';
 import {
   shopifyIdTransformer,
   shopifyUrlTransformer,
+  APOLLO_CLIENT_NAME,
 } from '@daffodil/driver/shopify';
 import { DaffProduct } from '@daffodil/product';
 import {
@@ -19,7 +20,6 @@ import {
   getProductByUrl,
 } from './queries/public_api';
 import { daffShopifyProductTransformer } from './transforms/public_api';
-
 /**
  * A service for getting DaffProducts {@link DaffProduct} from apollo shopify product requests.
  *
@@ -35,7 +35,7 @@ implements DaffProductServiceInterface {
   constructor(private apollo: Apollo) {}
 
   getAll(): Observable<DaffProduct[]> {
-    return this.apollo
+    return this.apollo.use(APOLLO_CLIENT_NAME)
       .query({
         query: getAllProducts,
         variables: {
@@ -51,7 +51,7 @@ implements DaffProductServiceInterface {
   }
 
   get(productId: DaffProduct['id']): Observable<DaffProductDriverResponse> {
-    return this.apollo
+    return this.apollo.use(APOLLO_CLIENT_NAME)
       .query({
         query: getProduct,
         variables: { id: shopifyIdTransformer(productId, 'Product') },
@@ -68,7 +68,7 @@ implements DaffProductServiceInterface {
   }
 
   getByUrl(url: DaffProduct['url']): Observable<DaffProductDriverResponse> {
-    return this.apollo
+    return this.apollo.use(APOLLO_CLIENT_NAME)
       .query({
         query: getProductByUrl,
         variables: { handle: shopifyUrlTransformer(url) },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, we don't use a named Apollo client. This means that when multiple drivers are used that used Apollo (i.e. shopify and Magento) whichever driver is loaded last "wins". While this isn't very common, this is how the demo.daff.io works.

Fixes: N/A


## What is the new behavior?
We now name the shopify driver internally with a named client called "shopify". This constant is used as follows:

```ts
import {
  shopifyIdTransformer,
  shopifyUrlTransformer,
  APOLLO_CLIENT_NAME,
} from '@daffodil/driver/shopify';
```

```ts
this.apollo.use(APOLLO_CLIENT_NAME).query(...)
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information