### PR TITLE
feat(navigation): add provideDaffNavigationMagentoDriver

### DIFF
--- a/libs/navigation/driver/magento/src/navigation-driver.module.ts
+++ b/libs/navigation/driver/magento/src/navigation-driver.module.ts
@@ -4,21 +4,15 @@ import {
   ModuleWithProviders,
 } from '@angular/core';
 
-import { provideDaffMagentoCacheableOperation } from '@daffodil/driver/magento';
-import {
-  provideDaffNavigationDriver,
-  DaffNavigationTransformer,
-} from '@daffodil/navigation/driver';
-
 import {
   MagentoNavigationDriverConfig,
   MAGENTO_NAVIGATION_DRIVER_CONFIG_DEFAULT,
-  provideMagentoNavigationDriverConfig,
 } from './config/public_api';
-import { DaffMagentoNavigationService } from './navigation.service';
-import { DAFF_MAGENTO_GET_CATEGORY_TREE_QUERY_NAME } from './queries/get-category-tree';
-import { DaffMagentoNavigationTransformerService } from './transformers/navigation-transformer';
+import { provideDaffNavigationMagentoDriver } from './provider';
 
+/**
+ * @deprecated
+ */
 @NgModule({
   imports: [
     CommonModule,
@@ -29,13 +23,7 @@ export class DaffNavigationMagentoDriverModule {
     return {
       ngModule: DaffNavigationMagentoDriverModule,
       providers: [
-        provideDaffNavigationDriver(DaffMagentoNavigationService),
-        {
-          provide: DaffNavigationTransformer,
-          useExisting: DaffMagentoNavigationTransformerService,
-        },
-        provideMagentoNavigationDriverConfig(config),
-        provideDaffMagentoCacheableOperation(DAFF_MAGENTO_GET_CATEGORY_TREE_QUERY_NAME),
+        provideDaffNavigationMagentoDriver(config),
       ],
     };
   }

--- a/libs/navigation/driver/magento/src/provider.ts
+++ b/libs/navigation/driver/magento/src/provider.ts
@@ -1,0 +1,40 @@
+import { Provider } from '@angular/core';
+
+import { provideDaffMagentoCacheableOperation } from '@daffodil/driver/magento';
+import {
+  DaffNavigationTransformer,
+  provideDaffNavigationDriver,
+} from '@daffodil/navigation/driver';
+
+import { DaffMagentoNavigationService } from './navigation.service';
+import {
+  DAFF_MAGENTO_GET_CATEGORY_TREE_QUERY_NAME,
+  DaffMagentoNavigationTransformerService,
+  MAGENTO_NAVIGATION_DRIVER_CONFIG_DEFAULT,
+  MagentoNavigationDriverConfig,
+  provideMagentoNavigationDriverConfig,
+} from './public_api';
+
+/**
+ * Provides the Magento drivers for the navigation package.
+ *
+ * @example
+ * ```ts
+ * export const appConfig: ApplicationConfig = {
+ *   providers: [
+ *     provideRouter(routes),
+ *     provideMagentoDriver('https://some-magento-store.com/graphql'),
+ *     provideDaffNavigationMagentoDriver(),
+ *   ]
+ * };
+ * ```
+ */
+export const provideDaffNavigationMagentoDriver = (config: MagentoNavigationDriverConfig = MAGENTO_NAVIGATION_DRIVER_CONFIG_DEFAULT): Provider[] => [
+  provideDaffNavigationDriver(DaffMagentoNavigationService),
+  {
+    provide: DaffNavigationTransformer,
+    useExisting: DaffMagentoNavigationTransformerService,
+  },
+  provideMagentoNavigationDriverConfig(config),
+  provideDaffMagentoCacheableOperation(DAFF_MAGENTO_GET_CATEGORY_TREE_QUERY_NAME),
+];

--- a/libs/navigation/driver/magento/src/public_api.ts
+++ b/libs/navigation/driver/magento/src/public_api.ts
@@ -5,3 +5,5 @@ export * from './queries/public_api';
 export * from './config/public_api';
 export * from './models/public_api';
 export * from './transforms/public_api';
+
+export { provideDaffNavigationMagentoDriver } from './provider';

--- a/libs/navigation/guides/driver/magento.md
+++ b/libs/navigation/guides/driver/magento.md
@@ -1,0 +1,41 @@
+# Magento
+
+The `@daffodil/navigation` Magento driver provides the connections between your storefront's menus and your underlying Magento store.
+
+## Features
+
+- **Caching Support**: Built-in caching capabilities for improved performance
+- **Breadcrumb Support**: Generates breadcrumb navigation based on category hierarchy
+- **Multi-level Navigation**: Supports nested category structures with unlimited depth
+
+## Usage
+
+```ts
+import { provideMagentoDriver } from '@daffodil/navigation/driver/magento';
+
+export const appConfig: ApplicationConfig = {
+	providers: [
+		provideRouter(routes),
+		provideMagentoDriver('https://some-magento-store.com/graphql'),
+		provideDaffNavigationMagentoDriver(),
+	],
+};
+```
+
+## A note on performance
+
+By default, the underlying driver will [call Magento's GraphQl API ](https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/) to retrieve the store's root category. However, you can skip this call by providing a `rootCategoryId` to the provider configuration:
+
+```ts
+import { provideMagentoDriver } from '@daffodil/navigation/driver/magento';
+
+export const appConfig: ApplicationConfig = {
+	providers: [
+		provideRouter(routes),
+		provideMagentoDriver('https://some-magento-store.com/graphql'),
+		provideDaffNavigationMagentoDriver({
+			rootCategoryId: 'Mg=='
+		}),
+	],
+};
+```


### PR DESCRIPTION
This also deprecates DaffNavigationMagentoDriverModule

## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, we use `DaffNavigationMagentoDriverModule.forRoot`. This is an older style API.

Touches https://github.com/graycoreio/daffodil/issues/4024

## New behavior

This adds a new provider `provideDaffNavigationMagentoDriver` that can be used instead of `DaffNavigationMagentoDriverModule.forRoot`

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->