### PR TITLE
refactor: Replace caching logic with `defaultMemoize` for selector factories

### DIFF
--- a/libs/auth/state/src/selectors/auth-all.selector.ts
+++ b/libs/auth/state/src/selectors/auth-all.selector.ts
@@ -1,4 +1,7 @@
-import { MemoizedSelector } from '@ngrx/store';
+import {
+  MemoizedSelector,
+  defaultMemoize,
+} from '@ngrx/store';
 
 import {
   daffAuthSelectorFactory,
@@ -27,14 +30,10 @@ export interface DaffAuthSelectors extends
   selectAuthFeatureState: MemoizedSelector<Record<string, any>, DaffAuthFeatureState>;
 }
 
-export const getDaffAuthSelectors = (() => {
-  let cache;
-  return (): DaffAuthSelectors =>
-    cache = cache || {
-      ...daffAuthSelectorFactory(),
-      ...daffAuthLoginSelectorFactory(),
-      ...daffAuthRegisterSelectorFactory(),
-      ...daffAuthResetPasswordSelectorFactory(),
-      selectAuthFeatureState: getDaffAuthFeatureStateSelector(),
-    };
-})();
+export const getDaffAuthSelectors: () => DaffAuthSelectors = defaultMemoize(() => ({
+  ...daffAuthSelectorFactory(),
+  ...daffAuthLoginSelectorFactory(),
+  ...daffAuthRegisterSelectorFactory(),
+  ...daffAuthResetPasswordSelectorFactory(),
+  selectAuthFeatureState: getDaffAuthFeatureStateSelector(),
+})).memoized;

--- a/libs/auth/state/src/selectors/auth-feature.selector.ts
+++ b/libs/auth/state/src/selectors/auth-feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -11,8 +12,4 @@ import {
 /**
  * Feature State Selector
  */
-export const getDaffAuthFeatureStateSelector = (() => {
-  let cache;
-  return (): MemoizedSelector<Record<string, any>, DaffAuthFeatureState> =>
-    cache = cache || createFeatureSelector<DaffAuthFeatureState>(DAFF_AUTH_STORE_FEATURE_KEY);
-})();
+export const getDaffAuthFeatureStateSelector: () => MemoizedSelector<Record<string, any>, DaffAuthFeatureState> = defaultMemoize(() => createFeatureSelector<DaffAuthFeatureState>(DAFF_AUTH_STORE_FEATURE_KEY)).memoized;

--- a/libs/auth/state/src/selectors/auth/auth.selector.ts
+++ b/libs/auth/state/src/selectors/auth/auth.selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -37,8 +38,4 @@ const createAuthSelectors = () => {
   };
 };
 
-export const daffAuthSelectorFactory = (() => {
-  let cache;
-  return (): AuthSelectors =>
-    cache = cache || createAuthSelectors();
-})();
+export const daffAuthSelectorFactory: () => AuthSelectors = defaultMemoize(() => createAuthSelectors()).memoized;

--- a/libs/auth/state/src/selectors/login/login.selector.ts
+++ b/libs/auth/state/src/selectors/login/login.selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -31,8 +32,4 @@ const createLoginSelectors = () => {
   };
 };
 
-export const daffAuthLoginSelectorFactory = (() => {
-  let cache;
-  return (): DaffAuthLoginSelectors =>
-    cache = cache || createLoginSelectors();
-})();
+export const daffAuthLoginSelectorFactory: () => DaffAuthLoginSelectors = defaultMemoize(() => createLoginSelectors()).memoized;

--- a/libs/auth/state/src/selectors/register/register.selector.ts
+++ b/libs/auth/state/src/selectors/register/register.selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -30,8 +31,4 @@ const createRegisterSelectors = () => {
   };
 };
 
-export const daffAuthRegisterSelectorFactory = (() => {
-  let cache;
-  return (): DaffAuthRegisterSelectors =>
-    cache = cache || createRegisterSelectors();
-})();
+export const daffAuthRegisterSelectorFactory: () => DaffAuthRegisterSelectors = defaultMemoize(() => createRegisterSelectors()).memoized;

--- a/libs/auth/state/src/selectors/reset-password/selector.ts
+++ b/libs/auth/state/src/selectors/reset-password/selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffAuthResetPasswordInfo } from '@daffodil/auth';
@@ -38,8 +39,4 @@ const createResetPasswordSelectors = (): DaffAuthResetPasswordSelectors => {
   };
 };
 
-export const daffAuthResetPasswordSelectorFactory = (() => {
-  let cache;
-  return (): DaffAuthResetPasswordSelectors =>
-    cache = cache || createResetPasswordSelectors();
-})();
+export const daffAuthResetPasswordSelectorFactory: () => DaffAuthResetPasswordSelectors = defaultMemoize(() => createResetPasswordSelectors()).memoized;

--- a/libs/authorizenet/state/src/selectors/authorize-net.selector.ts
+++ b/libs/authorizenet/state/src/selectors/authorize-net.selector.ts
@@ -2,6 +2,7 @@ import {
   createSelector,
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffStateError } from '@daffodil/core/state';
@@ -80,9 +81,4 @@ const createAuthorizeNetSelectors = (): DaffAuthorizeNetMemoizedSelectors => {
   };
 };
 
-export const daffAuthorizeNetSelectors = (() => {
-  let cache;
-  return (): DaffAuthorizeNetMemoizedSelectors => cache = cache
-    ? cache
-    : createAuthorizeNetSelectors();
-})();
+export const daffAuthorizeNetSelectors: () => DaffAuthorizeNetMemoizedSelectors = defaultMemoize(() => createAuthorizeNetSelectors()).memoized;

--- a/libs/cart-store-credit/state/src/selectors/feature.selector.ts
+++ b/libs/cart-store-credit/state/src/selectors/feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -16,10 +17,6 @@ export interface DaffCartStoreCreditFeatureSelector {
   selectCustomerStoreCreditFeatureState: MemoizedSelector<DaffCartStoreCreditStateRootSlice, DaffCartStoreCreditReducersState>;
 }
 
-export const getDaffCartStoreCreditReducersStateSelector = (() => {
-  let cache;
-  return (): DaffCartStoreCreditFeatureSelector =>
-    cache = cache || {
-      selectCustomerStoreCreditFeatureState: createFeatureSelector<DaffCartStoreCreditReducersState>(DAFF_CART_STORE_CREDIT_STORE_FEATURE_KEY),
-    };
-})();
+export const getDaffCartStoreCreditReducersStateSelector: () => DaffCartStoreCreditFeatureSelector = defaultMemoize(() => ({
+  selectCustomerStoreCreditFeatureState: createFeatureSelector<DaffCartStoreCreditReducersState>(DAFF_CART_STORE_CREDIT_STORE_FEATURE_KEY),
+})).memoized;

--- a/libs/cart-store-credit/state/src/selectors/store-credit/selector.ts
+++ b/libs/cart-store-credit/state/src/selectors/store-credit/selector.ts
@@ -1,4 +1,7 @@
-import { createSelector } from '@ngrx/store';
+import {
+  createSelector,
+  defaultMemoize,
+} from '@ngrx/store';
 
 import {
   daffOperationStateSelectorFactory,
@@ -29,9 +32,5 @@ const daffCartStoreCreditCreateSelectors = (): DaffCartStoreCreditSelectors => {
   return daffOperationStateSelectorFactory(selectCustomerStoreCreditState);
 };
 
-export const daffCartStoreCreditGetSelectors = (() => {
-  let cache;
-  return (): DaffCartStoreCreditSelectors =>
-    cache = cache || daffCartStoreCreditCreateSelectors();
-})();
+export const daffCartStoreCreditGetSelectors: () => DaffCartStoreCreditSelectors = defaultMemoize(() => daffCartStoreCreditCreateSelectors()).memoized;
 

--- a/libs/cart/state/src/selectors/cart-feature.selector.ts
+++ b/libs/cart/state/src/selectors/cart-feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -21,15 +22,13 @@ export interface DaffCartFeatureMemoizedSelectors<
   selectCartFeatureState: MemoizedSelector<DaffCartStateRootSlice<T, V>, DaffCartReducersState<T, V>>;
 }
 
-export const getDaffCartFeatureSelector = (() => {
-  let cache;
-  return <
-    T extends DaffCart = DaffCart,
-    V extends DaffCartOrderResult = DaffCartOrderResult,
-  >(): DaffCartFeatureMemoizedSelectors<T, V> => cache = cache
-    ? cache
-    : {
-      selectCartFeatureState:
-        createFeatureSelector<DaffCartStateRootSlice<T, V>, DaffCartReducersState<T, V>>(DAFF_CART_STORE_FEATURE_KEY),
-    };
-})();
+export const getDaffCartFeatureSelector: <
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult,
+>() => DaffCartFeatureMemoizedSelectors<T, V> = defaultMemoize(<
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult,
+>() => ({
+  selectCartFeatureState:
+    createFeatureSelector<DaffCartStateRootSlice<T, V>, DaffCartReducersState<T, V>>(DAFF_CART_STORE_FEATURE_KEY),
+})).memoized;

--- a/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.ts
+++ b/libs/cart/state/src/selectors/cart-item-entities/cart-item-entities.selectors.ts
@@ -176,12 +176,10 @@ const createCartItemEntitiesSelectors = <
   };
 };
 
-export const getDaffCartItemEntitiesSelectors = (() => {
-  let cache;
-  return <
-    T extends DaffCart = DaffCart,
-    V extends DaffCartOrderResult = DaffCartOrderResult,
-  >(): DaffCartItemEntitiesMemoizedSelectors<T, V> => cache = cache
-    ? cache
-    : createCartItemEntitiesSelectors<T, V>();
-})();
+export const getDaffCartItemEntitiesSelectors: <
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult,
+>() => DaffCartItemEntitiesMemoizedSelectors<T, V> = defaultMemoize(<
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult,
+>() => createCartItemEntitiesSelectors<T, V>()).memoized;

--- a/libs/cart/state/src/selectors/cart-order/cart-order.selector.ts
+++ b/libs/cart/state/src/selectors/cart-order/cart-order.selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -89,12 +90,10 @@ const createCartOrderSelectors = <
   };
 };
 
-export const getCartOrderSelectors = (() => {
-  let cache;
-  return <
-    T extends DaffCart = DaffCart,
-    V extends DaffCartOrderResult = DaffCartOrderResult,
-  >(): DaffCartOrderMemoizedSelectors<T, V> => cache = cache
-    ? cache
-    : createCartOrderSelectors<T, V>();
-})();
+export const getCartOrderSelectors: <
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult,
+>() => DaffCartOrderMemoizedSelectors<T, V> = defaultMemoize(<
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult,
+>() => createCartOrderSelectors<T, V>()).memoized;

--- a/libs/cart/state/src/selectors/cart.selector.ts
+++ b/libs/cart/state/src/selectors/cart.selector.ts
@@ -1,3 +1,5 @@
+import { defaultMemoize } from '@ngrx/store';
+
 import {
   DaffCart,
   DaffCartOrderResult,
@@ -38,12 +40,10 @@ const createCartSelectors = <
   ...getDaffCartItemEntitiesSelectors<T, V>(),
 });
 
-export const getDaffCartSelectors = (() => {
-  let cache;
-  return <
-    T extends DaffCart = DaffCart,
-    V extends DaffCartOrderResult = DaffCartOrderResult,
-  >(): DaffCartMemoizedSelectors<T, V> => cache = cache
-    ? cache
-    : createCartSelectors<T, V>();
-})();
+export const getDaffCartSelectors: <
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult,
+>() => DaffCartMemoizedSelectors<T, V> = defaultMemoize(<
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult,
+>() => createCartSelectors<T, V>()).memoized;

--- a/libs/cart/state/src/selectors/cart/cart.selector.ts
+++ b/libs/cart/state/src/selectors/cart/cart.selector.ts
@@ -2,6 +2,7 @@ import {
   createSelector,
   MemoizedSelector,
   DefaultProjectorFn,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -557,12 +558,10 @@ const createCartSelectors = <
   };
 };
 
-export const getCartSelectors = (() => {
-  let cache;
-  return <
-    T extends DaffCart = DaffCart,
-    V extends DaffCartOrderResult = DaffCartOrderResult,
-  >(): DaffCartStateMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createCartSelectors<T, V>();
-})();
+export const getCartSelectors: <
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult,
+>() => DaffCartStateMemoizedSelectors<T> = defaultMemoize(<
+  T extends DaffCart = DaffCart,
+  V extends DaffCartOrderResult = DaffCartOrderResult,
+>() => createCartSelectors<T, V>()).memoized;

--- a/libs/category/state/src/selectors/category-entities/category-entities.selector.ts
+++ b/libs/category/state/src/selectors/category-entities/category-entities.selector.ts
@@ -5,6 +5,7 @@ import {
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -85,9 +86,4 @@ const createCategoryFeatureSelectors = <V extends DaffGenericCategory<V>>(): Daf
 /**
  * A function that returns all selectors related to category entities.
  */
-export const getDaffCategoryEntitiesSelectors = (() => {
-  let cache;
-  return <V extends DaffGenericCategory<V>>(): DaffCategoryEntitiesMemoizedSelectors<V> => cache = cache
-    ? cache
-    : createCategoryFeatureSelectors<V>();
-})();
+export const getDaffCategoryEntitiesSelectors: <V extends DaffGenericCategory<V>>() => DaffCategoryEntitiesMemoizedSelectors<V> = defaultMemoize(<V extends DaffGenericCategory<V>>() => createCategoryFeatureSelectors<V>()).memoized;

--- a/libs/category/state/src/selectors/category-feature.selector.ts
+++ b/libs/category/state/src/selectors/category-feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -26,9 +27,4 @@ export interface DaffCategoryFeatureMemoizedSelectors<
 /**
  * A function that returns a selector for the entire category feature state.
  */
-export const getDaffCategoryFeatureSelector = (() => {
-  let cache;
-  return <V extends DaffGenericCategory<V>>(): DaffCategoryFeatureMemoizedSelectors<V> => cache = cache
-    ? cache
-    : { selectCategoryFeatureState: createFeatureSelector<DaffCategoryStateRootSlice<V>,DaffCategoryReducersState<V>>(DAFF_CATEGORY_STORE_FEATURE_KEY) };
-})();
+export const getDaffCategoryFeatureSelector: <V extends DaffGenericCategory<V>>() => DaffCategoryFeatureMemoizedSelectors<V> = defaultMemoize(<V extends DaffGenericCategory<V>>() => ({ selectCategoryFeatureState: createFeatureSelector<DaffCategoryStateRootSlice<V>,DaffCategoryReducersState<V>>(DAFF_CATEGORY_STORE_FEATURE_KEY) })).memoized;

--- a/libs/category/state/src/selectors/category-page/category-page.selector.ts
+++ b/libs/category/state/src/selectors/category-page/category-page.selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -86,9 +87,4 @@ const createCategoryPageSelectors = <V extends DaffGenericCategory<V>>(): DaffCa
  * A function that returns all selectors related to the category page metadata, category loading, and errors.
  * Returns {@link DaffCategoryPageMemoizedSelectors}.
  */
-export const getDaffCategoryPageSelectors = (() => {
-  let cache;
-  return <V extends DaffGenericCategory<V>>(): DaffCategoryPageMemoizedSelectors<V> => cache = cache
-    ? cache
-    : createCategoryPageSelectors<V>();
-})();
+export const getDaffCategoryPageSelectors: <V extends DaffGenericCategory<V>>() => DaffCategoryPageMemoizedSelectors<V> = defaultMemoize(<V extends DaffGenericCategory<V>>() => createCategoryPageSelectors<V>()).memoized;

--- a/libs/category/state/src/selectors/category.selector.ts
+++ b/libs/category/state/src/selectors/category.selector.ts
@@ -129,12 +129,10 @@ const createCategorySelectors = <V extends DaffGenericCategory<V>, W extends Daf
 /**
  * A function that returns all combinatoric category selectors.
  */
-export const getDaffCategorySelectors = (() => {
-  let cache;
-  return <
-    V extends DaffGenericCategory<V> = DaffCategory,
-    W extends DaffProduct = DaffProduct
-  >(): DaffCategoryMemoizedSelectors<V, W> => cache = cache
-    ? cache
-    : createCategorySelectors<V, W>();
-})();
+export const getDaffCategorySelectors: <
+  V extends DaffGenericCategory<V> = DaffCategory,
+  W extends DaffProduct = DaffProduct
+>() => DaffCategoryMemoizedSelectors<V, W> = defaultMemoize(<
+  V extends DaffGenericCategory<V> = DaffCategory,
+  W extends DaffProduct = DaffProduct
+>() => createCategorySelectors<V, W>()).memoized;

--- a/libs/category/state/src/selectors/collection/selectors.ts
+++ b/libs/category/state/src/selectors/collection/selectors.ts
@@ -1,4 +1,7 @@
-import { createSelector } from '@ngrx/store';
+import {
+  createSelector,
+  defaultMemoize,
+} from '@ngrx/store';
 
 import { DaffCategoryPageMetadata } from '@daffodil/category';
 import {
@@ -20,8 +23,4 @@ const selectCategoryProductCollectionState = createSelector(
   state => state.pageMetadata,
 );
 
-export const getCategoryProductCollectionSelectors = (() => {
-  let cache;
-  return (): DaffCategoryPageProductCollectionSelectors =>
-    cache = cache || daffCollectionSelectorFactory<DaffCategoryStateRootSlice, DaffCategoryPageMetadata>(selectCategoryProductCollectionState);
-})();
+export const getCategoryProductCollectionSelectors: () => DaffCategoryPageProductCollectionSelectors = defaultMemoize(() => daffCollectionSelectorFactory<DaffCategoryStateRootSlice, DaffCategoryPageMetadata>(selectCategoryProductCollectionState)).memoized;

--- a/libs/checkout/state/src/selectors/checkout-all.selector.ts
+++ b/libs/checkout/state/src/selectors/checkout-all.selector.ts
@@ -1,3 +1,5 @@
+import { defaultMemoize } from '@ngrx/store';
+
 import { DaffOrder } from '@daffodil/order';
 
 import {
@@ -10,10 +12,6 @@ export type DaffCheckoutSelectors<T extends DaffOrder = DaffOrder> = DaffCheckou
 /**
  * Gets all of `@daffodil/checkout/state` selectors.
  */
-export const getDaffCheckoutSelectors = (() => {
-  let cache;
-  return <T extends DaffOrder = DaffOrder>(): DaffCheckoutSelectors<T> =>
-    cache = cache || {
-      ...getCheckoutPlacedOrderSelectors<T>(),
-    };
-})();
+export const getDaffCheckoutSelectors: <T extends DaffOrder = DaffOrder>() => DaffCheckoutSelectors<T> = defaultMemoize(<T extends DaffOrder = DaffOrder>() => ({
+  ...getCheckoutPlacedOrderSelectors<T>(),
+})).memoized;

--- a/libs/checkout/state/src/selectors/placed-order.selector.ts
+++ b/libs/checkout/state/src/selectors/placed-order.selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { getDaffCartSelectors } from '@daffodil/cart/state';
@@ -47,8 +48,4 @@ const createCheckoutPlacedOrderSelectors = <T extends DaffOrder = DaffOrder>(): 
 /**
  * Gets the placed order selectors.
  */
-export const getCheckoutPlacedOrderSelectors = (() => {
-  let cache;
-  return <T extends DaffOrder = DaffOrder>(): DaffCheckoutPlacedOrderSelectors<T> =>
-    cache = cache || createCheckoutPlacedOrderSelectors<T>();
-})();
+export const getCheckoutPlacedOrderSelectors: <T extends DaffOrder = DaffOrder>() => DaffCheckoutPlacedOrderSelectors<T> = defaultMemoize(<T extends DaffOrder = DaffOrder>() => createCheckoutPlacedOrderSelectors<T>()).memoized;

--- a/libs/customer-payment/state/src/selectors/feature.selector.ts
+++ b/libs/customer-payment/state/src/selectors/feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffCustomerPayment } from '@daffodil/customer-payment';
@@ -20,10 +21,6 @@ export interface DaffCustomerPaymentFeatureSelector<
   selectCustomerPaymentFeatureState: MemoizedSelector<DaffCustomerPaymentStateRootSlice<TPayment>, DaffCustomerPaymentReducersState<TPayment>>;
 }
 
-export const getDaffCustomerPaymentReducersStateSelector = (() => {
-  let cache;
-  return <TPayment extends DaffCustomerPayment = DaffCustomerPayment>(): DaffCustomerPaymentFeatureSelector<TPayment> =>
-    cache = cache || {
-      selectCustomerPaymentFeatureState: createFeatureSelector<DaffCustomerPaymentReducersState<TPayment>>(DAFF_CUSTOMER_PAYMENT_STORE_FEATURE_KEY),
-    };
-})();
+export const getDaffCustomerPaymentReducersStateSelector: <TPayment extends DaffCustomerPayment = DaffCustomerPayment>() => DaffCustomerPaymentFeatureSelector<TPayment> = defaultMemoize(<TPayment extends DaffCustomerPayment = DaffCustomerPayment>() => ({
+  selectCustomerPaymentFeatureState: createFeatureSelector<DaffCustomerPaymentReducersState<TPayment>>(DAFF_CUSTOMER_PAYMENT_STORE_FEATURE_KEY),
+})).memoized;

--- a/libs/customer-payment/state/src/selectors/payment/selector.ts
+++ b/libs/customer-payment/state/src/selectors/payment/selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -56,9 +57,5 @@ const daffCustomerPaymentCreateSelectors = <T extends DaffCustomerPayment = Daff
   };
 };
 
-export const daffCustomerPaymentGetSelectors = (() => {
-  let cache;
-  return <T extends DaffCustomerPayment = DaffCustomerPayment>(): DaffCustomerPaymentSelectors<T> =>
-    cache = cache || daffCustomerPaymentCreateSelectors<T>();
-})();
+export const daffCustomerPaymentGetSelectors: <T extends DaffCustomerPayment = DaffCustomerPayment>() => DaffCustomerPaymentSelectors<T> = defaultMemoize(<T extends DaffCustomerPayment = DaffCustomerPayment>() => daffCustomerPaymentCreateSelectors<T>()).memoized;
 

--- a/libs/customer-store-credit/state/src/selectors/feature.selector.ts
+++ b/libs/customer-store-credit/state/src/selectors/feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffCustomerStoreCredit } from '@daffodil/customer-store-credit';
@@ -20,10 +21,6 @@ export interface DaffCustomerStoreCreditFeatureSelector<
   selectCustomerStoreCreditFeatureState: MemoizedSelector<DaffCustomerStoreCreditStateRootSlice<TStoreCredit>, DaffCustomerStoreCreditReducersState<TStoreCredit>>;
 }
 
-export const getDaffCustomerStoreCreditReducersStateSelector = (() => {
-  let cache;
-  return <TStoreCredit extends DaffCustomerStoreCredit = DaffCustomerStoreCredit>(): DaffCustomerStoreCreditFeatureSelector<TStoreCredit> =>
-    cache = cache || {
-      selectCustomerStoreCreditFeatureState: createFeatureSelector<DaffCustomerStoreCreditReducersState<TStoreCredit>>(DAFF_CUSTOMER_STORE_CREDIT_STORE_FEATURE_KEY),
-    };
-})();
+export const getDaffCustomerStoreCreditReducersStateSelector: <TStoreCredit extends DaffCustomerStoreCredit = DaffCustomerStoreCredit>() => DaffCustomerStoreCreditFeatureSelector<TStoreCredit> = defaultMemoize(<TStoreCredit extends DaffCustomerStoreCredit = DaffCustomerStoreCredit>() => ({
+  selectCustomerStoreCreditFeatureState: createFeatureSelector<DaffCustomerStoreCreditReducersState<TStoreCredit>>(DAFF_CUSTOMER_STORE_CREDIT_STORE_FEATURE_KEY),
+})).memoized;

--- a/libs/customer-store-credit/state/src/selectors/store-credit/selector.ts
+++ b/libs/customer-store-credit/state/src/selectors/store-credit/selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -45,9 +46,5 @@ const daffCustomerStoreCreditCreateSelectors = <T extends DaffCustomerStoreCredi
   };
 };
 
-export const daffCustomerStoreCreditGetSelectors = (() => {
-  let cache;
-  return <T extends DaffCustomerStoreCredit = DaffCustomerStoreCredit>(): DaffCustomerStoreCreditSelectors<T> =>
-    cache = cache || daffCustomerStoreCreditCreateSelectors<T>();
-})();
+export const daffCustomerStoreCreditGetSelectors: <T extends DaffCustomerStoreCredit = DaffCustomerStoreCredit>() => DaffCustomerStoreCreditSelectors<T> = defaultMemoize(<T extends DaffCustomerStoreCredit = DaffCustomerStoreCredit>() => daffCustomerStoreCreditCreateSelectors<T>()).memoized;
 

--- a/libs/customer/state/src/selectors/address/selector.ts
+++ b/libs/customer/state/src/selectors/address/selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -55,9 +56,5 @@ const daffCustomerAddressCreateSelectors = <T extends DaffCustomerAddress = Daff
   };
 };
 
-export const daffCustomerAddressGetSelectors = (() => {
-  let cache;
-  return <T extends DaffCustomerAddress = DaffCustomerAddress>(): DaffCustomerAddressSelectors<T> =>
-    cache = cache || daffCustomerAddressCreateSelectors<T>();
-})();
+export const daffCustomerAddressGetSelectors: <T extends DaffCustomerAddress = DaffCustomerAddress>() => DaffCustomerAddressSelectors<T> = defaultMemoize(<T extends DaffCustomerAddress = DaffCustomerAddress>() => daffCustomerAddressCreateSelectors<T>()).memoized;
 

--- a/libs/customer/state/src/selectors/customer/selector.ts
+++ b/libs/customer/state/src/selectors/customer/selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -47,9 +48,5 @@ const daffCustomerCreateSelectors = <T extends DaffCustomer = DaffCustomer>(): D
 };
 
 
-export const daffCustomerGetSelectors = (() => {
-  let cache;
-  return <T extends DaffCustomer = DaffCustomer>(): DaffCustomerSelectors<T> =>
-    cache = cache || daffCustomerCreateSelectors<T>();
-})();
+export const daffCustomerGetSelectors: <T extends DaffCustomer = DaffCustomer>() => DaffCustomerSelectors<T> = defaultMemoize(<T extends DaffCustomer = DaffCustomer>() => daffCustomerCreateSelectors<T>()).memoized;
 

--- a/libs/customer/state/src/selectors/feature.selector.ts
+++ b/libs/customer/state/src/selectors/feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -24,10 +25,6 @@ export interface DaffCustomerFeatureSelector<
   selectCustomerFeatureState: MemoizedSelector<DaffCustomerStateRootSlice<TCustomer, TAddress>, DaffCustomerReducersState<TCustomer, TAddress>>;
 }
 
-export const getDaffCustomerReducersStateSelector = (() => {
-  let cache;
-  return <TCustomer extends DaffCustomer = DaffCustomer, TAddress extends DaffCustomerAddress = DaffCustomerAddress>(): DaffCustomerFeatureSelector<TCustomer, TAddress> =>
-    cache = cache || {
-      selectCustomerFeatureState: createFeatureSelector<DaffCustomerReducersState<TCustomer, TAddress>>(DAFF_CUSTOMER_STORE_FEATURE_KEY),
-    };
-})();
+export const getDaffCustomerReducersStateSelector: <TCustomer extends DaffCustomer = DaffCustomer, TAddress extends DaffCustomerAddress = DaffCustomerAddress>() => DaffCustomerFeatureSelector<TCustomer, TAddress> = defaultMemoize(<TCustomer extends DaffCustomer = DaffCustomer, TAddress extends DaffCustomerAddress = DaffCustomerAddress>() => ({
+  selectCustomerFeatureState: createFeatureSelector<DaffCustomerReducersState<TCustomer, TAddress>>(DAFF_CUSTOMER_STORE_FEATURE_KEY),
+})).memoized;

--- a/libs/geography/state/src/selectors/country-entities.selector.ts
+++ b/libs/geography/state/src/selectors/country-entities.selector.ts
@@ -82,9 +82,5 @@ const createCountryEntitySelectors = <T extends DaffCountry = DaffCountry>() => 
   };
 };
 
-export const getDaffCountryEntitySelectors = (() => {
-  let cache;
-  return <T extends DaffCountry>(): DaffCountryEntitySelectors<T> =>
-    cache = cache || createCountryEntitySelectors<T>();
-})();
+export const getDaffCountryEntitySelectors: <T extends DaffCountry>() => DaffCountryEntitySelectors<T> = defaultMemoize(<T extends DaffCountry>() => createCountryEntitySelectors<T>()).memoized;
 

--- a/libs/geography/state/src/selectors/geography-all.selector.ts
+++ b/libs/geography/state/src/selectors/geography-all.selector.ts
@@ -1,3 +1,5 @@
+import { defaultMemoize } from '@ngrx/store';
+
 import { DaffCountry } from '@daffodil/geography';
 
 import {
@@ -18,12 +20,8 @@ export interface DaffGeographyAllSelectors<T extends DaffCountry = DaffCountry> 
   DaffGeographySelectors,
   DaffGeographyFeatureSelector<T> {}
 
-export const getDaffGeographySelectors = (() => {
-  let cache;
-  return <T extends DaffCountry = DaffCountry>(): DaffGeographyAllSelectors<T> =>
-    cache = cache || {
-      ...getGeographySelectors<T>(),
-      ...getDaffCountryEntitySelectors<T>(),
-      ...getDaffGeographyFeatureStateSelector<T>(),
-    };
-})();
+export const getDaffGeographySelectors: <T extends DaffCountry = DaffCountry>() => DaffGeographyAllSelectors<T> = defaultMemoize(<T extends DaffCountry = DaffCountry>() => ({
+  ...getGeographySelectors<T>(),
+  ...getDaffCountryEntitySelectors<T>(),
+  ...getDaffGeographyFeatureStateSelector<T>(),
+})).memoized;

--- a/libs/geography/state/src/selectors/geography-feature.selector.ts
+++ b/libs/geography/state/src/selectors/geography-feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffCountry } from '@daffodil/geography';
@@ -15,10 +16,6 @@ export interface DaffGeographyFeatureSelector<T extends DaffCountry = DaffCountr
   selectGeographyFeatureState: MemoizedSelector<DaffGeographyStateRootSlice<T>, DaffGeographyFeatureState<T>>;
 }
 
-export const getDaffGeographyFeatureStateSelector = (() => {
-  let cache;
-  return <T extends DaffCountry = DaffCountry>(): DaffGeographyFeatureSelector<T> =>
-    cache = cache || {
-      selectGeographyFeatureState: createFeatureSelector<DaffGeographyFeatureState<T>>(DAFF_GEOGRAPHY_STORE_FEATURE_KEY),
-    };
-})();
+export const getDaffGeographyFeatureStateSelector: <T extends DaffCountry = DaffCountry>() => DaffGeographyFeatureSelector<T> = defaultMemoize(<T extends DaffCountry = DaffCountry>() => ({
+  selectGeographyFeatureState: createFeatureSelector<DaffGeographyFeatureState<T>>(DAFF_GEOGRAPHY_STORE_FEATURE_KEY),
+})).memoized;

--- a/libs/geography/state/src/selectors/geography.selector.ts
+++ b/libs/geography/state/src/selectors/geography.selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffStateError } from '@daffodil/core/state';
@@ -40,8 +41,4 @@ const createGeographySelectors = <T extends DaffCountry = DaffCountry>() => {
   };
 };
 
-export const getGeographySelectors = (() => {
-  let cache;
-  return <T extends DaffCountry = DaffCountry>(): DaffGeographySelectors =>
-    cache = cache || createGeographySelectors<T>();
-})();
+export const getGeographySelectors: <T extends DaffCountry = DaffCountry>() => DaffGeographySelectors = defaultMemoize(<T extends DaffCountry = DaffCountry>() => createGeographySelectors<T>()).memoized;

--- a/libs/navigation/state/src/selectors/navigation.selector.ts
+++ b/libs/navigation/state/src/selectors/navigation.selector.ts
@@ -2,6 +2,7 @@ import {
   createSelector,
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffStateError } from '@daffodil/core/state';
@@ -55,9 +56,4 @@ const createNavigationFeatureSelectors = <T extends DaffGenericNavigationTree<T>
   };
 };
 
-export const getDaffNavigationSelectors = (() => {
-  let cache;
-  return <T extends DaffGenericNavigationTree<T>>(): DaffNavigationMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createNavigationFeatureSelectors<T>();
-})();
+export const getDaffNavigationSelectors: <T extends DaffGenericNavigationTree<T>>() => DaffNavigationMemoizedSelectors<T> = defaultMemoize(<T extends DaffGenericNavigationTree<T>>() => createNavigationFeatureSelectors<T>()).memoized;

--- a/libs/order/state/src/selectors/order-all.selector.ts
+++ b/libs/order/state/src/selectors/order-all.selector.ts
@@ -1,3 +1,5 @@
+import { defaultMemoize } from '@ngrx/store';
+
 import { DaffOrder } from '@daffodil/order';
 
 import {
@@ -18,12 +20,8 @@ export interface DaffOrderAllSelectors<T extends DaffOrder = DaffOrder> extends
   DaffOrderSelectors<T>,
   DaffOrderFeatureSelector<T> {}
 
-export const getDaffOrderSelectors = (() => {
-  let cache;
-  return <T extends DaffOrder = DaffOrder>(): DaffOrderAllSelectors<T> =>
-    cache = cache || {
-      ...getOrderSelectors<T>(),
-      ...getDaffOrderEntitySelectors<T>(),
-      ...getDaffOrderReducersStateSelector<T>(),
-    };
-})();
+export const getDaffOrderSelectors: <T extends DaffOrder = DaffOrder>() => DaffOrderAllSelectors<T> = defaultMemoize(<T extends DaffOrder = DaffOrder>() => ({
+  ...getOrderSelectors<T>(),
+  ...getDaffOrderEntitySelectors<T>(),
+  ...getDaffOrderReducersStateSelector<T>(),
+})).memoized;

--- a/libs/order/state/src/selectors/order-collection/selectors.ts
+++ b/libs/order/state/src/selectors/order-collection/selectors.ts
@@ -1,4 +1,7 @@
-import { createSelector } from '@ngrx/store';
+import {
+  createSelector,
+  defaultMemoize,
+} from '@ngrx/store';
 
 import {
   DaffCollectionMemoizedSelectors,
@@ -20,8 +23,4 @@ const selectProductReviewsCollectionState = createSelector(
   state => state.collection,
 );
 
-export const getDaffOrderCollectionSelectors = (() => {
-  let cache;
-  return (): DaffOrderCollectionMemoizedSelectors =>
-    cache = cache || daffCollectionSelectorFactory<DaffOrderStateRootSlice, DaffOrderCollection['metadata']>(selectProductReviewsCollectionState);
-})();
+export const getDaffOrderCollectionSelectors: () => DaffOrderCollectionMemoizedSelectors = defaultMemoize(() => daffCollectionSelectorFactory<DaffOrderStateRootSlice, DaffOrderCollection['metadata']>(selectProductReviewsCollectionState)).memoized;

--- a/libs/order/state/src/selectors/order-entities.selector.ts
+++ b/libs/order/state/src/selectors/order-entities.selector.ts
@@ -252,9 +252,5 @@ const createOrderEntitySelectors = <T extends DaffOrder = DaffOrder>() => {
   };
 };
 
-export const getDaffOrderEntitySelectors = (() => {
-  let cache;
-  return <T extends DaffOrder = DaffOrder>(): DaffOrderEntitySelectors<T> =>
-    cache = cache || createOrderEntitySelectors<T>();
-})();
+export const getDaffOrderEntitySelectors: <T extends DaffOrder = DaffOrder>() => DaffOrderEntitySelectors<T> = defaultMemoize(<T extends DaffOrder = DaffOrder>() => createOrderEntitySelectors<T>()).memoized;
 

--- a/libs/order/state/src/selectors/order-feature.selector.ts
+++ b/libs/order/state/src/selectors/order-feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffOrder } from '@daffodil/order';
@@ -15,10 +16,6 @@ export interface DaffOrderFeatureSelector<T extends DaffOrder = DaffOrder> {
   selectOrderFeatureState: MemoizedSelector<DaffOrderStateRootSlice<T>, DaffOrderReducersState<T>>;
 }
 
-export const getDaffOrderReducersStateSelector = (() => {
-  let cache;
-  return <T extends DaffOrder = DaffOrder>(): DaffOrderFeatureSelector<T> =>
-    cache = cache || {
-      selectOrderFeatureState: createFeatureSelector<DaffOrderReducersState<T>>(DAFF_ORDER_STORE_FEATURE_KEY),
-    };
-})();
+export const getDaffOrderReducersStateSelector: <T extends DaffOrder = DaffOrder>() => DaffOrderFeatureSelector<T> = defaultMemoize(<T extends DaffOrder = DaffOrder>() => ({
+  selectOrderFeatureState: createFeatureSelector<DaffOrderReducersState<T>>(DAFF_ORDER_STORE_FEATURE_KEY),
+})).memoized;

--- a/libs/order/state/src/selectors/order.selector.ts
+++ b/libs/order/state/src/selectors/order.selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -48,8 +49,4 @@ const createOrderSelectors = <T extends DaffOrder = DaffOrder>() => {
   };
 };
 
-export const getOrderSelectors = (() => {
-  let cache;
-  return <T extends DaffOrder = DaffOrder>(): DaffOrderSelectors<T> =>
-    cache = cache || createOrderSelectors<T>();
-})();
+export const getOrderSelectors: <T extends DaffOrder = DaffOrder>() => DaffOrderSelectors<T> = defaultMemoize(<T extends DaffOrder = DaffOrder>() => createOrderSelectors<T>()).memoized;

--- a/libs/payment/state/src/selectors/feature.selector.ts
+++ b/libs/payment/state/src/selectors/feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -16,10 +17,6 @@ export interface DaffPaymentFeatureSelector {
   selectPaymentFeatureState: MemoizedSelector<DaffPaymentStateRootSlice, DaffPaymentReducersState>;
 }
 
-export const getDaffPaymentReducersStateSelector = (() => {
-  let cache;
-  return (): DaffPaymentFeatureSelector =>
-    cache = cache || {
-      selectPaymentFeatureState: createFeatureSelector<DaffPaymentReducersState>(DAFF_PAYMENT_STORE_FEATURE_KEY),
-    };
-})();
+export const getDaffPaymentReducersStateSelector: () => DaffPaymentFeatureSelector = defaultMemoize(() => ({
+  selectPaymentFeatureState: createFeatureSelector<DaffPaymentReducersState>(DAFF_PAYMENT_STORE_FEATURE_KEY),
+})).memoized;

--- a/libs/payment/state/src/selectors/payment.selector.ts
+++ b/libs/payment/state/src/selectors/payment.selector.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffStateError } from '@daffodil/core/state';
@@ -49,9 +50,5 @@ const daffPaymentCreateSelectors = () => {
 };
 
 
-export const daffPaymentGetSelectors = (() => {
-  let cache;
-  return (): DaffPaymentSelectors =>
-    cache = cache || daffPaymentCreateSelectors();
-})();
+export const daffPaymentGetSelectors: () => DaffPaymentSelectors = defaultMemoize(() => daffPaymentCreateSelectors()).memoized;
 

--- a/libs/paypal/state/src/selectors/paypal.selector.ts
+++ b/libs/paypal/state/src/selectors/paypal.selector.ts
@@ -2,6 +2,7 @@ import {
   createSelector,
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffStateError } from '@daffodil/core/state';
@@ -56,9 +57,4 @@ const createPaypalSelectors = (): DaffPaypalMemoizedSelectors => {
   };
 };
 
-export const getDaffPaypalSelectors = (() => {
-  let cache;
-  return (): DaffPaypalMemoizedSelectors => cache = cache
-    ? cache
-    : createPaypalSelectors();
-})();
+export const getDaffPaypalSelectors: () => DaffPaypalMemoizedSelectors = defaultMemoize(() => createPaypalSelectors()).memoized;

--- a/libs/product-composite/state/src/selectors/composite-product-entities/composite-product-entities.selectors.ts
+++ b/libs/product-composite/state/src/selectors/composite-product-entities/composite-product-entities.selectors.ts
@@ -137,9 +137,4 @@ const createCompositeProductAppliedOptionsEntitiesSelectors = <T extends DaffPro
  * A function that returns all selectors related to composite product applied option entities.
  * Returns {@link DaffCompositeProductEntitiesMemoizedSelectors}.
  */
-export const getDaffCompositeProductEntitiesSelectors = (() => {
-  let cache;
-  return <T extends DaffProduct>(): DaffCompositeProductEntitiesMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createCompositeProductAppliedOptionsEntitiesSelectors<T>();
-})();
+export const getDaffCompositeProductEntitiesSelectors: <T extends DaffProduct>() => DaffCompositeProductEntitiesMemoizedSelectors<T> = defaultMemoize(<T extends DaffProduct>() => createCompositeProductAppliedOptionsEntitiesSelectors<T>()).memoized;

--- a/libs/product-composite/state/src/selectors/composite-product/composite-product.selectors.ts
+++ b/libs/product-composite/state/src/selectors/composite-product/composite-product.selectors.ts
@@ -167,12 +167,7 @@ const createCompositeProductSelectors = <T extends DaffProduct>(): DaffComposite
  *
  * Returns {@link DaffCompositeProductMemoizedSelectors}.
  */
-export const getDaffCompositeProductPriceSelectors = (() => {
-  let cache;
-  return <T extends DaffProduct = DaffProduct>(): DaffCompositeProductMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createCompositeProductSelectors<T>();
-})();
+export const getDaffCompositeProductPriceSelectors: <T extends DaffProduct = DaffProduct>() => DaffCompositeProductMemoizedSelectors<T> = defaultMemoize(<T extends DaffProduct = DaffProduct>() => createCompositeProductSelectors<T>()).memoized;
 
 /**
  * The minimum price of an item is zero if the item is optional.

--- a/libs/product-composite/state/src/selectors/feature.selector.ts
+++ b/libs/product-composite/state/src/selectors/feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffCompositeProductReducersState } from '../reducers/composite-product-reducers-state.interface';
@@ -16,9 +17,4 @@ export interface DaffCompositeProductFeatureMemoizedSelector {
 /**
  * A function that returns a selector for the composite product feature state.
  */
-export const getDaffCompositeProductFeatureSelector = (() => {
-  let cache;
-  return (): DaffCompositeProductFeatureMemoizedSelector => cache = cache
-    ? cache
-    : { selectCompositeProductState: createFeatureSelector<DaffCompositeProductReducersState>(DAFF_COMPOSITE_PRODUCT_STORE_FEATURE_KEY) };
-})();
+export const getDaffCompositeProductFeatureSelector: () => DaffCompositeProductFeatureMemoizedSelector = defaultMemoize(() => ({ selectCompositeProductState: createFeatureSelector<DaffCompositeProductReducersState>(DAFF_COMPOSITE_PRODUCT_STORE_FEATURE_KEY) })).memoized;

--- a/libs/product-configurable/state/src/selectors/configurable-product-entities/configurable-product-entities.selectors.ts
+++ b/libs/product-configurable/state/src/selectors/configurable-product-entities/configurable-product-entities.selectors.ts
@@ -108,9 +108,4 @@ const createConfigurableProductAppliedAttributesEntitiesSelectors = <T extends D
  * A function that returns all selectors related to configurable product applied attributes.
  * Returns {@link DaffConfigurableProductEntitiesMemoizedSelectors}.
  */
-export const getDaffConfigurableProductEntitiesSelectors = (() => {
-  let cache;
-  return <T extends DaffProduct>(): DaffConfigurableProductEntitiesMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createConfigurableProductAppliedAttributesEntitiesSelectors<T>();
-})();
+export const getDaffConfigurableProductEntitiesSelectors: <T extends DaffProduct>() => DaffConfigurableProductEntitiesMemoizedSelectors<T> = defaultMemoize(<T extends DaffProduct>() => createConfigurableProductAppliedAttributesEntitiesSelectors<T>()).memoized;

--- a/libs/product-configurable/state/src/selectors/configurable-product/configurable-product.selectors.ts
+++ b/libs/product-configurable/state/src/selectors/configurable-product/configurable-product.selectors.ts
@@ -283,12 +283,7 @@ function getSelectableAttributesFromVariants<T extends DaffConfigurableProduct =
  * A function that returns all configurable product selectors.
  * Returns {@link DaffConfigurableProductMemoizedSelectors}.
  */
-export const getDaffConfigurableProductSelectors = (() => {
-  let cache;
-  return <T extends DaffConfigurableProduct = DaffConfigurableProduct>(): DaffConfigurableProductMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createConfigurableProductSelectors();
-})();
+export const getDaffConfigurableProductSelectors: <T extends DaffConfigurableProduct = DaffConfigurableProduct>() => DaffConfigurableProductMemoizedSelectors<T> = defaultMemoize(<T extends DaffConfigurableProduct = DaffConfigurableProduct>() => createConfigurableProductSelectors()).memoized;
 
 function isVariantAvailable(
   appliedAttributes: DaffConfigurableProductEntityAttribute[],

--- a/libs/product-configurable/state/src/selectors/feature.selector.ts
+++ b/libs/product-configurable/state/src/selectors/feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -18,9 +19,4 @@ export interface DaffConfigurableProductFeatureMemoizedSelector {
 /**
  * A function that returns a selector for the entire configurable product feature state.
  */
-export const getDaffConfigurableProductFeatureSelector = (() => {
-  let cache;
-  return (): DaffConfigurableProductFeatureMemoizedSelector => cache = cache
-    ? cache
-    : { selectConfigurableProductState: createFeatureSelector<DaffConfigurableProductReducersState>(DAFF_CONFIGURABLE_PRODUCT_STORE_FEATURE_KEY) };
-})();
+export const getDaffConfigurableProductFeatureSelector: () => DaffConfigurableProductFeatureMemoizedSelector = defaultMemoize(() => ({ selectConfigurableProductState: createFeatureSelector<DaffConfigurableProductReducersState>(DAFF_CONFIGURABLE_PRODUCT_STORE_FEATURE_KEY) })).memoized;

--- a/libs/product/state/src/selectors/product-entities/product-entities.selectors.ts
+++ b/libs/product/state/src/selectors/product-entities/product-entities.selectors.ts
@@ -179,9 +179,4 @@ const createProductEntitiesSelectors = <T extends DaffProduct>(): DaffProductEnt
 /**
  * A function that returns all selectors related to product entities and simple product prices.
  */
-export const getDaffProductEntitiesSelectors = (() => {
-  let cache;
-  return <T extends DaffProduct>(): DaffProductEntitiesMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createProductEntitiesSelectors<T>();
-})();
+export const getDaffProductEntitiesSelectors: <T extends DaffProduct>() => DaffProductEntitiesMemoizedSelectors<T> = defaultMemoize(<T extends DaffProduct>() => createProductEntitiesSelectors<T>()).memoized;

--- a/libs/product/state/src/selectors/product-feature.selector.ts
+++ b/libs/product/state/src/selectors/product-feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffProduct } from '@daffodil/product';
@@ -18,9 +19,4 @@ export interface DaffProductFeatureMemoizedSelector<T extends DaffProduct = Daff
 /**
  * A function that returns a selector for the entire product feature state.
  */
-export const getDaffProductFeatureSelector = (() => {
-  let cache;
-  return <T extends DaffProduct>(): DaffProductFeatureMemoizedSelector<T> => cache = cache
-    ? cache
-    : { selectProductState: createFeatureSelector<DaffProductReducersState<T>>(DAFF_PRODUCT_STORE_FEATURE_KEY) };
-})();
+export const getDaffProductFeatureSelector: <T extends DaffProduct>() => DaffProductFeatureMemoizedSelector<T> = defaultMemoize(<T extends DaffProduct>() => ({ selectProductState: createFeatureSelector<DaffProductReducersState<T>>(DAFF_PRODUCT_STORE_FEATURE_KEY) })).memoized;

--- a/libs/product/state/src/selectors/product-grid/product-grid.selectors.ts
+++ b/libs/product/state/src/selectors/product-grid/product-grid.selectors.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffProduct } from '@daffodil/product';
@@ -51,9 +52,4 @@ const createProductGridSelectors = <T extends DaffProduct>(): DaffProductGridMem
  * A function that returns all selectors related to loading a grid of products.
  * Returns {@link DaffProductGridMemoizedSelectors}.
  */
-export const getDaffProductGridSelectors = (() => {
-  let cache;
-  return <T extends DaffProduct>(): DaffProductGridMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createProductGridSelectors<T>();
-})();
+export const getDaffProductGridSelectors: <T extends DaffProduct>() => DaffProductGridMemoizedSelectors<T> = defaultMemoize(<T extends DaffProduct>() => createProductGridSelectors<T>()).memoized;

--- a/libs/product/state/src/selectors/product/product.selectors.ts
+++ b/libs/product/state/src/selectors/product/product.selectors.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -68,9 +69,4 @@ const createProductPageSelectors = <T extends DaffProduct = DaffProduct>(): Daff
  * A function that returns all selectors related to the product page.
  * Returns {@link DaffProductPageMemoizedSelectors}.
  */
-export const getDaffProductPageSelectors = (() => {
-  let cache;
-  return <T extends DaffProduct>(): DaffProductPageMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createProductPageSelectors<T>();
-})();
+export const getDaffProductPageSelectors: <T extends DaffProduct>() => DaffProductPageMemoizedSelectors<T> = defaultMemoize(<T extends DaffProduct>() => createProductPageSelectors<T>()).memoized;

--- a/libs/related-products/state/src/selectors/feature.selector.ts
+++ b/libs/related-products/state/src/selectors/feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffProduct } from '@daffodil/product';
@@ -21,9 +22,4 @@ export interface DaffRelatedProductsFeatureMemoizedSelector<T extends DaffProduc
 /**
  * A function that returns a selector for the entire related products feature state.
  */
-export const getDaffRelatedProductsFeatureSelector = (() => {
-  let cache;
-  return <T extends DaffProduct>(): DaffRelatedProductsFeatureMemoizedSelector<T> => cache = cache
-    ? cache
-    : { selectRelatedProductsState: createFeatureSelector<DaffRelatedProductsReducersState>(DAFF_RELATED_PRODUCTS_STORE_FEATURE_KEY) };
-})();
+export const getDaffRelatedProductsFeatureSelector: <T extends DaffProduct>() => DaffRelatedProductsFeatureMemoizedSelector<T> = defaultMemoize(<T extends DaffProduct>() => ({ selectRelatedProductsState: createFeatureSelector<DaffRelatedProductsReducersState>(DAFF_RELATED_PRODUCTS_STORE_FEATURE_KEY) })).memoized;

--- a/libs/related-products/state/src/selectors/related-products/selectors.ts
+++ b/libs/related-products/state/src/selectors/related-products/selectors.ts
@@ -2,6 +2,7 @@ import { Dictionary } from '@ngrx/entity';
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffProduct } from '@daffodil/product';
@@ -62,9 +63,4 @@ const createRelatedProductSelectors = <T extends DaffProduct = DaffProduct>(): D
  * A function that returns all selectors of related products for the current product page.
  * Returns {@link DaffRelatedProductsMemoizedSelectors}.
  */
-export const getDaffRelatedProductsPageSelectors = (() => {
-  let cache;
-  return <T extends DaffProduct>(): DaffRelatedProductsMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createRelatedProductSelectors<T>();
-})();
+export const getDaffRelatedProductsPageSelectors: <T extends DaffProduct>() => DaffRelatedProductsMemoizedSelectors<T> = defaultMemoize(<T extends DaffProduct>() => createRelatedProductSelectors<T>()).memoized;

--- a/libs/reviews/state/src/selectors/feature.selector.ts
+++ b/libs/reviews/state/src/selectors/feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffProductReview } from '@daffodil/reviews';
@@ -18,9 +19,4 @@ export interface DaffReviewsFeatureMemoizedSelector<T extends DaffProductReview 
 /**
  * A function that returns a selector for the entire product feature state.
  */
-export const getDaffReviewsFeatureSelector = (() => {
-  let cache;
-  return <T extends DaffProductReview = DaffProductReview>(): DaffReviewsFeatureMemoizedSelector<T> => cache = cache
-    ? cache
-    : { selectReviewsState: createFeatureSelector<DaffReviewsReducersState<T>>(DAFF_REVIEWS_STORE_FEATURE_KEY) };
-})();
+export const getDaffReviewsFeatureSelector: <T extends DaffProductReview = DaffProductReview>() => DaffReviewsFeatureMemoizedSelector<T> = defaultMemoize(<T extends DaffProductReview = DaffProductReview>() => ({ selectReviewsState: createFeatureSelector<DaffReviewsReducersState<T>>(DAFF_REVIEWS_STORE_FEATURE_KEY) })).memoized;

--- a/libs/reviews/state/src/selectors/product-review-collection/selectors.ts
+++ b/libs/reviews/state/src/selectors/product-review-collection/selectors.ts
@@ -1,4 +1,7 @@
-import { createSelector } from '@ngrx/store';
+import {
+  createSelector,
+  defaultMemoize,
+} from '@ngrx/store';
 
 import {
   DaffCollectionMemoizedSelectors,
@@ -20,8 +23,4 @@ const selectProductReviewsCollectionState = createSelector(
   state => state.productReviewsCollection,
 );
 
-export const getDaffProductReviewsCollectionSelectors = (() => {
-  let cache;
-  return (): DaffProductReviewsCollectionMemoizedSelectors =>
-    cache = cache || daffCollectionSelectorFactory<DaffReviewsStateRootSlice, DaffProductReviews['metadata']>(selectProductReviewsCollectionState);
-})();
+export const getDaffProductReviewsCollectionSelectors: () => DaffProductReviewsCollectionMemoizedSelectors = defaultMemoize(() => daffCollectionSelectorFactory<DaffReviewsStateRootSlice, DaffProductReviews['metadata']>(selectProductReviewsCollectionState)).memoized;

--- a/libs/reviews/state/src/selectors/product-review-entities/selectors.ts
+++ b/libs/reviews/state/src/selectors/product-review-entities/selectors.ts
@@ -95,9 +95,4 @@ const createProductReviewEntitiesSelectors = <T extends DaffProductReview = Daff
 /**
  * A function that returns all selectors related to product review entities.
  */
-export const getDaffProductReviewEntitiesSelectors = (() => {
-  let cache;
-  return <T extends DaffProductReview = DaffProductReview>(): DaffProductReviewEntitiesMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createProductReviewEntitiesSelectors<T>();
-})();
+export const getDaffProductReviewEntitiesSelectors: <T extends DaffProductReview = DaffProductReview>() => DaffProductReviewEntitiesMemoizedSelectors<T> = defaultMemoize(<T extends DaffProductReview = DaffProductReview>() => createProductReviewEntitiesSelectors<T>()).memoized;

--- a/libs/reviews/state/src/selectors/product-reviews/selectors.ts
+++ b/libs/reviews/state/src/selectors/product-reviews/selectors.ts
@@ -1,6 +1,7 @@
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffStateError } from '@daffodil/core/state';
@@ -83,9 +84,4 @@ const createProductPageSelectors = <T extends DaffProductReview = DaffProductRev
  * A function that returns all selectors related to the product page.
  * Returns {@link DaffProductPageMemoizedSelectors}.
  */
-export const getDaffProductPageReviewsSelectors = (() => {
-  let cache;
-  return <T extends DaffProductReview = DaffProductReview>(): DaffProductPageReviewsMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createProductPageSelectors<T>();
-})();
+export const getDaffProductPageReviewsSelectors: <T extends DaffProductReview = DaffProductReview>() => DaffProductPageReviewsMemoizedSelectors<T> = defaultMemoize(<T extends DaffProductReview = DaffProductReview>() => createProductPageSelectors<T>()).memoized;

--- a/libs/search-product/state/src/selectors/collection/selectors.ts
+++ b/libs/search-product/state/src/selectors/collection/selectors.ts
@@ -1,4 +1,7 @@
-import { createSelector } from '@ngrx/store';
+import {
+  createSelector,
+  defaultMemoize,
+} from '@ngrx/store';
 
 import {
   DaffCollectionMemoizedSelectors,
@@ -17,8 +20,4 @@ const selectSearchProductCollectionState = createSelector(
   state => state.productCollection,
 );
 
-export const getSearchProductCollectionSelectors = (() => {
-  let cache;
-  return (): DaffCollectionMemoizedSelectors<DaffSearchProductStateRootSlice> =>
-    cache = cache || daffCollectionSelectorFactory<DaffSearchProductStateRootSlice>(selectSearchProductCollectionState);
-})();
+export const getSearchProductCollectionSelectors: () => DaffCollectionMemoizedSelectors<DaffSearchProductStateRootSlice> = defaultMemoize(() => daffCollectionSelectorFactory<DaffSearchProductStateRootSlice>(selectSearchProductCollectionState)).memoized;

--- a/libs/search-product/state/src/selectors/search-feature.selector.ts
+++ b/libs/search-product/state/src/selectors/search-feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import {
@@ -16,10 +17,6 @@ export interface DaffSearchProductFeatureSelector {
   selectSearchProductFeatureState: MemoizedSelector<DaffSearchProductStateRootSlice, DaffSearchProductReducersState>;
 }
 
-export const getDaffSearchProductReducersStateSelector = (() => {
-  let cache;
-  return (): DaffSearchProductFeatureSelector =>
-    cache = cache || {
-      selectSearchProductFeatureState: createFeatureSelector<DaffSearchProductReducersState>(DAFF_SEARCH_PRODUCT_STORE_FEATURE_KEY),
-    };
-})();
+export const getDaffSearchProductReducersStateSelector: () => DaffSearchProductFeatureSelector = defaultMemoize(() => ({
+  selectSearchProductFeatureState: createFeatureSelector<DaffSearchProductReducersState>(DAFF_SEARCH_PRODUCT_STORE_FEATURE_KEY),
+})).memoized;

--- a/libs/search/state/src/selectors/incremental/selectors.ts
+++ b/libs/search/state/src/selectors/incremental/selectors.ts
@@ -1,4 +1,7 @@
-import { createSelector } from '@ngrx/store';
+import {
+  createSelector,
+  defaultMemoize,
+} from '@ngrx/store';
 
 import { DaffSearchResult } from '@daffodil/search';
 
@@ -14,8 +17,4 @@ const selectIncrementalState = createSelector(
   state => state.incremental,
 );
 
-export const daffSearchGetIncrementalSelectors = (() => {
-  let cache;
-  return <T extends DaffSearchResult = DaffSearchResult>(): DaffSearchSelectors<T> =>
-    cache = cache || daffSearchCreateSearchSelectors<T>(selectIncrementalState);
-})();
+export const daffSearchGetIncrementalSelectors: <T extends DaffSearchResult = DaffSearchResult>() => DaffSearchSelectors<T> = defaultMemoize(<T extends DaffSearchResult = DaffSearchResult>() => daffSearchCreateSearchSelectors<T>(selectIncrementalState)).memoized;

--- a/libs/search/state/src/selectors/page/selectors.ts
+++ b/libs/search/state/src/selectors/page/selectors.ts
@@ -1,4 +1,7 @@
-import { createSelector } from '@ngrx/store';
+import {
+  createSelector,
+  defaultMemoize,
+} from '@ngrx/store';
 
 import { DaffSearchResult } from '@daffodil/search';
 
@@ -14,8 +17,4 @@ const selectSearchState = createSelector(
   state => state.search,
 );
 
-export const daffSearchGetPageSelectors = (() => {
-  let cache;
-  return <T extends DaffSearchResult = DaffSearchResult>(): DaffSearchSelectors<T> =>
-    cache = cache || daffSearchCreateSearchSelectors<T>(selectSearchState);
-})();
+export const daffSearchGetPageSelectors: <T extends DaffSearchResult = DaffSearchResult>() => DaffSearchSelectors<T> = defaultMemoize(<T extends DaffSearchResult = DaffSearchResult>() => daffSearchCreateSearchSelectors<T>(selectSearchState)).memoized;

--- a/libs/search/state/src/selectors/search-feature.selector.ts
+++ b/libs/search/state/src/selectors/search-feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffSearchResult } from '@daffodil/search';
@@ -18,10 +19,6 @@ export interface DaffSearchFeatureSelector<T extends DaffSearchResult = DaffSear
   selectSearchFeatureState: MemoizedSelector<DaffSearchStateRootSlice<T>, DaffSearchReducersState<T>>;
 }
 
-export const getDaffSearchReducersStateSelector = (() => {
-  let cache;
-  return <T extends DaffSearchResult = DaffSearchResult>(): DaffSearchFeatureSelector<T> =>
-    cache = cache || {
-      selectSearchFeatureState: createFeatureSelector<DaffSearchReducersState<T>>(DAFF_SEARCH_STORE_FEATURE_KEY),
-    };
-})();
+export const getDaffSearchReducersStateSelector: <T extends DaffSearchResult = DaffSearchResult>() => DaffSearchFeatureSelector<T> = defaultMemoize(<T extends DaffSearchResult = DaffSearchResult>() => ({
+  selectSearchFeatureState: createFeatureSelector<DaffSearchReducersState<T>>(DAFF_SEARCH_STORE_FEATURE_KEY),
+})).memoized;

--- a/libs/upsell-products/state/src/selectors/feature.selector.ts
+++ b/libs/upsell-products/state/src/selectors/feature.selector.ts
@@ -1,6 +1,7 @@
 import {
   createFeatureSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffProduct } from '@daffodil/product';
@@ -21,9 +22,4 @@ export interface DaffUpsellProductsFeatureMemoizedSelector<T extends DaffProduct
 /**
  * A function that returns a selector for the entire upsell products feature state.
  */
-export const getDaffUpsellProductsFeatureSelector = (() => {
-  let cache;
-  return <T extends DaffProduct>(): DaffUpsellProductsFeatureMemoizedSelector<T> => cache = cache
-    ? cache
-    : { selectUpsellProductsState: createFeatureSelector<DaffUpsellProductsReducersState>(DAFF_UPSELL_PRODUCTS_STORE_FEATURE_KEY) };
-})();
+export const getDaffUpsellProductsFeatureSelector: <T extends DaffProduct>() => DaffUpsellProductsFeatureMemoizedSelector<T> = defaultMemoize(<T extends DaffProduct>() => ({ selectUpsellProductsState: createFeatureSelector<DaffUpsellProductsReducersState>(DAFF_UPSELL_PRODUCTS_STORE_FEATURE_KEY) })).memoized;

--- a/libs/upsell-products/state/src/selectors/upsell-products/selectors.ts
+++ b/libs/upsell-products/state/src/selectors/upsell-products/selectors.ts
@@ -2,6 +2,7 @@ import { Dictionary } from '@ngrx/entity';
 import {
   createSelector,
   MemoizedSelector,
+  defaultMemoize,
 } from '@ngrx/store';
 
 import { DaffProduct } from '@daffodil/product';
@@ -62,9 +63,4 @@ const createUpsellProductSelectors = <T extends DaffProduct = DaffProduct>(): Da
  * A function that returns all selectors of upsell products for the current product page.
  * Returns {@link DaffUpsellProductsMemoizedSelectors}.
  */
-export const getDaffUpsellProductsPageSelectors = (() => {
-  let cache;
-  return <T extends DaffProduct>(): DaffUpsellProductsMemoizedSelectors<T> => cache = cache
-    ? cache
-    : createUpsellProductSelectors<T>();
-})();
+export const getDaffUpsellProductsPageSelectors: <T extends DaffProduct>() => DaffUpsellProductsMemoizedSelectors<T> = defaultMemoize(<T extends DaffProduct>() => createUpsellProductSelectors<T>()).memoized;


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [x] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #2109 

## New behavior

Selector factories now use `defaultMemoize` for caching

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->