### PR TITLE
fix(daffio): fix wrong link in getting started doc

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -60,7 +60,6 @@ NOTE: Raw file sizes do not reflect development server per-request transformatio
 Visit the path in `Local` (e.g., http://localhost:4200) to see your application.
 
 ## Next steps
-
-- [Understanding drivers](./essentials/drivers): Learn how drivers abstract platform differences
+- [Understanding drivers](/docs/guides/essentials/drivers.md): Learn how drivers abstract platform differences
 - [Browse packages](/docs/packages): Add features to your store
 - [Get help on Discord](https://discord.gg/BdaJVZ53sR): Ask questions in the help channel


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [x] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4228

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->