### PR TITLE
feat(external-router): add initial shopify driver

### DIFF
--- a/libs/external-router/driver/shopify/ng-package.json
+++ b/libs/external-router/driver/shopify/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../node_modules/ng-packagr/ng-entrypoint.schema.json",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/external-router/driver/shopify/src/index.ts
+++ b/libs/external-router/driver/shopify/src/index.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/libs/external-router/driver/shopify/src/provider.ts
+++ b/libs/external-router/driver/shopify/src/provider.ts
@@ -1,0 +1,14 @@
+import {
+  EnvironmentProviders,
+  makeEnvironmentProviders,
+  Provider,
+} from '@angular/core';
+
+import { provideDaffExternalRouterDriver } from '@daffodil/external-router/driver';
+
+import { DaffShopifyExternalRouterDriver } from './shopify.service';
+
+export const provideDaffExternalRouterShopifyDriver = (): (Provider | EnvironmentProviders)[] => [
+  makeEnvironmentProviders([DaffShopifyExternalRouterDriver]),
+  provideDaffExternalRouterDriver(DaffShopifyExternalRouterDriver),
+];

--- a/libs/external-router/driver/shopify/src/public_api.ts
+++ b/libs/external-router/driver/shopify/src/public_api.ts
@@ -1,0 +1,2 @@
+export { DaffShopifyExternalRouterDriver } from './shopify.service';
+export { provideDaffExternalRouterShopifyDriver } from './provider';

--- a/libs/external-router/driver/shopify/src/shopify.service.spec.ts
+++ b/libs/external-router/driver/shopify/src/shopify.service.spec.ts
@@ -194,10 +194,10 @@ describe('@daffodil/external-router/driver/shopify | DaffShopifyExternalRouterDr
 
           expectObservable(service.resolve('/collections/summer-sale')).toBe(expected, {
             a: {
-              id: 'null',
-              url: '/collections/summer-sale',
+              id: null,
+              url: null,
               code: 404,
-              type: 'UNKNOWN',
+              type: null,
             },
           });
         });
@@ -210,10 +210,10 @@ describe('@daffodil/external-router/driver/shopify | DaffShopifyExternalRouterDr
 
           expectObservable(service.resolve('/')).toBe(expected, {
             a: {
-              id: 'null',
-              url: '/',
+              id: null,
+              url: null,
               code: 404,
-              type: 'UNKNOWN',
+              type: null,
             },
           });
         });
@@ -226,10 +226,10 @@ describe('@daffodil/external-router/driver/shopify | DaffShopifyExternalRouterDr
 
           expectObservable(service.resolve('')).toBe(expected, {
             a: {
-              id: 'null',
-              url: '/',
+              id: null,
+              url: null,
               code: 404,
-              type: 'UNKNOWN',
+              type: null,
             },
           });
         });
@@ -242,10 +242,10 @@ describe('@daffodil/external-router/driver/shopify | DaffShopifyExternalRouterDr
 
           expectObservable(service.resolve('/pages/about')).toBe(expected, {
             a: {
-              id: 'null',
-              url: '/pages/about',
+              id: null,
+              url: null,
               code: 404,
-              type: 'UNKNOWN',
+              type: null,
             },
           });
         });
@@ -258,10 +258,10 @@ describe('@daffodil/external-router/driver/shopify | DaffShopifyExternalRouterDr
 
           expectObservable(service.resolve('/blogs/news')).toBe(expected, {
             a: {
-              id: 'null',
-              url: '/blogs/news',
+              id: null,
+              url: null,
               code: 404,
-              type: 'UNKNOWN',
+              type: null,
             },
           });
         });
@@ -274,10 +274,10 @@ describe('@daffodil/external-router/driver/shopify | DaffShopifyExternalRouterDr
 
           expectObservable(service.resolve('/product/my-item')).toBe(expected, {
             a: {
-              id: 'null',
-              url: '/product/my-item',
+              id: null,
+              url: null,
               code: 404,
-              type: 'UNKNOWN',
+              type: null,
             },
           });
         });
@@ -290,10 +290,10 @@ describe('@daffodil/external-router/driver/shopify | DaffShopifyExternalRouterDr
 
           expectObservable(service.resolve('/products')).toBe(expected, {
             a: {
-              id: 'null',
-              url: '/products',
+              id: null,
+              url: null,
               code: 404,
-              type: 'UNKNOWN',
+              type: null,
             },
           });
         });
@@ -306,10 +306,10 @@ describe('@daffodil/external-router/driver/shopify | DaffShopifyExternalRouterDr
 
           expectObservable(service.resolve('/products/')).toBe(expected, {
             a: {
-              id: 'null',
-              url: '/products/',
+              id: null,
+              url: null,
               code: 404,
-              type: 'UNKNOWN',
+              type: null,
             },
           });
         });

--- a/libs/external-router/driver/shopify/src/shopify.service.spec.ts
+++ b/libs/external-router/driver/shopify/src/shopify.service.spec.ts
@@ -1,0 +1,319 @@
+import { TestBed } from '@angular/core/testing';
+import { TestScheduler } from 'rxjs/testing';
+
+import { DaffShopifyExternalRouterDriver } from './shopify.service';
+
+describe('@daffodil/external-router/driver/shopify | DaffShopifyExternalRouterDriver', () => {
+  let service: DaffShopifyExternalRouterDriver;
+  let scheduler: TestScheduler;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [DaffShopifyExternalRouterDriver],
+    });
+    service = TestBed.inject(DaffShopifyExternalRouterDriver);
+
+    scheduler = new TestScheduler((actual, expected) => {
+      // eslint-disable-next-line jasmine/no-expect-in-setup-teardown
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('resolve', () => {
+    describe('when the URL matches a product pattern', () => {
+      it('should return a resolved product route for /products/my-product', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products/my-product')).toBe(expected, {
+            a: {
+              id: 'my-product',
+              url: 'products/my-product',
+              code: 200,
+              type: 'PRODUCT',
+            },
+          });
+        });
+      });
+
+      it('should return a resolved product route for products/slug (no leading slash)', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('products/my-product')).toBe(expected, {
+            a: {
+              id: 'my-product',
+              url: 'products/my-product',
+              code: 200,
+              type: 'PRODUCT',
+            },
+          });
+        });
+      });
+
+      it('should handle product slugs with dashes', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products/my-awesome-product')).toBe(expected, {
+            a: {
+              id: 'my-awesome-product',
+              url: 'products/my-awesome-product',
+              code: 200,
+              type: 'PRODUCT',
+            },
+          });
+        });
+      });
+
+      it('should handle product slugs with underscores', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products/my_awesome_product')).toBe(expected, {
+            a: {
+              id: 'my_awesome_product',
+              url: 'products/my_awesome_product',
+              code: 200,
+              type: 'PRODUCT',
+            },
+          });
+        });
+      });
+
+      it('should handle product slugs with numbers', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products/product-123')).toBe(expected, {
+            a: {
+              id: 'product-123',
+              url: 'products/product-123',
+              code: 200,
+              type: 'PRODUCT',
+            },
+          });
+        });
+      });
+
+      it('should handle product slugs with file extensions and return a slug without extension', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products/my-product.html')).toBe(expected, {
+            a: {
+              id: 'my-product',
+              url: 'products/my-product.html',
+              code: 200,
+              type: 'PRODUCT',
+            },
+          });
+        });
+      });
+
+      it('should return successfully for URLs with query parameters (undefined behavior)', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products/my-product?variant=blue')).toBe(expected, {
+            a: {
+              id: 'my-product?variant=blue',
+              url: 'products/my-product?variant=blue',
+              code: 200,
+              type: 'PRODUCT',
+            },
+          });
+        });
+      });
+
+      it('should return successfully for URLs with hash fragments (undefined behavior)', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products/my-product#reviews')).toBe(expected, {
+            a: {
+              id: 'my-product#reviews',
+              url: 'products/my-product#reviews',
+              code: 200,
+              type: 'PRODUCT',
+            },
+          });
+        });
+      });
+
+      it('should handle product slugs with special characters (undefined behavior)', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products/my-product@special')).toBe(expected, {
+            a: {
+              id: 'my-product@special',
+              url: 'products/my-product@special',
+              code: 200,
+              type: 'PRODUCT',
+            },
+          });
+        });
+      });
+
+      it('should return 404 for nested paths (regex only matches direct product slugs)', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products/category/subcategory/product')).toBe(expected, {
+            a: {
+              id: 'null',
+              url: '/products/category/subcategory/product',
+              code: 404,
+              type: 'UNKNOWN',
+            },
+          });
+        });
+      });
+    });
+
+    describe('when the URL does not match any pattern', () => {
+      it('should return a 404 result for non-product URLs', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/collections/summer-sale')).toBe(expected, {
+            a: {
+              id: 'null',
+              url: '/collections/summer-sale',
+              code: 404,
+              type: 'UNKNOWN',
+            },
+          });
+        });
+      });
+
+      it('should return a 404 result for homepage', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/')).toBe(expected, {
+            a: {
+              id: 'null',
+              url: '/',
+              code: 404,
+              type: 'UNKNOWN',
+            },
+          });
+        });
+      });
+
+      it('should return a 404 result for empty string', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('')).toBe(expected, {
+            a: {
+              id: 'null',
+              url: '/',
+              code: 404,
+              type: 'UNKNOWN',
+            },
+          });
+        });
+      });
+
+      it('should return a 404 result for /pages/about', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/pages/about')).toBe(expected, {
+            a: {
+              id: 'null',
+              url: '/pages/about',
+              code: 404,
+              type: 'UNKNOWN',
+            },
+          });
+        });
+      });
+
+      it('should return a 404 result for /blogs/news', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/blogs/news')).toBe(expected, {
+            a: {
+              id: 'null',
+              url: '/blogs/news',
+              code: 404,
+              type: 'UNKNOWN',
+            },
+          });
+        });
+      });
+
+      it('should return a 404 result for URLs that start with product but not products', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/product/my-item')).toBe(expected, {
+            a: {
+              id: 'null',
+              url: '/product/my-item',
+              code: 404,
+              type: 'UNKNOWN',
+            },
+          });
+        });
+      });
+
+      it('should return a 404 result for /products without a slug', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products')).toBe(expected, {
+            a: {
+              id: 'null',
+              url: '/products',
+              code: 404,
+              type: 'UNKNOWN',
+            },
+          });
+        });
+      });
+
+      it('should return a 404 result for /products/ with trailing slash but no slug', () => {
+        scheduler.run(helpers => {
+          const { expectObservable } = helpers;
+          const expected = '(a|)';
+
+          expectObservable(service.resolve('/products/')).toBe(expected, {
+            a: {
+              id: 'null',
+              url: '/products/',
+              code: 404,
+              type: 'UNKNOWN',
+            },
+          });
+        });
+      });
+    });
+  });
+});

--- a/libs/external-router/driver/shopify/src/shopify.service.spec.ts
+++ b/libs/external-router/driver/shopify/src/shopify.service.spec.ts
@@ -176,10 +176,10 @@ describe('@daffodil/external-router/driver/shopify | DaffShopifyExternalRouterDr
 
           expectObservable(service.resolve('/products/category/subcategory/product')).toBe(expected, {
             a: {
-              id: 'null',
-              url: '/products/category/subcategory/product',
+              id: null,
+              url: null,
               code: 404,
-              type: 'UNKNOWN',
+              type: null,
             },
           });
         });

--- a/libs/external-router/driver/shopify/src/shopify.service.ts
+++ b/libs/external-router/driver/shopify/src/shopify.service.ts
@@ -10,7 +10,10 @@ import {
   daffUriTruncateLeadingSlash,
 } from '@daffodil/core/routing';
 import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
-import { DaffExternalRouterDriverInterface } from '@daffodil/external-router/driver';
+import {
+  DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION,
+  DaffExternalRouterDriverInterface,
+} from '@daffodil/external-router/driver';
 
 @Injectable({
   providedIn:'root',
@@ -28,11 +31,6 @@ export class DaffShopifyExternalRouterDriver implements DaffExternalRouterDriver
       });
     }
 
-    return of({
-      id: 'null',
-      url: (new URL('https://www.example.com' + url)).pathname,
-      code: 404,
-      type: 'UNKNOWN',
-    });
+    return of(DAFF_EXTERNAL_ROUTER_NOT_FOUND_RESOLUTION);
   }
 }

--- a/libs/external-router/driver/shopify/src/shopify.service.ts
+++ b/libs/external-router/driver/shopify/src/shopify.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import {
+  Observable,
+  of,
+} from 'rxjs';
+
+import {
+  daffUriTruncateFileExtension,
+  daffUriTruncateLeadingPathSegments,
+  daffUriTruncateLeadingSlash,
+} from '@daffodil/core/routing';
+import { DaffExternallyResolvableUrl } from '@daffodil/external-router';
+import { DaffExternalRouterDriverInterface } from '@daffodil/external-router/driver';
+
+@Injectable({
+  providedIn:'root',
+})
+export class DaffShopifyExternalRouterDriver implements DaffExternalRouterDriverInterface {
+
+  resolve(url: string): Observable<DaffExternallyResolvableUrl> {
+    const productsMatch = url.match(/^\/?products\/(?<slug>[^/]+?)(?:\.[^/.]+)?$/);
+    if(productsMatch && productsMatch.groups?.['slug']) {
+      return of({
+        id: daffUriTruncateFileExtension(daffUriTruncateLeadingPathSegments(url)),
+        url: daffUriTruncateLeadingSlash(url),
+        code: 200,
+        type: 'PRODUCT',
+      });
+    }
+
+    return of({
+      id: 'null',
+      url: (new URL('https://www.example.com' + url)).pathname,
+      code: 404,
+      type: 'UNKNOWN',
+    });
+  }
+}

--- a/libs/external-router/guides/drivers/shopify.md
+++ b/libs/external-router/guides/drivers/shopify.md
@@ -1,0 +1,50 @@
+# Shopify
+
+The `@daffodil/external-router` Shopify driver provides URL resolution for Shopify-style routes, enabling your application to handle Shopify's standard URL patterns for products and other resources.
+
+## Features
+
+- **Product URL Resolution**: Automatically resolves `/products/{slug}` patterns
+- **File Extension Handling**: Supports SEO-friendly URLs with extensions (e.g., `.html`)
+- **Flexible Slug Formats**: Handles dashes, underscores, and alphanumeric slugs
+
+## Usage
+
+```ts
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideClientHydration } from '@angular/platform-browser';
+import { provideExternalRouter } from '@daffodil/external-router';
+import { provideDaffExternalRouterShopifyDriver } from '@daffodil/external-router/driver/shopify';
+
+export const appConfig: ApplicationConfig = {
+	providers: [
+		provideRouter(routes),
+		provideClientHydration(),
+		provideExternalRouter(),
+		provideDaffExternalRouterShopifyDriver(),
+	],
+};
+```
+
+## Supported URL Patterns
+
+### Product Routes
+
+The driver recognizes and resolves the following product URL patterns:
+
+| Pattern                  | Example                     | Resolved Type |
+| ------------------------ | --------------------------- | ------------- |
+| `/products/{slug}`       | `/products/my-product`      | PRODUCT       |
+| `products/{slug}`        | `products/my-product`       | PRODUCT       |
+| `/products/{slug}.{ext}` | `/products/my-product.html` | PRODUCT       |
+
+The driver extracts the product slug (without file extension) as the resource ID and returns a successful resolution (200 status) for matching patterns.
+
+### Unsupported Routes
+
+The following URL patterns are not currently supported and will return 404:
+
+- Collection pages (`/collections/*`)
+- Page routes (`/pages/*`)
+- Blog routes (`/blogs/*`)

--- a/libs/external-router/guides/drivers/shopify.md
+++ b/libs/external-router/guides/drivers/shopify.md
@@ -1,12 +1,12 @@
 # Shopify
 
-The `@daffodil/external-router` Shopify driver provides URL resolution for Shopify-style routes, enabling your application to handle Shopify's standard URL patterns for products and other resources.
+The `@daffodil/external-router` Shopify driver provides URL resolution for Shopify routes, enabling your application to handle Shopify's URL patterns for products and other resources.
 
 ## Features
 
-- **Product URL Resolution**: Automatically resolves `/products/{slug}` patterns
-- **File Extension Handling**: Supports SEO-friendly URLs with extensions (e.g., `.html`)
-- **Flexible Slug Formats**: Handles dashes, underscores, and alphanumeric slugs
+- **Product URL resolution**: Automatically resolves `/products/{slug}` patterns
+- **File extension handling**: Supports SEO-friendly URLs with extensions (e.g., `.html`)
+- **Flexible slug formats**: Handles dashes, underscores, and alphanumeric characters
 
 ## Usage
 
@@ -27,9 +27,9 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-## Supported URL Patterns
+## Supported URL patterns
 
-### Product Routes
+### Product routes
 
 The driver recognizes and resolves the following product URL patterns:
 
@@ -41,7 +41,7 @@ The driver recognizes and resolves the following product URL patterns:
 
 The driver extracts the product slug (without file extension) as the resource ID and returns a successful resolution (200 status) for matching patterns.
 
-### Unsupported Routes
+### Unsupported routes
 
 The following URL patterns are not currently supported and will return 404:
 


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, we do not have an external router implementation for Shopify. This means that devs are forced to write `routes` specifically for shopify's expected patterns like `product/${handle}` and `collections/${handle}`. 

## New behavior
We now encapsulate Shopify's routing behavior into the external-router driver. Users can simply provide the driver via:

```ts
import { ApplicationConfig } from '@angular/core';
import { provideRouter } from '@angular/router';
import { provideClientHydration } from '@angular/platform-browser';
import { provideExternalRouter } from '@daffodil/external-router';
import { provideDaffExternalRouterShopifyDriver } from '@daffodil/external-router/driver/shopify';

export const appConfig: ApplicationConfig = {
	providers: [
		provideRouter(routes),
		provideClientHydration(),
		provideExternalRouter(),
		provideDaffExternalRouterShopifyDriver(),
	],
};
```

And use the same behavior as other platforms:

```ts
import { Routes } from '@angular/router';

import { [daffExternalMatcherTypeGuard](https://next.daff.io/docs/api/external-router/routing/daffExternalMatcherTypeGuard) } from '@daffodil/external-router/routing';

export const routes: Routes = [
  {
    path: '',
    pathMatch: 'full',
    component: HomeComponent,
  },
  {
    path: '**',
    component: TestComponent,
    canMatch: [daffExternalMatcherTypeGuard('PRODUCT')],
  },
  {
    path: '**',
    component: OtherTypeComponent,
    canMatch: [daffExternalMatcherTypeGuard('CATEGORY')],
  },
];
```

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->