### PR TITLE
refactor(daffio): replace deprecated `@daffodil/design` module imports in why pwa components

### DIFF
--- a/apps/daffio/src/app/content/why-pwa/components/why-pwa-examples/why-pwa-examples.component.ts
+++ b/apps/daffio/src/app/content/why-pwa/components/why-pwa-examples/why-pwa-examples.component.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular/core';
 
 import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
-import { DAFF_CARD_COMPONENTS } from '@daffodil/design/card';
+import { DAFF_STROKED_CARD_COMPONENTS } from '@daffodil/design/card';
 import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 @Component({
@@ -16,7 +16,7 @@ import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
   imports: [
     DAFF_CONTAINER_COMPONENTS,
     DAFF_CALLOUT_COMPONENTS,
-    DAFF_CARD_COMPONENTS,
+    DAFF_STROKED_CARD_COMPONENTS,
   ],
 })
 

--- a/apps/daffio/src/app/content/why-pwa/components/why-pwa-examples/why-pwa-examples.component.ts
+++ b/apps/daffio/src/app/content/why-pwa/components/why-pwa-examples/why-pwa-examples.component.ts
@@ -4,9 +4,9 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DaffCalloutModule } from '@daffodil/design/callout';
-import { DaffCardModule } from '@daffodil/design/card';
-import { DaffContainerModule } from '@daffodil/design/container';
+import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
+import { DAFF_CARD_COMPONENTS } from '@daffodil/design/card';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 @Component({
   selector: 'daffio-why-pwa-examples',
@@ -14,9 +14,9 @@ import { DaffContainerModule } from '@daffodil/design/container';
   styleUrls: ['./why-pwa-examples.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffContainerModule,
-    DaffCalloutModule,
-    DaffCardModule,
+    DAFF_CONTAINER_COMPONENTS,
+    DAFF_CALLOUT_COMPONENTS,
+    DAFF_CARD_COMPONENTS,
   ],
 })
 

--- a/apps/daffio/src/app/content/why-pwa/components/why-pwa-hero/why-pwa-hero.component.ts
+++ b/apps/daffio/src/app/content/why-pwa/components/why-pwa-hero/why-pwa-hero.component.ts
@@ -4,9 +4,9 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DaffButtonModule } from '@daffodil/design/button';
-import { DaffContainerModule } from '@daffodil/design/container';
-import { DaffHeroModule } from '@daffodil/design/hero';
+import { DAFF_BASIC_BUTTON_COMPONENTS } from '@daffodil/design/button';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
+import { DAFF_HERO_COMPONENTS } from '@daffodil/design/hero';
 
 @Component({
   selector: 'daffio-why-pwa-hero',
@@ -14,9 +14,9 @@ import { DaffHeroModule } from '@daffodil/design/hero';
   styleUrls: ['./why-pwa-hero.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffContainerModule,
-    DaffHeroModule,
-    DaffButtonModule,
+    DAFF_CONTAINER_COMPONENTS,
+    DAFF_HERO_COMPONENTS,
+    DAFF_BASIC_BUTTON_COMPONENTS,
   ],
 })
 

--- a/apps/daffio/src/app/content/why-pwa/components/why-pwa-overview/why-pwa-overview.component.ts
+++ b/apps/daffio/src/app/content/why-pwa/components/why-pwa-overview/why-pwa-overview.component.ts
@@ -11,9 +11,9 @@ import {
   faShieldAlt,
 } from '@fortawesome/free-solid-svg-icons';
 
-import { DaffCalloutModule } from '@daffodil/design/callout';
-import { DaffCardModule } from '@daffodil/design/card';
-import { DaffContainerModule } from '@daffodil/design/container';
+import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
+import { DAFF_CARD_COMPONENTS } from '@daffodil/design/card';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 
 
@@ -23,9 +23,9 @@ import { DaffContainerModule } from '@daffodil/design/container';
   styleUrls: ['./why-pwa-overview.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffContainerModule,
-    DaffCalloutModule,
-    DaffCardModule,
+    DAFF_CONTAINER_COMPONENTS,
+    DAFF_CALLOUT_COMPONENTS,
+    DAFF_CARD_COMPONENTS,
     FontAwesomeModule,
   ],
 })

--- a/apps/daffio/src/app/content/why-pwa/components/why-pwa-solution/why-pwa-solution.component.ts
+++ b/apps/daffio/src/app/content/why-pwa/components/why-pwa-solution/why-pwa-solution.component.ts
@@ -4,9 +4,9 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DaffCalloutModule } from '@daffodil/design/callout';
-import { DaffContainerModule } from '@daffodil/design/container';
-import { DaffListModule } from '@daffodil/design/list';
+import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
+import { DAFF_LIST_COMPONENTS } from '@daffodil/design/list';
 
 import { DaffioFeatureComparisonComponent } from '../feature-comparison/feature-comparison.component';
 
@@ -16,9 +16,9 @@ import { DaffioFeatureComparisonComponent } from '../feature-comparison/feature-
   styleUrls: ['./why-pwa-solution.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffContainerModule,
-    DaffCalloutModule,
-    DaffListModule,
+    DAFF_CONTAINER_COMPONENTS,
+    DAFF_CALLOUT_COMPONENTS,
+    DAFF_LIST_COMPONENTS,
     DaffioFeatureComparisonComponent,
   ],
 })

--- a/apps/daffio/src/app/content/why-pwa/components/why-pwa-stats/why-pwa-stats.component.ts
+++ b/apps/daffio/src/app/content/why-pwa/components/why-pwa-stats/why-pwa-stats.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@fortawesome/free-regular-svg-icons';
 
 import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
-import { DAFF_CARD_COMPONENTS } from '@daffodil/design/card';
+import { DAFF_RAISED_CARD_COMPONENTS } from '@daffodil/design/card';
 import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 @Component({
@@ -21,7 +21,7 @@ import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
   imports: [
     DAFF_CONTAINER_COMPONENTS,
     DAFF_CALLOUT_COMPONENTS,
-    DAFF_CARD_COMPONENTS,
+    DAFF_RAISED_CARD_COMPONENTS,
     FontAwesomeModule,
   ],
 })

--- a/apps/daffio/src/app/content/why-pwa/components/why-pwa-stats/why-pwa-stats.component.ts
+++ b/apps/daffio/src/app/content/why-pwa/components/why-pwa-stats/why-pwa-stats.component.ts
@@ -9,9 +9,9 @@ import {
   faFileAlt,
 } from '@fortawesome/free-regular-svg-icons';
 
-import { DaffCalloutModule } from '@daffodil/design/callout';
-import { DaffCardModule } from '@daffodil/design/card';
-import { DaffContainerModule } from '@daffodil/design/container';
+import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
+import { DAFF_CARD_COMPONENTS } from '@daffodil/design/card';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 @Component({
   selector: 'daffio-why-pwa-stats',
@@ -19,9 +19,9 @@ import { DaffContainerModule } from '@daffodil/design/container';
   styleUrls: ['./why-pwa-stats.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    DaffContainerModule,
-    DaffCalloutModule,
-    DaffCardModule,
+    DAFF_CONTAINER_COMPONENTS,
+    DAFF_CALLOUT_COMPONENTS,
+    DAFF_CARD_COMPONENTS,
     FontAwesomeModule,
   ],
 })

--- a/apps/daffio/src/app/content/why-pwa/components/why-pwa-stats/why-pwa-stats.component.ts
+++ b/apps/daffio/src/app/content/why-pwa/components/why-pwa-stats/why-pwa-stats.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@fortawesome/free-regular-svg-icons';
 
 import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
-import { DAFF_RAISED_CARD_COMPONENTS } from '@daffodil/design/card';
+import { DAFF_CARD_COMPONENTS } from '@daffodil/design/card';
 import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 @Component({
@@ -21,7 +21,7 @@ import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
   imports: [
     DAFF_CONTAINER_COMPONENTS,
     DAFF_CALLOUT_COMPONENTS,
-    DAFF_RAISED_CARD_COMPONENTS,
+    DAFF_CARD_COMPONENTS,
     FontAwesomeModule,
   ],
 })


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [x] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4058

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->