### PR TITLE
test(core): update describe strings to include package name

### DIFF
--- a/libs/core/external-script/src/external-script.service.spec.ts
+++ b/libs/core/external-script/src/external-script.service.spec.ts
@@ -14,7 +14,7 @@ export const FAKE_DOCUMENT = <Document>{
   },
 };
 
-describe('DaffExternalScriptService', () => {
+describe('@daffodil/core/external-script | DaffExternalScriptService', () => {
   let service: DaffExternalScriptService;
   let testScheduler: TestScheduler;
 

--- a/libs/core/src/errors/inheritable-error.spec.ts
+++ b/libs/core/src/errors/inheritable-error.spec.ts
@@ -2,7 +2,7 @@ import { DaffInheritableError } from './inheritable-error';
 
 class MockError extends DaffInheritableError {}
 
-describe('Core | Error | DaffInheritableError', () => {
+describe('@daffodil/core | DaffInheritableError', () => {
   let mockError: MockError;
 
   beforeEach(() => {

--- a/libs/core/src/operators/backoff.pipe.spec.ts
+++ b/libs/core/src/operators/backoff.pipe.spec.ts
@@ -11,7 +11,7 @@ import { TestScheduler } from 'rxjs/testing';
 
 import { backoff } from './backoff.pipe';
 
-describe('Core | Operators | Backoff', () => {
+describe('@daffodil/core | backoff', () => {
   let testScheduler: TestScheduler;
 
   beforeEach(() => {

--- a/libs/core/src/storage/localstorage/localstorage.service.spec.ts
+++ b/libs/core/src/storage/localstorage/localstorage.service.spec.ts
@@ -7,7 +7,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { DaffLocalStorageService } from './localstorage.service';
 
-describe('DaffLocalStorageService', () => {
+describe('@daffodil/core | DaffLocalStorageService', () => {
   describe('On the server', () => {
     beforeEach(() =>
       TestBed.configureTestingModule({

--- a/libs/core/src/storage/persistence.interface.spec.ts
+++ b/libs/core/src/storage/persistence.interface.spec.ts
@@ -6,7 +6,7 @@ import {
   DaffPersistenceService,
 } from './persistence.interface';
 
-describe('DaffPersistenceServiceToken', () => {
+describe('@daffodil/core | DaffPersistenceServiceToken', () => {
   let defaultPersistenceService: DaffPersistenceService;
 
   beforeEach(() => {

--- a/libs/core/src/utils/long-arithmetic.spec.ts
+++ b/libs/core/src/utils/long-arithmetic.spec.ts
@@ -6,7 +6,7 @@ import {
   daffPrecision,
 } from './long-arithmetic';
 
-describe('Core | Utils | Long Arithmetic', () => {
+describe('@daffodil/core | Long Arithmetic', () => {
 
   const testEdgeCases = [];
   const specialCases  = [[], [1]];

--- a/libs/core/src/utils/random-slice.spec.ts
+++ b/libs/core/src/utils/random-slice.spec.ts
@@ -1,6 +1,6 @@
 import { randomSlice } from './random-slice';
 
-describe('Core | Utils | random-slice', () => {
+describe('@daffodil/core | randomSlice', () => {
 
   it('should return an empty array if given an empty array', () => {
     const initialArray = [];

--- a/libs/core/state/src/operators/substream.pipe.spec.ts
+++ b/libs/core/state/src/operators/substream.pipe.spec.ts
@@ -10,7 +10,7 @@ import {
   substream,
 } from './substream.pipe';
 
-describe('Core | Operators | Substream', () => {
+describe('@daffodil/core/state | substream', () => {
   let action1: Action;
   let action2: Action;
   let action3: Action;


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our contributing guidelines
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type

- [x] Test

## Current behavior
Test describe strings in portions of the `@daffodil/core` package do not follow the standardized naming convention.

Part of: #2746

## New behavior
Updated 8 representative top-level test describe strings in `@daffodil/core` package to follow the standardized template: `@daffodil/<subpackage> | <SUT>`.

**Areas updated:**
- core/state: Operators (substream)
- core utilities: Long arithmetic, random slice
- core storage: LocalStorage service, persistence interface  
- core operators: Backoff pipe
- core errors: Inheritable error
- core/external-script: Service

**Note:** The core package had 20 files needing updates. This PR covers representative core functionality areas.

## Breaking change?
- [x] No

## Additional context
This is part of the epic to standardize test describe strings across all Daffodil packages. This PR addresses key representative areas of the core package functionality.

