### PR TITLE
refactor(daffio): replace deprecated `@daffodil/design` module imports in support components

### DIFF
--- a/apps/daffio/src/app/content/support/support.component.ts
+++ b/apps/daffio/src/app/content/support/support.component.ts
@@ -3,9 +3,9 @@ import {
   Component,
 } from '@angular/core';
 
-import { DaffButtonModule } from '@daffodil/design/button';
-import { DaffContainerModule } from '@daffodil/design/container';
-import { DaffHeroModule } from '@daffodil/design/hero';
+import { DAFF_BASIC_BUTTON_COMPONENTS } from '@daffodil/design/button';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
+import { DAFF_HERO_COMPONENTS } from '@daffodil/design/hero';
 
 @Component({
   selector: 'daffio-support',
@@ -14,9 +14,9 @@ import { DaffHeroModule } from '@daffodil/design/hero';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
-    DaffHeroModule,
-    DaffContainerModule,
-    DaffButtonModule,
+    DAFF_HERO_COMPONENTS,
+    DAFF_CONTAINER_COMPONENTS,
+    DAFF_BASIC_BUTTON_COMPONENTS,
   ],
 })
 export class DaffioSupportComponent {}

--- a/apps/daffio/src/app/content/support/support.component.ts
+++ b/apps/daffio/src/app/content/support/support.component.ts
@@ -3,7 +3,10 @@ import {
   Component,
 } from '@angular/core';
 
-import { DAFF_BASIC_BUTTON_COMPONENTS } from '@daffodil/design/button';
+import {
+  DAFF_BASIC_BUTTON_COMPONENTS,
+  DAFF_STROKED_BUTTON_COMPONENTS,
+} from '@daffodil/design/button';
 import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 import { DAFF_HERO_COMPONENTS } from '@daffodil/design/hero';
 
@@ -17,6 +20,7 @@ import { DAFF_HERO_COMPONENTS } from '@daffodil/design/hero';
     DAFF_HERO_COMPONENTS,
     DAFF_CONTAINER_COMPONENTS,
     DAFF_BASIC_BUTTON_COMPONENTS,
+    DAFF_STROKED_BUTTON_COMPONENTS,
   ],
 })
 export class DaffioSupportComponent {}


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [x] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4058 

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->