### PR TITLE
refactor(daffio): replace deprecated `@daffodil/design` module imports in footer components

### DIFF
--- a/apps/daffio/src/app/core/footer/footer/footer.component.spec.ts
+++ b/apps/daffio/src/app/core/footer/footer/footer.component.spec.ts
@@ -15,7 +15,7 @@ import {
   DaffLogoModule,
   DaffCopyrightModule,
 } from '@daffodil/branding';
-import { DaffContainerModule } from '@daffodil/design/container';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 import { DaffioFooterComponent } from './footer.component';
 
@@ -39,7 +39,7 @@ describe('DaffioFooterComponent', () => {
       imports: [
         DaffioFooterComponent,
         RouterTestingModule,
-        DaffContainerModule,
+        DAFF_CONTAINER_COMPONENTS,
         DaffLogoModule,
         DaffCopyrightModule,
         FontAwesomeModule,

--- a/apps/daffio/src/app/core/footer/footer/footer.component.ts
+++ b/apps/daffio/src/app/core/footer/footer/footer.component.ts
@@ -15,7 +15,7 @@ import {
   DaffCopyrightModule,
   DaffLogoModule,
 } from '@daffodil/branding';
-import { DaffContainerModule } from '@daffodil/design/container';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 @Component({
   selector: 'daffio-footer',
@@ -24,7 +24,7 @@ import { DaffContainerModule } from '@daffodil/design/container';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     FontAwesomeModule,
-    DaffContainerModule,
+    DAFF_CONTAINER_COMPONENTS,
     DaffLogoModule,
     DaffCopyrightModule,
     RouterLink,

--- a/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.ts
+++ b/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.ts
@@ -7,11 +7,12 @@ import {
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import { DAFF_BRANDING_CONSTANTS } from '@daffodil/branding';
-import { DaffButtonModule } from '@daffodil/design/button';
-import { DaffCalloutModule } from '@daffodil/design/callout';
-import { DaffContainerModule } from '@daffodil/design/container';
-
-
+import {
+  DAFF_BASIC_BUTTON_COMPONENTS,
+  DAFF_STROKED_BUTTON_COMPONENTS,
+} from '@daffodil/design/button';
+import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
+import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 
 @Component({
   selector: 'daffio-sub-footer',
@@ -22,9 +23,10 @@ import { DaffContainerModule } from '@daffodil/design/container';
   standalone: true,
   imports: [
     FontAwesomeModule,
-    DaffCalloutModule,
-    DaffContainerModule,
-    DaffButtonModule,
+    DAFF_CALLOUT_COMPONENTS,
+    DAFF_CONTAINER_COMPONENTS,
+    DAFF_BASIC_BUTTON_COMPONENTS,
+    DAFF_STROKED_BUTTON_COMPONENTS,
   ],
 })
 export class DaffioSubFooterComponent {


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [x] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4058 
Part of: # <!-- Keeps issue open -->

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->