### PR TITLE
fix(daffio): Replace `@use 'utilities'` with `@use '@daffodil/design/scss/utilities'`

### DIFF
--- a/apps/daffio/src/app/content/home/components/home-callout-commerce/home-callout-commerce-theme.scss
+++ b/apps/daffio/src/app/content/home/components/home-callout-commerce/home-callout-commerce-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-home-callout-commerce-theme($theme) {
 	$primary: daff-get-palette($theme, primary);

--- a/apps/daffio/src/app/content/home/components/home-callout-commerce/home-callout-commerce.component.scss
+++ b/apps/daffio/src/app/content/home/components/home-callout-commerce/home-callout-commerce.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 .daffio-home-callout-commerce {
 	&__grid {

--- a/apps/daffio/src/app/content/home/components/home-callout-platforms/home-callout-platforms.component.scss
+++ b/apps/daffio/src/app/content/home/components/home-callout-platforms/home-callout-platforms.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 .daffio-home-callout-platforms {
 	&__logos {

--- a/apps/daffio/src/app/content/home/components/home-callout-sponsors/home-callout-sponsors-theme.scss
+++ b/apps/daffio/src/app/content/home/components/home-callout-sponsors/home-callout-sponsors-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-home-callout-sponsors-theme($theme) {
 	$secondary: daff-get-palette($theme, secondary);

--- a/apps/daffio/src/app/content/home/components/home-callout-sponsors/home-callout-sponsors.component.scss
+++ b/apps/daffio/src/app/content/home/components/home-callout-sponsors/home-callout-sponsors.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 .daffio-home-callout-sponsors {
 	&__logo-wrapper {

--- a/apps/daffio/src/app/content/home/components/home-hero/home-hero-theme.scss
+++ b/apps/daffio/src/app/content/home/components/home-hero/home-hero-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-home-hero-theme($theme) {
 	$primary: daff-get-palette($theme, primary);

--- a/apps/daffio/src/app/content/home/components/home-hero/home-hero.component.scss
+++ b/apps/daffio/src/app/content/home/components/home-hero/home-hero.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 :host {
 	display: block;

--- a/apps/daffio/src/app/content/support/support.component.scss
+++ b/apps/daffio/src/app/content/support/support.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 .daffio-support {
 	&__body {

--- a/apps/daffio/src/app/core/footer/docs-footer/docs-footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/docs-footer/docs-footer-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-docs-footer-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);

--- a/apps/daffio/src/app/core/footer/docs-footer/docs-footer.component.scss
+++ b/apps/daffio/src/app/core/footer/docs-footer/docs-footer.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 :host {
 	display: flex;

--- a/apps/daffio/src/app/core/footer/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/footer/footer-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 @use 'sass:map';
 
 @mixin daffio-footer-theme($theme) {

--- a/apps/daffio/src/app/core/footer/footer/footer.component.scss
+++ b/apps/daffio/src/app/core/footer/footer/footer.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 :host {
 	display: block;

--- a/apps/daffio/src/app/core/footer/sub-footer/sub-footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/sub-footer/sub-footer-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-sub-footer-theme($theme) {
 	$secondary: daff-get-palette($theme, secondary);

--- a/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.scss
+++ b/apps/daffio/src/app/core/footer/sub-footer/sub-footer.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 /* stylelint-disable-line scss/comment-no-loud */
 .daffio-sub-footer {

--- a/apps/daffio/src/app/core/header/components/header/header-theme.scss
+++ b/apps/daffio/src/app/core/header/components/header/header-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 // stylelint-disable selector-class-pattern
 @mixin daffio-header-theme($theme) {

--- a/apps/daffio/src/app/core/header/components/header/header.component.scss
+++ b/apps/daffio/src/app/core/header/components/header/header.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 :host {
 	$root: '.daffio-header';

--- a/apps/daffio/src/app/core/sidebar/components/docs/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/sidebar/components/docs/footer/footer-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-docs-sidebar-footer-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);

--- a/apps/daffio/src/app/core/sidebar/components/docs/footer/footer.component.scss
+++ b/apps/daffio/src/app/core/sidebar/components/docs/footer/footer.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 .daffio-docs-sidebar-footer {
 	@include daff.clickable();

--- a/apps/daffio/src/app/core/sidebar/components/marketing/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/sidebar/components/marketing/footer/footer-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-marketing-sidebar-footer-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);

--- a/apps/daffio/src/app/core/sidebar/components/marketing/footer/footer.component.scss
+++ b/apps/daffio/src/app/core/sidebar/components/marketing/footer/footer.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 .daffio-marketing-sidebar-footer {
 	@include daff.clickable();

--- a/apps/daffio/src/app/docs/api/components/api-item-label/api-item-label-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-item-label/api-item-label-theme.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
 @use 'theme' as *;
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 // stylelint-disable selector-class-pattern
 @mixin type-theming($color, $opacity: 0.05) {

--- a/apps/daffio/src/app/docs/api/components/api-item-label/api-item-label-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-item-label/api-item-label-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 @use '@daffodil/design/scss/utilities' as daff;
 
 // stylelint-disable selector-class-pattern

--- a/apps/daffio/src/app/docs/api/components/api-item-label/api-item-label.component.scss
+++ b/apps/daffio/src/app/docs/api/components/api-item-label/api-item-label.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 :host {
 	display: block;

--- a/apps/daffio/src/app/docs/api/components/api-list-section/api-list-section-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-list-section/api-list-section-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-api-list-section-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);

--- a/apps/daffio/src/app/docs/api/components/api-list-section/api-list-section.component.scss
+++ b/apps/daffio/src/app/docs/api/components/api-list-section/api-list-section.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 $api-list-section-item-border-radius: 0.25rem;
 

--- a/apps/daffio/src/app/docs/api/components/api-list/api-list-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-list/api-list-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-api-list-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);

--- a/apps/daffio/src/app/docs/api/components/api-list/api-list.component.scss
+++ b/apps/daffio/src/app/docs/api/components/api-list/api-list.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 :host {
 	display: flex;

--- a/apps/daffio/src/app/docs/api/components/api-package/api-package-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-package/api-package-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-api-package-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);

--- a/apps/daffio/src/app/docs/api/components/api-package/api-package.component.scss
+++ b/apps/daffio/src/app/docs/api/components/api-package/api-package.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 .daffio-api-package {
 	display: flex;

--- a/apps/daffio/src/app/docs/api/components/fragments/inputs/inputs-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/fragments/inputs/inputs-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-api-inputs-fragment-theme($theme) {
 	$primary: daff-get-palette($theme, primary);

--- a/apps/daffio/src/app/docs/api/components/fragments/methods/methods-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/fragments/methods/methods-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-api-methods-fragment-theme($theme) {
 	$tertiary: daff-get-palette($theme, tertiary);

--- a/apps/daffio/src/app/docs/api/components/fragments/outputs/outputs-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/fragments/outputs/outputs-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-api-outputs-fragment-theme($theme) {
 	$secondary: daff-get-palette($theme, secondary);

--- a/apps/daffio/src/app/docs/api/components/fragments/params/params-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/fragments/params/params-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-api-params-fragment-theme($theme) {
 	$red: daff-get-palette($theme, critical);

--- a/apps/daffio/src/app/docs/api/components/method-block/method-block-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/method-block/method-block-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-method-block-theme($theme) {
 	$red: daff-get-palette($theme, critical);

--- a/apps/daffio/src/app/docs/api/pages/api-list-page/api-list-page.component.scss
+++ b/apps/daffio/src/app/docs/api/pages/api-list-page/api-list-page.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 :host {
 	display: block;

--- a/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer-theme.scss
+++ b/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-doc-viewer-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);

--- a/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.scss
+++ b/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 // stylelint-disable selector-class-pattern
 :host {

--- a/apps/daffio/src/app/docs/components/example-viewer/example-viewer-code/example-viewer-code.component.scss
+++ b/apps/daffio/src/app/docs/components/example-viewer/example-viewer-code/example-viewer-code.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 // stylelint-disable selector-class-pattern
 :host {

--- a/apps/daffio/src/app/docs/components/example-viewer/example-viewer-preview/example-viewer-preview.component.scss
+++ b/apps/daffio/src/app/docs/components/example-viewer/example-viewer-preview/example-viewer-preview.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 $border-radius: 0.5rem;
 

--- a/apps/daffio/src/app/docs/components/example-viewer/example-viewer-theme.scss
+++ b/apps/daffio/src/app/docs/components/example-viewer/example-viewer-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 // stylelint-disable selector-class-pattern
 @mixin daffio-docs-example-viewer-theme($theme) {

--- a/apps/daffio/src/app/docs/components/member-heading/member-heading-theme.scss
+++ b/apps/daffio/src/app/docs/components/member-heading/member-heading-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 // stylelint-disable selector-class-pattern
 @mixin daffio-docs-member-heading-theme($theme) {

--- a/apps/daffio/src/app/docs/components/scroll-to-top/scroll-to-top-theme.scss
+++ b/apps/daffio/src/app/docs/components/scroll-to-top/scroll-to-top-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-docs-scroll-to-top-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);

--- a/apps/daffio/src/app/docs/components/scroll-to-top/scroll-to-top.component.scss
+++ b/apps/daffio/src/app/docs/components/scroll-to-top/scroll-to-top.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 .daffio-docs-scroll-to-top {
 	&__button {

--- a/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents-theme.scss
+++ b/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daffio-docs-table-of-contents-theme($theme) {
 	$neutral: daff-get-palette($theme, neutral);

--- a/apps/daffio/src/app/docs/design/pages/components-overview/component-overview.component.scss
+++ b/apps/daffio/src/app/docs/design/pages/components-overview/component-overview.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 .daffio-docs-design-component-overview {
 	&__body {

--- a/apps/daffio/src/app/docs/design/pages/overview/overview.component.scss
+++ b/apps/daffio/src/app/docs/design/pages/overview/overview.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 :host {
 	display: block;

--- a/apps/daffio/src/app/docs/packages/components/package-cards/package-cards.component.scss
+++ b/apps/daffio/src/app/docs/packages/components/package-cards/package-cards.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 :host {
 	display: grid;

--- a/apps/daffio/src/app/docs/packages/pages/packages-overview/packages-overview.component.scss
+++ b/apps/daffio/src/app/docs/packages/pages/packages-overview/packages-overview.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 .daffio-packages-overview {
 	&__card-grid {

--- a/apps/demo/src/app/cart/components/add-to-cart-notification/components/add-to-cart-notification/add-to-cart-notification.component.scss
+++ b/apps/demo/src/app/cart/components/add-to-cart-notification/components/add-to-cart-notification/add-to-cart-notification.component.scss
@@ -1,5 +1,5 @@
 @use 'demo-theme';
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-add-to-cart-notification {
 	background-color: demo-theme.$white;

--- a/apps/demo/src/app/cart/components/add-to-cart-notification/components/product-added/product-added.component.scss
+++ b/apps/demo/src/app/cart/components/add-to-cart-notification/components/product-added/product-added.component.scss
@@ -1,5 +1,5 @@
 @use 'demo-theme';
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-product-added {
 	display: grid;

--- a/apps/demo/src/app/cart/components/cart-item-count/cart-item-count.component.scss
+++ b/apps/demo/src/app/cart/components/cart-item-count/cart-item-count.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @use 'demo-theme' as *;
 
 .demo-cart-item-count {

--- a/apps/demo/src/app/cart/components/cart-item/cart-item.component.scss
+++ b/apps/demo/src/app/cart/components/cart-item/cart-item.component.scss
@@ -1,5 +1,5 @@
 @use 'demo-theme';
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-cart-item {
 	display: grid;

--- a/apps/demo/src/app/cart/components/cart-sidebar/cart-sidebar.component.scss
+++ b/apps/demo/src/app/cart/components/cart-sidebar/cart-sidebar.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @use 'demo-theme' as *;
 @use '../../../../scss/mixins/dividers' as *;
 

--- a/apps/demo/src/app/cart/components/cart-summary-wrapper/cart-summary-wrapper.component.scss
+++ b/apps/demo/src/app/cart/components/cart-summary-wrapper/cart-summary-wrapper.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @use 'demo-theme' as *;
 @use '../../../../scss/mixins/dividers' as *;
 

--- a/apps/demo/src/app/cart/components/cart-summary/cart-summary.component.scss
+++ b/apps/demo/src/app/cart/components/cart-summary/cart-summary.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @use 'demo-theme' as *;
 @use '../../../../scss/mixins/dividers' as *;
 

--- a/apps/demo/src/app/cart/components/cart-totals-item/cart-totals-item.component.scss
+++ b/apps/demo/src/app/cart/components/cart-totals-item/cart-totals-item.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 :host {
 	display: block;

--- a/apps/demo/src/app/cart/components/cart/cart.component.scss
+++ b/apps/demo/src/app/cart/components/cart/cart.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @use 'demo-theme' as *;
 @use '../../../../scss/mixins/dividers' as *;
 

--- a/apps/demo/src/app/cart/components/minicart-item/minicart-item.component.scss
+++ b/apps/demo/src/app/cart/components/minicart-item/minicart-item.component.scss
@@ -1,5 +1,5 @@
 @use 'demo-theme';
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 :host {
 	display: grid;

--- a/apps/demo/src/app/cart/pages/cart-view/cart-view.component.scss
+++ b/apps/demo/src/app/cart/pages/cart-view/cart-view.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @import 'theme';
 
 .demo-cart-view {

--- a/apps/demo/src/app/checkout/components/forms/address/components/address-form/address-form.component.scss
+++ b/apps/demo/src/app/checkout/components/forms/address/components/address-form/address-form.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-checkout-address-form {
 	display: grid;

--- a/apps/demo/src/app/checkout/components/payment/billing-summary/billing-summary.component.scss
+++ b/apps/demo/src/app/checkout/components/payment/billing-summary/billing-summary.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-checkout-billing-summary {
 	font-size: $font-size-sm;

--- a/apps/demo/src/app/checkout/components/payment/payment-form/payment-form.component.scss
+++ b/apps/demo/src/app/checkout/components/payment/payment-form/payment-form.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-checkout-payment-form {
 	display: flex;

--- a/apps/demo/src/app/checkout/components/payment/payment-info-form/components/payment-info-form/payment-info-form.component.scss
+++ b/apps/demo/src/app/checkout/components/payment/payment-info-form/components/payment-info-form/payment-info-form.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-payment-info-form {
 	display: grid;

--- a/apps/demo/src/app/checkout/components/payment/payment-summary/payment-summary.component.scss
+++ b/apps/demo/src/app/checkout/components/payment/payment-summary/payment-summary.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-checkout-payment-summary {
 	font-size: $font-size-sm;

--- a/apps/demo/src/app/checkout/components/shipping-address/form/shipping-address-form.component.scss
+++ b/apps/demo/src/app/checkout/components/shipping-address/form/shipping-address-form.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-checkout-shipping-address-form {
 	display: flex;

--- a/apps/demo/src/app/checkout/components/shipping-address/summary/shipping-address-summary.component.scss
+++ b/apps/demo/src/app/checkout/components/shipping-address/summary/shipping-address-summary.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-checkout-shipping-address-summary {
 	font-size: $font-size-sm;

--- a/apps/demo/src/app/checkout/components/shipping/shipping-form/shipping-form.component.scss
+++ b/apps/demo/src/app/checkout/components/shipping/shipping-form/shipping-form.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-checkout-shipping-form {
 	display: flex;

--- a/apps/demo/src/app/checkout/components/shipping/shipping-options/components/shipping-options/shipping-options.component.scss
+++ b/apps/demo/src/app/checkout/components/shipping/shipping-options/components/shipping-options/shipping-options.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @import 'theme';
 
 .demo-checkout-shipping-options {

--- a/apps/demo/src/app/checkout/components/shipping/shipping-summary/shipping-summary.component.scss
+++ b/apps/demo/src/app/checkout/components/shipping/shipping-summary/shipping-summary.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-checkout-shipping-summary {
 	font-size: $font-size-sm;

--- a/apps/demo/src/app/checkout/pages/checkout-view/checkout-view.component.scss
+++ b/apps/demo/src/app/checkout/pages/checkout-view/checkout-view.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @import 'theme';
 
 .demo-checkout {

--- a/apps/demo/src/app/core/footer/footer.component.scss
+++ b/apps/demo/src/app/core/footer/footer.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 :host {
 	display: block;

--- a/apps/demo/src/app/core/header/components/header/header.component.scss
+++ b/apps/demo/src/app/core/header/components/header/header.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @use 'demo-theme' as *;
 @use '../../../../../scss/mixins/dividers' as *;
 

--- a/apps/demo/src/app/core/sidebar/components/sidebar-list/sidebar-list.component.scss
+++ b/apps/demo/src/app/core/sidebar/components/sidebar-list/sidebar-list.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @import 'theme';
 
 .demo-sidebar-list {

--- a/apps/demo/src/app/core/sidebar/containers/sidebar/sidebar.component.scss
+++ b/apps/demo/src/app/core/sidebar/containers/sidebar/sidebar.component.scss
@@ -1,5 +1,5 @@
 @use 'demo-theme';
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-sidebar {
 	padding: 75px 25px 0;

--- a/apps/demo/src/app/misc/help-box/help-box.component.scss
+++ b/apps/demo/src/app/misc/help-box/help-box.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @import 'theme';
 
 .demo-help-box {

--- a/apps/demo/src/app/misc/not-found/not-found.component.scss
+++ b/apps/demo/src/app/misc/not-found/not-found.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-not-found {
 	padding-top: 50px;

--- a/apps/demo/src/app/newsletter/newsletter.component.scss
+++ b/apps/demo/src/app/newsletter/newsletter.component.scss
@@ -1,5 +1,5 @@
 @use 'demo-theme';
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 :host {
 	display: block;

--- a/apps/demo/src/app/product/components/add-to-cart/add-to-cart.component.scss
+++ b/apps/demo/src/app/product/components/add-to-cart/add-to-cart.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-add-to-cart {
 	display: inline-block;

--- a/apps/demo/src/app/product/components/product-card/product-card.component.scss
+++ b/apps/demo/src/app/product/components/product-card/product-card.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-product-card {
 	@include clickable();

--- a/apps/demo/src/app/product/components/product-grid/product-grid.component.scss
+++ b/apps/demo/src/app/product/components/product-grid/product-grid.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 :host {
 	display: grid;

--- a/apps/demo/src/app/product/components/product/product.component.scss
+++ b/apps/demo/src/app/product/components/product/product.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @import 'theme';
 
 .demo-product {

--- a/apps/demo/src/app/product/containers/best-sellers/best-sellers.component.scss
+++ b/apps/demo/src/app/product/containers/best-sellers/best-sellers.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 
 .demo-best-sellers {
 	&__title {

--- a/apps/demo/src/app/thank-you/components/thank-you/thank-you.component.scss
+++ b/apps/demo/src/app/thank-you/components/thank-you/thank-you.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @use '../../../../scss/mixins/dividers' as *;
 @use 'demo-theme' as *;
 

--- a/apps/demo/src/app/thank-you/pages/thank-you-view.component.scss
+++ b/apps/demo/src/app/thank-you/pages/thank-you-view.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as *;
+@use '@daffodil/design/scss/utilities' as *;
 @use 'demo-theme' as *;
 
 .demo-thank-you-view {

--- a/libs/docs/src/color-palettes/color-palettes-theme.scss
+++ b/libs/docs/src/color-palettes/color-palettes-theme.scss
@@ -1,4 +1,4 @@
-@use 'theme' as *;
+@use '@daffodil/design/scss/theme' as *;
 
 @mixin daff-docs-color-palettes-theme($theme) {
 	$black: daff-get-base-color($theme, 'black');

--- a/libs/docs/src/color-palettes/color-palettes.component.scss
+++ b/libs/docs/src/color-palettes/color-palettes.component.scss
@@ -1,4 +1,4 @@
-@use 'utilities' as daff;
+@use '@daffodil/design/scss/utilities' as daff;
 
 :host {
 	display: grid;

--- a/tools/karma/karma.conf.js
+++ b/tools/karma/karma.conf.js
@@ -1,4 +1,5 @@
 var SassDaffodilImporterPlugin = require('./sass-daffodil-importer-plugin');
+var { interceptNgBuildWebpack } = require('./ng-webpack-interceptor');
 
 module.exports = function(config) {
   var coverageDir = require('path').join(__dirname, '../../coverage');
@@ -42,18 +43,13 @@ module.exports = function(config) {
     browserNoActivityTimeout : 210000,
     singleRun: false,
   });
-  var _buildWebpack;
-  Object.defineProperty(config, 'buildWebpack', {
-    get: function() { return _buildWebpack; },
-    set: function(value) {
-      if (value && value.webpackConfig) {
-        value.webpackConfig.plugins = value.webpackConfig.plugins || [];
-        value.webpackConfig.plugins.push(new SassDaffodilImporterPlugin());
-      }
-      _buildWebpack = value;
-    },
-    enumerable: true,
-    configurable: true,
+  // Angular's Karma builder sets `config.buildWebpack` after this function
+  // returns, so we can't access the webpack config directly. Instead, intercept
+  // the assignment with a setter so we can inject our Sass importer plugin
+  // into the webpack config the moment Angular provides it.
+  interceptNgBuildWebpack(config, function(webpackConfig) {
+    webpackConfig.plugins = webpackConfig.plugins || [];
+    webpackConfig.plugins.push(new SassDaffodilImporterPlugin());
   });
 
   return config;

--- a/tools/karma/karma.conf.js
+++ b/tools/karma/karma.conf.js
@@ -1,3 +1,5 @@
+var SassDaffodilImporterPlugin = require('./sass-daffodil-importer-plugin');
+
 module.exports = function(config) {
   var coverageDir = require('path').join(__dirname, '../../coverage');
 
@@ -39,6 +41,19 @@ module.exports = function(config) {
     browserDisconnectTimeout : 210000,
     browserNoActivityTimeout : 210000,
     singleRun: false,
+  });
+  var _buildWebpack;
+  Object.defineProperty(config, 'buildWebpack', {
+    get: function() { return _buildWebpack; },
+    set: function(value) {
+      if (value && value.webpackConfig) {
+        value.webpackConfig.plugins = value.webpackConfig.plugins || [];
+        value.webpackConfig.plugins.push(new SassDaffodilImporterPlugin());
+      }
+      _buildWebpack = value;
+    },
+    enumerable: true,
+    configurable: true,
   });
 
   return config;

--- a/tools/karma/ng-webpack-interceptor.js
+++ b/tools/karma/ng-webpack-interceptor.js
@@ -1,0 +1,18 @@
+/**
+ * Intercepts the moment Angular's Karma builder assigns `config.buildWebpack`,
+ * calling `callback(webpackConfig)` so you can modify it before the build runs.
+ */
+export const interceptNgBuildWebpack = (config, callback) => {
+  let _buildWebpack;
+  Object.defineProperty(config, 'buildWebpack', {
+    get() { return _buildWebpack; },
+    set(value) {
+      if (value?.webpackConfig) {
+        callback(value.webpackConfig);
+      }
+      _buildWebpack = value;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+};

--- a/tools/karma/sass-daffodil-importer-plugin.js
+++ b/tools/karma/sass-daffodil-importer-plugin.js
@@ -1,0 +1,52 @@
+var path = require('path');
+var url = require('url');
+var fs = require('fs');
+
+var DIST_DIR = path.resolve(__dirname, '../../dist');
+
+/**
+ * Webpack plugin that adds a Sass importer resolving `@daffodil/*` to `dist/*`.
+ * Needed because @ngtools/webpack's TypeScriptPathsPlugin only applies tsconfig
+ * path mapping to JS/TS issuers, skipping .scss files entirely.
+ */
+function DaffodilSassPlugin() {}
+
+DaffodilSassPlugin.prototype.apply = function(compiler) {
+  var importer = {
+    findFileUrl: function(importUrl) {
+      if (importUrl.indexOf('@daffodil/') !== 0) return null;
+      var mapped = path.join(DIST_DIR, importUrl.slice('@daffodil/'.length));
+      var candidates = [
+        mapped + '.scss',
+        path.join(path.dirname(mapped), '_' + path.basename(mapped) + '.scss'),
+        path.join(mapped, '_index.scss'),
+        path.join(mapped, 'index.scss'),
+      ];
+      for (var i = 0; i < candidates.length; i++) {
+        if (fs.existsSync(candidates[i])) return url.pathToFileURL(candidates[i]);
+      }
+      return null;
+    },
+  };
+
+  (function patch(rules) {
+    if (!rules) return;
+    rules.forEach(function(rule) {
+      if (!rule) return;
+      patch(rule.rules);
+      patch(rule.oneOf);
+      (Array.isArray(rule.use) ? rule.use : []).forEach(function(loader) {
+        if (!loader || !loader.loader || loader.loader.indexOf('sass-loader') === -1) return;
+        if (!loader.options || typeof loader.options.sassOptions !== 'function') return;
+        var orig = loader.options.sassOptions;
+        loader.options.sassOptions = function(ctx) {
+          var opts = orig(ctx);
+          opts.importers = (opts.importers || []).concat(importer);
+          return opts;
+        };
+      });
+    });
+  })(compiler.options.module && compiler.options.module.rules);
+};
+
+module.exports = DaffodilSassPlugin;


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4249 

## New behavior
<!-- Describe the changes -->

Imports scss utilities in daffio with `@use '@daffodil/design/scss/utilities'` instead of `@use 'utilities'` 

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->