### PR TITLE
feat(content): introduce schema types

### DIFF
--- a/libs/content/guides/schema.md
+++ b/libs/content/guides/schema.md
@@ -30,7 +30,7 @@ interface DaffTextSchema {
 ```typescript
 const textSchema: DaffTextSchema = {
   type: 'textSchema',
-  text: 'This is a paragraph of text.'
+  text: 'This is some text.'
 };
 ```
 

--- a/libs/content/guides/schema.md
+++ b/libs/content/guides/schema.md
@@ -1,0 +1,259 @@
+# Content Schema
+
+The schema system provides a flexible, type-safe way to define content structure in `@daffodil/content`. Schemas are hierarchical definitions that can represent elements, components, and text, allowing you to build complex page layouts programmatically. 
+
+Simply stated, this schema corresponds to a JSON-structure representing HTML.
+
+## Overview
+
+A content schema is a tree structure defined by the type `DaffContentSchema` where each node can be one of three types:
+
+- [**Text Schema**](#text-schema): Represents text nodes
+- [**Element Schema**](#element-schema): Represents HTML elements with attributes and styles
+- [**Component Schema**](#component-schema): Represents Angular components with inputs
+
+## Text Schema
+
+Text schemas represent simple text nodes.
+
+### Interface
+
+```typescript
+interface DaffTextSchema {
+  type: 'textSchema';
+  text: string;
+}
+```
+
+### Example
+
+```typescript
+const textSchema: DaffTextSchema = {
+  type: 'textSchema',
+  text: 'This is a paragraph of text.'
+};
+```
+
+## Element Schema
+
+`DaffContentElementSchema` define HTML elements with optional attributes, styles, and children.
+
+### Example: Basic Element
+
+```typescript
+const divSchema: DaffContentElementSchema = {
+  type: 'elementSchema',
+  element: 'div',
+  attributes: {
+    class: 'container',
+    id: 'main-content'
+  },
+  children: [
+    {
+      type: 'textSchema',
+      text: 'Hello World'
+    }
+  ]
+};
+```
+
+### Example: Responsive Styles
+
+Element schemas support responsive styling through breakpoint definitions:
+
+```typescript
+const heroSchema: DaffContentElementSchema = {
+  type: 'elementSchema',
+  element: 'section',
+  styles: {
+    base: {
+      padding: '20px',
+      backgroundColor: '#f5f5f5',
+      textAlign: 'center'
+    },
+    breakpoints: {
+      '(min-width: 768px)': {
+        padding: '40px'
+      },
+      '(min-width: 1024px)': {
+        padding: '60px',
+        fontSize: '1.5rem'
+      }
+    }
+  },
+  children: [
+    {
+      type: 'elementSchema',
+      element: 'h1',
+      children: [
+        {
+          type: 'textSchema',
+          text: 'Welcome to Our Site'
+        }
+      ]
+    }
+  ]
+};
+```
+
+## Component Schema
+
+`DaffContentComponentSchema` allow you to render Angular components dynamically with specified inputs.
+
+### Example: Component with Inputs
+
+```typescript
+const productCardSchema: DaffContentComponentSchema = {
+  type: 'componentSchema',
+  name: 'ProductCard',
+  inputs: {
+    productId: '12345',
+    showPrice: true,
+    variant: 'compact'
+  }
+};
+```
+
+### Example: Component with Children
+
+```typescript
+const cardSchema: DaffContentComponentSchema = {
+  type: 'componentSchema',
+  name: 'Card',
+  inputs: {
+    title: 'Featured Product',
+    variant: 'elevated'
+  },
+  children: [
+    {
+      type: 'elementSchema',
+      element: 'p',
+      children: [
+        {
+          type: 'textSchema',
+          text: 'Check out our latest offering!'
+        }
+      ]
+    }
+  ]
+};
+```
+
+### Registering Components
+
+Components must be registered to be rendered.
+
+> If the component is not registered, a `br` will be rendered where that component is supposed to be.
+
+```typescript
+
+import {
+  ApplicationConfig,
+} from '@angular/core';
+import { provideDynamicComponent } from '@daffodil/content';
+
+import { ProductCardComponent } from './product-card.component';
+import { CardComponent } from './card.component';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideDynamicComponent({
+      componentType: ProductCardComponent,
+      name: 'ProductCardComponent',
+      description: 'Component for wrapping and styling content',
+    }),
+    provideDynamicComponent({
+      componentType: CardComponent,
+      name: 'CardComponent',
+      description: 'Component for wrapping and styling content',
+    }),
+  ],
+};
+```
+
+## Complex Example
+
+Here's a complete example combining all schema types to create a product feature section:
+
+```typescript
+const featureSectionSchema: DaffContentSchema = {
+  type: 'elementSchema',
+  element: 'section',
+  attributes: {
+    class: 'feature-section'
+  },
+  styles: {
+    base: {
+      padding: '40px 20px',
+      backgroundColor: '#ffffff'
+    },
+    breakpoints: {
+      '(min-width: 768px)': {
+        padding: '80px 40px'
+      }
+    }
+  },
+  children: [
+    {
+      type: 'elementSchema',
+      element: 'div',
+      attributes: {
+        class: 'container'
+      },
+      children: [
+        {
+          type: 'elementSchema',
+          element: 'h2',
+          styles: {
+            base: {
+              fontSize: '2rem',
+              fontWeight: 'bold',
+              marginBottom: '20px',
+              textAlign: 'center'
+            }
+          },
+          children: [
+            {
+              type: 'textSchema',
+              text: 'Featured Products'
+            }
+          ]
+        },
+        {
+          type: 'elementSchema',
+          element: 'div',
+          styles: {
+            base: {
+              display: 'grid',
+              gridTemplateColumns: '1fr',
+              gap: '20px'
+            },
+            breakpoints: {
+              '(min-width: 768px)': {
+                gridTemplateColumns: '1fr 1fr 1fr'
+              }
+            }
+          },
+          children: [
+            {
+              type: 'componentSchema',
+              name: 'ProductCard',
+              inputs: { productId: '1', featured: true }
+            },
+            {
+              type: 'componentSchema',
+              name: 'ProductCard',
+              inputs: { productId: '2', featured: true }
+            },
+            {
+              type: 'componentSchema',
+              name: 'ProductCard',
+              inputs: { productId: '3', featured: true }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+```

--- a/libs/content/guides/schema.md
+++ b/libs/content/guides/schema.md
@@ -139,38 +139,6 @@ const cardSchema: DaffContentComponentSchema = {
 };
 ```
 
-### Registering Components
-
-Components must be registered to be rendered.
-
-> If the component is not registered, a `br` will be rendered where that component is supposed to be.
-
-```typescript
-
-import {
-  ApplicationConfig,
-} from '@angular/core';
-import { provideDynamicComponent } from '@daffodil/content';
-
-import { ProductCardComponent } from './product-card.component';
-import { CardComponent } from './card.component';
-
-export const appConfig: ApplicationConfig = {
-  providers: [
-    provideDynamicComponent({
-      componentType: ProductCardComponent,
-      name: 'ProductCardComponent',
-      description: 'Component for wrapping and styling content',
-    }),
-    provideDynamicComponent({
-      componentType: CardComponent,
-      name: 'CardComponent',
-      description: 'Component for wrapping and styling content',
-    }),
-  ],
-};
-```
-
 ## Complex Example
 
 Here's a complete example combining all schema types to create a product feature section:

--- a/libs/content/guides/schema.md
+++ b/libs/content/guides/schema.md
@@ -6,7 +6,7 @@ Simply stated, this schema corresponds to a JSON-structure representing HTML.
 
 ## Overview
 
-A content schema is a tree structure defined by the type `DaffContentSchema` where each node can be one of three types:
+A content schema is a static tree structure defined by the type `DaffContentSchema` where each node can be one of three types:
 
 - [**Text Schema**](#text-schema): Represents text nodes
 - [**Element Schema**](#element-schema): Represents HTML elements with attributes and styles
@@ -90,6 +90,8 @@ const heroSchema: DaffContentElementSchema = {
 ## Component Schema
 
 `DaffContentComponentSchema` allow you to render Angular components dynamically with specified inputs.
+
+> Schema is designed static. Inputs, as defined by schema, are static properties. Schema does not support functions or callbacks. Downstream schema renderers should be designed so that changes to schema trigger re-renders.
 
 ### Example: Component with Inputs
 

--- a/libs/content/guides/schema.md
+++ b/libs/content/guides/schema.md
@@ -16,15 +16,6 @@ A content schema is a tree structure defined by the type `DaffContentSchema` whe
 
 Text schemas represent simple text nodes.
 
-### Interface
-
-```typescript
-interface DaffTextSchema {
-  type: 'textSchema';
-  text: string;
-}
-```
-
 ### Example
 
 ```typescript

--- a/libs/content/src/models/content-schema.ts
+++ b/libs/content/src/models/content-schema.ts
@@ -1,0 +1,103 @@
+/**
+ * A union type representing all possible content schema nodes.
+ * Can be an element, component, text node, or undefined.
+ */
+export type DaffContentSchema = DaffContentElementSchema | DaffContentComponentSchema | DaffTextSchema | undefined;
+
+/**
+ * Represents a text node in the content schema.
+ *
+ * @example
+ * ```typescript
+ * const textNode: DaffTextSchema = {
+ *   type: 'textSchema',
+ *   text: 'Hello, world!'
+ * };
+ * ```
+ */
+export interface DaffTextSchema {
+  /** Discriminator for text schema nodes. */
+  type: 'textSchema';
+  /** The text content to render. */
+  text: string;
+}
+
+/**
+ * Represents an Angular component in the content schema.
+ * Used to dynamically render components with inputs and optional children.
+ *
+ * @example
+ * ```typescript
+ * const buttonComponent: DaffContentComponentSchema = {
+ *   type: 'componentSchema',
+ *   name: 'DaffButtonComponent',
+ *   inputs: {
+ *     color: 'primary',
+ *     size: 'lg'
+ *   },
+ *   children: [
+ *     { type: 'textSchema', text: 'Click me' }
+ *   ]
+ * };
+ * ```
+ */
+export interface DaffContentComponentSchema {
+  /** Discriminator for component schema nodes. */
+  type: 'componentSchema';
+  /** The component name to render. Must be registered in the component registry. */
+  name: string;
+  /** Key-value pairs of inputs to pass to the component. */
+  inputs: {[key: string]: any};
+  /** Optional child content to project into the component. */
+  children?: DaffContentSchema[];
+}
+
+/**
+ * Represents an HTML element in the content schema.
+ * Used to render native HTML elements with attributes, styles, and children.
+ *
+ * @example
+ * ```typescript
+ * const divElement: DaffContentElementSchema = {
+ *   type: 'elementSchema',
+ *   element: 'div',
+ *   attributes: {
+ *     'class': 'container',
+ *     'id': 'main-content'
+ *   },
+ *   styles: {
+ *     base: {
+ *       padding: 16,
+ *       'background-color': '#f5f5f5'
+ *     },
+ *     breakpoints: {
+ *       '(min-width: 768px': {
+ *         padding: 32
+ *       }
+ *     }
+ *   },
+ *   children: [
+ *     { type: 'textSchema', text: 'Welcome!' }
+ *   ]
+ * };
+ * ```
+ */
+export interface DaffContentElementSchema {
+  /** Discriminator for element schema nodes. */
+  type: 'elementSchema';
+  /** The HTML element tag name (e.g., 'div', 'span', 'section'). */
+  element: string;
+  /** Optional HTML attributes to apply to the element. */
+  attributes?: {[key: string]: string};
+  /** Optional child content to render inside the element. */
+  children?: DaffContentSchema[];
+  /** Optional styles to apply to the element. */
+  styles?: {
+    /** Base styles applied at all viewport sizes. Numeric values are converted to px. */
+    base?: {[key: string]: string | number};
+    /** Responsive styles applied via container queries. */
+    breakpoints?: {
+      [mediaQuery: string]: {[key: string]: string | number};
+    };
+  };
+}

--- a/libs/content/src/models/public_api.ts
+++ b/libs/content/src/models/public_api.ts
@@ -1,3 +1,9 @@
 export { DaffContentBlock } from './block.interface';
 export { DaffContentPage } from './page.interface';
 export { DaffContentBlockCollection } from './collection.interface';
+export {
+  DaffContentSchema,
+  DaffTextSchema,
+  DaffContentElementSchema,
+  DaffContentComponentSchema,
+} from './content-schema';


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, we have no way to render content from ecommerce to Daffodil storefronts beyond simple HTML.

## New behavior
This defines an AST so that we can bring content from these platforms in a structured format without requiring custom elements.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->