### PR TITLE
test(cart): update describe strings to include package name

### DIFF
--- a/libs/cart/driver/magento/src/injection-tokens/transforms/cart-item/token.spec.ts
+++ b/libs/cart/driver/magento/src/injection-tokens/transforms/cart-item/token.spec.ts
@@ -7,7 +7,7 @@ import {
   DAFF_CART_MAGENTO_CART_ITEM_TRANSFORMS,
 } from './token';
 
-describe('provideDaffCartMagentoCartItemTransforms', () => {
+describe('@daffodil/cart/driver/magento | provideDaffCartMagentoCartItemTransforms', () => {
   let transforms: DaffCartMagentoCartItemTransform[];
   let result: DaffCartMagentoCartItemTransform[];
 

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-item/bundle-cart-item-transformer.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-item/bundle-cart-item-transformer.spec.ts
@@ -4,7 +4,7 @@ import { MagentoBundleCartItemFactory } from '@daffodil/cart/driver/magento/test
 
 import { transformMagentoBundleCartItem } from './bundle-cart-item-transformer';
 
-describe('transformMagentoBundleCartItem', () => {
+describe('@daffodil/cart/driver/magento | transformMagentoBundleCartItem', () => {
   let stubMagentoBundleCartItem: MagentoBundleCartItem;
   let transformedCartItem: DaffCompositeCartItem;
 

--- a/libs/cart/driver/magento/src/transforms/outputs/cart-totals-transformer.spec.ts
+++ b/libs/cart/driver/magento/src/transforms/outputs/cart-totals-transformer.spec.ts
@@ -11,7 +11,7 @@ import { daffAdd } from '@daffodil/core';
 
 import { transformCartTotals } from './cart-totals-transformer';
 
-describe('transformCartTotals', () => {
+describe('@daffodil/cart/driver/magento | transformCartTotals', () => {
   let magentoShippingAddressFactory: MagentoShippingAddressFactory;
   let magentoShippingMethodFactory: MagentoCartShippingMethodFactory;
 

--- a/libs/cart/driver/magento/testing/src/factories/cart-address.factory.spec.ts
+++ b/libs/cart/driver/magento/testing/src/factories/cart-address.factory.spec.ts
@@ -4,7 +4,7 @@ import { MagentoCartAddress } from '@daffodil/cart/driver/magento';
 
 import { MagentoCartAddressFactory } from './cart-address.factory';
 
-describe('Cart | Testing | Factories | CartAddressFactory', () => {
+describe('@daffodil/cart/driver/magento/testing | MagentoCartAddressFactory', () => {
   let factory: MagentoCartAddressFactory;
 
   beforeEach(() => {

--- a/libs/cart/driver/magento/testing/src/factories/cart-payment-method.factory.spec.ts
+++ b/libs/cart/driver/magento/testing/src/factories/cart-payment-method.factory.spec.ts
@@ -4,7 +4,7 @@ import { MagentoCartPaymentMethod } from '@daffodil/cart/driver/magento';
 
 import { MagentoCartPaymentMethodFactory } from './cart-payment-method.factory';
 
-describe('Cart | Testing | Factories | CartPaymentMethodFactory', () => {
+describe('@daffodil/cart/driver/magento/testing | MagentoCartPaymentMethodFactory', () => {
   let factory: MagentoCartPaymentMethodFactory;
 
   beforeEach(() => {

--- a/libs/cart/driver/magento/testing/src/factories/cart-shipping-method.factory.spec.ts
+++ b/libs/cart/driver/magento/testing/src/factories/cart-shipping-method.factory.spec.ts
@@ -4,7 +4,7 @@ import { MagentoCartShippingMethod } from '@daffodil/cart/driver/magento';
 
 import { MagentoCartShippingMethodFactory } from './cart-shipping-method.factory';
 
-describe('Cart | Testing | Factories | CartShippingMethodFactory', () => {
+describe('@daffodil/cart/driver/magento/testing | MagentoCartShippingMethodFactory', () => {
   let factory: MagentoCartShippingMethodFactory;
 
   beforeEach(() => {

--- a/libs/cart/driver/magento/testing/src/factories/shipping-address.factory.spec.ts
+++ b/libs/cart/driver/magento/testing/src/factories/shipping-address.factory.spec.ts
@@ -4,7 +4,7 @@ import { MagentoShippingAddress } from '@daffodil/cart/driver/magento';
 
 import { MagentoShippingAddressFactory } from './shipping-address.factory';
 
-describe('Cart | Testing | Factories | ShippingAddressFactory', () => {
+describe('@daffodil/cart/driver/magento/testing | MagentoShippingAddressFactory', () => {
   let factory: MagentoShippingAddressFactory;
 
   beforeEach(() => {

--- a/libs/cart/driver/testing/src/drivers/cart-billing-address/cart-billing-address.service.spec.ts
+++ b/libs/cart/driver/testing/src/drivers/cart-billing-address/cart-billing-address.service.spec.ts
@@ -12,7 +12,7 @@ import {
 
 import { DaffTestingCartBillingAddressService } from './cart-billing-address.service';
 
-describe('Driver | Testing | Cart | CartBillingAddressService', () => {
+describe('@daffodil/cart/driver/testing | DaffTestingCartBillingAddressService', () => {
   let service: DaffTestingCartBillingAddressService;
   let cartFactory: DaffCartFactory;
   let cartAddressFactory: DaffCartAddressFactory;

--- a/libs/cart/driver/testing/src/drivers/cart-coupon/cart-coupon.service.spec.ts
+++ b/libs/cart/driver/testing/src/drivers/cart-coupon/cart-coupon.service.spec.ts
@@ -12,7 +12,7 @@ import {
 
 import { DaffTestingCartCouponService } from './cart-coupon.service';
 
-describe('Driver | Testing | Cart | CartCouponService', () => {
+describe('@daffodil/cart/driver/testing | DaffTestingCartCouponService', () => {
   let service: DaffTestingCartCouponService;
   let cartFactory: DaffCartFactory;
   let cartCouponFactory: DaffCartCouponFactory;

--- a/libs/cart/routing/src/resolvers/empty-cart-resolver.service.spec.ts
+++ b/libs/cart/routing/src/resolvers/empty-cart-resolver.service.spec.ts
@@ -27,7 +27,7 @@ import {
 
 import { DaffEmptyCartResolver } from './empty-cart-resolver.service';
 
-describe('DaffEmptyCartResolver', () => {
+describe('@daffodil/cart/routing | DaffEmptyCartResolver', () => {
   const actions$: Observable<any> = null;
   let emptyCartResolver: DaffEmptyCartResolver;
   let store: Store<any>;

--- a/libs/cart/state/src/facades/cart/cart.facade.spec.ts
+++ b/libs/cart/state/src/facades/cart/cart.facade.spec.ts
@@ -78,7 +78,7 @@ import {
 
 import { DaffCartFacade } from './cart.facade';
 
-describe('DaffCartFacade', () => {
+describe('@daffodil/cart/state | DaffCartFacade', () => {
   let store: Store<DaffCartStateRootSlice>;
   let facade: DaffCartFacade;
   let cartFactory: DaffCartFactory;

--- a/libs/cart/testing/src/factories/cart-payment.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart-payment.factory.spec.ts
@@ -4,7 +4,7 @@ import { DaffCartPaymentMethod } from '@daffodil/cart';
 
 import { DaffCartPaymentFactory } from './cart-payment.factory';
 
-describe('Cart | Testing | Factories | CartPaymentFactory', () => {
+describe('@daffodil/cart/testing | DaffCartPaymentFactory', () => {
 
   let cartPaymentFactory: DaffCartPaymentFactory;
 

--- a/libs/cart/testing/src/factories/cart.factory.spec.ts
+++ b/libs/cart/testing/src/factories/cart.factory.spec.ts
@@ -4,7 +4,7 @@ import { DaffCart } from '@daffodil/cart';
 
 import { DaffCartFactory } from './cart.factory';
 
-describe('Cart | Testing | Factories | DaffCartFactory', () => {
+describe('@daffodil/cart/testing | DaffCartFactory', () => {
 
   let cartFactory: DaffCartFactory;
 


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our contributing guidelines
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type

- [x] Test

## Current behavior
Test describe strings in the `@daffodil/cart` package do not follow the standardized naming convention.

Part of: #2746

## New behavior
Updated 13 representative top-level test describe strings in `@daffodil/cart` package to follow the standardized template: `@daffodil/<subpackage> | <SUT>`.

**Subpackages updated:**
- cart/state
- cart/driver/magento/testing  
- cart/driver/magento
- cart/driver/testing
- cart/routing

## Breaking change?
- [x] No

## Additional context
This is part of the epic to standardize test describe strings across all Daffodil packages. This PR covers a representative sample of the cart package's spec files.

