### PR TITLE
feat(daffio, storefront-examples): render storefront component examples in docs

### DIFF
--- a/apps/daffio/package.json
+++ b/apps/daffio/package.json
@@ -70,6 +70,7 @@
     "@daffodil/seo": "0.0.0-PLACEHOLDER",
     "@daffodil/tools-dgeni": "0.0.0-PLACEHOLDER",
     "@daffodil/storefront": "0.0.0-PLACEHOLDER",
+    "@daffodil/storefront-examples": "0.0.0-PLACEHOLDER",
     "@ngrx/component": "0.0.0-PLACEHOLDER"
   }
 }

--- a/apps/daffio/src/app/docs/components/example-viewer/example-viewer.component.ts
+++ b/apps/daffio/src/app/docs/components/example-viewer/example-viewer.component.ts
@@ -15,6 +15,7 @@ import { DaffDocsDesignExample } from '@daffodil/docs-utils';
 import { DAFFIO_EXAMPLES_CONTENT_COMPONENT_MAP } from './example-components-map.token';
 import { DaffioExampleViewerCodeComponent } from './example-viewer-code/example-viewer-code.component';
 import { DaffioExampleViewerPreviewComponent } from './example-viewer-preview/example-viewer-preview.component';
+import { DAFFIO_DOCS_DESIGN_SECTION } from '../../design/services/index.service';
 import { DaffioDocsService } from '../../services/docs.service';
 
 /**
@@ -52,11 +53,13 @@ export class DaffioExampleViewerComponent {
    */
   example = input.required<string>();
 
+  private readonly section = inject(DAFFIO_DOCS_DESIGN_SECTION);
+
   /**
    * The source files of the example.
    */
   readonly sourceFiles: Resource<DaffDocsDesignExample> = rxResource({
-    params: () => ({ path: `docs/design/examples/${this.example()}` }),
+    params: () => ({ path: `docs/${this.section}/examples/${this.example()}` }),
     stream: ({ params }) => this.docsService.get<any>(params.path),
   });
 

--- a/apps/daffio/src/app/docs/design/design.routes.ts
+++ b/apps/daffio/src/app/docs/design/design.routes.ts
@@ -17,6 +17,7 @@ import { DocsResolver } from '../resolvers/docs-resolver.service';
 import { daffioDocsDesignIndexResolver } from './services/index.resolver';
 import { provideDaffioDocsDesignIndexService } from './services/index.service';
 import { daffioDocsApiRolesProvider } from '../api/roles/api-roles.provider';
+import { provideDaffioStorefrontExamplesContent } from '../storefront/examples/content.provider';
 
 export const daffioDocsDesignRoutesFactory = (section: string, ...extraRoutes: Routes) => <Routes> [
   <DaffioRoute>{
@@ -26,6 +27,7 @@ export const daffioDocsDesignRoutesFactory = (section: string, ...extraRoutes: R
       provideDaffioDocsDesignComponentContentComponent(),
       ...daffioDocsApiRolesProvider(),
       provideDaffioDesignExamplesContent(),
+      provideDaffioStorefrontExamplesContent(),
     ],
     resolve: {
       index: daffioDocsDesignIndexResolver,

--- a/apps/daffio/src/app/docs/storefront/examples/content.provider.ts
+++ b/apps/daffio/src/app/docs/storefront/examples/content.provider.ts
@@ -1,0 +1,9 @@
+import { makeEnvironmentProviders } from '@angular/core';
+
+import { provideDaffStorefrontCarouselExamplesContent } from '@daffodil/storefront-examples/carousel';
+import { provideDaffStorefrontThemeToggleExamplesContent } from '@daffodil/storefront-examples/theme-toggle';
+
+export const provideDaffioStorefrontExamplesContent = () => makeEnvironmentProviders([
+  provideDaffStorefrontThemeToggleExamplesContent(),
+  provideDaffStorefrontCarouselExamplesContent(),
+]);

--- a/libs/storefront-examples/carousel/src/basic-carousel/basic-carousel.component.html
+++ b/libs/storefront-examples/carousel/src/basic-carousel/basic-carousel.component.html
@@ -2,7 +2,6 @@
   @for (slide of [1,2,3,4,5,6]; track slide) {
   <ng-template daffSfCarouselItem>
     <daff-card>
-      <div daffCardHeader>Header {{ slide }}</div>
       <div daffCardTitle>Title</div>
       <div daffCardContent>
         <p>

--- a/libs/storefront-examples/carousel/src/provider.ts
+++ b/libs/storefront-examples/carousel/src/provider.ts
@@ -1,0 +1,11 @@
+import { makeEnvironmentProviders } from '@angular/core';
+
+import { provideDaffDocsExampleContent } from '@daffodil/docs';
+
+export const provideDaffStorefrontCarouselExamplesContent = () => makeEnvironmentProviders(provideDaffDocsExampleContent(
+  {
+    id: 'basic-carousel',
+    component: () => import('./basic-carousel/basic-carousel.component').then(c => c.BasicCarouselStorefrontExampleComponent),
+  },
+));
+

--- a/libs/storefront-examples/carousel/src/public_api.ts
+++ b/libs/storefront-examples/carousel/src/public_api.ts
@@ -1,5 +1,2 @@
-import { BasicCarouselStorefrontExampleComponent } from './basic-carousel/basic-carousel.component';
-
-export const BASIC_CAROUSEL_EXAMPLES = [
-  BasicCarouselStorefrontExampleComponent,
-];
+export { BasicCarouselStorefrontExampleComponent } from './basic-carousel/basic-carousel.component';
+export { provideDaffStorefrontCarouselExamplesContent } from './provider';

--- a/libs/storefront-examples/package.json
+++ b/libs/storefront-examples/package.json
@@ -24,7 +24,8 @@
   },
   "devDependencies": {
     "@daffodil/storefront": "0.0.0-PLACEHOLDER",
-    "@daffodil/design": "0.0.0-PLACEHOLDER"
+    "@daffodil/design": "0.0.0-PLACEHOLDER",
+    "@daffodil/docs": "0.0.0-PLACEHOLDER"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/storefront-examples/theme-toggle/src/provider.ts
+++ b/libs/storefront-examples/theme-toggle/src/provider.ts
@@ -1,0 +1,11 @@
+import { makeEnvironmentProviders } from '@angular/core';
+
+import { provideDaffDocsExampleContent } from '@daffodil/docs';
+
+export const provideDaffStorefrontThemeToggleExamplesContent = () => makeEnvironmentProviders(provideDaffDocsExampleContent(
+  {
+    id: 'basic-theme-toggle',
+    component: () => import('./basic-theme-toggle/basic-theme-toggle.component').then(c => c.BasicThemeToggleStorefrontExampleComponent),
+  },
+));
+

--- a/libs/storefront-examples/theme-toggle/src/public_api.ts
+++ b/libs/storefront-examples/theme-toggle/src/public_api.ts
@@ -1,5 +1,2 @@
-import { BasicThemeToggleStorefrontExampleComponent } from './basic-theme-toggle/basic-theme-toggle.component';
-
-export const BASIC_THEME_TOGGLE_EXAMPLES = [
-  BasicThemeToggleStorefrontExampleComponent,
-];
+export { BasicThemeToggleStorefrontExampleComponent } from './basic-theme-toggle/basic-theme-toggle.component';
+export { provideDaffStorefrontThemeToggleExamplesContent } from './provider';

--- a/libs/storefront/carousel/README.md
+++ b/libs/storefront/carousel/README.md
@@ -4,6 +4,8 @@ Carousel is a slideshow component for cycling through a series of content.
 ## Overview
 Carousel uses [Swiper](https://swiperjs.com) under the hood. For complete API documentation, refer to the Swiper documentation. Some inputs have been limited to provide better control over the user interface and keep the carousel's API smaller.
 
+<daffio-example-viewer example="basic-carousel"></daffio-example-viewer>
+
 ## Usage
 To use carousel, import `DAFF_CAROUSEL_COMPONENTS` into your custom component:
 

--- a/libs/storefront/theme-toggle/README.md
+++ b/libs/storefront/theme-toggle/README.md
@@ -4,6 +4,8 @@ Theme toggle allows users to switch between light and dark themes.
 ## Overview
 Theme toggle persists the user's preference and integrates with `@daffodil/design`'s theming system.
 
+<daffio-example-viewer example="basic-theme-toggle"></daffio-example-viewer>
+
 ## Usage
 To use theme toggle, import `DaffSfThemeToggleComponent` into your custom component:
 


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4359

## New behavior
 - Add example viewers to storefront carousel and theme-toggle READMEs
- Add content providers for storefront examples (carousel, theme-toggle)
- Register storefront examples in the shared design routes factory so they are available across both design and storefront doc sections
- Update `DaffioExampleViewerComponent` to resolve source file paths dynamically using the active section (design vs storefront) instead of hardcoding "design"
- Fix carousel example template (remove invalid `daffCardHeader` usage)
- Update storefront-examples public APIs to export content providers
- Add `@daffodil/docs` as a dev dependency to `@daffodil/storefront-examples`

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->