### PR TITLE
chore(deps): upgrade @nx/azure-cache from 1.3.1 to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "@graphql-codegen/typescript-apollo-angular": "^4.0.0",
         "@ngrx/schematics": "^20.0.0",
         "@ngrx/store-devtools": "^20.0.0",
-        "@nx/azure-cache": "^1.3.1",
+        "@nx/azure-cache": "^4.0.0",
         "@schematics/angular": "^20.0.0",
         "@stylistic/eslint-plugin": "^2.7.2",
         "@stylistic/stylelint-plugin": "^3.1.1",
@@ -7338,17 +7338,22 @@
       }
     },
     "node_modules/@nx/azure-cache": {
-      "version": "1.3.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/azure-cache/-/azure-cache-4.0.0.tgz",
+      "integrity": "sha512-z5OJzPtKPQppce6Qqxf0kYDX80xBt0KVAkBuQY6UyF9O4cut6bAiILpYSrqttI6vSMkid+nACbxoTT45n2gIxA==",
       "dev": true,
       "license": "Commercial",
       "dependencies": {
         "@azure/identity": "4.5.0",
         "@azure/storage-blob": "12.25.0",
-        "@nx/devkit": ">= 19 < 21",
-        "@nx/key": "1.3.1",
+        "@nx/devkit": "21.5.1",
+        "@nx/key": "4.0.0",
         "enquirer": "^2.4.1",
         "semver": "7.5.4",
         "tar-stream": "^3.1.7"
+      },
+      "peerDependencies": {
+        "nx": ">= 18 < 22"
       }
     },
     "node_modules/@nx/azure-cache/node_modules/enquirer": {
@@ -7404,7 +7409,9 @@
       "license": "ISC"
     },
     "node_modules/@nx/devkit": {
-      "version": "20.4.1",
+      "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-21.5.1.tgz",
+      "integrity": "sha512-eVFFLMUcxO/holHdWo0YabyUs6H3wNvnovt/0LddIRGoiMHWpbFZLB/KThiyUWvuFVuqqyDzRmS0XRo/M2kOqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7418,11 +7425,13 @@
         "yargs-parser": "21.1.1"
       },
       "peerDependencies": {
-        "nx": ">= 19 <= 21"
+        "nx": ">= 20 <= 22"
       }
     },
     "node_modules/@nx/devkit/node_modules/ignore": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7431,6 +7440,8 @@
     },
     "node_modules/@nx/devkit/node_modules/minimatch": {
       "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7444,7 +7455,9 @@
       }
     },
     "node_modules/@nx/devkit/node_modules/tmp": {
-      "version": "0.2.3",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7452,14 +7465,16 @@
       }
     },
     "node_modules/@nx/key": {
-      "version": "1.3.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/key/-/key-4.0.0.tgz",
+      "integrity": "sha512-oXYTVb79zV3J3GIMT0jUzzPBSzd6Z5ku4hkfvpSfFAQ8b0LGzNMuPWkw+wfbR7vOZZSQ2iAEzLNEm4r1O9zHnw==",
       "dev": true,
       "license": "Commercial",
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.4",
         "axios": "^1.6.7",
         "axios-retry": "^4.5.0",
-        "chalk": "^4.1.2",
+        "chalk": "4.1.2",
         "enquirer": "^2.4.1",
         "ora": "^5.4.1"
       },
@@ -7467,19 +7482,106 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@nx/key-darwin-arm64": "1.3.1",
-        "@nx/key-darwin-x64": "1.3.1",
-        "@nx/key-linux-arm-gnueabihf": "1.3.1",
-        "@nx/key-linux-arm64-gnu": "1.3.1",
-        "@nx/key-linux-arm64-musl": "1.3.1",
-        "@nx/key-linux-x64-gnu": "1.3.1",
-        "@nx/key-linux-x64-musl": "1.3.1",
-        "@nx/key-win32-arm64-msvc": "1.3.1",
-        "@nx/key-win32-x64-msvc": "1.3.1"
+        "@nx/key-darwin-arm64": "4.0.0",
+        "@nx/key-darwin-x64": "4.0.0",
+        "@nx/key-linux-arm-gnueabihf": "4.0.0",
+        "@nx/key-linux-arm64-gnu": "4.0.0",
+        "@nx/key-linux-arm64-musl": "4.0.0",
+        "@nx/key-linux-x64-gnu": "4.0.0",
+        "@nx/key-linux-x64-musl": "4.0.0",
+        "@nx/key-win32-arm64-msvc": "4.0.0",
+        "@nx/key-win32-x64-msvc": "4.0.0"
+      }
+    },
+    "node_modules/@nx/key-darwin-arm64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/key-darwin-arm64/-/key-darwin-arm64-4.0.0.tgz",
+      "integrity": "sha512-TnKePtrLWaDS/m001FSYOadhAHCTpcHbQnx0TYY+G3ISeDsNCC2ORVrWc4zjbgmxUNvi7J0NqfSyJk4MvKIqKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Commercial",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/key-darwin-x64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/key-darwin-x64/-/key-darwin-x64-4.0.0.tgz",
+      "integrity": "sha512-p1XB9IWBIPMvBp7D4QImgk4zFw07aEj5A7mUGBFNKr+Em2xc+EE8aWOarOz2GaRpFUaNbS5TjNLsL7JTWk6kuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Commercial",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/key-linux-arm-gnueabihf": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/key-linux-arm-gnueabihf/-/key-linux-arm-gnueabihf-4.0.0.tgz",
+      "integrity": "sha512-V9PI6UBa5H4PpIv5XgUoKooYlrsXDxQT6bqTT84S8PFrZ2GQM9SrlcE4qrQ+WQj6xF/nDg5xZz2bwhqXHlE2Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Commercial",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/key-linux-arm64-gnu": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/key-linux-arm64-gnu/-/key-linux-arm64-gnu-4.0.0.tgz",
+      "integrity": "sha512-DYy9Q5ss5uoktZ3IA2Top25l3QsFXdXlkHLpD9h6dmqAKy3rAhOlNHaMTTPhvRiC9lemBQl1TQ7xcZeUQA2LWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Commercial",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/key-linux-arm64-musl": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/key-linux-arm64-musl/-/key-linux-arm64-musl-4.0.0.tgz",
+      "integrity": "sha512-UKqaA0tNaqYCNFOAXwdZsozl09eIrLg3JwDu4N3U0Z8NQAQoqfOacDq/23d9D7lO+uR7Umsi7xl5h578MPrTKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Commercial",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nx/key-linux-x64-gnu": {
-      "version": "1.3.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/key-linux-x64-gnu/-/key-linux-x64-gnu-4.0.0.tgz",
+      "integrity": "sha512-RC4FpcJ+72J8NgJnhwx4XyO1xm0zHzZKe3Wz3xg2LAUj/h/RVWJmqiSVcAItZcBk0XNEvJXR9YlKkT615+Y//A==",
       "cpu": [
         "x64"
       ],
@@ -7494,7 +7596,9 @@
       }
     },
     "node_modules/@nx/key-linux-x64-musl": {
-      "version": "1.3.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/key-linux-x64-musl/-/key-linux-x64-musl-4.0.0.tgz",
+      "integrity": "sha512-GNORZAgYLPm1I3sJSLukbBv3ac4ctbN1HsPBPzrSxHJygr6R/AaLGEmCVlhOgl2eD+x47Dqcg5WonuY9nwfl8Q==",
       "cpu": [
         "x64"
       ],
@@ -7508,8 +7612,44 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nx/key-win32-arm64-msvc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/key-win32-arm64-msvc/-/key-win32-arm64-msvc-4.0.0.tgz",
+      "integrity": "sha512-liOMgjzIZbAtePSSpwPER7QIcUTuf883UAFpaQ8v/6w8egysKbJNEOmBk+ANig6/zJ5p6I0S4a7B8J/gUk0tXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Commercial",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nx/key-win32-x64-msvc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/key-win32-x64-msvc/-/key-win32-x64-msvc-4.0.0.tgz",
+      "integrity": "sha512-jfsRGnaWv75JQxO/r8QlllbIHVD/VKaSM4GGEyUmO8aXWRwEB4SIAtlYQSIyLAdkV68qzIPkfJjCGGNWGeFt7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Commercial",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nx/key/node_modules/enquirer": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10184,6 +10324,8 @@
     },
     "node_modules/async": {
       "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
     },
@@ -10328,6 +10470,8 @@
     },
     "node_modules/axios-retry": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13806,6 +13950,8 @@
     },
     "node_modules/ejs": {
       "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15690,6 +15836,8 @@
     },
     "node_modules/filelist": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -15698,6 +15846,8 @@
     },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -18885,6 +19035,8 @@
     },
     "node_modules/is-retry-allowed": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19247,40 +19399,21 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.9.2",
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
+        "async": "^3.2.6",
         "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "jake": "bin/cli.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jasmine": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@graphql-codegen/typescript-apollo-angular": "^4.0.0",
     "@ngrx/schematics": "^20.0.0",
     "@ngrx/store-devtools": "^20.0.0",
-    "@nx/azure-cache": "^1.3.1",
+    "@nx/azure-cache": "^4.0.0",
     "@schematics/angular": "^20.0.0",
     "@stylistic/eslint-plugin": "^2.7.2",
     "@stylistic/stylelint-plugin": "^3.1.1",


### PR DESCRIPTION
Updates the NX Azure cache plugin to the latest major version to resolve potential caching compatibility issues

## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [x] Deps

## Current behavior
A few jobs are failing in CI with unclear errors. I was able to remedy this by disabling the remote cache with --skipRemoteCache.

I was also able to remedy by bumping the package. This leads me to believe there's a bug that was fixed in `@nx/azure-cache`, but I don't see a changelog for the package anywhere.

Fixes: build failures in #4144

## New behavior
new verison.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->