### PR TITLE
feat(navigation): create provideDaffNavigationInMemoryDriver

### DIFF
--- a/libs/navigation/driver/in-memory/src/navigation-driver.module.ts
+++ b/libs/navigation/driver/in-memory/src/navigation-driver.module.ts
@@ -7,7 +7,7 @@ import {
 import { provideDaffNavigationInMemoryDriver } from './provider';
 
 /**
- * @deprecated
+ * @deprecated in favor of {@link provideDaffNavigationInMemoryDriver}
  */
 @NgModule({
   imports: [

--- a/libs/navigation/driver/in-memory/src/navigation-driver.module.ts
+++ b/libs/navigation/driver/in-memory/src/navigation-driver.module.ts
@@ -4,12 +4,11 @@ import {
   ModuleWithProviders,
 } from '@angular/core';
 
-import { provideDaffInMemoryBackends } from '@daffodil/driver/in-memory';
-import { provideDaffNavigationDriver } from '@daffodil/navigation/driver';
+import { provideDaffNavigationInMemoryDriver } from './provider';
 
-import { DaffInMemoryBackendNavigationService } from './backend/navigation.service';
-import { DaffInMemoryNavigationService } from './navigation.service';
-
+/**
+ * @deprecated
+ */
 @NgModule({
   imports: [
     CommonModule,
@@ -20,8 +19,7 @@ export class DaffNavigationInMemoryDriverModule {
     return {
       ngModule: DaffNavigationInMemoryDriverModule,
       providers: [
-        provideDaffNavigationDriver(DaffInMemoryNavigationService),
-        provideDaffInMemoryBackends(DaffInMemoryBackendNavigationService),
+        provideDaffNavigationInMemoryDriver(),
       ],
     };
   }

--- a/libs/navigation/driver/in-memory/src/provider.ts
+++ b/libs/navigation/driver/in-memory/src/provider.ts
@@ -26,7 +26,7 @@ import { DaffInMemoryBackendNavigationService } from './public_api';
  * };
  * ```
  */
-export const provideDaffNavigationInMemoryDriver = (): Provider | EnvironmentProviders[] => [
+export const provideDaffNavigationInMemoryDriver = (): (Provider | EnvironmentProviders)[] => [
   provideDaffNavigationDriver(DaffInMemoryNavigationService),
   makeEnvironmentProviders(provideDaffInMemoryBackends(DaffInMemoryBackendNavigationService)),
 ];

--- a/libs/navigation/driver/in-memory/src/provider.ts
+++ b/libs/navigation/driver/in-memory/src/provider.ts
@@ -1,0 +1,32 @@
+import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
+  Provider,
+} from '@angular/core';
+
+import { provideDaffInMemoryBackends } from '@daffodil/driver/in-memory';
+import { provideDaffNavigationDriver } from '@daffodil/navigation/driver';
+
+import { DaffInMemoryNavigationService } from './navigation.service';
+import { DaffInMemoryBackendNavigationService } from './public_api';
+
+/**
+ * Provides the `@daffodil/navigation` driver interfaces.
+ *
+ * @example Configuring your app.config
+ *
+ * ```ts
+ * export const appConfig: ApplicationConfig = {
+ *   providers: [
+ *     provideRouter(routes),
+ *     provideHttpClient(),
+ *     provideDaffInMemoryDriver(myConfig),
+ *     provideDaffNavigationInMemoryDriver(),
+ *   ]
+ * };
+ * ```
+ */
+export const provideDaffNavigationInMemoryDriver = (): Provider | EnvironmentProviders[] => [
+  provideDaffNavigationDriver(DaffInMemoryNavigationService),
+  makeEnvironmentProviders(provideDaffInMemoryBackends(DaffInMemoryBackendNavigationService)),
+];

--- a/libs/navigation/driver/in-memory/src/public_api.ts
+++ b/libs/navigation/driver/in-memory/src/public_api.ts
@@ -3,3 +3,5 @@ export { DaffInMemoryNavigationService } from './navigation.service';
 export { DaffNavigationInMemoryDriverModule } from './navigation-driver.module';
 
 export * from './seed-data-provider/public_api';
+
+export { provideDaffNavigationInMemoryDriver } from './provider';

--- a/libs/navigation/guides/driver/in-memory.md
+++ b/libs/navigation/guides/driver/in-memory.md
@@ -4,11 +4,11 @@ The `@daffodil/navigation` in-memory driver provides randomly generated menus fo
 
 ## Features
 
-- The in-memory driver uses Angular's `angular-in-memory-web-api` under the hood
-- Random data is generated using the `@daffodil/navigation/testing` factories
-- The driver is intended for development and testing only - use appropriate production drivers for production environments
-- Navigation trees are cached in memory and persist until refresh.
-- [Custom Seed Data](#custom-seed-data) can be provided for more persistent behavior.
+- Uses Angular's `angular-in-memory-web-api` under the hood
+- Generates random data using `@daffodil/navigation/testing` factories
+- Intended for development and testing only — use appropriate drivers for production environments
+- Caches navigation trees in memory until page refresh
+- Supports [custom seed data](/libs/navigation/guides/driver/in-memory.md#custom-seed-data) for persistent behavior
 
 ## Basic Usage
 

--- a/libs/navigation/guides/driver/in-memory.md
+++ b/libs/navigation/guides/driver/in-memory.md
@@ -10,7 +10,7 @@ The `@daffodil/navigation` in-memory driver provides randomly generated menus fo
 - Caches navigation trees in memory until page refresh
 - Supports [custom seed data](/libs/navigation/guides/driver/in-memory.md#custom-seed-data) for persistent behavior
 
-## Basic Usage
+## Basic usage
 
 The recommended approach for modern Angular applications is to use the standalone provider function:
 
@@ -31,9 +31,9 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-## Custom Seed Data
+## Custom seed data
 
-By default, the in-memory driver generates random navigation data using the `DaffNavigationTreeFactory`. However, you can provide your own custom navigation tree data:
+By default, the in-memory driver generates random navigation data using `DaffNavigationTreeFactory`. You can also provide your own custom navigation tree data:
 
 ```ts
 import { ApplicationConfig } from '@angular/core';
@@ -97,11 +97,11 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-## Common Use Cases
+## Common use cases
 
-### Development Environment
+### Development environment
 
-Use the in-memory driver during development to work without a backend:
+Use the in-memory driver to develop without a backend:
 
 ```ts
 import { environment } from './environments/environment';

--- a/libs/navigation/guides/driver/in-memory.md
+++ b/libs/navigation/guides/driver/in-memory.md
@@ -1,0 +1,125 @@
+# In Memory
+
+The `@daffodil/navigation` In-Memory driver provides randomly generated menus that your application can use as necessary to render trees of navigational elements. This driver is particularly useful for development, testing, and prototyping scenarios where you don't have a backend navigation service available.
+
+## Features
+
+- The in-memory driver uses Angular's `angular-in-memory-web-api` under the hood
+- Random data is generated using the `@daffodil/navigation/testing` factories
+- The driver is intended for development and testing only - use appropriate production drivers for production environments
+- Navigation trees are cached in memory and persist until refresh.
+- [Custom Seed Data](#custom-seed-data) can be provided for more persistent behavior.
+
+## Basic Usage
+
+The recommended approach for modern Angular applications is to use the standalone provider function:
+
+```ts
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideDaffInMemoryDriver } from '@daffodil/driver/in-memory';
+import { provideDaffNavigationInMemoryDriver } from '@daffodil/navigation/driver/in-memory';
+
+export const appConfig: ApplicationConfig = {
+	providers: [
+		provideRouter(routes),
+		provideHttpClient(),
+		provideDaffInMemoryDriver(myConfig),
+		provideDaffNavigationInMemoryDriver(),
+	],
+};
+```
+
+## Custom Seed Data
+
+By default, the in-memory driver generates random navigation data using the `DaffNavigationTreeFactory`. However, you can provide your own custom navigation tree data:
+
+```ts
+import { ApplicationConfig } from '@angular/core';
+import { provideDaffNavigationInMemorySeedDataProvider } from '@daffodil/navigation/driver/in-memory';
+import { DaffNavigationTree } from '@daffodil/navigation';
+
+const customNavigationTree: DaffNavigationTree = {
+	id: 'root',
+	url: '/',
+	name: 'Main Navigation',
+	breadcrumbs: [],
+	children: [
+		{
+			id: 'products',
+			url: '/products',
+			name: 'Products',
+			breadcrumbs: [{ id: 'root', name: 'Home', url: '/' }],
+			children: [
+				{
+					id: 'category-1',
+					url: '/products/category-1',
+					name: 'Category 1',
+					total_products: 25,
+					breadcrumbs: [
+						{ id: 'root', name: 'Home', url: '/' },
+						{ id: 'products', name: 'Products', url: '/products' }
+					],
+					children: []
+				},
+				{
+					id: 'category-2',
+					url: '/products/category-2',
+					name: 'Category 2',
+					total_products: 15,
+					breadcrumbs: [
+						{ id: 'root', name: 'Home', url: '/' },
+						{ id: 'products', name: 'Products', url: '/products' }
+					],
+					children: []
+				}
+			]
+		},
+		{
+			id: 'about',
+			url: '/about',
+			name: 'About Us',
+			breadcrumbs: [{ id: 'root', name: 'Home', url: '/' }],
+			children: []
+		}
+	]
+};
+
+export const appConfig: ApplicationConfig = {
+	providers: [
+		provideRouter(routes),
+		provideHttpClient(),
+		provideDaffInMemoryDriver(myConfig),
+		provideDaffNavigationInMemoryDriver(),
+		provideDaffNavigationInMemorySeedDataProvider(() => customNavigationTree),
+	],
+};
+```
+
+## Common Use Cases
+
+### Development Environment
+
+Use the in-memory driver during development to work without a backend:
+
+```ts
+import { environment } from './environments/environment';
+
+const providers = [
+	provideRouter(routes),
+	provideHttpClient(),
+];
+
+if (!environment.production) {
+	providers.push(
+		provideDaffInMemoryDriver(),
+		provideDaffNavigationInMemoryDriver()
+	);
+} else {
+	// Add production navigation driver
+}
+
+export const appConfig: ApplicationConfig = { providers };
+```
+

--- a/libs/navigation/guides/driver/in-memory.md
+++ b/libs/navigation/guides/driver/in-memory.md
@@ -1,6 +1,6 @@
 # In Memory
 
-The `@daffodil/navigation` In-Memory driver provides randomly generated menus that your application can use as necessary to render trees of navigational elements. This driver is particularly useful for development, testing, and prototyping scenarios where you don't have a backend navigation service available.
+The `@daffodil/navigation` in-memory driver provides randomly generated menus for rendering navigational element trees. This driver is useful for development, testing, and prototyping when a backend navigation service is unavailable.
 
 ## Features
 


### PR DESCRIPTION
This also deprecates the DaffNavigationInMemoryDriverModule

## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, there's a `DaffNavigationInMemoryDriverModule.forRoot()` method, which is an older api style.

Touches: #4024 

## New behavior
We now have a `provideDaffNavigationInMemoryDriver`

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->