### PR TITLE
feat(design): add `aria-controls` support to `DaffMenuComponent`

### DIFF
--- a/libs/design-examples/menu/src/menu-with-id/menu-content/menu-content.component.html
+++ b/libs/design-examples/menu/src/menu-with-id/menu-content/menu-content.component.html
@@ -1,0 +1,13 @@
+<daff-menu>
+  <a href="#" daff-menu-item>
+    <fa-icon [icon]="faUser" [fixedWidth]="true" daffPrefix></fa-icon> My
+    Account
+  </a>
+  <a href="#" daff-menu-item>
+    <fa-icon [icon]="faInfo" [fixedWidth]="true" daffPrefix></fa-icon> Help
+  </a>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+</daff-menu>

--- a/libs/design-examples/menu/src/menu-with-id/menu-content/menu-content.component.ts
+++ b/libs/design-examples/menu/src/menu-with-id/menu-content/menu-content.component.ts
@@ -1,0 +1,27 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import {
+  faEnvelope,
+  faInfo,
+  faUser,
+} from '@fortawesome/free-solid-svg-icons';
+
+import { DaffMenuModule } from '@daffodil/design/menu';
+
+@Component({
+  selector: 'menu-with-id-content',
+  templateUrl: './menu-content.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DaffMenuModule,
+    FaIconComponent,
+  ],
+})
+export class MenuWithIdContentExampleComponent {
+  faUser = faUser;
+  faInfo = faInfo;
+  faEnvelope = faEnvelope;
+}

--- a/libs/design-examples/menu/src/menu-with-id/menu-with-id.component.html
+++ b/libs/design-examples/menu/src/menu-with-id/menu-with-id.component.html
@@ -1,0 +1,7 @@
+<button
+  daff-button
+  color="theme"
+  [daffMenuActivator]="menu"
+  id="menu-with-id">
+  Menu
+</button>

--- a/libs/design-examples/menu/src/menu-with-id/menu-with-id.component.ts
+++ b/libs/design-examples/menu/src/menu-with-id/menu-with-id.component.ts
@@ -1,0 +1,22 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+
+import { DaffButtonComponent } from '@daffodil/design/button';
+import { DaffMenuModule } from '@daffodil/design/menu';
+
+import { MenuWithIdContentExampleComponent } from './menu-content/menu-content.component';
+
+@Component({
+  selector: 'menu-with-id-example',
+  templateUrl: './menu-with-id.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DaffButtonComponent,
+    DaffMenuModule,
+  ],
+})
+export class MenuWithIdExampleComponent {
+  public menu = MenuWithIdContentExampleComponent;
+}

--- a/libs/design-examples/menu/src/provider.ts
+++ b/libs/design-examples/menu/src/provider.ts
@@ -11,5 +11,9 @@ export const provideDaffDesignMenuExamplesContent = () => makeEnvironmentProvide
     id: 'menu-with-icon-toggle',
     component: () => import('./menu-with-icon-toggle/menu-with-icon-toggle.component').then(c => c.MenuWithIconToggleExampleComponent),
   },
+  {
+    id: 'menu-with-id',
+    component: () => import('./menu-with-id/menu-with-id.component').then(c => c.MenuWithIdExampleComponent),
+  },
 ));
 

--- a/libs/design-examples/menu/src/public_api.ts
+++ b/libs/design-examples/menu/src/public_api.ts
@@ -1,3 +1,4 @@
 export { BasicMenuExampleComponent } from './basic-menu/basic-menu.component';
 export { MenuWithIconToggleExampleComponent } from './menu-with-icon-toggle/menu-with-icon-toggle.component';
+export { MenuWithIdExampleComponent } from './menu-with-id/menu-with-id.component';
 export { provideDaffDesignMenuExamplesContent } from './provider';

--- a/libs/design/menu/README.md
+++ b/libs/design/menu/README.md
@@ -105,18 +105,12 @@ The menu activator provides an `isOpen` property that tracks whether the menu is
 
 <daff-docs-example-viewer example="menu-with-icon-toggle"></daff-docs-example-viewer>
 
-```html
-<button [daffMenuActivator]="menuContent" #menu="daffMenuActivator">
-  Options
-  <fa-icon [icon]="menu.isOpen() ? faChevronUp : faChevronDown"></fa-icon>
-</button>
 
-<ng-template #menuContent>
-  <daff-menu>
-    <button daff-menu-item>Menu Item</button>
-  </daff-menu>
-</ng-template>
-```
+### Setting an ID
+
+The menu activator accepts an optional `id` input. When set, the opened menu's `id` is derived as `{id}-menu`. When no `id` is provided, a unique ID is auto-generated.
+
+<daff-docs-example-viewer example="menu-with-id"></daff-docs-example-viewer>
 
 ## Accessibility
 Menu follows the [Menu and Menubar WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/).

--- a/libs/design/menu/src/config/menu-config.ts
+++ b/libs/design/menu/src/config/menu-config.ts
@@ -1,0 +1,26 @@
+import { createConfigInjectionToken } from '@daffodil/core';
+
+/**
+ * Configuration for a menu instance.
+ */
+export interface DaffMenuConfig {
+  /**
+   * A unique identifier for the menu instance.
+   */
+  menuId?: string;
+}
+
+const daffMenuConfigDefault: DaffMenuConfig = {
+  menuId: '',
+};
+
+export const {
+  /**
+   * An injection token for the menu configuration.
+   */
+  token: DAFF_MENU_CONFIG,
+  /**
+   * Provider function for {@link DAFF_MENU_CONFIG}.
+   */
+  provider: provideDaffMenuConfig,
+} = createConfigInjectionToken<DaffMenuConfig>(daffMenuConfigDefault, 'DAFF_MENU_CONFIG');

--- a/libs/design/menu/src/config/menu-id.ts
+++ b/libs/design/menu/src/config/menu-id.ts
@@ -1,0 +1,7 @@
+let daffMenuUniqueId = 0;
+
+/**
+ * Generates a unique menu ID for each menu instance.
+ */
+export const daffNextMenuId = (): string =>
+  `daff-menu-${daffMenuUniqueId++}`;

--- a/libs/design/menu/src/menu-activator/menu-activator.component.spec.ts
+++ b/libs/design/menu/src/menu-activator/menu-activator.component.spec.ts
@@ -9,6 +9,10 @@ import {
 import { By } from '@angular/platform-browser';
 
 import { DaffMenuActivatorDirective } from './menu-activator.component';
+import {
+  DAFF_MENU_CONFIG,
+  DaffMenuConfig,
+} from '../config/menu-config';
 import { DaffMenuComponent } from '../menu/menu.component';
 import { DaffMenuService } from '../services/menu.service';
 import { provideTestMenuService } from '../testing/dummy-service';
@@ -37,6 +41,7 @@ describe('@daffodil/design/menu | DaffMenuActivatorDirective', () => {
       ],
       providers: [
         provideTestMenuService(),
+        { provide: DAFF_MENU_CONFIG, useValue: <DaffMenuConfig>{ menuId: 'daff-menu-test' }},
       ],
     }).compileComponents();
 
@@ -53,6 +58,10 @@ describe('@daffodil/design/menu | DaffMenuActivatorDirective', () => {
 
   it('should have set aria-haspopup to menu', () => {
     expect(de.nativeElement.getAttribute('aria-haspopup')).toBe('menu');
+  });
+
+  it('should set aria-controls to the reserved menu id on init', () => {
+    expect(de.nativeElement.getAttribute('aria-controls')).toMatch(/^daff-menu-\d+$/);
   });
 
   it('should open the menu when the button is clicked', () => {

--- a/libs/design/menu/src/menu-activator/menu-activator.component.ts
+++ b/libs/design/menu/src/menu-activator/menu-activator.component.ts
@@ -1,6 +1,8 @@
 import {
   ChangeDetectorRef,
+  computed,
   Directive,
+  input,
   Input,
   OnDestroy,
   signal,
@@ -13,6 +15,7 @@ import {
   takeUntil,
 } from 'rxjs';
 
+import { daffNextMenuId } from '../config/menu-id';
 import { DaffMenuService } from '../services/menu.service';
 
 /**
@@ -31,6 +34,7 @@ import { DaffMenuService } from '../services/menu.service';
     '(click)': 'onClick($event)',
     'aria-haspopup': 'menu',
     '[attr.aria-expanded]': 'ariaExpanded',
+    '[attr.aria-controls]': '_open ? menuId() : null',
   },
   exportAs: 'daffMenuActivator',
 })
@@ -38,12 +42,27 @@ export class DaffMenuActivatorDirective implements OnDestroy {
 
   private _destroyed$ = new Subject<boolean>();
   private _open: boolean;
+  private _defaultMenuId = daffNextMenuId();
   readonly isOpen = signal(false);
 
   /**
    * The menu content to display when activated.
    */
   @Input() daffMenuActivator: Type<unknown> | TemplateRef<unknown>;
+
+  /**
+   * An optional ID for the activator.
+   * When set, the menu's ID is derived as `${id}-menu`.
+   */
+  id = input<string>();
+
+  /**
+   * The resolved menu ID.
+   */
+  menuId = computed(() => {
+    const id = this.id();
+    return id ? `${id}-menu` : this._defaultMenuId;
+  });
 
   /**
    * @docs-private
@@ -86,6 +105,6 @@ export class DaffMenuActivatorDirective implements OnDestroy {
    */
   onClick(event: MouseEvent) {
     event.preventDefault();
-    this.service.open(this.viewContainerRef, this.daffMenuActivator);
+    this.service.open(this.viewContainerRef, this.daffMenuActivator, { menuId: this.menuId() });
   }
 }

--- a/libs/design/menu/src/menu-activator/menu-activator.component.ts
+++ b/libs/design/menu/src/menu-activator/menu-activator.component.ts
@@ -59,7 +59,7 @@ export class DaffMenuActivatorDirective implements OnDestroy {
   /**
    * The resolved menu ID.
    */
-  menuId = computed(() => {
+  private menuId = computed(() => {
     const id = this.id();
     return id ? `${id}-menu` : this._defaultMenuId;
   });

--- a/libs/design/menu/src/menu/menu.component.spec.ts
+++ b/libs/design/menu/src/menu/menu.component.spec.ts
@@ -10,6 +10,10 @@ import {
 import { By } from '@angular/platform-browser';
 
 import { DaffMenuComponent } from './menu.component';
+import {
+  DAFF_MENU_CONFIG,
+  DaffMenuConfig,
+} from '../config/menu-config';
 import { DaffMenuItemComponent } from '../menu-item/menu-item.component';
 import { provideTestMenuService } from '../testing/dummy-service';
 
@@ -35,6 +39,7 @@ describe('@daffodil/design/menu | DaffMenuComponent | Defaults', () => {
       ],
       providers: [
         provideTestMenuService(),
+        { provide: DAFF_MENU_CONFIG, useValue: <DaffMenuConfig>{ menuId: 'daff-menu-test' }},
       ],
     })
       .compileComponents();
@@ -65,5 +70,9 @@ describe('@daffodil/design/menu | DaffMenuComponent | Defaults', () => {
 
   it('should have a role of menu', () => {
     expect(de.nativeElement.getAttribute('role')).toBe('menu');
+  });
+
+  it('should have an id matching the provided DAFF_MENU_CONFIG menuId', () => {
+    expect(de.nativeElement.getAttribute('id')).toBe('daff-menu-test');
   });
 });

--- a/libs/design/menu/src/menu/menu.component.ts
+++ b/libs/design/menu/src/menu/menu.component.ts
@@ -11,11 +11,16 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  Inject,
   QueryList,
   ContentChildren,
   ViewEncapsulation,
 } from '@angular/core';
 
+import {
+  DAFF_MENU_CONFIG,
+  DaffMenuConfig,
+} from '../config/menu-config';
 import { DaffMenuItemComponent } from '../menu-item/menu-item.component';
 import { DAFF_MENU_ITEM_TOKEN } from '../menu-item/menu-item.token';
 import { DaffMenuService } from '../services/menu.service';
@@ -51,6 +56,7 @@ import { DaffMenuService } from '../services/menu.service';
     class: 'daff-menu',
     'tabindex': '0',
     'role': 'menu',
+    '[id]': 'config.menuId',
     '(keydown)': 'handleKeydown($event)',
   },
   imports: [
@@ -73,6 +79,7 @@ export class DaffMenuComponent implements AfterContentInit, AfterViewInit {
     private _focusTrapFactory: ConfigurableFocusTrapFactory,
     private _elementRef: ElementRef<HTMLElement>,
     private menuService: DaffMenuService,
+    @Inject(DAFF_MENU_CONFIG) public readonly config: DaffMenuConfig,
   ) {}
 
   /**

--- a/libs/design/menu/src/menu/menu.component.ts
+++ b/libs/design/menu/src/menu/menu.component.ts
@@ -79,6 +79,10 @@ export class DaffMenuComponent implements AfterContentInit, AfterViewInit {
     private _focusTrapFactory: ConfigurableFocusTrapFactory,
     private _elementRef: ElementRef<HTMLElement>,
     private menuService: DaffMenuService,
+
+    /**
+     * @docs-private
+     */
     @Inject(DAFF_MENU_CONFIG) public readonly config: DaffMenuConfig,
   ) {}
 

--- a/libs/design/menu/src/menu/specs/usage.spec.ts
+++ b/libs/design/menu/src/menu/specs/usage.spec.ts
@@ -10,6 +10,10 @@ import {
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
+import {
+  DAFF_MENU_CONFIG,
+  DaffMenuConfig,
+} from '../../config/menu-config';
 import { DaffMenuItemComponent } from '../../menu-item/menu-item.component';
 import { DaffMenuService } from '../../services/menu.service';
 import { provideTestMenuService } from '../../testing/dummy-service';
@@ -43,6 +47,7 @@ describe('@daffodil/design/menu | DaffMenuComponent | Usage', () => {
       ],
       providers: [
         provideTestMenuService(),
+        { provide: DAFF_MENU_CONFIG, useValue: <DaffMenuConfig>{ menuId: 'daff-menu-test' }},
       ],
     })
       .compileComponents();

--- a/libs/design/menu/src/public_api.ts
+++ b/libs/design/menu/src/public_api.ts
@@ -1,4 +1,8 @@
-export { DaffMenuService } from './services/menu.service';
+export { DaffMenuConfig } from './config/menu-config';
+export {
+  DaffMenuService,
+  DaffMenuSlot,
+} from './services/menu.service';
 export { DaffMenuActivatorDirective } from './menu-activator/menu-activator.component';
 export { DaffMenuModule } from './menu.module';
 export { DaffMenuComponent } from './menu/menu.component';

--- a/libs/design/menu/src/services/menu.service.ts
+++ b/libs/design/menu/src/services/menu.service.ts
@@ -7,7 +7,6 @@ import {
   TemplatePortal,
 } from '@angular/cdk/portal';
 import {
-  ElementRef,
   Injectable,
   Injector,
   TemplateRef,
@@ -22,12 +21,11 @@ import {
 
 import { DaffLazyComponent } from '@daffodil/design';
 
+import {
+  DAFF_MENU_CONFIG,
+  DaffMenuConfig,
+} from '../config/menu-config';
 import { daffMenuCreateOverlay } from '../helpers/create-overlay';
-
-export interface DaffActivatedMenu {
-  el: ElementRef;
-  component: Type<unknown>;
-}
 
 export type DaffMenuSlot = TemplateRef<unknown> | DaffLazyComponent | Type<unknown>;
 
@@ -47,17 +45,22 @@ export class DaffMenuService {
   /**
    * @docs-private
    */
-  protected async _createOverlay(activatorElement: ViewContainerRef, component: DaffMenuSlot) {
+  protected async _createOverlay(activatorElement: ViewContainerRef, component: DaffMenuSlot, config?: DaffMenuConfig) {
     if (!this._overlay) {
       this._overlay = daffMenuCreateOverlay(this.overlay, activatorElement.element);
       if(typeof component === 'object' && (<DaffLazyComponent>component)?.import) {
         component = await (<DaffLazyComponent>component).import();
       }
 
+      const injector = Injector.create({
+        providers: [{ provide: DAFF_MENU_CONFIG, useValue: config }],
+        parent: this.injector,
+      });
+
       if(component instanceof Type) {
-        this._overlay.attach(new ComponentPortal(<Type<unknown>>component, null, this.injector));
+        this._overlay.attach(new ComponentPortal(<Type<unknown>>component, null, injector));
       } else if (component instanceof TemplateRef) {
-        this._overlay.attach(new TemplatePortal(component, activatorElement, null, this.injector));
+        this._overlay.attach(new TemplatePortal(component, activatorElement, null, injector));
       }
 
       this._overlay.backdropClick().pipe(
@@ -83,11 +86,11 @@ export class DaffMenuService {
     this._activator.element.nativeElement.focus();
   }
 
-  open(activator: ViewContainerRef, component: DaffMenuSlot) {
+  open(activator: ViewContainerRef, component: DaffMenuSlot, config?: DaffMenuConfig) {
     if (this._overlay) {
       this._destroyOverlay();
     }
-    this._createOverlay(activator, component);
+    this._createOverlay(activator, component, config);
     this._activator = activator;
     this.$_open.next(true);
   }


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4159 

## New behavior
- Menu activator reserves unique menu id on init, which it uses for its `aria-controls`
- When menu is opened, the menu activator passes the menu id to the menu component through injection
- Menu IDs are unique because all menu activators access the same instance of `daffMenuUniqueId`
- `aria-controls` of menu activator always matches `id` of menu component

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->