### PR TITLE
feat(product)!: use route prefixes to calculate shopify url

### DIFF
--- a/libs/product/driver/shopify/src/transforms/shopify-daff-product-transform.ts
+++ b/libs/product/driver/shopify/src/transforms/shopify-daff-product-transform.ts
@@ -1,4 +1,7 @@
-import { ShopifyProductNode } from '@daffodil/driver/shopify';
+import {
+  SHOPIFY_ROUTE_PREFIXES,
+  ShopifyProductNode,
+} from '@daffodil/driver/shopify';
 import {
   DaffProduct,
   DaffProductTypeEnum,
@@ -24,7 +27,7 @@ export const daffShopifyProductTransformer = (node: ShopifyProductNode): DaffPro
     id: node.images.nodes[0]?.id,
   },
   id: node.id,
-  url: `/${node.handle}`,
+  url: `/${SHOPIFY_ROUTE_PREFIXES.PRODUCTS}/${node.handle}`,
   type: DaffProductTypeEnum.Simple,
   price: node.priceRange.maxVariantPrice.amount,
   in_stock: node.availableForSale,


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, urls for products are simply configured as `${handle}`, which means that the product pages are indistinguishable from collection pages with shopify. 

## New behavior
This adjust that behavior so that we can different why kind of page to load.

Product urls will now be:

```
products/${handle}
```

## Breaking change?

- [x] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->