### PR TITLE
feat(product): register products as routable objects for automatic URL resolution

### DIFF
--- a/libs/product/driver/in-memory/src/driver/provider.ts
+++ b/libs/product/driver/in-memory/src/driver/provider.ts
@@ -17,7 +17,7 @@ import {
   DaffInMemoryBackendProductService,
   DaffInMemoryProductService,
 } from '../public_api';
-import { _DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS } from './routable-objects.token';
+import { daffProductInMemoryRoutableObjects } from './routable-objects.token';
 
 /**
  * Provides the Daffodil product in-memory driver and its dependencies.
@@ -27,5 +27,5 @@ export const provideDaffProductInMemoryDriver = (): Array<Provider | Environment
   provideDaffProductDriver(DaffInMemoryProductService),
   provideDaffProductExtraFactoryTypes(DaffDefaultProductFactory),
   provideDaffInMemoryBackends(DaffInMemoryBackendProductService),
-  provideDaffInMemoryRoutableObjects('PRODUCT', _DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS),
+  provideDaffInMemoryRoutableObjects('PRODUCT', daffProductInMemoryRoutableObjects),
 ];

--- a/libs/product/driver/in-memory/src/driver/provider.ts
+++ b/libs/product/driver/in-memory/src/driver/provider.ts
@@ -1,6 +1,12 @@
-import { Provider } from '@angular/core';
+import {
+  EnvironmentProviders,
+  Provider,
+} from '@angular/core';
 
-import { provideDaffInMemoryBackends } from '@daffodil/driver/in-memory';
+import {
+  provideDaffInMemoryBackends,
+  provideDaffInMemoryRoutableObjects,
+} from '@daffodil/driver/in-memory';
 import { provideDaffProductDriver } from '@daffodil/product/driver';
 import {
   DaffDefaultProductFactory,
@@ -11,13 +17,15 @@ import {
   DaffInMemoryBackendProductService,
   DaffInMemoryProductService,
 } from '../public_api';
+import { _DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS } from './routable-objects.token';
 
 /**
  * Provides the Daffodil product in-memory driver and its dependencies.
  */
-export const provideDaffProductInMemoryDriver = (): Provider[] => [
+export const provideDaffProductInMemoryDriver = (): Array<Provider | EnvironmentProviders> => [
   DaffInMemoryProductService,
   provideDaffProductDriver(DaffInMemoryProductService),
   provideDaffProductExtraFactoryTypes(DaffDefaultProductFactory),
   provideDaffInMemoryBackends(DaffInMemoryBackendProductService),
+  provideDaffInMemoryRoutableObjects('PRODUCT', _DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS),
 ];

--- a/libs/product/driver/in-memory/src/driver/routable-objects.token.ts
+++ b/libs/product/driver/in-memory/src/driver/routable-objects.token.ts
@@ -1,32 +1,18 @@
-import {
-  inject,
-  InjectionToken,
-} from '@angular/core';
+import { inject } from '@angular/core';
 
-import { DaffInMemoryRoutableObjectsResolver } from '@daffodil/driver/in-memory';
 
 import { DaffInMemoryBackendProductService } from '../backend/product.service';
 
 /**
- * Injection token that provides routable product objects for the in-memory driver.
+ * A factory function that provides routable product objects for the in-memory driver.
  *
- * This token returns a function that, when called, provides all product entities
- * with their URL properties. It is used with {@link provideDaffInMemoryRoutableObjects}
- * to enable automatic URL resolution for products.
+ * Returns a function that provides all product entities with their URL properties.
+ * Used internally by {@link provideDaffProductInMemoryDriver} with
+ * {@link provideDaffInMemoryRoutableObjects} to enable automatic URL resolution for products.
  *
- * @usageNotes
- *
- * This token is automatically provided when using {@link provideDaffProductInMemoryDriver}.
- * You typically don't need to use this token directly unless you're customizing
- * the product in-memory driver configuration.
+ * @docs-private
  */
-export const _DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS = new InjectionToken<DaffInMemoryRoutableObjectsResolver>(
-  '_DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS',
-  {
-    providedIn: 'root',
-    factory: () => {
-      const service = inject(DaffInMemoryBackendProductService);
-      return () => service.products.map((p) => ({ url: p.url }));
-    },
-  },
-);
+export const daffProductInMemoryRoutableObjects = () => {
+  const service = inject(DaffInMemoryBackendProductService);
+  return service.products.map((p) => ({ url: p.url }));
+};

--- a/libs/product/driver/in-memory/src/driver/routable-objects.token.ts
+++ b/libs/product/driver/in-memory/src/driver/routable-objects.token.ts
@@ -1,0 +1,32 @@
+import {
+  inject,
+  InjectionToken,
+} from '@angular/core';
+
+import { DaffInMemoryRoutableObjectsResolver } from '@daffodil/driver/in-memory';
+
+import { DaffInMemoryBackendProductService } from '../backend/product.service';
+
+/**
+ * Injection token that provides routable product objects for the in-memory driver.
+ *
+ * This token returns a function that, when called, provides all product entities
+ * with their URL properties. It is used with {@link provideDaffInMemoryRoutableObjects}
+ * to enable automatic URL resolution for products.
+ *
+ * @usageNotes
+ *
+ * This token is automatically provided when using {@link provideDaffProductInMemoryDriver}.
+ * You typically don't need to use this token directly unless you're customizing
+ * the product in-memory driver configuration.
+ */
+export const _DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS = new InjectionToken<DaffInMemoryRoutableObjectsResolver>(
+  '_DAFF_PRODUCT_INMEMORY_ROUTABLE_OBJECTS',
+  {
+    providedIn: 'root',
+    factory: () => {
+      const service = inject(DaffInMemoryBackendProductService);
+      return () => service.products.map((p) => ({ url: p.url }));
+    },
+  },
+);


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4143 

## New behavior
Integrates the product in-memory driver from with the routable objects system #4144, allowing product URLs to be automatically resolved by the external router driver without manual configuration.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
Depends on #4144