### PR TITLE
refactor(daffio): replace deprecated `@daffodil/design` module imports in not found components

### DIFF
--- a/apps/daffio/src/app/content/not-found/not-found.component.ts
+++ b/apps/daffio/src/app/content/not-found/not-found.component.ts
@@ -3,9 +3,9 @@ import {
   Component,
 } from '@angular/core';
 
-import { DaffButtonModule } from '@daffodil/design/button';
-import { DaffContainerModule } from '@daffodil/design/container';
-import { DaffHeroModule } from '@daffodil/design/hero';
+import { DAFF_BASIC_BUTTON_COMPONENTS } from '@daffodil/design/button';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
+import { DAFF_HERO_COMPONENTS } from '@daffodil/design/hero';
 
 @Component({
   selector: 'daffio-not-found',
@@ -14,9 +14,9 @@ import { DaffHeroModule } from '@daffodil/design/hero';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
-    DaffHeroModule,
-    DaffContainerModule,
-    DaffButtonModule,
+    DAFF_HERO_COMPONENTS,
+    DAFF_CONTAINER_COMPONENTS,
+    DAFF_BASIC_BUTTON_COMPONENTS,
   ],
 })
 export class DaffioNotFoundComponent {}

--- a/apps/daffio/src/app/core/footer/footer/footer.component.spec.ts
+++ b/apps/daffio/src/app/core/footer/footer/footer.component.spec.ts
@@ -15,7 +15,7 @@ import {
   DaffLogoModule,
   DaffCopyrightModule,
 } from '@daffodil/branding';
-import { DaffContainerModule } from '@daffodil/design/container';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 import { DaffioFooterComponent } from './footer.component';
 
@@ -39,7 +39,7 @@ describe('DaffioFooterComponent', () => {
       imports: [
         DaffioFooterComponent,
         RouterTestingModule,
-        DaffContainerModule,
+        DAFF_CONTAINER_COMPONENTS,
         DaffLogoModule,
         DaffCopyrightModule,
         FontAwesomeModule,

--- a/apps/daffio/src/app/core/footer/footer/footer.component.ts
+++ b/apps/daffio/src/app/core/footer/footer/footer.component.ts
@@ -16,7 +16,7 @@ import {
   DaffCopyrightModule,
   DaffLogoModule,
 } from '@daffodil/branding';
-import { DaffContainerModule } from '@daffodil/design/container';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 @Component({
   selector: 'daffio-footer',
@@ -25,7 +25,7 @@ import { DaffContainerModule } from '@daffodil/design/container';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     FontAwesomeModule,
-    DaffContainerModule,
+    DAFF_CONTAINER_COMPONENTS,
     DaffLogoModule,
     DaffCopyrightModule,
     NgFor,


### PR DESCRIPTION
Replaced usage of deprecated Daffodil design modules with the new component array imports.

- Removed `DaffHeroModule`, `DaffContainerModule`, and `DaffButtonModule`
- Added `DAFF_HERO_COMPONENTS`, `DAFF_CONTAINER_COMPONENTS`, and relevant button component arrays
- No functional or API changes

## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->