### PR TITLE
docs(design): Added tag component to @daffodil/design README

### DIFF
--- a/libs/design/README.md
+++ b/libs/design/README.md
@@ -38,6 +38,7 @@ Refer to the [Upgrade Guide](/libs/design/guides/upgrading.md).
   * [Quantity Field](/libs/design/src/atoms/form/quantity-field/README.md)
 * [Image](/libs/design/image/README.md)
 * [Loading Icon](/libs/design/loading-icon/README.md)
+* [Tag](/libs/design/tag/README.md)
 
 ### Molecules
 * [Accordion](/libs/design/accordion/README.md)


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [x] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Part of: #4007 

## New behavior
In #4007, the commit did not add the tag component to the main @daffodil/design README. This commit updates the README with a link to the tag component.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->