### PR TITLE
test(branding): update describe strings to include package name

### DIFF
--- a/libs/branding/src/lib/copyright/copyright.component.spec.ts
+++ b/libs/branding/src/lib/copyright/copyright.component.spec.ts
@@ -6,7 +6,7 @@ import {
 
 import { DaffCopyrightComponent } from './copyright.component';
 
-describe('DaffCopyrightComponent', () => {
+describe('@daffodil/branding | DaffCopyrightComponent', () => {
   let component: DaffCopyrightComponent;
   let fixture: ComponentFixture<DaffCopyrightComponent>;
 

--- a/libs/branding/src/lib/license/license.component.spec.ts
+++ b/libs/branding/src/lib/license/license.component.spec.ts
@@ -6,7 +6,7 @@ import {
 
 import { DaffLicenseComponent } from './license.component';
 
-describe('DaffLicenseComponent', () => {
+describe('@daffodil/branding | DaffLicenseComponent', () => {
   let component: DaffLicenseComponent;
   let fixture: ComponentFixture<DaffLicenseComponent>;
 

--- a/libs/branding/src/lib/logo/logo.component.spec.ts
+++ b/libs/branding/src/lib/logo/logo.component.spec.ts
@@ -17,7 +17,7 @@ import { DaffLogoComponent } from './logo.component';
 })
 class WrapperComponent {}
 
-describe('DaffLogoComponent', () => {
+describe('@daffodil/branding | DaffLogoComponent', () => {
   let wrapper: WrapperComponent;
   let component: DaffLogoComponent;
   let de: DebugElement;


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [x] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Test describe strings in the `@daffodil/branding` package do not follow the standardized naming convention. Top-level describe statements use simple class names without package context.

Part of: #2746 <!-- Keeps issue open -->

## New behavior
<!-- Describe the changes -->

Updated all top-level test describe strings in `@daffodil/branding` package to follow the standardized template: `@daffodil/<subpackage> | <SUT>`.

**Files updated:**
- `libs/branding/src/lib/copyright/copyright.component.spec.ts`
- `libs/branding/src/lib/license/license.component.spec.ts` 
- `libs/branding/src/lib/logo/logo.component.spec.ts`

**Example change:**
```typescript
// Before
describe('DaffCopyrightComponent', () => {

// After  
describe('@daffodil/branding | DaffCopyrightComponent', () => {
```

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->
This is part of the epic to standardize test describe strings across all Daffodil packages. Following the contribution guidelines of "one package per PR", this PR only addresses the @daffodil/branding package.

All changes are cosmetic to test descriptions only - no functional changes to tests or source code.