### PR TITLE
chore(daffio): fix missing routerLink import on homepage

### DIFF
--- a/apps/daffio/src/app/content/home/components/home-callout-pwa/home-callout-pwa.component.spec.ts
+++ b/apps/daffio/src/app/content/home/components/home-callout-pwa/home-callout-pwa.component.spec.ts
@@ -8,6 +8,7 @@ import {
   TestBed,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
 
 import { DaffioHomeCalloutPwaComponent } from './home-callout-pwa.component';
 
@@ -25,7 +26,12 @@ describe('DaffioHomeCalloutPwaComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [WrapperComponent],
+      imports: [
+        WrapperComponent,
+      ],
+      providers: [
+        provideRouter([]),
+      ],
     })
       .compileComponents();
   }));

--- a/apps/daffio/src/app/content/home/components/home-callout-pwa/home-callout-pwa.component.ts
+++ b/apps/daffio/src/app/content/home/components/home-callout-pwa/home-callout-pwa.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   HostBinding,
 } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 import { DAFF_BUTTON_COMPONENTS } from '@daffodil/design/button';
 import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
@@ -19,6 +20,7 @@ import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
     DAFF_CARD_COMPONENTS,
     DAFF_CONTAINER_COMPONENTS,
     DAFF_BUTTON_COMPONENTS,
+    RouterLink,
   ],
 })
 

--- a/apps/daffio/src/app/content/home/view/home-view.component.spec.ts
+++ b/apps/daffio/src/app/content/home/view/home-view.component.spec.ts
@@ -1,9 +1,9 @@
-import { CUSTOM_ELEMENTS_SCHEMA  } from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { DaffioHomeViewComponent } from './home-view.component';
 
@@ -13,9 +13,11 @@ describe('DaffioHomeViewComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [DaffioHomeViewComponent],
-      schemas: [
-        CUSTOM_ELEMENTS_SCHEMA,
+      imports: [
+        DaffioHomeViewComponent,
+      ],
+      providers: [
+        provideRouter([]),
       ],
     })
       .compileComponents();


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [x] Other (please describe)

## Current behavior
Currently, the ` Learn more about PWAs`  button does nothing when you click on it. 

Fixes: #

## New behavior
The button works again.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->