### PR TITLE
fix(design): correct `DaffOrientableDirective` orientation input handling

### DIFF
--- a/libs/design/src/core/orientable/orientable.directive.ts
+++ b/libs/design/src/core/orientable/orientable.directive.ts
@@ -14,12 +14,12 @@ import {
   DaffOrientationEnum,
 } from './orientable';
 
-const orientationtValues = (orientationt: string) => (<any>Object).values(DaffOrientationEnum).includes(orientationt);
+const orientationValues = (orientation: string) => (<any>Object).values(DaffOrientationEnum).includes(orientation);
 
-const validateOrientation = (orientationt: string) => {
+const validateOrientation = (orientation: string) => {
   if(isDevMode()) {
-    if(orientationt !== undefined && !orientationtValues(orientationt)) {
-      console.warn(`'${orientationt}' is not a valid value of the orientationt property. The available values are: left, center, or right.`);
+    if(orientation !== undefined && !orientationValues(orientation)) {
+      console.warn(`'${orientation}' is not a valid value of the orientation property. The available values are: left, center, or right.`);
     }
   }
 };
@@ -84,7 +84,7 @@ export class DaffOrientableDirective implements DaffOrientable, OnChanges, OnIni
    *
    * Options are: `horizontal` and `vertical`.
    */
-  @Input() orientation: DaffOrientation = 'vertical';
+  @Input() orientation: DaffOrientation;
 
   /**
    * Sets a default orientation.
@@ -95,11 +95,11 @@ export class DaffOrientableDirective implements DaffOrientable, OnChanges, OnIni
    * @docs-private
    */
   ngOnInit() {
-    validateOrientation(this.orientation);
-
-    if (this.orientation !== this.defaultOrientation && this.defaultOrientation) {
+    if (this.defaultOrientation && !this.orientation) {
       this.orientation = this.defaultOrientation;
     }
+
+    validateOrientation(this.orientation);
   }
 
   /**

--- a/libs/design/src/core/orientable/specs/defaults.spec.ts
+++ b/libs/design/src/core/orientable/specs/defaults.spec.ts
@@ -1,0 +1,65 @@
+import { Component } from '@angular/core';
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+
+import {
+  DaffOrientation,
+  DaffOrientableDirective,
+} from '@daffodil/design';
+
+@Component({
+  template: '',
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'custom-component',
+  hostDirectives: [
+    {
+      directive: DaffOrientableDirective,
+      inputs: ['orientation'],
+    },
+  ],
+})
+
+class WrapperComponent {
+  orientationValue: DaffOrientation;
+
+  constructor(private orientation: DaffOrientableDirective) {
+    this.orientation.defaultOrientation = 'vertical';
+  }
+}
+
+describe('@daffodil/design | DaffOrientableDirective | Default Defined', () => {
+  let wrapper: WrapperComponent;
+  let fixture: ComponentFixture<WrapperComponent>;
+  let directive: DaffOrientableDirective;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        WrapperComponent,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WrapperComponent);
+    wrapper = fixture.componentInstance;
+
+    directive = fixture.debugElement.injector.get(DaffOrientableDirective);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(wrapper).toBeTruthy();
+    expect(directive).toBeTruthy();
+  });
+
+  describe('if a defaultOrientation is defined', () => {
+    it('should set the orientation to the defaultOrientation', () => {
+      expect(directive.orientation).toEqual('vertical');
+    });
+  });
+});

--- a/libs/design/src/core/orientable/specs/defaults.spec.ts
+++ b/libs/design/src/core/orientable/specs/defaults.spec.ts
@@ -1,17 +1,18 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  DebugElement,
+} from '@angular/core';
 import {
   waitForAsync,
   ComponentFixture,
   TestBed,
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 
-import {
-  DaffOrientation,
-  DaffOrientableDirective,
-} from '@daffodil/design';
+import { DaffOrientableDirective } from '@daffodil/design';
 
 @Component({
-  template: '',
+  template: `<div>Test</div>`,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'custom-component',
   hostDirectives: [
@@ -21,45 +22,79 @@ import {
     },
   ],
 })
-
-class WrapperComponent {
-  orientationValue: DaffOrientation;
-
-  constructor(private orientation: DaffOrientableDirective) {
-    this.orientation.defaultOrientation = 'vertical';
+class TestComponent {
+  constructor(public orientationDirective: DaffOrientableDirective) {
+    this.orientationDirective.defaultOrientation = 'vertical';
   }
 }
 
-describe('@daffodil/design | DaffOrientableDirective | Default Defined', () => {
-  let wrapper: WrapperComponent;
-  let fixture: ComponentFixture<WrapperComponent>;
-  let directive: DaffOrientableDirective;
+describe('@daffodil/design | DaffOrientableDirective | Default Status Behavior', () => {
+  describe('when only defaultOrientation is set', () => {
+    let component: TestComponent;
+    let fixture: ComponentFixture<TestComponent>;
+    let directive: DaffOrientableDirective;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        WrapperComponent,
-      ],
-    })
-      .compileComponents();
-  }));
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          TestComponent,
+        ],
+      })
+        .compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(WrapperComponent);
-    wrapper = fixture.componentInstance;
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TestComponent);
+      component = fixture.componentInstance;
+      directive = fixture.debugElement.injector.get(DaffOrientableDirective);
+      fixture.detectChanges();
+    });
 
-    directive = fixture.debugElement.injector.get(DaffOrientableDirective);
-    fixture.detectChanges();
-  });
+    it('should create', () => {
+      expect(component).toBeTruthy();
+      expect(directive).toBeTruthy();
+    });
 
-  it('should create', () => {
-    expect(wrapper).toBeTruthy();
-    expect(directive).toBeTruthy();
-  });
-
-  describe('if a defaultOrientation is defined', () => {
     it('should set the orientation to the defaultOrientation', () => {
       expect(directive.orientation).toEqual('vertical');
+    });
+  });
+
+  describe('when defaultOrientation is set but orientation input is provided', () => {
+    @Component({
+      template: `<custom-component orientation="horizontal"></custom-component>`,
+      imports: [
+        TestComponent,
+      ],
+    })
+    class WrapperComponent {}
+
+    let wrapper: WrapperComponent;
+    let de: DebugElement;
+    let fixture: ComponentFixture<WrapperComponent>;
+
+    beforeEach(waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          WrapperComponent,
+        ],
+      })
+        .compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(WrapperComponent);
+      de = fixture.debugElement.query(By.css('custom-component'));
+      wrapper = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(wrapper).toBeTruthy();
+    });
+
+    it('should set the orientation to the user provided value', () => {
+      expect(de.nativeElement.classList.contains('daff-horizontal')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4168

## New behavior
Fixed by removing the default value from the `@Input()` declaration and correcting the ngOnInit logic to only apply defaultOrientation when no orientation input is provided.

Also fixed a typo: orientationt -> orientation in variable names and error messages.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->