### PR TITLE
test(category): update describe strings to include package name

### DIFF
--- a/libs/category/driver/magento/src/transformers/applied-filter-transformer.service.spec.ts
+++ b/libs/category/driver/magento/src/transformers/applied-filter-transformer.service.spec.ts
@@ -15,7 +15,7 @@ import {
 
 import { DaffMagentoAppliedFiltersTransformService } from './applied-filter-transformer.service';
 
-describe('DaffMagentoAppliedFiltersTransformService', () => {
+describe('@daffodil/category/driver/magento | DaffMagentoAppliedFiltersTransformService', () => {
   let rangeFilterRequestFactory: DaffFilterRequestRangeNumericFactory;
   let equalFilterRequestFactory: DaffFilterRequestEqualFactory;
   let service: DaffMagentoAppliedFiltersTransformService;

--- a/libs/category/routing/src/injection-tokens/request/builders.token.spec.ts
+++ b/libs/category/routing/src/injection-tokens/request/builders.token.spec.ts
@@ -8,7 +8,7 @@ import {
 } from './builders.token';
 
 
-describe('provideDaffCategoryRoutingRequestBuilders', () => {
+describe('@daffodil/category/routing | provideDaffCategoryRoutingRequestBuilders', () => {
   let builders: DaffCategoryRoutingRequestBuilder[];
   let result: DaffCategoryRoutingRequestBuilder[];
 

--- a/libs/category/routing/src/resolvers/category-page-url/category-page-url.resolver.spec.ts
+++ b/libs/category/routing/src/resolvers/category-page-url/category-page-url.resolver.spec.ts
@@ -58,7 +58,7 @@ import { DAFF_CATEGORY_ROUTING_OPTIONS_BUILDER } from '../../injection-tokens/re
 })
 class TestComponent {}
 
-describe('DaffCategoryPageUrlResolver', () => {
+describe('@daffodil/category/routing | DaffCategoryPageUrlResolver', () => {
   const actions$: Observable<any> = null;
   let categoryResolver: DaffCategoryPageUrlResolver;
   let store: Store<DaffCategoryReducersState>;

--- a/libs/category/state/src/effects/category-page-metadata.effects.spec.ts
+++ b/libs/category/state/src/effects/category-page-metadata.effects.spec.ts
@@ -64,7 +64,7 @@ class MockError extends DaffInheritableError implements DaffError {
   }
 }
 
-describe('DaffCategoryPageMetadataEffects', () => {
+describe('@daffodil/category/state | DaffCategoryPageMetadataEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCategoryPageMetadataEffects<DaffCategory, DaffProduct>;
   let daffCategoryDriver: DaffCategoryServiceInterface;

--- a/libs/category/state/src/effects/category-page.effects.spec.ts
+++ b/libs/category/state/src/effects/category-page.effects.spec.ts
@@ -49,7 +49,7 @@ import { DaffProductFactory } from '@daffodil/product/testing';
 
 import { DaffCategoryPageEffects } from './category-page.effects';
 
-describe('DaffCategoryPageEffects', () => {
+describe('@daffodil/category/state | DaffCategoryPageEffects', () => {
   let actions$: Observable<any>;
   let effects: DaffCategoryPageEffects<DaffCategory, DaffProduct>;
   let stubCategory: DaffCategory;

--- a/libs/category/state/src/facades/page/category.facade.spec.ts
+++ b/libs/category/state/src/facades/page/category.facade.spec.ts
@@ -39,7 +39,7 @@ import { DaffProductFactory } from '@daffodil/product/testing';
 
 import { DaffCategoryFacade } from './category.facade';
 
-describe('DaffCategoryFacade', () => {
+describe('@daffodil/category/state | DaffCategoryFacade', () => {
   let store: Store<DaffCategoryStateRootSlice>;
   let facade: DaffCategoryFacade<DaffCategory, DaffProduct>;
   let categoryFactory: DaffCategoryFactory;

--- a/libs/category/state/src/reducers/category-reducers.spec.ts
+++ b/libs/category/state/src/reducers/category-reducers.spec.ts
@@ -6,7 +6,7 @@ import {
 import { daffCategoryReducers } from './category-reducers';
 import { daffCategoryPageMetadataReducer } from './page-metadata/reducer';
 
-describe('selectCategoryState', () => {
+describe('@daffodil/category/state | selectCategoryState', () => {
 
   it('should return a reducer map with CategoryReducer', () => {
     expect(daffCategoryReducers.category).toEqual(daffCategoryReducer);

--- a/libs/category/state/src/selectors/category-page/category-page.selector.spec.ts
+++ b/libs/category/state/src/selectors/category-page/category-page.selector.spec.ts
@@ -29,7 +29,7 @@ import {
 
 import { getDaffCategoryPageSelectors } from './category-page.selector';
 
-describe('DaffCategoryPageSelectors', () => {
+describe('@daffodil/category/state | DaffCategoryPageSelectors', () => {
 
   let store: Store<DaffCategoryStateRootSlice>;
   let categoryFactory: DaffCategoryFactory;

--- a/libs/category/state/src/selectors/category.selector.spec.ts
+++ b/libs/category/state/src/selectors/category.selector.spec.ts
@@ -33,7 +33,7 @@ import { DaffProductFactory } from '@daffodil/product/testing';
 
 import { getDaffCategorySelectors } from './category.selector';
 
-describe('DaffCategorySelectors', () => {
+describe('@daffodil/category/state | DaffCategorySelectors', () => {
 
   let store: Store<DaffCategoryStateRootSlice>;
 

--- a/libs/category/testing/src/factories/category-page-metadata.factory.spec.ts
+++ b/libs/category/testing/src/factories/category-page-metadata.factory.spec.ts
@@ -4,7 +4,7 @@ import { DaffCategoryPageMetadata } from '@daffodil/category';
 
 import { DaffCategoryPageMetadataFactory } from './category-page-metadata.factory';
 
-describe('Category | Testing | Factories | DaffCategoryPageMetadataFactory', () => {
+describe('@daffodil/category/testing | DaffCategoryPageMetadataFactory', () => {
 
   let categoryPageMetadataFactory;
 


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our contributing guidelines
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type

- [x] Test

## Current behavior
Test describe strings in the `@daffodil/category` package do not follow the standardized naming convention.

Part of: #2746

## New behavior
Updated 10 top-level test describe strings in `@daffodil/category` package to follow the standardized template: `@daffodil/<subpackage> | <SUT>`.

**Subpackages updated:**
- category/state: Effects, facades, selectors, reducers
- category/routing: Resolvers and injection tokens  
- category/driver/magento: Transform services
- category/testing: Factory specs

## Breaking change?
- [x] No

## Additional context
This is part of the epic to standardize test describe strings across all Daffodil packages. This PR covers the core category package functionality.

