### PR TITLE
feat(design): add `isOpen` property to menu activator to track the menu's open state

### DIFF
--- a/apps/design-land/src/app/menu/menu.component.html
+++ b/apps/design-land/src/app/menu/menu.component.html
@@ -7,6 +7,8 @@
 <h2>Basic Menu</h2>
 <design-land-example-viewer-container example="basic-menu"></design-land-example-viewer-container>
 
+<design-land-example-viewer-container example="menu-with-icon-toggle"></design-land-example-viewer-container>
+
 <h2>Supported Content Types</h2>
 
 <h3>Menu Item</h3>

--- a/libs/design-examples/menu/src/menu-with-icon-toggle/menu-content/menu-content.component.html
+++ b/libs/design-examples/menu/src/menu-with-icon-toggle/menu-content/menu-content.component.html
@@ -1,0 +1,11 @@
+<daff-menu>
+  <a href="#" daff-menu-item>
+    <fa-icon [icon]="faUser" [fixedWidth]="true" daffPrefix></fa-icon> My Account
+  </a>
+  <a href="#" daff-menu-item>
+    <fa-icon [icon]="faInfo" [fixedWidth]="true" daffPrefix></fa-icon> Help
+  </a>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon> Contact Us
+  </button>
+</daff-menu>

--- a/libs/design-examples/menu/src/menu-with-icon-toggle/menu-content/menu-content.component.ts
+++ b/libs/design-examples/menu/src/menu-with-icon-toggle/menu-content/menu-content.component.ts
@@ -1,0 +1,27 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import {
+  faEnvelope,
+  faInfo,
+  faUser,
+} from '@fortawesome/free-solid-svg-icons';
+
+import { DaffMenuModule } from '@daffodil/design/menu';
+
+@Component({
+  selector: 'menu-content',
+  templateUrl: './menu-content.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DaffMenuModule,
+    FaIconComponent,
+  ],
+})
+export class MenuContentExampleComponent {
+  faUser = faUser;
+  faInfo = faInfo;
+  faEnvelope = faEnvelope;
+}

--- a/libs/design-examples/menu/src/menu-with-icon-toggle/menu-with-icon-toggle.component.html
+++ b/libs/design-examples/menu/src/menu-with-icon-toggle/menu-with-icon-toggle.component.html
@@ -1,0 +1,1 @@
+<button daff-button color="theme" [daffMenuActivator]="menuContent" #activator="daffMenuActivator">Design <fa-icon daffSuffix size="sm" [icon]="activator.isOpen() ? faChevronUp : faChevronDown"></fa-icon></button>

--- a/libs/design-examples/menu/src/menu-with-icon-toggle/menu-with-icon-toggle.component.ts
+++ b/libs/design-examples/menu/src/menu-with-icon-toggle/menu-with-icon-toggle.component.ts
@@ -1,0 +1,30 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import {
+  faChevronDown,
+  faChevronUp,
+} from '@fortawesome/free-solid-svg-icons';
+
+import { DAFF_BASIC_BUTTON_COMPONENTS } from '@daffodil/design/button';
+import { DaffMenuModule } from '@daffodil/design/menu';
+
+import { MenuContentExampleComponent } from './menu-content/menu-content.component';
+
+@Component({
+  selector: 'menu-with-icon-toggle-example',
+  templateUrl: './menu-with-icon-toggle.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DAFF_BASIC_BUTTON_COMPONENTS,
+    DaffMenuModule,
+    FaIconComponent,
+  ],
+})
+export class MenuWithIconToggleExampleComponent {
+  faChevronUp = faChevronUp;
+  faChevronDown = faChevronDown;
+  public menuContent = MenuContentExampleComponent;
+}

--- a/libs/design-examples/menu/src/public_api.ts
+++ b/libs/design-examples/menu/src/public_api.ts
@@ -1,6 +1,7 @@
 import { BasicMenuExampleComponent } from './basic-menu/basic-menu.component';
-
+import { MenuWithIconToggleExampleComponent } from './menu-with-icon-toggle/menu-with-icon-toggle.component';
 
 export const MENU_EXAMPLES = [
   BasicMenuExampleComponent,
+  MenuWithIconToggleExampleComponent,
 ];

--- a/libs/design/menu/README.md
+++ b/libs/design/menu/README.md
@@ -78,6 +78,26 @@ Use the `[daffPrefix]` directive to add a decorative icon before the menu item c
 </ng-template>
 ```
 
+## Features
+
+### Accessing menu state
+The menu activator provides an `isOpen` property that tracks whether the menu is currently open or closed. Use this to update your UI based on the menu state, such as changing icons or styling.
+
+<design-land-example-viewer-container example="menu-with-icon-toggle"></design-land-example-viewer-container>
+
+```html
+<button [daffMenuActivator]="menuContent" #menu="daffMenuActivator">
+  Options
+  <fa-icon [icon]="menu.isOpen() ? faChevronUp : faChevronDown"></fa-icon>
+</button>
+
+<ng-template #menuContent>
+  <daff-menu>
+    <button daff-menu-item>Menu Item</button>
+  </daff-menu>
+</ng-template>
+```
+
 ## Accessibility
 Menu follows the [Menu and Menubar WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/).
 

--- a/libs/design/menu/src/menu-activator/menu-activator.component.ts
+++ b/libs/design/menu/src/menu-activator/menu-activator.component.ts
@@ -3,6 +3,7 @@ import {
   Directive,
   Input,
   OnDestroy,
+  signal,
   TemplateRef,
   Type,
   ViewContainerRef,
@@ -31,11 +32,13 @@ import { DaffMenuService } from '../services/menu.service';
     'aria-haspopup': 'menu',
     '[attr.aria-expanded]': 'ariaExpanded',
   },
+  exportAs: 'daffMenuActivator',
 })
 export class DaffMenuActivatorDirective implements OnDestroy {
 
   private _destroyed$ = new Subject<boolean>();
   private _open: boolean;
+  readonly isOpen = signal(false);
 
   /**
    * The menu content to display when activated.
@@ -58,6 +61,7 @@ export class DaffMenuActivatorDirective implements OnDestroy {
       takeUntil(this._destroyed$),
     ).subscribe((val: boolean) => {
       this._open = val;
+      this.isOpen.set(this._open);
       this.cdRef.markForCheck();
     });
   }


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
Added a `isOpen` signal property to track the menu's open state and exports the directive as `daffMenuActivator`, enabling templates to reactively display the menu state (e.g., toggle icons based on whether the menu is open).

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->