### PR TITLE
test(authorizenet): update describe strings to include package name

### DIFF
--- a/libs/authorizenet/driver/in-memory/src/backend/authorize-net.service.spec.ts
+++ b/libs/authorizenet/driver/in-memory/src/backend/authorize-net.service.spec.ts
@@ -4,7 +4,7 @@ import { DAFF_IN_MEMORY_AUTHORIZE_NET_PAYMENT_ID } from '@daffodil/authorizenet/
 
 import { DaffInMemoryBackendAuthorizenetService } from './authorize-net.service';
 
-describe('Driver | InMemory | Authorizenet | DaffInMemoryBackendAuthorizenetService', () => {
+describe('@daffodil/authorizenet/driver | DaffInMemoryBackendAuthorizenetService', () => {
   let authorizenetBackend: DaffInMemoryBackendAuthorizenetService;
 
   beforeEach(() => {

--- a/libs/authorizenet/driver/in-memory/src/backend/authorize-net.service.spec.ts
+++ b/libs/authorizenet/driver/in-memory/src/backend/authorize-net.service.spec.ts
@@ -4,7 +4,7 @@ import { DAFF_IN_MEMORY_AUTHORIZE_NET_PAYMENT_ID } from '@daffodil/authorizenet/
 
 import { DaffInMemoryBackendAuthorizenetService } from './authorize-net.service';
 
-describe('@daffodil/authorizenet/driver | DaffInMemoryBackendAuthorizenetService', () => {
+describe('@daffodil/authorizenet/driver/in-memory | DaffInMemoryBackendAuthorizenetService', () => {
   let authorizenetBackend: DaffInMemoryBackendAuthorizenetService;
 
   beforeEach(() => {

--- a/libs/authorizenet/driver/magento/src/payment.service.spec.ts
+++ b/libs/authorizenet/driver/magento/src/payment.service.spec.ts
@@ -16,7 +16,7 @@ import { MagentoAuthorizeNetPayment } from '@daffodil/authorizenet/driver/magent
 
 import { DaffMagentoAuthorizeNetService } from './authorize-net.service';
 
-describe('@daffodil/authorizenet/driver | DaffMagentoAuthorizeNetService', () => {
+describe('@daffodil/authorizenet/driver/magento | DaffMagentoAuthorizeNetService', () => {
   let service: DaffMagentoAuthorizeNetService;
 
   let acceptSpy: jasmine.Spy;

--- a/libs/authorizenet/driver/magento/src/payment.service.spec.ts
+++ b/libs/authorizenet/driver/magento/src/payment.service.spec.ts
@@ -16,7 +16,7 @@ import { MagentoAuthorizeNetPayment } from '@daffodil/authorizenet/driver/magent
 
 import { DaffMagentoAuthorizeNetService } from './authorize-net.service';
 
-describe('Driver | Magento | Authorize.net | DaffMagentoAuthorizeNetService', () => {
+describe('@daffodil/authorizenet/driver | DaffMagentoAuthorizeNetService', () => {
   let service: DaffMagentoAuthorizeNetService;
 
   let acceptSpy: jasmine.Spy;

--- a/libs/authorizenet/driver/magento/src/transformers/authorize-net-transformer.spec.ts
+++ b/libs/authorizenet/driver/magento/src/transformers/authorize-net-transformer.spec.ts
@@ -10,7 +10,7 @@ import {
   transformMagentoAuthorizeNetResponse,
 } from './authorize-net-transformer';
 
-describe('AuthorizeNet | Drivers | Magento | Transformers', () => {
+describe('@daffodil/authorizenet/driver | Transformers', () => {
   const stubCreditCard: DaffAuthorizeNetCreditCard = {
     cardnumber: 'cardnumber',
     month: 'month',

--- a/libs/authorizenet/driver/magento/src/transformers/authorize-net-transformer.spec.ts
+++ b/libs/authorizenet/driver/magento/src/transformers/authorize-net-transformer.spec.ts
@@ -10,7 +10,7 @@ import {
   transformMagentoAuthorizeNetResponse,
 } from './authorize-net-transformer';
 
-describe('@daffodil/authorizenet/driver | Transformers', () => {
+describe('@daffodil/authorizenet/driver/magento | Transformers', () => {
   const stubCreditCard: DaffAuthorizeNetCreditCard = {
     cardnumber: 'cardnumber',
     month: 'month',

--- a/libs/authorizenet/driver/testing/src/drivers/authorize-net.service.spec.ts
+++ b/libs/authorizenet/driver/testing/src/drivers/authorize-net.service.spec.ts
@@ -3,7 +3,7 @@ import { cold } from 'jasmine-marbles';
 
 import { DaffTestingAuthorizeNetService } from './authorize-net.service';
 
-describe('@daffodil/authorizenet/driver | AuthorizeNetService', () => {
+describe('@daffodil/authorizenet/driver/testing | AuthorizeNetService', () => {
   let service: DaffTestingAuthorizeNetService;
 
   beforeEach(() => {

--- a/libs/authorizenet/driver/testing/src/drivers/authorize-net.service.spec.ts
+++ b/libs/authorizenet/driver/testing/src/drivers/authorize-net.service.spec.ts
@@ -3,7 +3,7 @@ import { cold } from 'jasmine-marbles';
 
 import { DaffTestingAuthorizeNetService } from './authorize-net.service';
 
-describe('Driver | Testing | AuthorizeNet | AuthorizeNetService', () => {
+describe('@daffodil/authorizenet/driver | AuthorizeNetService', () => {
   let service: DaffTestingAuthorizeNetService;
 
   beforeEach(() => {

--- a/libs/authorizenet/src/services/accept-js-loading.service.spec.ts
+++ b/libs/authorizenet/src/services/accept-js-loading.service.spec.ts
@@ -5,7 +5,7 @@ import { DAFF_AUTHORIZENET_ACCEPT_JS_PRODUCTION } from '@daffodil/authorizenet';
 
 import { DaffAcceptJsLoadingService } from './accept-js-loading.service';
 
-describe('DaffAcceptJsLoadingService', () => {
+describe('@daffodil/authorizenet | DaffAcceptJsLoadingService', () => {
   let service: DaffAcceptJsLoadingService;
   let production: boolean;
 

--- a/libs/authorizenet/state/src/effects/authorize-net.effects.spec.ts
+++ b/libs/authorizenet/state/src/effects/authorize-net.effects.spec.ts
@@ -62,7 +62,7 @@ class MockError extends DaffInheritableError implements DaffError {
   }
 }
 
-describe('DaffAuthorizeNetEffects', () => {
+describe('@daffodil/authorizenet/state | DaffAuthorizeNetEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffAuthorizeNetEffects;
   const paymentTokenRequest: DaffAuthorizeNetTokenRequest = {

--- a/libs/authorizenet/state/src/facades/authorize-net.facade.spec.ts
+++ b/libs/authorizenet/state/src/facades/authorize-net.facade.spec.ts
@@ -19,7 +19,7 @@ import { DaffStateError } from '@daffodil/core/state';
 
 import { DaffAuthorizeNetFacade } from './authorize-net.facade';
 
-describe('DaffAuthorizeNetFacade', () => {
+describe('@daffodil/authorizenet/state | DaffAuthorizeNetFacade', () => {
   let store: Store<DaffAuthorizeNetStateRootSlice>;
   let facade: DaffAuthorizeNetFacade;
   let mockError: DaffStateError;

--- a/libs/authorizenet/state/src/reducers/authorize-net.reducers.spec.ts
+++ b/libs/authorizenet/state/src/reducers/authorize-net.reducers.spec.ts
@@ -2,7 +2,7 @@ import { daffAuthorizeNetReducer } from '@daffodil/authorizenet/state';
 
 import { daffAuthorizeNetReducers } from './authorize-net.reducers';
 
-describe('daffAuthorizeNetReducers', () => {
+describe('@daffodil/authorizenet/state | daffAuthorizeNetReducers', () => {
 
   it('should return a reducer map with daffAuthorizeNetReducer', () => {
     expect(daffAuthorizeNetReducers.authorizeNet).toEqual(daffAuthorizeNetReducer);

--- a/libs/authorizenet/state/src/selectors/authorize-net.selector.spec.ts
+++ b/libs/authorizenet/state/src/selectors/authorize-net.selector.spec.ts
@@ -20,7 +20,7 @@ import { DaffStateError } from '@daffodil/core/state';
 
 import { daffAuthorizeNetSelectors } from './authorize-net.selector';
 
-describe('DaffAuthorizeNetSelectors', () => {
+describe('@daffodil/authorizenet/state | DaffAuthorizeNetSelectors', () => {
 
   let store: Store<DaffAuthorizeNetStateRootSlice>;
   let mockError: DaffStateError;


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [x] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Test describe strings in the @daffodil/branding package do not follow the standardized naming convention. Top-level describe statements use simple class names without package context.

Part of: https://github.com/graycoreio/daffodil/issues/2746

## New behavior
Updated all top-level test describe strings in @daffodil/authorizenet package to follow the standardized template: @daffodil/<subpackage> | \<SUT>.

**Files updated:**
- libs/authorizenet/driver/in-memory/src/backend/authorize-net.service.spec.ts
- libs/authorizenet/driver/magento/src/payment.service.spec.ts
- libs/authorizenet/driver/magento/src/transformers/authorize-net-transformer.spec.ts
- libs/authorizenet/driver/testing/src/drivers/authorize-net.service.spec.ts
- libs/authorizenet/src/services/accept-js-loading.service.spec.ts
- libs/authorizenet/state/src/effects/authorize-net.effects.spec.ts
- libs/authorizenet/state/src/facades/authorize-net.facade.spec.ts
- libs/authorizenet/state/src/reducers/authorize-net.reducers.spec.ts
- libs/authorizenet/state/src/selectors/authorize-net.selector.spec.ts

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->
This is part of the epic to standardize test describe strings across all Daffodil packages. Following the contribution guidelines of "one package per PR", this PR only addresses the @daffodil/authorizenet package.

All changes are cosmetic to test descriptions only - no functional changes to tests or source code.