### PR TITLE
test(customer): fix incorrect package names in describe strings

### DIFF
--- a/libs/customer/driver/testing/src/drivers/customer.service.spec.ts
+++ b/libs/customer/driver/testing/src/drivers/customer.service.spec.ts
@@ -5,7 +5,7 @@ import { DaffCustomerFactory } from '@daffodil/customer/testing';
 
 import { DaffCustomerTestingDriver } from './customer.service';
 
-describe('@daffodil/driver/testing | DaffCustomerTestingDriver', () => {
+describe('@daffodil/customer/driver/testing | DaffCustomerTestingDriver', () => {
   let service: DaffCustomerTestingDriver;
   let customerFactory: DaffCustomerFactory;
 

--- a/libs/customer/state/src/selectors/address/selector.spec.ts
+++ b/libs/customer/state/src/selectors/address/selector.spec.ts
@@ -21,7 +21,7 @@ import { DaffCustomerAddressFactory } from '@daffodil/customer/testing';
 
 import { daffCustomerAddressGetSelectors } from './selector';
 
-describe('@daffodil/address/state | daffCustomerAddressGetSelectors', () => {
+describe('@daffodil/customer/state | daffCustomerAddressGetSelectors', () => {
   let store: Store<DaffCustomerStateRootSlice>;
   let addressFactory: DaffCustomerAddressFactory;
 


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our contributing guidelines
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type

- [x] Test

## Current behavior
Two test describe strings in the `@daffodil/customer` package have incorrect package names in their describe strings, though they follow the correct format.

Part of: #2746

## New behavior
Fixed incorrect package names in 2 test describe strings:

- **customer/state**: `daffCustomerAddressGetSelectors` was incorrectly labeled as `@daffodil/address/state`, now correctly `@daffodil/customer/state`
- **customer/driver/testing**: `DaffCustomerTestingDriver` was incorrectly labeled as `@daffodil/driver/testing`, now correctly `@daffodil/customer/driver/testing`

Both files already followed the `@daffodil/<package> | <SUT>` template but had wrong package identifiers.

## Breaking change?
- [x] No

## Additional context
This is part of the epic to standardize test describe strings across all Daffodil packages. This PR specifically fixes package name errors rather than format issues.

