### PR TITLE
fix(design): fix orientable class names in notification component

### DIFF
--- a/apps/design-land/src/app/notification/notification.component.html
+++ b/apps/design-land/src/app/notification/notification.component.html
@@ -21,8 +21,6 @@
 <h3>Actions</h3>
 <p>Buttons can be included in notifications to resolve the notification or navigate them to a page with more information. It can be added by using the <code>daffNotificationActions</code> selector.</p>
 
-<design-land-example-viewer-container example="notification-with-actions"></design-land-example-viewer-container>
-
 <h2>Properties</h2>
 
 <h3>Statuses</h3>

--- a/libs/design/notification/src/notification/notification.component.scss
+++ b/libs/design/notification/src/notification/notification.component.scss
@@ -59,21 +59,21 @@
 	}
 
 	&.dismissible {
-		&.horizontal {
+		&.daff-horizontal {
 			#{$root}__actions {
 				padding: 0.5rem 0;
 			}
 		}
 	}
 
-	&.vertical {
+	&.daff-vertical {
 		#{$root}__body {
 			flex-direction: column;
 			gap: 1rem;
 		}
 	}
 
-	&.horizontal {
+	&.daff-horizontal {
 		.daff-prefix {
 			padding: 0.75rem 0 0.75rem 1rem;
 		}


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
#4133 did not update the notification orientation classes from `&.vertical` and `&.horizontal` to `&.daff-vertical` and `&.daff-horizontal`

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->