### PR TITLE
refactor(daffio): replace `DaffRaisedCardComponent` with `elevated` property in pwa stats component

### DIFF
--- a/apps/daffio/src/app/content/why-pwa/components/why-pwa-stats/why-pwa-stats.component.html
+++ b/apps/daffio/src/app/content/why-pwa/components/why-pwa-stats/why-pwa-stats.component.html
@@ -7,7 +7,7 @@
       Don't just take our word for it. Check out the statistics and see how Progressive Web Apps have helped your competitors improve their presence on the web.
     </p>
     <div daffCalloutBody class="daffio-why-pwa-stats__card-grid">
-      <a daff-raised-card color="secondary" href="https://developers.google.com/web/showcase/vertical/#retail" target="_blank" rel="noopener noreferrer">
+      <a daff-card [elevated]="true" color="secondary" href="https://developers.google.com/web/showcase/vertical/#retail" target="_blank" rel="noopener noreferrer">
         <fa-icon daffCardIcon [icon]="faFileAlt" size="lg"></fa-icon>
         <div daffCardTagline>Google Developers</div>
         <div daffCardTitle>
@@ -17,7 +17,7 @@
           <p>Learn why and how developers have used the web to create amazing web experiences for their users.</p>
         </div>
       </a>
-      <a daff-raised-card color="secondary" href="https://www.pwastats.com/" target="_blank" rel="noopener noreferrer">
+      <a daff-card [elevated]="true" color="secondary" href="https://www.pwastats.com/" target="_blank" rel="noopener noreferrer">
         <fa-icon daffCardIcon [icon]="faChartBar" size="lg"></fa-icon>
         <p daffCardTagline>PWA Stats</p>
         <div daffCardTitle>


### PR DESCRIPTION
Replaced <a daff-raised-card> with <a daff-card [elevated]="true"> for consistency and deprecation cleanup.

## PR Checklist

- 

- [X] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)

- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [X] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->
<a daff-raised-card>

Fixes: #4090
Part of: # <!-- Keeps issue open -->

## New behavior
<!-- Describe the changes -->
<a daff-card [elevated]="true">

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->