### PR TITLE
fix(docs): exclude @daffodil/docs from package list generation

### DIFF
--- a/tools/dgeni/src/constants/excluded-packages.ts
+++ b/tools/dgeni/src/constants/excluded-packages.ts
@@ -6,6 +6,7 @@ export const DAFF_DGENI_EXCLUDED_PACKAGES = <const>[
   'design',
   'documentation',
   'docs-components',
+  'docs',
   'docs-utils',
   'theme-switch',
   'dgeni',

--- a/tools/dgeni/src/constants/excluded-packages.ts
+++ b/tools/dgeni/src/constants/excluded-packages.ts
@@ -1,18 +1,70 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import * as path from 'path';
+
 /**
- * List of packages to be left out of API generation
+ * Base static list of packages to be left out of API/doc generation.
+ * These are always excluded regardless of `private` flags.
  */
-export const DAFF_DGENI_EXCLUDED_PACKAGES = <const>[
+const STATIC_EXCLUDED = <const>[
   'branding',
   'design',
   'documentation',
   'docs-components',
-  'docs',
   'docs-utils',
   'theme-switch',
   'dgeni',
 ];
 
 /**
- * Regex of list of package names to be left out of API generation
+ * Resolve workspace root from this file location.
+ */
+const PROJECT_ROOT = path.resolve(__dirname, '../../../..');
+
+/**
+ * Read package.json files under a folder (e.g., libs or tools) and collect
+ * package names that are marked as private.
+ */
+function getPrivatePackageNames(folder: 'libs' | 'tools'): string[] {
+  const base = path.resolve(PROJECT_ROOT, folder);
+  let names: string[] = [];
+  try {
+    const entries = readdirSync(base, { withFileTypes: true });
+    entries.forEach((entry) => {
+      if (!entry.isDirectory()) return;
+      const pkgDir = path.join(base, entry.name);
+      const pkgJsonPath = path.join(pkgDir, 'package.json');
+      try {
+        // Only consider direct child packages with a package.json
+        if (statSync(pkgJsonPath).isFile()) {
+          const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) as { name?: string; private?: boolean };
+          if (pkg?.private) {
+            // Use the folder name as the exclusion key to match glob segments
+            names.push(entry.name);
+          }
+        }
+      } catch {
+        // ignore missing files or JSON errors in non-package folders
+      }
+    });
+  } catch {
+    // folder missing, ignore
+  }
+  return names;
+}
+
+/**
+ * Combined set of excluded package names: static list plus any workspace
+ * packages with `"private": true`.
+ */
+export const DAFF_DGENI_EXCLUDED_PACKAGES = Array.from(new Set([
+  ...STATIC_EXCLUDED,
+  ...getPrivatePackageNames('libs'),
+  ...getPrivatePackageNames('tools'),
+]));
+
+/**
+ * Regex of list of package names to be left out of API generation.
+ * This is used in glob patterns like `${basePath}/${REGEX}/**` where the
+ * `!()` extglob excludes matching directories.
  */
 export const DAFF_DGENI_EXCLUDED_PACKAGES_REGEX = '!(' + DAFF_DGENI_EXCLUDED_PACKAGES.join('|') + ')';


### PR DESCRIPTION
The @daffodil/docs link on the packages page previously redirected to /docs/packages/README which resulted in a 404. This commit updates the excluded-packages.ts file to ignore 'docs' as it is considered as Private.

Thank you.

## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type

- [x] Bug fix

## Current behavior
in https://next.daff.io/docs/packages, the @daffodil/docs link is: https://next.daff.io/docs/packages/README

Fixes: #3959 
## New behavior
/docs is included in excluded-packages.ts
as it is mentioned as Private in its Package.json
-> therefore docs card will no longer appear on the packages page.

## Breaking change?

- [x] No

##Message
Thank You, i would like to contribute more as i developed more understanding about this repo.