### PR TITLE
feat(daffio): Redirect to Daffio instead of Github

### DIFF
--- a/apps/daffio/src/app/content/home/components/home-hero/home-hero.component.html
+++ b/apps/daffio/src/app/content/home/components/home-hero/home-hero.component.html
@@ -8,7 +8,7 @@
     </h2>
     <div daffHeroBody>
       <div class="daffio-home-hero__actions">
-        <a [href]="repoLink" target="_blank" daff-button color="primary">Get Started</a>
+        <a [routerLink]="docsLink" daff-button color="primary">Get Started</a>
         <a [href]="demoLink" target="_blank" daff-stroked-button color="theme-contrast">See a Demo</a>
       </div>
     </div>

--- a/apps/daffio/src/app/content/home/components/home-hero/home-hero.component.spec.ts
+++ b/apps/daffio/src/app/content/home/components/home-hero/home-hero.component.spec.ts
@@ -8,6 +8,7 @@ import {
   TestBed,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
 
 import { DaffioHomeHeroComponent } from './home-hero.component';
 
@@ -26,6 +27,7 @@ describe('DaffioHomeHeroComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [WrapperComponent],
+      providers: [provideRouter([])],
     })
       .compileComponents();
   }));

--- a/apps/daffio/src/app/content/home/components/home-hero/home-hero.component.ts
+++ b/apps/daffio/src/app/content/home/components/home-hero/home-hero.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
 } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 import { DAFF_BRANDING_CONSTANTS } from '@daffodil/branding';
 import { DAFF_BUTTON_COMPONENTS } from '@daffodil/design/button';
@@ -14,6 +15,7 @@ import { DAFF_HERO_COMPONENTS } from '@daffodil/design/hero';
   styleUrls: ['./home-hero.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    RouterLink,
     DAFF_HERO_COMPONENTS,
     DAFF_CONTAINER_COMPONENTS,
     DAFF_BUTTON_COMPONENTS,
@@ -21,6 +23,6 @@ import { DAFF_HERO_COMPONENTS } from '@daffodil/design/hero';
 })
 
 export class DaffioHomeHeroComponent {
-  repoLink = DAFF_BRANDING_CONSTANTS.REPO_URL;
+  docsLink = DAFF_BRANDING_CONSTANTS.DOCS_URL;
   demoLink = DAFF_BRANDING_CONSTANTS.DEMO_URL;
 }

--- a/apps/daffio/src/app/content/home/components/home-hero/home-hero.component.ts
+++ b/apps/daffio/src/app/content/home/components/home-hero/home-hero.component.ts
@@ -8,6 +8,7 @@ import { DAFF_BRANDING_CONSTANTS } from '@daffodil/branding';
 import { DAFF_BUTTON_COMPONENTS } from '@daffodil/design/button';
 import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 import { DAFF_HERO_COMPONENTS } from '@daffodil/design/hero';
+import { DAFF_DOCS_PATH } from '@daffodil/docs-utils';
 
 @Component({
   selector: 'daffio-home-hero',
@@ -23,6 +24,6 @@ import { DAFF_HERO_COMPONENTS } from '@daffodil/design/hero';
 })
 
 export class DaffioHomeHeroComponent {
-  docsLink = DAFF_BRANDING_CONSTANTS.DOCS_URL;
+  docsLink = DAFF_DOCS_PATH;
   demoLink = DAFF_BRANDING_CONSTANTS.DEMO_URL;
 }

--- a/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.html
+++ b/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.html
@@ -5,7 +5,7 @@
     </h4>
     <div daffCalloutBody class="daffio-sub-footer__body">
       <div class="daffio-sub-footer__actions">
-        <a [href]="repoLink" target="_blank" rel="noopener noreferrer" daff-button color="light">Explore Daffodil</a>
+        <a [routerLink]="docsLink" daff-button color="light">Explore Daffodil</a>
         <a [href]="discordLink" target="_blank" rel="noopener noreferrer" daff-stroked-button color="light">Join the Conversation</a>
       </div>
     </div>

--- a/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.ts
+++ b/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.ts
@@ -14,6 +14,7 @@ import {
 } from '@daffodil/design/button';
 import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
 import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
+import { DAFF_DOCS_PATH } from '@daffodil/docs-utils';
 
 @Component({
   selector: 'daffio-sub-footer',
@@ -34,6 +35,6 @@ import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 export class DaffioSubFooterComponent {
   @HostBinding('class.daffio-sub-footer') class = true;
 
-  docsLink = DAFF_BRANDING_CONSTANTS.DOCS_INTRO_URL;
+  docsLink = DAFF_DOCS_PATH;
   discordLink = DAFF_BRANDING_CONSTANTS.DISCORD_URL;
 }

--- a/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.ts
+++ b/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.ts
@@ -4,6 +4,7 @@ import {
   HostBinding,
   ChangeDetectionStrategy,
 } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import { DAFF_BRANDING_CONSTANTS } from '@daffodil/branding';
@@ -22,6 +23,7 @@ import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
+    RouterLink,
     FontAwesomeModule,
     DAFF_CALLOUT_COMPONENTS,
     DAFF_CONTAINER_COMPONENTS,
@@ -32,6 +34,6 @@ import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
 export class DaffioSubFooterComponent {
   @HostBinding('class.daffio-sub-footer') class = true;
 
-  repoLink = DAFF_BRANDING_CONSTANTS.REPO_URL;
+  docsLink = DAFF_BRANDING_CONSTANTS.DOCS_INTRO_URL;
   discordLink = DAFF_BRANDING_CONSTANTS.DISCORD_URL;
 }

--- a/apps/daffio/src/app/core/nav/marketing/marketing.component.html
+++ b/apps/daffio/src/app/core/nav/marketing/marketing.component.html
@@ -12,7 +12,7 @@
       <a daffioHeaderItem [routerLink]="link.url" [active]="rla.isActive" routerLinkActive #rla="routerLinkActive">{{link.title}}</a>
     }
   }
-  <a daff-button color="theme-contrast" size="sm" href="https://github.com/graycoreio/daffodil" rel="noopener noreferrer" target="_blank" quickstart-button>Get Started</a>
+  <a daff-button color="theme-contrast" size="sm" [routerLink]="docsLink" quickstart-button>Get Started</a>
   <button daff-icon-button color="theme-contrast" aria-label="Open Navigation Sidebar"
     sidebar-button
     (click)="openSidebar()">

--- a/apps/daffio/src/app/core/nav/marketing/marketing.component.ts
+++ b/apps/daffio/src/app/core/nav/marketing/marketing.component.ts
@@ -19,14 +19,12 @@ import {
   map,
 } from 'rxjs';
 
-import {
-  DAFF_BRANDING_CONSTANTS,
-  DaffLogoModule,
-} from '@daffodil/branding';
+import { DaffLogoModule } from '@daffodil/branding';
 import {
   DaffButtonComponent,
   DaffIconButtonComponent,
 } from '@daffodil/design/button';
+import { DAFF_DOCS_PATH } from '@daffodil/docs-utils';
 import { DaffRouterDataService } from '@daffodil/router';
 import { DaffSfThemeToggleComponent } from '@daffodil/storefront/theme-toggle';
 
@@ -59,7 +57,7 @@ import { DaffioNavLink } from '../link/type';
 export class DaffioMarketingNavContainer implements OnInit {
   readonly isComponent = isComponent;
   faBars = faBars;
-  docsLink = DAFF_BRANDING_CONSTANTS.DOCS_URL;
+  docsLink = DAFF_DOCS_PATH;
 
   links$: Observable<Array<DaffioNavLink | Type<unknown>>>;
 

--- a/apps/daffio/src/app/core/nav/marketing/marketing.component.ts
+++ b/apps/daffio/src/app/core/nav/marketing/marketing.component.ts
@@ -19,7 +19,10 @@ import {
   map,
 } from 'rxjs';
 
-import { DaffLogoModule } from '@daffodil/branding';
+import {
+  DAFF_BRANDING_CONSTANTS,
+  DaffLogoModule,
+} from '@daffodil/branding';
 import {
   DaffButtonComponent,
   DaffIconButtonComponent,
@@ -56,6 +59,7 @@ import { DaffioNavLink } from '../link/type';
 export class DaffioMarketingNavContainer implements OnInit {
   readonly isComponent = isComponent;
   faBars = faBars;
+  docsLink = DAFF_BRANDING_CONSTANTS.DOCS_URL;
 
   links$: Observable<Array<DaffioNavLink | Type<unknown>>>;
 

--- a/libs/branding/src/lib/constants.ts
+++ b/libs/branding/src/lib/constants.ts
@@ -7,4 +7,6 @@ export const DAFF_BRANDING_CONSTANTS = {
   DISCORD_URL: 'https://discord.gg/BdaJVZ53sR',
   REPO_URL: 'https://github.com/graycoreio/daffodil',
   DEMO_URL: 'https://demo.daff.io',
+  DOCS_URL: '/docs/guides/getting-started',
+  DOCS_INTRO_URL: '/docs/guides/introduction',
 };

--- a/libs/branding/src/lib/constants.ts
+++ b/libs/branding/src/lib/constants.ts
@@ -7,6 +7,4 @@ export const DAFF_BRANDING_CONSTANTS = {
   DISCORD_URL: 'https://discord.gg/BdaJVZ53sR',
   REPO_URL: 'https://github.com/graycoreio/daffodil',
   DEMO_URL: 'https://demo.daff.io',
-  DOCS_URL: '/docs/guides/getting-started',
-  DOCS_INTRO_URL: '/docs/guides/introduction',
 };


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Currently, users are redirected to Daffodil GitHub page when they click on 'Get Started' and 'Explore' on the daffio home page. Since daffio now contains more user-friendly documentation than the GitHub, it would make sense for users to be redirected to the daffio docs when they click on 'Get Started' and 'Explore'.

## New behavior
<!-- Describe the changes -->

Users are redirected to the daffio docs when they click on 'Get Started' and 'Explore'.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->