### PR TITLE
feat(driver): expose shopify route prefixes

### DIFF
--- a/libs/driver/shopify/src/public_api.ts
+++ b/libs/driver/shopify/src/public_api.ts
@@ -3,3 +3,4 @@ export * from './codegen/public_api';
 export * from './graphql/public_api';
 export * from './transforms/public_api';
 export { provideShopifyDriver } from './provider';
+export { SHOPIFY_ROUTE_PREFIXES } from './route-prefixes';

--- a/libs/driver/shopify/src/route-prefixes.ts
+++ b/libs/driver/shopify/src/route-prefixes.ts
@@ -1,0 +1,8 @@
+/**
+ * Route prefixes used for Shopify API endpoints.
+ * These prefixes are used to construct the full paths for different resources.
+ */
+export const enum SHOPIFY_ROUTE_PREFIXES {
+  PRODUCTS = 'products',
+  COLLECTIONS = 'collections',
+}


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
In other parts of the codebase, we need route prefixes to transform urls to meet Shopify user's expectations for routing URLs. There's no shared source for these prefixes.

## New behavior
We now have shared (albeit small) source of these route prefixes.

## Breaking change?

- [ ] Yes
- [x] No

