### PR TITLE
fix(product): getByUrl on DaffInMemoryProductService works with urls

### DIFF
--- a/libs/product/driver/in-memory/src/backend/product.service.spec.ts
+++ b/libs/product/driver/in-memory/src/backend/product.service.spec.ts
@@ -42,14 +42,18 @@ describe('Driver | InMemory | Product | DaffInMemoryBackendProductService', () =
 
   describe('get', () => {
 
-    describe('when reqInfo.id is "best-sellers"', () => {
+    describe('when reqInfo.id contains ".html" and matches a product URL', () => {
 
       let reqInfoStub;
       let result;
+      let testProduct;
 
       beforeEach(() => {
+        testProduct = productTestingService.products[0];
+        const productUrl = testProduct.url.startsWith('/') ? testProduct.url.slice(1) : testProduct.url;
+
         reqInfoStub = {
-          id: 'best-sellers',
+          id: productUrl,
           utils: {
             createResponse$: (func) => func(),
           },
@@ -58,9 +62,51 @@ describe('Driver | InMemory | Product | DaffInMemoryBackendProductService', () =
         result = productTestingService.get(reqInfoStub);
       });
 
-      it('should return an Array of 4 products', () => {
-        expect(result.body).toEqual(jasmine.any(Array));
-        expect(result.body.length).toEqual(4);
+      it('should return the matching product', () => {
+        expect(result.body).toEqual(testProduct);
+        expect(result.status).toEqual(200);
+      });
+    });
+
+    describe('when reqInfo.id contains ".html" but does not match any product URL', () => {
+
+      let reqInfoStub;
+      let result;
+
+      beforeEach(() => {
+        reqInfoStub = {
+          id: 'non-existent-product.html',
+          utils: {
+            createResponse$: (func) => func(),
+          },
+        };
+
+        result = productTestingService.get(reqInfoStub);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when reqInfo.id does not contain ".html"', () => {
+
+      let reqInfoStub;
+      let result;
+
+      beforeEach(() => {
+        reqInfoStub = {
+          id: 'some-id',
+          utils: {
+            createResponse$: (func) => func(),
+          },
+        };
+
+        result = productTestingService.get(reqInfoStub);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
       });
     });
   });

--- a/libs/product/driver/in-memory/src/backend/product.service.ts
+++ b/libs/product/driver/in-memory/src/backend/product.service.ts
@@ -1,20 +1,21 @@
-import { Injectable } from '@angular/core';
+import {
+  inject,
+  Injectable,
+} from '@angular/core';
 import {
   InMemoryDbService,
   RequestInfoUtilities,
   ParsedRequestUrl,
+  RequestInfo,
   STATUS,
 } from 'angular-in-memory-web-api';
 
+import { daffUriTruncateLeadingSlash } from '@daffodil/core/routing';
 import { DaffInMemorySingleRouteableBackend } from '@daffodil/driver/in-memory';
 import { DaffProduct } from '@daffodil/product';
-import {
-  DaffProductImageFactory,
-  DaffProductExtensionFactory,
-} from '@daffodil/product/testing';
+import { DaffProductExtensionFactory } from '@daffodil/product/testing';
 
 import { DAFF_PRODUCT_IN_MEMORY_COLLECTION_NAME } from '../collection-name.const';
-
 /**
  * An in-memory service that stubs out the backend services for getting products.
  *
@@ -37,46 +38,10 @@ export class DaffInMemoryBackendProductService implements InMemoryDbService, Daf
     return this._products;
   };
 
-  constructor(
-    private productFactory: DaffProductExtensionFactory,
-    private productImageFactory: DaffProductImageFactory) {
-    this._products = [
-      '1001',
-      '1002',
-      '1003',
-      '1004',
-      '1005',
-      '1006',
-      '1007',
-      '1008',
-      '1009',
-      '1010',
-      '1011',
-      '1012',
-      '1013',
-      '1014',
-      '1015',
-      '1016',
-      '1017',
-      '1018',
-      '1019',
-      '1020',
-      '1021',
-      '1022',
-      '1023',
-      '1024',
-      '1025',
-      '1026',
-      '1027',
-      '1028',
-      '1029',
-      '1030',
-      '1031',
-      '1032',
-      '1033',
-      '1034',
-      '1035',
-    ].map(id => this.productFactory.create({ id, url: `/${id}` }));
+  productFactory = inject(DaffProductExtensionFactory);
+
+  constructor(){
+    this._products = this.productFactory.createMany(35);
   }
 
   /**
@@ -109,14 +74,19 @@ export class DaffInMemoryBackendProductService implements InMemoryDbService, Daf
    * @param reqInfo request object
    * @returns An http response object
    */
-  get(reqInfo: any) {
-    if (reqInfo.id === 'best-sellers') {
+  get(reqInfo: RequestInfo) {
+    if(reqInfo.id?.includes('.html')) {
+      const product =  this._products.find((p) => daffUriTruncateLeadingSlash(p.url)  === reqInfo.id);
+
+      if(!product) {
+        return undefined;
+      }
+
       return reqInfo.utils.createResponse$(() => ({
-        body: this._products.slice(0,4),
+        body: product,
         status: STATUS.OK,
       }));
     }
-
     return undefined;
   }
 }

--- a/libs/product/driver/in-memory/src/driver/product.service.ts
+++ b/libs/product/driver/in-memory/src/driver/product.service.ts
@@ -10,6 +10,7 @@ import {
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+import { daffUriTruncateLeadingSlash } from '@daffodil/core/routing';
 import { DaffInMemoryDriverBase } from '@daffodil/driver/in-memory';
 import { DaffProduct } from '@daffodil/product';
 import {
@@ -48,7 +49,7 @@ export class DaffInMemoryProductService extends DaffInMemoryDriverBase implement
   }
 
   getByUrl(url: DaffProduct['url']): Observable<DaffProductDriverResponse> {
-    return this.http.get<DaffProduct>(`${this.url}${url}`).pipe(
+    return this.http.get<DaffProduct>(`${this.url}/${daffUriTruncateLeadingSlash(url)}`).pipe(
       map(this.transform),
     );
   }


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, `getByUrl` will always fail with legitimate paths since we currently assume that a path is just an `id`. This is a confusing and mistaken assumption. 

Part of: #4143 

## New behavior
I removed the stale `best-sellers` functionality since it's entirely unused in the framework. Any product `id` that contains the string `.html` will be treated as a `url` lookup. Everything else will still continue to be treated as an `id`. Additionally, product urls stored in the in-memory backend will now appropriately be URLs.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->