### PR TITLE
refactor(daffio): replace deprecated `@daffodil/design` module imports in footer components

### DIFF
--- a/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.ts
+++ b/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.ts
@@ -7,9 +7,9 @@ import {
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import { DAFF_BRANDING_CONSTANTS } from '@daffodil/branding';
-import { DaffButtonModule } from '@daffodil/design/button';
-import { DaffCalloutModule } from '@daffodil/design/callout';
-import { DaffContainerModule } from '@daffodil/design/container';
+import { DAFF_BASIC_BUTTON_COMPONENTS } from '@daffodil/design/button';
+import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 
 
@@ -22,9 +22,9 @@ import { DaffContainerModule } from '@daffodil/design/container';
   standalone: true,
   imports: [
     FontAwesomeModule,
-    DaffCalloutModule,
-    DaffContainerModule,
-    DaffButtonModule,
+    DAFF_CALLOUT_COMPONENTS,
+    DAFF_CONTAINER_COMPONENTS,
+    DAFF_BASIC_BUTTON_COMPONENTS,
   ],
 })
 export class DaffioSubFooterComponent {

--- a/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.ts
+++ b/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.ts
@@ -7,9 +7,15 @@ import {
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import { DAFF_BRANDING_CONSTANTS } from '@daffodil/branding';
+<<<<<<< Updated upstream
 import { DAFF_BASIC_BUTTON_COMPONENTS } from '@daffodil/design/button';
 import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
 import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
+=======
+import { DAFF_BUTTON_COMPONENTS } from '@daffodil/design/button';
+import { DaffCalloutModule } from '@daffodil/design/callout';
+import { DaffContainerModule } from '@daffodil/design/container';
+>>>>>>> Stashed changes
 
 
 
@@ -22,9 +28,15 @@ import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
   standalone: true,
   imports: [
     FontAwesomeModule,
+<<<<<<< Updated upstream
     DAFF_CALLOUT_COMPONENTS,
     DAFF_CONTAINER_COMPONENTS,
     DAFF_BASIC_BUTTON_COMPONENTS,
+=======
+    DaffCalloutModule,
+    DaffContainerModule,
+    DAFF_BUTTON_COMPONENTS,
+>>>>>>> Stashed changes
   ],
 })
 export class DaffioSubFooterComponent {


### PR DESCRIPTION
…mports

Updated the footer component and its unit test to remove deprecated @daffodil/design module usage.

- Replaced `DaffContainerModule` and `DaffButtonModule` with `DAFF_CONTAINER_COMPONENTS` and the relevant button component arrays
- Updated `footer.component.ts` and `footer.component.spec.ts`
- No functional or API changes; purely a refactor

## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4058

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->