### PR TITLE
feat(daffio): remove `docs` from docs path token

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -236,8 +236,8 @@
               },
               {
                 "glob": "!(search-index)/**/*",
-                "input": "dist/docs-assets/docs",
-                "output": "/assets/daffio/docs"
+                "input": "dist/docs-assets",
+                "output": "/assets/daffio"
               }
             ],
             "styles": [

--- a/apps/daffio/src/app/docs/design/services/index.service.ts
+++ b/apps/daffio/src/app/docs/design/services/index.service.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 
 import {
   DAFF_DOCS_DESIGN_PATH,
+  DAFF_DOCS_PATH,
   DaffDocsDesignGuideNavList,
 } from '@daffodil/docs-utils';
 
@@ -25,6 +26,6 @@ export class DaffioDocsDesignIndexService<T extends DaffDocsDesignGuideNavList =
   ) {}
 
   getList(): Observable<T> {
-    return this.fetchAsset.fetch<T>(`${this.docsPath}/${DAFF_DOCS_DESIGN_PATH}/index.json`, this._key);
+    return this.fetchAsset.fetch<T>(`${this.docsPath}/${DAFF_DOCS_PATH}/${DAFF_DOCS_DESIGN_PATH}/index.json`, this._key);
   }
 }

--- a/apps/daffio/src/app/docs/index/index.service.ts
+++ b/apps/daffio/src/app/docs/index/index.service.ts
@@ -5,6 +5,7 @@ import {
 
 import {
   DAFF_DOC_KIND_PATH_SEGMENT_MAP,
+  DAFF_DOCS_PATH,
   DaffDocKind,
   DaffDocsNavList,
 } from '@daffodil/docs-utils';
@@ -25,6 +26,6 @@ export class DaffioDocsIndexService<T extends DaffDocsNavList = DaffDocsNavList>
 
   getListForKind(kind: DaffDocKind) {
     const path = `${DAFF_DOC_KIND_PATH_SEGMENT_MAP[kind]}/index`;
-    return this.fetchAsset.fetch<T>(`${this.docsPath}/${path}.json`, path);
+    return this.fetchAsset.fetch<T>(`${this.docsPath}/${DAFF_DOCS_PATH}/${path}.json`, path);
   }
 }

--- a/apps/daffio/src/app/docs/services/docs-path-server.ts
+++ b/apps/daffio/src/app/docs/services/docs-path-server.ts
@@ -33,11 +33,11 @@ export function provideServerDocsPath(): Provider {
     provide: DAFFIO_DOCS_PATH_TOKEN,
     useFactory: () => {
       if(isAngularDevServer()) {
-        return resolve(findProjectRoot(import.meta.url), 'dist/docs-assets/docs');
+        return resolve(findProjectRoot(import.meta.url), 'dist/docs-assets');
       }
       //This works so long as chunks are located in the same folder as the default Angular `server.mjs`.
       //If these move, we'll get missing files.
-      return resolve(dirname(fileURLToPath(import.meta.url)), '../browser/assets/daffio/docs');
+      return resolve(dirname(fileURLToPath(import.meta.url)), '../browser/assets/daffio');
     },
   };
 };

--- a/apps/daffio/src/app/docs/services/docs-path.token.ts
+++ b/apps/daffio/src/app/docs/services/docs-path.token.ts
@@ -6,4 +6,4 @@ export const {
    * Provider function for {@link DAFFIO_DOCS_PATH_TOKEN}.
    */
   provider: provideDaffioDocsPath,
-} = createSingleInjectionToken<string>('DAFFIO_DOCS_PATH_TOKEN', { factory: () => '/assets/daffio/docs' });
+} = createSingleInjectionToken<string>('DAFFIO_DOCS_PATH_TOKEN', { factory: () => '/assets/daffio' });

--- a/apps/daffio/src/app/docs/services/docs.service.ts
+++ b/apps/daffio/src/app/docs/services/docs.service.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 
 import {
   crossOsFilename,
+  DAFF_DOCS_PATH,
   DaffDoc,
 } from '@daffodil/docs-utils';
 
@@ -28,6 +29,6 @@ export class DaffioDocsService implements DaffioDocsServiceInterface {
 
   get<T extends DaffDoc = DaffDoc>(path: string): Observable<T> {
     path = getSafePath(path);
-    return this.fetchAsset.fetch<T>(`${this.docsPath}/${crossOsFilename(path)}.json`, path);
+    return this.fetchAsset.fetch<T>(`${this.docsPath}/${DAFF_DOCS_PATH}/${crossOsFilename(path)}.json`, path);
   }
 }

--- a/tools/dgeni/build.ts
+++ b/tools/dgeni/build.ts
@@ -14,7 +14,7 @@ import {
 } from './src/transforms/daffodil-guides-package';
 import { daffodilRoutesPackage } from './src/transforms/daffodil-routes-package';
 
-rimraf('../../dist/docs-assets/*', { glob: true }).then(() => {
+rimraf('../../dist/docs-assets/docs/*', { glob: true }).then(() => {
   new Dgeni([apiDocs]).generate().then(() => {
     // base docs
     Promise.all([


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Only files in `/dist/docs-assets/docs` can be included

## New behavior
`/dist/docs-assets/sassdoc` can be included

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->