### PR TITLE
refactor(daffio): replace deprecated `@daffodil/design` module imports in header components

### DIFF
--- a/apps/daffio/src/app/core/header/components/header/header.component.spec.ts
+++ b/apps/daffio/src/app/core/header/components/header/header.component.spec.ts
@@ -4,7 +4,7 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 
-import { DaffNavbarModule } from '@daffodil/design/navbar';
+import { DAFF_NAVBAR_COMPONENTS } from '@daffodil/design/navbar';
 
 import { DaffioHeaderComponent } from './header.component';
 
@@ -15,7 +15,7 @@ describe('DaffioHeaderComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        DaffNavbarModule,
+        DAFF_NAVBAR_COMPONENTS,
         DaffioHeaderComponent,
       ],
     })

--- a/apps/daffio/src/app/core/header/components/header/header.component.ts
+++ b/apps/daffio/src/app/core/header/components/header/header.component.ts
@@ -5,7 +5,7 @@ import {
   Input,
 } from '@angular/core';
 
-import { DaffNavbarModule } from '@daffodil/design/navbar';
+import { DAFF_NAVBAR_COMPONENTS } from '@daffodil/design/navbar';
 
 @Component({
   selector: 'daffio-header',
@@ -13,7 +13,7 @@ import { DaffNavbarModule } from '@daffodil/design/navbar';
   styleUrls: ['./header.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffNavbarModule,
+    DAFF_NAVBAR_COMPONENTS,
   ],
 })
 


### PR DESCRIPTION
…mports

Updated the header component to remove deprecated @daffodil/design modules.

- Replaced `DaffContainerModule` and any deprecated button modules with `DAFF_CONTAINER_COMPONENTS` and the relevant button component arrays
- Updated `header.component.ts` accordingly
- No functional or API changes; purely a refactor

## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [x] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4058

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->