### PR TITLE
feat(design): Prevent article encapsulated components from including code copy button

### DIFF
--- a/libs/design/article/src/article-copy-button/service/copy-button.service.spec.ts
+++ b/libs/design/article/src/article-copy-button/service/copy-button.service.spec.ts
@@ -100,6 +100,29 @@ describe('@daffodil/design/article | DaffArticleCopyButtonService', () => {
 
       expect(mockViewContainerRef.createComponent).toHaveBeenCalledTimes(2);
     });
+
+    it('should skip pre elements inside article-encapsulated elements', () => {
+      hostElement.innerHTML = `
+        <pre><code>Should get button</code></pre>
+        <div class="daff-ae">
+          <pre><code>Should be skipped</code></pre>
+          <div>
+            <pre><code>Should be skipped</code></pre>
+          </div>
+        </div>
+        <pre><code>Should also get button</code></pre>
+      `;
+
+      mockViewContainerRef.createComponent.and.returnValue(<any>{
+        setInput: jasmine.createSpy('setInput'),
+        location: {
+          nativeElement: document.createElement('daff-article-copy-button'),
+        },
+      });
+
+      service.addCopyButtonsToCodeBlocks(hostElement, mockViewContainerRef);
+      expect(mockViewContainerRef.createComponent).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('cleanup', () => {

--- a/libs/design/article/src/article-copy-button/service/copy-button.service.ts
+++ b/libs/design/article/src/article-copy-button/service/copy-button.service.ts
@@ -26,6 +26,7 @@ export class DaffArticleCopyButtonService {
     viewContainerRef: ViewContainerRef,
   ): void {
     const codeBlocks = hostElement.querySelectorAll('pre');
+    const encapsulatedElements = Array.from(hostElement.querySelectorAll('.daff-ae'));
 
     codeBlocks.forEach((pre: HTMLPreElement) => {
       const code = pre.querySelector('code');
@@ -35,6 +36,11 @@ export class DaffArticleCopyButtonService {
 
       // Skip if nocopy attribute is present
       if (pre.hasAttribute('nocopy')) {
+        return;
+      }
+
+      // Skip if inside an article-encapsulated component
+      if (encapsulatedElements.some(ee => ee.contains(pre))) {
         return;
       }
 


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4275 

## New behavior
<!-- Describe the changes -->
Copy buttons are not added to `pre` elements in article encapsulated components

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->