### PR TITLE
feat(product): transfer in-memory state when hydrating backend 

### DIFF
--- a/libs/product/driver/in-memory/src/backend/product.service.spec.ts
+++ b/libs/product/driver/in-memory/src/backend/product.service.spec.ts
@@ -1,3 +1,7 @@
+import {
+  PLATFORM_ID,
+  TransferState,
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import {
@@ -7,6 +11,7 @@ import {
 } from '@daffodil/product/testing';
 
 import { DaffInMemoryBackendProductService } from './product.service';
+import { TRANSFER_STATE_KEY } from './transfer-state-key';
 
 describe('Driver | InMemory | Product | DaffInMemoryBackendProductService', () => {
   let productTestingService;
@@ -24,6 +29,91 @@ describe('Driver | InMemory | Product | DaffInMemoryBackendProductService', () =
 
   it('should be created', () => {
     expect(productTestingService).toBeTruthy();
+  });
+
+  describe('transferring state from the server to the browser', () => {
+    describe('on browser platform', () => {
+      let transferState: TransferState;
+      let mockProducts;
+
+      beforeEach(() => {
+        mockProducts = [
+          { id: '1', url: '/product-1.html', name: 'Product 1' },
+          { id: '2', url: '/product-2.html', name: 'Product 2' },
+        ];
+
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          providers: [
+            DaffInMemoryBackendProductService,
+            provideDaffProductExtraFactoryTypes(DaffProductFactory),
+            { provide: PLATFORM_ID, useValue: 'browser' },
+          ],
+        });
+
+        transferState = TestBed.inject(TransferState);
+        transferState.set(TRANSFER_STATE_KEY, { data: JSON.stringify(mockProducts) });
+
+        productTestingService = TestBed.inject(DaffInMemoryBackendProductService);
+      });
+
+      it('should load products from transfer state', () => {
+        expect(productTestingService.products).toEqual(mockProducts);
+      });
+
+      it('should not create new products', () => {
+        expect(productTestingService.products.length).toEqual(2);
+      });
+    });
+
+    describe('on browser platform without transfer state', () => {
+      beforeEach(() => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          providers: [
+            DaffInMemoryBackendProductService,
+            provideDaffProductExtraFactoryTypes(DaffProductFactory),
+            { provide: PLATFORM_ID, useValue: 'browser' },
+          ],
+        });
+
+        productTestingService = TestBed.inject(DaffInMemoryBackendProductService);
+      });
+
+      it('should create default products from factory', () => {
+        expect(productTestingService.products.length).toEqual(35);
+      });
+    });
+
+    describe('on server platform', () => {
+      let transferState: TransferState;
+
+      beforeEach(() => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          providers: [
+            DaffInMemoryBackendProductService,
+            provideDaffProductExtraFactoryTypes(DaffProductFactory),
+            { provide: PLATFORM_ID, useValue: 'server' },
+          ],
+        });
+
+        transferState = TestBed.inject(TransferState);
+        productTestingService = TestBed.inject(DaffInMemoryBackendProductService);
+      });
+
+      it('should set products in transfer state', () => {
+        const transferStateData = transferState.get(TRANSFER_STATE_KEY, null);
+        expect(transferStateData).toBeTruthy();
+        expect(transferStateData.data).toBeDefined();
+      });
+
+      it('should serialize products as JSON in transfer state', () => {
+        const transferStateData = transferState.get(TRANSFER_STATE_KEY, null);
+        const products = JSON.parse(transferStateData.data);
+        expect(Array.isArray(products)).toBe(true);
+      });
+    });
   });
 
   describe('createDb', () => {

--- a/libs/product/driver/in-memory/src/backend/product.service.spec.ts
+++ b/libs/product/driver/in-memory/src/backend/product.service.spec.ts
@@ -52,7 +52,7 @@ describe('Driver | InMemory | Product | DaffInMemoryBackendProductService', () =
         });
 
         transferState = TestBed.inject(TransferState);
-        transferState.set(TRANSFER_STATE_KEY, { data: JSON.stringify(mockProducts) });
+        transferState.set(TRANSFER_STATE_KEY, mockProducts);
 
         productTestingService = TestBed.inject(DaffInMemoryBackendProductService);
       });
@@ -105,13 +105,7 @@ describe('Driver | InMemory | Product | DaffInMemoryBackendProductService', () =
       it('should set products in transfer state', () => {
         const transferStateData = transferState.get(TRANSFER_STATE_KEY, null);
         expect(transferStateData).toBeTruthy();
-        expect(transferStateData.data).toBeDefined();
-      });
-
-      it('should serialize products as JSON in transfer state', () => {
-        const transferStateData = transferState.get(TRANSFER_STATE_KEY, null);
-        const products = JSON.parse(transferStateData.data);
-        expect(Array.isArray(products)).toBe(true);
+        expect(Array.isArray(transferStateData)).toBe(true);
       });
     });
   });

--- a/libs/product/driver/in-memory/src/backend/product.service.ts
+++ b/libs/product/driver/in-memory/src/backend/product.service.ts
@@ -55,6 +55,7 @@ export class DaffInMemoryBackendProductService implements InMemoryDbService, Daf
         ).data,
       );
     } else {
+      this._products = productFactory.createMany(35);
       transferState.set(TRANSFER_STATE_KEY, { data: JSON.stringify(this._products) });
     }
   }

--- a/libs/product/driver/in-memory/src/backend/product.service.ts
+++ b/libs/product/driver/in-memory/src/backend/product.service.ts
@@ -1,6 +1,9 @@
+import { isPlatformBrowser } from '@angular/common';
 import {
   inject,
   Injectable,
+  PLATFORM_ID,
+  TransferState,
 } from '@angular/core';
 import {
   InMemoryDbService,
@@ -16,6 +19,7 @@ import { DaffProduct } from '@daffodil/product';
 import { DaffProductExtensionFactory } from '@daffodil/product/testing';
 
 import { DAFF_PRODUCT_IN_MEMORY_COLLECTION_NAME } from '../collection-name.const';
+import { TRANSFER_STATE_KEY } from './transfer-state-key';
 /**
  * An in-memory service that stubs out the backend services for getting products.
  *
@@ -38,10 +42,23 @@ export class DaffInMemoryBackendProductService implements InMemoryDbService, Daf
     return this._products;
   };
 
+  transferState = inject(TransferState);
+
+  platform = inject(PLATFORM_ID);
+
   productFactory = inject(DaffProductExtensionFactory);
 
   constructor(){
-    this._products = this.productFactory.createMany(35);
+    if(isPlatformBrowser(this.platform)) {
+      this._products = JSON.parse(
+        this.transferState.get(
+          TRANSFER_STATE_KEY,
+          { data: JSON.stringify(this.productFactory.createMany(35)) },
+        ).data,
+      );
+    } else {
+      this.transferState.set(TRANSFER_STATE_KEY, { data: JSON.stringify(this._products) });
+    }
   }
 
   /**

--- a/libs/product/driver/in-memory/src/backend/product.service.ts
+++ b/libs/product/driver/in-memory/src/backend/product.service.ts
@@ -42,22 +42,20 @@ export class DaffInMemoryBackendProductService implements InMemoryDbService, Daf
     return this._products;
   };
 
-  transferState = inject(TransferState);
-
-  platform = inject(PLATFORM_ID);
-
-  productFactory = inject(DaffProductExtensionFactory);
-
   constructor(){
-    if(isPlatformBrowser(this.platform)) {
+    const transferState = inject(TransferState);
+    const platform = inject(PLATFORM_ID);
+    const productFactory = inject(DaffProductExtensionFactory);
+
+    if(isPlatformBrowser(platform)) {
       this._products = JSON.parse(
-        this.transferState.get(
+        transferState.get(
           TRANSFER_STATE_KEY,
-          { data: JSON.stringify(this.productFactory.createMany(35)) },
+          { data: JSON.stringify(productFactory.createMany(35)) },
         ).data,
       );
     } else {
-      this.transferState.set(TRANSFER_STATE_KEY, { data: JSON.stringify(this._products) });
+      transferState.set(TRANSFER_STATE_KEY, { data: JSON.stringify(this._products) });
     }
   }
 

--- a/libs/product/driver/in-memory/src/backend/product.service.ts
+++ b/libs/product/driver/in-memory/src/backend/product.service.ts
@@ -48,15 +48,10 @@ export class DaffInMemoryBackendProductService implements InMemoryDbService, Daf
     const productFactory = inject(DaffProductExtensionFactory);
 
     if(isPlatformBrowser(platform)) {
-      this._products = JSON.parse(
-        transferState.get(
-          TRANSFER_STATE_KEY,
-          { data: JSON.stringify(productFactory.createMany(35)) },
-        ).data,
-      );
+      this._products = transferState.get(TRANSFER_STATE_KEY, productFactory.createMany(35));
     } else {
       this._products = productFactory.createMany(35);
-      transferState.set(TRANSFER_STATE_KEY, { data: JSON.stringify(this._products) });
+      transferState.set(TRANSFER_STATE_KEY, this._products);
     }
   }
 

--- a/libs/product/driver/in-memory/src/backend/transfer-state-key.ts
+++ b/libs/product/driver/in-memory/src/backend/transfer-state-key.ts
@@ -1,3 +1,5 @@
 import { makeStateKey } from '@angular/core';
 
-export const TRANSFER_STATE_KEY = makeStateKey<{data: string}>('DAFF_PRODUCTS_INMEMORY_DATA');
+import { DaffProduct } from '@daffodil/product';
+
+export const TRANSFER_STATE_KEY = makeStateKey<DaffProduct[]>('DAFF_PRODUCTS_INMEMORY_DATA');

--- a/libs/product/driver/in-memory/src/backend/transfer-state-key.ts
+++ b/libs/product/driver/in-memory/src/backend/transfer-state-key.ts
@@ -1,0 +1,3 @@
+import { makeStateKey } from '@angular/core';
+
+export const TRANSFER_STATE_KEY = makeStateKey<{data: string}>('DAFF_PRODUCTS_INMEMORY_DATA');


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4143 

## New behavior
Product backend data is transferred when hydrating backend from server to client.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context

Depends on #4147 