### PR TITLE
feat(driver): add routable objects system for in-memory drivers

### DIFF
--- a/libs/driver/in-memory/src/public_api.ts
+++ b/libs/driver/in-memory/src/public_api.ts
@@ -3,3 +3,4 @@ export * from './driver/public_api';
 export * from './config/public_api';
 export * from './module';
 export * from './provider';
+export * from './routing/public_api';

--- a/libs/driver/in-memory/src/routing/provider.ts
+++ b/libs/driver/in-memory/src/routing/provider.ts
@@ -12,7 +12,7 @@ import {
 
 /**
  * A function that returns an array of entities with URL properties.
- * Used to provide routable objects to the in-memory routing system.
+ * Used to provide routable in-memory object information to the routing system.
  */
 export type DaffInMemoryRoutableObjectsResolver = () => Array<{ url: string }>;
 
@@ -25,8 +25,11 @@ export type DaffInMemoryRoutableObjectsResolver = () => Array<{ url: string }>;
  *
  * @docs-private
  */
-const DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER = new InjectionToken<{ type: string; resolver: InjectionToken<DaffInMemoryRoutableObjectsResolver> }>(
-  'DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER',
+const DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER = new InjectionToken<{ type: string; resolver: DaffInMemoryRoutableObjectsResolver }[]>(
+  'DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER', {
+    providedIn: 'root',
+    factory: () => [],
+  },
 );
 
 /**
@@ -50,9 +53,8 @@ export const DAFF_INMEMORY_ROUTABLE_OBJECTS = new InjectionToken<DaffInMemoryRou
         throw new Error('DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER must be an array');
       }
 
-      resolvers.forEach((entry: { type: string; resolver: InjectionToken<DaffInMemoryRoutableObjectsResolver> }) => {
-        const resolverFn = inject(entry.resolver);
-        const entities = resolverFn();
+      resolvers.forEach((entry) => {
+        const entities = entry.resolver();
         entities.forEach(entity => {
           if (map.has(entity.url)) {
             const existing = map.get(entity.url);
@@ -76,30 +78,27 @@ export const DAFF_INMEMORY_ROUTABLE_OBJECTS = new InjectionToken<DaffInMemoryRou
  * Registers routable objects from an in-memory driver with the routing system.
  *
  * This function allows in-memory drivers to provide their entities (with URL properties)
- * to enable automatic URL resolution. Each driver creates an injection token that returns
- * a function providing its entities, then calls this function to register those entities
- * with a type identifier.
+ * to enable automatic URL resolution. Each driver provides a resolver function that
+ * returns its entities with URL properties, along with a type identifier.
+ *
+ * The resolver function runs in an injection context, which means you can use Angular's
+ * `inject()` function within it to access services and dependencies.
  *
  * @param type - The type identifier for these routable objects (e.g., "PRODUCTS")
- * @param resolver - An injection token that provides a DaffInMemoryRoutableObjectsResolver function
+ * @param resolver - A function that returns an array of entities with URL properties.
+ *                   This function runs in an injection context, allowing use of `inject()`.
  * @returns Environment providers that register the routable objects
  *
  * @usageNotes
  *
  * ### Basic Usage
  *
- * In your driver package, create an injection token:
+ * In your driver package, create a resolver function:
  *
  * ```typescript
- * export const DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS = new InjectionToken<DaffInMemoryRoutableObjectsResolver>(
- *   'DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS',
- *   {
- *     factory: () => {
- *       const service = inject(DaffInMemoryBackendProductService);
- *       return () => service.products;
- *     }
- *   }
- * );
+ * const productResolver = (): Array<{ url: string }> => {
+ *   return inject(DaffInMemoryBackendProductService).products.map((p) => ({ url: p.url }));
+ * };
  * ```
  *
  * Then in your app configuration:
@@ -107,14 +106,14 @@ export const DAFF_INMEMORY_ROUTABLE_OBJECTS = new InjectionToken<DaffInMemoryRou
  * ```typescript
  * export const appConfig: ApplicationConfig = {
  *   providers: [
- *     provideDaffInMemoryRoutableObjects("PRODUCTS", DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS),
+ *     provideDaffInMemoryRoutableObjects("PRODUCTS", productResolver),
  *   ]
  * };
  * ```
  */
 export const provideDaffInMemoryRoutableObjects = (
   type: string,
-  resolver: InjectionToken<DaffInMemoryRoutableObjectsResolver>,
+  resolver: DaffInMemoryRoutableObjectsResolver,
 ): EnvironmentProviders => makeEnvironmentProviders([
   {
     provide: DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER,

--- a/libs/driver/in-memory/src/routing/provider.ts
+++ b/libs/driver/in-memory/src/routing/provider.ts
@@ -1,0 +1,124 @@
+import {
+  EnvironmentProviders,
+  inject,
+  InjectionToken,
+  makeEnvironmentProviders,
+} from '@angular/core';
+
+import {
+  DaffInMemoryRoutableObject,
+  DaffInMemoryRoutableObjects,
+} from './routable-object';
+
+/**
+ * A function that returns an array of entities with URL properties.
+ * Used to provide routable objects to the in-memory routing system.
+ */
+export type DaffInMemoryRoutableObjectsResolver = () => Array<{ url: string }>;
+
+/**
+ * Multi-injection token for routable object resolvers.
+ *
+ * Each in-memory driver (e.g., product, navigation) can register a resolver
+ * that provides its entities with URL properties. This token collects all
+ * such resolvers so they can be processed together to build the routing map.
+ *
+ * @docs-private
+ */
+const DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER = new InjectionToken<{ type: string; resolver: InjectionToken<DaffInMemoryRoutableObjectsResolver> }>(
+  'DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER',
+);
+
+/**
+ * Internal injection token that builds and provides the complete map of routable objects.
+ *
+ * This token automatically collects all registered routable object resolvers and builds
+ * a Map where the key is the URL path and the value is an object containing both the URL
+ * and its associated type. This map is used by in-memory drivers to resolve URLs to their types.
+ *
+ * @docs-private
+ */
+export const DAFF_INMEMORY_ROUTABLE_OBJECTS = new InjectionToken<DaffInMemoryRoutableObjects>(
+  'DAFF_INMEMORY_ROUTABLE_OBJECTS',
+  {
+    providedIn: 'root',
+    factory: () => {
+      const resolvers = inject(DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER, { optional: true }) || [];
+      const map = new Map<string, DaffInMemoryRoutableObject>();
+
+      if (!Array.isArray(resolvers)) {
+        throw new Error('DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER must be an array');
+      }
+
+      resolvers.forEach((entry: { type: string; resolver: InjectionToken<DaffInMemoryRoutableObjectsResolver> }) => {
+        const resolverFn = inject(entry.resolver);
+        const entities = resolverFn();
+        entities.forEach(entity => {
+          if (map.has(entity.url)) {
+            const existing = map.get(entity.url);
+            console.warn(
+              `[@daffodil/driver/in-memory] Duplicate entity URL detected: "${entity.url}". ` +
+              `Already registered with type "${existing?.type}", attempting to register again with type "${entry.type}". ` +
+              `The first registration will be used.`,
+            );
+            return;
+          }
+          map.set(entity.url, { url: entity.url, type: entry.type });
+        });
+      });
+
+      return map;
+    },
+  },
+);
+
+/**
+ * Registers routable objects from an in-memory driver with the routing system.
+ *
+ * This function allows in-memory drivers to provide their entities (with URL properties)
+ * to enable automatic URL resolution. Each driver creates an injection token that returns
+ * a function providing its entities, then calls this function to register those entities
+ * with a type identifier.
+ *
+ * @param type - The type identifier for these routable objects (e.g., "PRODUCTS")
+ * @param resolver - An injection token that provides a DaffInMemoryRoutableObjectsResolver function
+ * @returns Environment providers that register the routable objects
+ *
+ * @usageNotes
+ *
+ * ### Basic Usage
+ *
+ * In your driver package, create an injection token:
+ *
+ * ```typescript
+ * export const DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS = new InjectionToken<DaffInMemoryRoutableObjectsResolver>(
+ *   'DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS',
+ *   {
+ *     factory: () => {
+ *       const service = inject(DaffInMemoryBackendProductService);
+ *       return () => service.products;
+ *     }
+ *   }
+ * );
+ * ```
+ *
+ * Then in your app configuration:
+ *
+ * ```typescript
+ * export const appConfig: ApplicationConfig = {
+ *   providers: [
+ *     provideDaffInMemoryRoutableObjects("PRODUCTS", DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS),
+ *   ]
+ * };
+ * ```
+ */
+export const provideDaffInMemoryRoutableObjects = (
+  type: string,
+  resolver: InjectionToken<DaffInMemoryRoutableObjectsResolver>,
+): EnvironmentProviders => makeEnvironmentProviders([
+  {
+    provide: DAFF_INMEMORY_ROUTABLE_OBJECTS_RESOLVER,
+    useValue: { type, resolver },
+    multi: true,
+  },
+]);

--- a/libs/driver/in-memory/src/routing/public_api.ts
+++ b/libs/driver/in-memory/src/routing/public_api.ts
@@ -1,0 +1,9 @@
+export {
+  DaffInMemoryRoutableObject,
+  DaffInMemoryRoutableObjects,
+} from './routable-object';
+export {
+  DaffInMemoryRoutableObjectsResolver,
+  provideDaffInMemoryRoutableObjects,
+  DAFF_INMEMORY_ROUTABLE_OBJECTS,
+} from './provider';

--- a/libs/driver/in-memory/src/routing/routable-object.ts
+++ b/libs/driver/in-memory/src/routing/routable-object.ts
@@ -19,4 +19,4 @@ export interface DaffInMemoryRoutableObject {
  * A map of URL paths to their corresponding routable objects.
  * The key is the URL path.
  */
-export type DaffInMemoryRoutableObjects = Map<string, DaffInMemoryRoutableObject>;
+export type DaffInMemoryRoutableObjects = ReadonlyMap<string, DaffInMemoryRoutableObject>;

--- a/libs/driver/in-memory/src/routing/routable-object.ts
+++ b/libs/driver/in-memory/src/routing/routable-object.ts
@@ -1,0 +1,22 @@
+/**
+ * Represents a routable object with a URL and type identifier.
+ * Used by in-memory drivers to enable automatic URL resolution
+ * of in-memory objects. See {@link DaffExternalRouterInMemoryDriver}
+ */
+export interface DaffInMemoryRoutableObject {
+  /**
+   * The URL path for this routable object (e.g., "/product-123").
+   */
+  url: string;
+
+  /**
+   * The type identifier for this routable object (e.g., "PRODUCTS", "NAVIGATION").
+   */
+  type: string;
+}
+
+/**
+ * A map of URL paths to their corresponding routable objects.
+ * The key is the URL path.
+ */
+export type DaffInMemoryRoutableObjects = Map<string, DaffInMemoryRoutableObject>;


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
See #4143 -- in short, making the in-memory drivers routable is annoying and tedious.

Fixes: #4143

## New behavior
Introduces a new routing system that allows in-memory drivers to register their entities with URLs, enabling automatic URL resolution by the @daffodil/external-router or another similar package. This provides a centralized way for in-memory drivers to contribute routable objects to the application.


## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->