### PR TITLE
feat(core): add factory providers to injection token factories

### DIFF
--- a/libs/core/src/injection-tokens/multi.factory.ts
+++ b/libs/core/src/injection-tokens/multi.factory.ts
@@ -31,9 +31,15 @@ export const createMultiInjectionToken = <T = unknown>(
     useValue: value,
     multi: true,
   }));
+  const factoryProvider = <R extends T = T>(...factories: Array<() => R>) => factories.map((factory) => ({
+    provide: token,
+    useFactory: factory,
+    multi: true,
+  }));
 
   return {
     token,
     provider,
+    factoryProvider,
   };
 };

--- a/libs/core/src/injection-tokens/multi.type.ts
+++ b/libs/core/src/injection-tokens/multi.type.ts
@@ -1,4 +1,5 @@
 import {
+  FactoryProvider,
   InjectionToken,
   ValueProvider,
 } from '@angular/core';
@@ -17,4 +18,9 @@ export interface DaffMultiInjectionToken<T = unknown> {
    * A helper function to provide values to the token.
    */
   provider: <R extends T = T>(...values: Array<R>) => Array<ValueProvider>;
+
+  /**
+   * A helper function to provide factories to the token.
+   */
+  factoryProvider: <R extends T = T>(...factories: Array<() => R>) => Array<FactoryProvider>;
 }

--- a/libs/core/src/injection-tokens/single.factory.ts
+++ b/libs/core/src/injection-tokens/single.factory.ts
@@ -20,9 +20,14 @@ export const createSingleInjectionToken = <T = unknown>(
     provide: token,
     useValue: value,
   });
+  const factoryProvider = <R extends T = T>(factory: () => R) => ({
+    provide: token,
+    useFactory: factory,
+  });
 
   return {
     token,
     provider,
+    factoryProvider,
   };
 };

--- a/libs/core/src/injection-tokens/single.type.ts
+++ b/libs/core/src/injection-tokens/single.type.ts
@@ -1,4 +1,5 @@
 import {
+  FactoryProvider,
   InjectionToken,
   ValueProvider,
 } from '@angular/core';
@@ -16,4 +17,9 @@ export interface DaffSingleInjectionToken<T = unknown> {
    * A helper function to provide a value to the token.
    */
   provider: <R extends T = T>(value: R) => ValueProvider;
+
+  /**
+   * A helper function to provide factories to the token.
+   */
+  factoryProvider: <R extends T = T>(factory: () => R) => FactoryProvider;
 }


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## New behavior
<!-- Describe the changes -->
Adds a way to provide single and multi injection values with a factory provider. This eliminates the need to ever provide the token directly (I hope)
## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->