### PR TITLE
fix(navigation): add store code to Magento navigation query

### DIFF
--- a/libs/navigation/driver/magento/src/navigation.service.spec.ts
+++ b/libs/navigation/driver/magento/src/navigation.service.spec.ts
@@ -142,6 +142,7 @@ describe('@daffodil/navigation/driver/magento | DaffMagentoNavigationService', (
       rootIdOp.flushData({
         storeConfig: {
           root_category_uid: navigation.id,
+          store_code: 'default',
         },
       });
 

--- a/libs/navigation/driver/magento/src/queries/get-root-category-id/query.ts
+++ b/libs/navigation/driver/magento/src/queries/get-root-category-id/query.ts
@@ -13,6 +13,7 @@ export const magentoNavigationGetRootCategoryIdQuery = gql<MagentoNavgiationGetR
   query ${MAGENTO_NAVIGATION_GET_ROOT_CATEGORY_ID_QUERY_NAME} {
     storeConfig {
       root_category_uid
+      store_code
     }
   }
 `;

--- a/libs/navigation/driver/magento/src/queries/get-root-category-id/response.type.ts
+++ b/libs/navigation/driver/magento/src/queries/get-root-category-id/response.type.ts
@@ -1,5 +1,6 @@
 export interface MagentoNavgiationGetRootCategoryIdResponse {
   storeConfig: {
     root_category_uid: string;
+    store_code: string;
   };
 }


### PR DESCRIPTION
…atability with typePolicies

## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
When using the navigation driver when using the Magento's pre-define type policies, an error occurs retrieving the category tree. 

Fixes: #

## New behavior
This no longer errors.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->