### PR TITLE
feat(design)!: remove deprecated color palette maps

### DIFF
--- a/libs/design/scss/theming/_color-palettes.scss
+++ b/libs/design/scss/theming/_color-palettes.scss
@@ -26,9 +26,6 @@ $daff-blue: (
 );
 
 /// @access private
-$daff-primary: $daff-blue;
-
-/// @access private
 $daff-purple: (
 	10: #ebebff,
 	20: #d4d3ff,
@@ -41,9 +38,6 @@ $daff-purple: (
 	90: #2c068a,
 	100: #110033
 );
-
-/// @access private
-$daff-accent: $daff-purple;
 
 /// @access private
 $daff-turquoise: (


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `$daff-primary` and `$daff-accent` color palette maps have been removed.

## Additional context
<!-- Any other relevant information -->