### PR TITLE
fix(daffio): fix `DaffioExampleViewerPreviewComponent` to always apply the viewport class

### DIFF
--- a/apps/daffio/src/app/docs/components/example-viewer/example-viewer-preview/example-viewer-preview.component.scss
+++ b/apps/daffio/src/app/docs/components/example-viewer/example-viewer-preview/example-viewer-preview.component.scss
@@ -48,6 +48,7 @@ $border-radius: 0.5rem;
 	&__content {
 		display: block;
 		margin: 0 auto;
+		width: 100%;
 
 		&.desktop {
 			max-width: 100%;

--- a/apps/daffio/src/app/docs/components/example-viewer/example-viewer-preview/example-viewer-preview.component.ts
+++ b/apps/daffio/src/app/docs/components/example-viewer/example-viewer-preview/example-viewer-preview.component.ts
@@ -47,5 +47,5 @@ export class DaffioExampleViewerPreviewComponent {
 
   viewport = signal<DaffioExampleViewerViewportOption>(DaffioExampleViewerViewportOption.DESKTOP);
 
-  viewportClass = computed(() => this.viewport() !== DaffioExampleViewerViewportOption.DESKTOP ? this.viewport() : '');
+  viewportClass = computed(() => this.viewport());
 }


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
the `desktop` class is not being applied.

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
the `desktop` class is applied when desktop is selected.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->