### PR TITLE
refactor(design)!: remove `daffMenuCreateOverlay` from the public api

### DIFF
--- a/libs/design/menu/src/helpers/public_api.ts
+++ b/libs/design/menu/src/helpers/public_api.ts
@@ -1,1 +1,0 @@
-export { daffMenuCreateOverlay } from './create-overlay';

--- a/libs/design/menu/src/public_api.ts
+++ b/libs/design/menu/src/public_api.ts
@@ -1,5 +1,3 @@
-export * from './helpers/public_api';
-
 export { DaffMenuService } from './services/menu.service';
 export { DaffMenuActivatorDirective } from './menu-activator/menu-activator.component';
 export { DaffMenuModule } from './menu.module';

--- a/libs/design/menu/src/services/menu.service.ts
+++ b/libs/design/menu/src/services/menu.service.ts
@@ -21,8 +21,7 @@ import {
 } from 'rxjs';
 
 import { DaffLazyComponent } from '@daffodil/design';
-
-import { daffMenuCreateOverlay } from '../helpers/public_api';
+import { daffMenuCreateOverlay } from '@daffodil/design/menu';
 
 export interface DaffActivatedMenu {
   el: ElementRef;

--- a/libs/design/menu/src/services/menu.service.ts
+++ b/libs/design/menu/src/services/menu.service.ts
@@ -21,7 +21,7 @@ import {
 } from 'rxjs';
 
 import { DaffLazyComponent } from '@daffodil/design';
-import { daffMenuCreateOverlay } from '@daffodil/design/menu';
+import { daffMenuCreateOverlay } from '../helpers/create-overlay';
 
 export interface DaffActivatedMenu {
   el: ElementRef;

--- a/libs/design/menu/src/services/menu.service.ts
+++ b/libs/design/menu/src/services/menu.service.ts
@@ -21,6 +21,7 @@ import {
 } from 'rxjs';
 
 import { DaffLazyComponent } from '@daffodil/design';
+
 import { daffMenuCreateOverlay } from '../helpers/create-overlay';
 
 export interface DaffActivatedMenu {


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [x] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
`daffMenuCreateOverlay` should not be part of the public api.

Fixes: #

## New behavior
Remove `daffMenuCreateOverlay` from the public api.

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `daffMenuCreateOverlay` is no longer part of the public api.

## Additional context
<!-- Any other relevant information -->