### PR TITLE
feat(design): create `daff-max-contrast` function

### DIFF
--- a/libs/design/scss/theming/contrast/_index.scss
+++ b/libs/design/scss/theming/contrast/_index.scss
@@ -2,4 +2,5 @@
 
 @forward 'luminance/luminance';
 @forward 'contrast-ratio/contrast-ratio';
+@forward 'max-contrast/max-contrast';
 @forward 'text-contrast/text-contrast';

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -17,8 +17,8 @@
 ) {
 	@if(list.length($colors) == 0) {
 		@return error-to-string.error-to-string(
-			'Cannot calculate max contrast for `#{$reference-color}` - the color list (`$colors`) is empty. 
-			Provide at least one color to compare against.'
+			'Cannot calculate max contrast for `#{$reference-color}` - the color list (`$colors`) is empty. ' +
+			'Provide at least one color to compare against.'
 		);
 	}
 	@else if(list.length($colors) == 1) {

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -9,7 +9,7 @@
 ///
 /// @param {Color} $reference-color
 /// @param {List} $colors — A list of colors to compare against the reference color
-/// @return {Number} The highest contrast ratio between the reference color and the color list
+/// @return {Color} The color with the highest contrast ratio between the reference color and the color list
 ///
 @function daff-max-contrast(
 	$reference-color,
@@ -17,7 +17,8 @@
 ) {
 	@if(list.length($colors) == 0) {
 		@return error-to-string.error-to-string(
-			'Cannot calculate max contrast for `#{$reference-color}` - the color list (`$colors`) is empty. Provide at least one color to compare against.'
+			'Cannot calculate max contrast for `#{$reference-color}` - the color list (`$colors`) is empty. '
+			'Provide at least one color to compare against.'
 		);
 	}
 	@else if(list.length($colors) == 1) {
@@ -25,12 +26,14 @@
 	}
 	@else {
 		$max-contrast: -1;
+		$max-contrast-color: null;
 
 		@each $color in $colors {
 			$current-contrast: cr.daff-contrast-ratio($reference-color, $color);
 
 			@if($current-contrast > $max-contrast) {
 				$max-contrast: $current-contrast;
+				$max-contrast-color: $color;
 			}
 		}
 

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -10,11 +10,11 @@
 /// @param {Color} $reference-color
 /// @param {List} $colors — A list of colors to compare against the reference color
 /// @return {Color} The color with the highest contrast ratio between the reference color and the color list
-/// 
+///
 /// @example scss
 /// 	.body {
 /// 		background: daff-color($neutral, 10);
-/// 		color: daff-max-contrast(daff-color($neutral, 10), (daff-color($primary, 20), daff-color($primary, 70), daff-color($secondary, 40)));
+/// 		color: daff-max-contrast(daff-color($neutral, 10), (daff-color($primary, 20), daff-color($secondary, 40)));
 /// 	}
 ///
 @function daff-max-contrast(
@@ -23,7 +23,7 @@
 ) {
 	@if(list.length($colors) == 0) {
 		@return error-to-string.error-to-string(
-			'Cannot calculate max contrast for `'+ $reference-color + '`Provide at least one color to compare against.'
+			'Cannot calculate max contrast for `' + $reference-color + '`Provide at least one color to compare against.'
 		);
 	}
 	@else if(list.length($colors) == 1) {

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -37,6 +37,6 @@
 			}
 		}
 
-		@return $max-contrast;
+		@return $max-contrast-color;
 	}
 }

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -1,0 +1,38 @@
+@use 'sass:list';
+@use '../contrast-ratio/contrast-ratio.scss' as cr;
+@use '../../../core/error/error-to-string';
+
+/// Returns the color from a list of colors that has the highest contrast ratio with a reference color.
+/// If the list is empty, an error is thrown. If the list has one color, that color is returned.
+/// Uses the cr.daff-contrast-ratio function to calculate contrast ratios.
+///
+/// @group Theming
+///
+/// @param {Color} $reference-color
+/// @param {List} $colors — A list of colors to compare against the reference color
+/// @return {Number} The highest contrast ratio between the reference color and the color list
+///
+@function daff-max-contrast(
+	$reference-color,
+	$colors: ()
+) {
+	@if(list.length($colors) == 0) {
+		@return error-to-string.error-to-string('Error: Attempting to calculate the max contrast between $reference-color and an empty list of colors');
+	}
+	@else if(list.length($colors) == 1) {
+		@return cr.daff-contrast-ratio($reference-color, list.nth($colors, 1));
+	}
+	@else {
+		$max-contrast: -1;
+
+		@each $color in $colors {
+			$current-contrast: cr.daff-contrast-ratio($reference-color, $color);
+
+			@if($current-contrast > $max-contrast) {
+				$max-contrast: $current-contrast;
+			}
+		}
+
+		@return $max-contrast;
+	}
+}

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -17,8 +17,7 @@
 ) {
 	@if(list.length($colors) == 0) {
 		@return error-to-string.error-to-string(
-			'Cannot calculate max contrast for `#{$reference-color}` - the color list (`$colors`) is empty. ' +
-			'Provide at least one color to compare against.'
+			'Cannot calculate max contrast for `#{$reference-color}` - the color list (`$colors`) is empty. Provide at least one color to compare against.'
 		);
 	}
 	@else if(list.length($colors) == 1) {

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -22,7 +22,7 @@
 		);
 	}
 	@else if(list.length($colors) == 1) {
-		@return cr.daff-contrast-ratio($reference-color, list.nth($colors, 1));
+		@return list.nth($colors, 1);
 	}
 	@else {
 		$max-contrast: -1;

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -10,6 +10,12 @@
 /// @param {Color} $reference-color
 /// @param {List} $colors — A list of colors to compare against the reference color
 /// @return {Color} The color with the highest contrast ratio between the reference color and the color list
+/// 
+/// @example scss
+/// 	.body {
+/// 		background: daff-color($neutral, 10);
+/// 		color: daff-max-contrast(daff-color($neutral, 10), (daff-color($primary, 20), daff-color($primary, 70), daff-color($secondary, 40)));
+/// 	}
 ///
 @function daff-max-contrast(
 	$reference-color,
@@ -17,8 +23,7 @@
 ) {
 	@if(list.length($colors) == 0) {
 		@return error-to-string.error-to-string(
-			'Cannot calculate max contrast for `#{$reference-color}` - the color list (`$colors`) is empty. '
-			'Provide at least one color to compare against.'
+			'Cannot calculate max contrast for `'+ $reference-color + '`Provide at least one color to compare against.'
 		);
 	}
 	@else if(list.length($colors) == 1) {

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -1,10 +1,9 @@
 @use 'sass:list';
-@use '../contrast-ratio/contrast-ratio.scss' as cr;
+@use '../contrast-ratio/contrast-ratio' as cr;
 @use '../../../core/error/error-to-string';
 
 /// Returns the color from a list of colors that has the highest contrast ratio with a reference color.
 /// If the list is empty, an error is thrown. If the list has one color, that color is returned.
-/// Uses the cr.daff-contrast-ratio function to calculate contrast ratios.
 ///
 /// @group Theming
 ///
@@ -18,7 +17,7 @@
 ) {
 	@if(list.length($colors) == 0) {
 		@return error-to-string.error-to-string(
-			'Error: Attempting to calculate the max contrast between $reference-color and an empty list of colors'
+			'Cannot calculate max contrast for `#{$reference-color}` - the color list (`$colors`) is empty. Provide at least one color to compare against.'
 		);
 	}
 	@else if(list.length($colors) == 1) {

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -17,7 +17,9 @@
 	$colors: ()
 ) {
 	@if(list.length($colors) == 0) {
-		@return error-to-string.error-to-string('Error: Attempting to calculate the max contrast between $reference-color and an empty list of colors');
+		@return error-to-string.error-to-string(
+			'Error: Attempting to calculate the max contrast between $reference-color and an empty list of colors'
+		);
 	}
 	@else if(list.length($colors) == 1) {
 		@return cr.daff-contrast-ratio($reference-color, list.nth($colors, 1));

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.scss
@@ -17,7 +17,8 @@
 ) {
 	@if(list.length($colors) == 0) {
 		@return error-to-string.error-to-string(
-			'Cannot calculate max contrast for `#{$reference-color}` - the color list (`$colors`) is empty. Provide at least one color to compare against.'
+			'Cannot calculate max contrast for `#{$reference-color}` - the color list (`$colors`) is empty. 
+			Provide at least one color to compare against.'
 		);
 	}
 	@else if(list.length($colors) == 1) {

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.spec.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.spec.scss
@@ -33,8 +33,8 @@
 		'Expected contrast ratio around 13.08, got #{$black-result}');
 
 		$white-result: daff-max-contrast($white, $multiple-color-list);
-		@include assert-true($white-result >= 13.96 and $white-result <= 13.98,
-		'Expected contrast ratio around 13.97, got #{$white-result}');
+		@include assert-true($white-result >= 12.62 and $white-result <= 12.64,
+		'Expected contrast ratio around 12.63, got #{$white-result}');
 	}
 
 	@include it('returns consistent results regardless of list order') {

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.spec.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.spec.scss
@@ -49,8 +49,7 @@
 	@include it('errors when given an empty color list') {
 		@include assert-equal(
 			daff-max-contrast($black, $empty-list),
-			'Cannot calculate max contrast for `#{$black}` - the color list (`$colors`) is empty. '
-			'Provide at least one color to compare against.'
+			'Cannot calculate max contrast for `' + $black + '`Provide at least one color to compare against.'
 		);
 	}
 

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.spec.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.spec.scss
@@ -29,12 +29,12 @@
 
 	@include it('returns the highest contrast ratio from multiple colors') {
 		$black-result: daff-max-contrast($black, $multiple-color-list);
-		@include assert-true($black-result >= 9.53 and $black-result <= 9.55,
-		'Expected contrast ratio around 9.54, got #{$black-result}');
+		@include assert-true($black-result >= 13.07 and $black-result <= 13.09,
+		'Expected contrast ratio around 13.08, got #{$black-result}');
 
 		$white-result: daff-max-contrast($white, $multiple-color-list);
-		@include assert-true($white-result >= 12.62 and $white-result <= 12.64,
-		'Expected contrast ratio around 12.63, got #{$white-result}');
+		@include assert-true($white-result >= 13.96 and $white-result <= 13.98,
+		'Expected contrast ratio around 13.97, got #{$white-result}');
 	}
 
 	@include it('returns consistent results regardless of list order') {

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.spec.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.spec.scss
@@ -1,0 +1,66 @@
+@use 'true' as *;
+@use './max-contrast' as *;
+@use '../../../core/error/error-to-string';
+
+@include describe('daff-max-contrast') {
+	$white: #ffffff;
+	$black: #000000;
+	$red: #ff0000;
+	$blue: #0000ff;
+	$gray: #808080;
+	$light-gray: #cccccc;
+	$dark-gray: #333333;
+
+	$single-color-list: ($white);
+	$two-color-list: ($white, $black);
+	$multiple-color-list: ($red, $blue, $gray, $light-gray, $dark-gray);
+	$empty-list: ();
+
+	@include error-to-string.set-use-string(true);
+
+	@include it('returns the contrast ratio for single color') {
+		@include assert-equal(daff-max-contrast($black, $single-color-list), 21);
+	}
+
+	@include it('returns the highest contrast ratio from two colors') {
+		@include assert-equal(daff-max-contrast($black, $two-color-list), 21);
+		@include assert-equal(daff-max-contrast($white, $two-color-list), 21);
+	}
+
+	@include it('returns the highest contrast ratio from multiple colors') {
+		$black-result: daff-max-contrast($black, $multiple-color-list);
+		@include assert-true($black-result >= 9.53 and $black-result <= 9.55,
+		'Expected contrast ratio around 9.54, got #{$black-result}');
+
+		$white-result: daff-max-contrast($white, $multiple-color-list);
+		@include assert-true($white-result >= 12.62 and $white-result <= 12.64,
+		'Expected contrast ratio around 12.63, got #{$white-result}');
+	}
+
+	@include it('returns consistent results regardless of list order') {
+		$reordered-list: ($dark-gray, $light-gray, $gray, $blue, $red);
+		@include assert-equal(
+			daff-max-contrast($black, $multiple-color-list),
+			daff-max-contrast($black, $reordered-list)
+		);
+	}
+
+	@include it('works with different reference colors') {
+		$red-result: daff-max-contrast($red, ($white, $black, $blue));
+		@include assert-true($red-result >= 5.24 and $red-result <= 5.26,
+		'Expected contrast ratio around 5.25, got #{$red-result}');
+
+		$blue-result: daff-max-contrast($blue, ($white, $black, $red));
+		@include assert-true($blue-result >= 8.58 and $blue-result <= 8.6,
+		'Expected contrast ratio around 8.59, got #{$blue-result}');
+	}
+
+	@include it('errors when given an empty color list') {
+		@include assert-equal(
+			daff-max-contrast($black, $empty-list),
+			'Error: Attempting to calculate the max contrast between $reference-color and an empty list of colors'
+		);
+	}
+
+	@include error-to-string.set-use-string(false);
+}

--- a/libs/design/scss/theming/contrast/max-contrast/max-contrast.spec.scss
+++ b/libs/design/scss/theming/contrast/max-contrast/max-contrast.spec.scss
@@ -19,22 +19,18 @@
 	@include error-to-string.set-use-string(true);
 
 	@include it('returns the contrast ratio for single color') {
-		@include assert-equal(daff-max-contrast($black, $single-color-list), 21);
+		@include assert-equal(daff-max-contrast($black, $single-color-list), white);
 	}
 
 	@include it('returns the highest contrast ratio from two colors') {
-		@include assert-equal(daff-max-contrast($black, $two-color-list), 21);
-		@include assert-equal(daff-max-contrast($white, $two-color-list), 21);
+		@include assert-equal(daff-max-contrast($black, $two-color-list), white);
+		@include assert-equal(daff-max-contrast($white, $two-color-list), black);
 	}
 
 	@include it('returns the highest contrast ratio from multiple colors') {
-		$black-result: daff-max-contrast($black, $multiple-color-list);
-		@include assert-true($black-result >= 13.07 and $black-result <= 13.09,
-		'Expected contrast ratio around 13.08, got #{$black-result}');
+		@include assert-equal(daff-max-contrast($black, $multiple-color-list), $light-gray);
 
-		$white-result: daff-max-contrast($white, $multiple-color-list);
-		@include assert-true($white-result >= 12.62 and $white-result <= 12.64,
-		'Expected contrast ratio around 12.63, got #{$white-result}');
+		@include assert-equal(daff-max-contrast($white, $multiple-color-list), $dark-gray);
 	}
 
 	@include it('returns consistent results regardless of list order') {
@@ -46,19 +42,15 @@
 	}
 
 	@include it('works with different reference colors') {
-		$red-result: daff-max-contrast($red, ($white, $black, $blue));
-		@include assert-true($red-result >= 5.24 and $red-result <= 5.26,
-		'Expected contrast ratio around 5.25, got #{$red-result}');
-
-		$blue-result: daff-max-contrast($blue, ($white, $black, $red));
-		@include assert-true($blue-result >= 8.58 and $blue-result <= 8.6,
-		'Expected contrast ratio around 8.59, got #{$blue-result}');
+		@include assert-equal(daff-max-contrast($red, ($white, $black, $blue)), black);
+		@include assert-equal(daff-max-contrast($blue, ($white, $black, $red)), white);
 	}
 
 	@include it('errors when given an empty color list') {
 		@include assert-equal(
 			daff-max-contrast($black, $empty-list),
-			'Error: Attempting to calculate the max contrast between $reference-color and an empty list of colors'
+			'Cannot calculate max contrast for `#{$black}` - the color list (`$colors`) is empty. '
+			'Provide at least one color to compare against.'
 		);
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #3924 

## New behavior
Implemented daff-max-contrast function in @daffodil/design, returning a color from a color list with the highest contrast ratio with the reference color.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->