### PR TITLE
feat(design): Update `daff-get-font-colors`

### DIFF
--- a/libs/design/scss/theming/_get-font-colors.scss
+++ b/libs/design/scss/theming/_get-font-colors.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use './get-base-color' as *;
 
 /// Returns a light and dark color.
@@ -21,6 +22,12 @@
 /// 	}
 ///
 @function daff-get-font-colors($theme) {
+	@if (map.get($theme, 'text-color-default')) {
+		@return (
+			map.get($theme, 'text-color-default'),
+			map.get($theme, 'text-color-inverse')
+		);
+	}
 	@return (
 		daff-get-base-color($theme, 'white'),
 		daff-get-base-color($theme, 'black')

--- a/libs/design/scss/theming/contrast/text-contrast/text-contrast.scss
+++ b/libs/design/scss/theming/contrast/text-contrast/text-contrast.scss
@@ -1,6 +1,6 @@
 @use 'sass:list';
 @use '../max-contrast/max-contrast' as mc;
-@use '../../get-font-colors' as fc;
+@use '../../get-font-colors/get-font-colors' as fc;
 @use '../../get-color';
 @use '../../color-palettes' as palette;
 

--- a/libs/design/scss/theming/get-font-colors/_get-font-colors.scss
+++ b/libs/design/scss/theming/get-font-colors/_get-font-colors.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
-@use './get-base-color' as *;
+@use 'sass:list';
+@use '../get-base-color' as *;
 
 /// Returns a light and dark color.
 ///

--- a/libs/design/scss/theming/get-font-colors/_get-font-colors.spec.scss
+++ b/libs/design/scss/theming/get-font-colors/_get-font-colors.spec.scss
@@ -1,0 +1,76 @@
+@use 'true' as *;
+@use 'sass:list';
+@use 'sass:map';
+@use '../create-theme' as *;
+@use '../color-palettes' as palette;
+@use '../configure-palette';
+@use '../get-color';
+@use '../get-base-color' as *;
+@use './get-font-colors' as fc;
+
+@include describe('daff-get-font-colors') {
+	$primary: configure-palette.daff-configure-palette(palette.$daff-blue, 60);
+	$secondary: configure-palette.daff-configure-palette(palette.$daff-purple, 60);
+	$tertiary: configure-palette.daff-configure-palette(palette.$daff-turquoise, 60);
+	$font-light: get-color.daff-color(palette.$daff-neutral, 10);
+	$font-dark: get-color.daff-color(palette.$daff-neutral, 100);
+	$default-dark: get-color.daff-color(palette.$daff-neutral, 110);
+	$default-light: get-color.daff-color(palette.$daff-neutral, 0);
+	$white: get-color.daff-color(palette.$daff-neutral, 0);
+	$black: get-color.daff-color(palette.$daff-neutral, 110);
+
+	@include it('returns theme text colors when provided') {
+		$config: (
+			'primary': $primary,
+			'secondary': $secondary,
+			'tertiary': $tertiary,
+			'text-color-default': $font-dark,
+			'text-color-inverse': $font-light
+		);
+		$theme: daff-create-theme($config);
+
+		$colors: fc.daff-get-font-colors($theme);
+		@include assert-equal(list.nth($colors, 1), $font-dark);
+		@include assert-equal(list.nth($colors, 2), $font-light);
+	}
+
+	@include it('falls back to default text colors when no explicit text colors') {
+		$config: (
+			'primary': $primary,
+			'secondary': $secondary,
+			'tertiary': $tertiary
+		);
+		$theme: daff-create-theme($config);
+
+		$colors: fc.daff-get-font-colors($theme);
+		@include assert-equal(list.nth($colors, 1), $default-dark);
+		@include assert-equal(list.nth($colors, 2), $default-light);
+	}
+
+	@include it('works when theme provides only one of the text colors') {
+		$config: (
+			'mode': 'dark',
+			'primary': $primary,
+			'secondary': $secondary,
+			'tertiary': $tertiary,
+			'text-color-default': $font-light
+		);
+		$theme: daff-create-theme($config);
+
+		$colors: fc.daff-get-font-colors($theme);
+		@include assert-equal(list.nth($colors, 1), $font-light);
+		@include assert-equal(list.nth($colors, 2), $default-dark);
+	}
+
+	@include it('falls back to base colors when argument is not a theme map created with daff-create-theme') {
+		$config: (
+			'primary': $primary,
+			'secondary': $secondary,
+			'tertiary': $tertiary
+		);
+
+		$colors: fc.daff-get-font-colors($theme);
+		@include assert-equal(list.nth($colors, 1), $white);
+		@include assert-equal(list.nth($colors, 2), $black);
+	}
+}

--- a/libs/design/scss/theming/get-font-colors/_get-font-colors.spec.scss
+++ b/libs/design/scss/theming/get-font-colors/_get-font-colors.spec.scss
@@ -6,7 +6,8 @@
 @use '../configure-palette';
 @use '../get-color';
 @use '../get-base-color' as *;
-@use './get-font-colors' as fc;
+@use './get-font-colors' as *;
+@use '../configure-theme' as ct;
 
 @include describe('daff-get-font-colors') {
 	$primary: configure-palette.daff-configure-palette(palette.$daff-blue, 60);
@@ -29,7 +30,7 @@
 		);
 		$theme: daff-create-theme($config);
 
-		$colors: fc.daff-get-font-colors($theme);
+		$colors: daff-get-font-colors($theme);
 		@include assert-equal(list.nth($colors, 1), $font-dark);
 		@include assert-equal(list.nth($colors, 2), $font-light);
 	}
@@ -42,7 +43,7 @@
 		);
 		$theme: daff-create-theme($config);
 
-		$colors: fc.daff-get-font-colors($theme);
+		$colors: daff-get-font-colors($theme);
 		@include assert-equal(list.nth($colors, 1), $default-dark);
 		@include assert-equal(list.nth($colors, 2), $default-light);
 	}
@@ -57,19 +58,14 @@
 		);
 		$theme: daff-create-theme($config);
 
-		$colors: fc.daff-get-font-colors($theme);
+		$colors: daff-get-font-colors($theme);
 		@include assert-equal(list.nth($colors, 1), $font-light);
 		@include assert-equal(list.nth($colors, 2), $default-dark);
 	}
 
-	@include it('falls back to base colors when argument is not a theme map created with daff-create-theme') {
-		$config: (
-			'primary': $primary,
-			'secondary': $secondary,
-			'tertiary': $tertiary
-		);
-
-		$colors: fc.daff-get-font-colors($theme);
+	@include it('falls back to base colors when argument is a theme map created with daff-configure-theme') {
+		$theme: ct.daff-configure-theme($primary, $secondary, $tertiary, 'light');
+		$colors: daff-get-font-colors($theme);
 		@include assert-equal(list.nth($colors, 1), $white);
 		@include assert-equal(list.nth($colors, 2), $black);
 	}

--- a/libs/design/scss/theming/get-font-colors/_get-font-colors.spec.scss
+++ b/libs/design/scss/theming/get-font-colors/_get-font-colors.spec.scss
@@ -63,7 +63,7 @@
 		@include assert-equal(list.nth($colors, 2), $default-dark);
 	}
 
-	@include it('falls back to base colors when argument is a theme map created with daff-configure-theme') {
+	@include it('returns base colors when theme map is created with daff-configure-theme instead of daff-create-theme') {
 		$theme: ct.daff-configure-theme($primary, $secondary, $tertiary, 'light');
 		$colors: daff-get-font-colors($theme);
 		@include assert-equal(list.nth($colors, 1), $white);


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4132

## New behavior
Updates `daff-get-font-colors` to return text colors set in the theme config map created with `daff-create-theme`

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->