### PR TITLE
fix(design-land): adjust assets path for dgeni assets

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -395,7 +395,7 @@
               "apps/design-land/src/assets",
               {
                 "glob": "**/*",
-                "input": "dist/docs/",
+                "input": "dist/docs-assets/docs",
                 "output": "/assets/"
               }
             ],


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [x] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
@sunray4 noted that the docs-gen assets were no longer loading in the design-land app. This was due to the docs-gen change in 7ecbe2d0dd92656b082c9270f977b3e3c4885682

## New behavior
Design-land works again.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->