### PR TITLE
fix(deps): pin rxjs to ^v7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "express": "^4.18.2",
         "graphql": "^16.10.0",
         "modern-normalize": "^3.0.1",
-        "rxjs": "7.8.1",
+        "rxjs": "^7.0.0",
         "tslib": "^2.3.0",
         "web-animations-js": "^2.3.2",
         "webfontloader": "^1.6.28",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "express": "^4.18.2",
     "graphql": "^16.10.0",
     "modern-normalize": "^3.0.1",
-    "rxjs": "7.8.1",
+    "rxjs": "^7.0.0",
     "tslib": "^2.3.0",
     "web-animations-js": "^2.3.2",
     "webfontloader": "^1.6.28",


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
See the issue in #4099 

Fixes: # 4099
Part of: # <!-- Keeps issue open -->

## New behavior
We use the range. This is compatible with Angular - see https://github.com/angular/angular/blob/main/package.json#L142

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->