### PR TITLE
feat(design, daffio): convert tree to signals and then make daffio render the tree sanely

### DIFF
--- a/apps/daffio/src/app/core/sidebar/services/sidebar.service.ts
+++ b/apps/daffio/src/app/core/sidebar/services/sidebar.service.ts
@@ -64,7 +64,6 @@ export class DaffioSidebarService extends DaffSidebarService {
       map((data) => data.daffioSidebars),
     ),
   ]).pipe(
-    distinctUntilChanged(),
     map(([id, sidebars]) => {
       if(!sidebars?.[id] && isDevMode()) {
         console.warn(
@@ -75,7 +74,7 @@ export class DaffioSidebarService extends DaffSidebarService {
       }
       return sidebars?.[id] ?? undefined;
     }),
-
+    distinctUntilChanged((prev, curr) => prev?.id === curr?.id),
   );
 
   constructor(

--- a/apps/daffio/src/app/docs/composables/nav-index.ts
+++ b/apps/daffio/src/app/docs/composables/nav-index.ts
@@ -1,5 +1,4 @@
 import { inject } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import {
   filter,
   map,
@@ -7,12 +6,14 @@ import {
 } from 'rxjs';
 
 import { DaffDocsNavList } from '@daffodil/docs-utils';
+import { DaffRouterDataService } from '@daffodil/router';
 
 export const useDaffioNavList = <T extends DaffDocsNavList = DaffDocsNavList>() => {
-  const route = inject(ActivatedRoute);
-  const list: Observable<T> = route.data.pipe(
+  const routerData = inject(DaffRouterDataService);
+  const list: Observable<T> = routerData.data$.pipe(
     filter(Boolean),
     map((data) => data.index),
+    filter(Boolean),
   );
 
   return {

--- a/apps/daffio/src/app/docs/docs.routes.ts
+++ b/apps/daffio/src/app/docs/docs.routes.ts
@@ -15,11 +15,8 @@ import { DaffioDocsFooterComponent } from '../core/footer/docs-footer/docs-foote
 import { DaffioDocsNavContainer } from '../core/nav/docs/docs.component';
 import { DAFF_DOCS_NAV_SIDEBAR_REGISTRATION } from '../core/nav/docs-sidebar.provider';
 import { DaffioDocsDesignNavMenuComponent } from './design/components/nav-menu/nav-menu.component';
-import { DaffioDocsDesignOverviewPageComponent } from './design/pages/overview/overview.component';
 import { DaffioRouterNamedViewsEnum } from '../core/router/named-views/models/named-views.enum';
 import { DaffioRoute } from '../core/router/route.type';
-import { provideDaffioDocsDesignSection } from './design/services/index.service';
-import { DaffioDocsStorefrontOverviewPageComponent } from './storefront/pages/overview/overview.component';
 
 export const daffioDocsRoutes = <Routes> [
   <DaffioRoute>{
@@ -59,28 +56,11 @@ export const daffioDocsRoutes = <Routes> [
       },
       {
         path: DAFF_DOCS_DESIGN_PATH,
-        loadChildren: () => import('./design/design.routes').then(r => r.daffioDocsDesignRoutesFactory(
-          DAFF_DOCS_DESIGN_PATH,
-          {
-            path: '',
-            pathMatch: 'full',
-            component: DaffioDocsDesignOverviewPageComponent,
-          },
-        )),
+        loadChildren: () => import('./design/design.routes').then(r => r.daffioDocsDesignRoutes),
       },
       {
         path: DAFF_DOCS_STOREFRONT_PATH,
-        providers: [
-          provideDaffioDocsDesignSection(DAFF_DOCS_STOREFRONT_PATH),
-        ],
-        loadChildren: () => import('./design/design.routes').then(r => r.daffioDocsDesignRoutesFactory(
-          DAFF_DOCS_STOREFRONT_PATH,
-          {
-            path: '',
-            pathMatch: 'full',
-            component: DaffioDocsStorefrontOverviewPageComponent,
-          },
-        )),
+        loadChildren: () => import('./storefront/storefront.routes').then(r => r.daffioDocsStorefrontRoutes),
       },
       {
         path: '',

--- a/apps/daffio/src/app/docs/storefront/storefront.routes.ts
+++ b/apps/daffio/src/app/docs/storefront/storefront.routes.ts
@@ -3,32 +3,32 @@ import { Routes } from '@angular/router';
 import { DaffSidebarModeEnum } from '@daffodil/design/sidebar';
 import {
   DAFF_DOC_KIND_PATH_SEGMENT_MAP,
-  DAFF_DOCS_DESIGN_PATH,
+  DAFF_DOCS_STOREFRONT_PATH,
   DaffDocKind,
 } from '@daffodil/docs-utils';
 
-import { provideDaffioDocsDesignComponentContentComponent } from './components/component-content/component-content.provider';
-import { DAFFIO_DOCS_DESIGN_LIST_SIDEBAR_REGISTRATION } from './containers/docs-list/sidebar.provider';
-import { provideDaffioDesignExamplesContent } from './examples/content.provider';
-import { DaffioDocsDesignComponentOverviewPageComponent } from './pages/components-overview/component-overview.component';
-import { DaffioDocsDesignOverviewPageComponent } from './pages/overview/overview.component';
-import { daffioDocsDesignComponentDocResolver } from './resolvers/component-doc.resolver';
-import { daffioDocsDesignComponentListResolverFactory } from './resolvers/component-list.resolver';
-import { daffioDocsDesignIndexResolver } from './resolvers/index.resolver';
-import { provideDaffioDocsDesignIndexService } from './services/index.service';
+import { provideDaffioStorefrontExamplesContent } from './examples/content.provider';
+import { DaffioDocsStorefrontOverviewPageComponent } from './pages/overview/overview.component';
 import { DaffioRoute } from '../../core/router/route.type';
 import { daffioDocsApiRolesProvider } from '../api/roles/api-roles.provider';
+import { provideDaffioDocsDesignComponentContentComponent } from '../design/components/component-content/component-content.provider';
+import { DAFFIO_DOCS_DESIGN_LIST_SIDEBAR_REGISTRATION } from '../design/containers/docs-list/sidebar.provider';
+import { DaffioDocsDesignComponentOverviewPageComponent } from '../design/pages/components-overview/component-overview.component';
+import { daffioDocsDesignComponentDocResolver } from '../design/resolvers/component-doc.resolver';
+import { daffioDocsDesignComponentListResolverFactory } from '../design/resolvers/component-list.resolver';
+import { daffioDocsDesignIndexResolver } from '../design/resolvers/index.resolver';
+import { provideDaffioDocsDesignIndexService } from '../design/services/index.service';
 import { DaffioDocsPageComponent } from '../pages/docs-page/docs-page.component';
 import { DocsResolver } from '../resolvers/docs-resolver.service';
 
-export const daffioDocsDesignRoutes = <Routes>[
+export const daffioDocsStorefrontRoutes = <Routes>[
   <DaffioRoute>{
     path: '',
     providers: [
-      provideDaffioDocsDesignIndexService(DAFF_DOCS_DESIGN_PATH),
+      provideDaffioDocsDesignIndexService(DAFF_DOCS_STOREFRONT_PATH),
       provideDaffioDocsDesignComponentContentComponent(),
       ...daffioDocsApiRolesProvider(),
-      provideDaffioDesignExamplesContent(),
+      provideDaffioStorefrontExamplesContent(),
     ],
     resolve: {
       index: daffioDocsDesignIndexResolver,
@@ -43,7 +43,7 @@ export const daffioDocsDesignRoutes = <Routes>[
       {
         path: '',
         pathMatch: 'full',
-        component: DaffioDocsDesignOverviewPageComponent,
+        component: DaffioDocsStorefrontOverviewPageComponent,
       },
       {
         path: DAFF_DOC_KIND_PATH_SEGMENT_MAP[DaffDocKind.COMPONENT],
@@ -58,33 +58,6 @@ export const daffioDocsDesignRoutes = <Routes>[
             data: {
               title: 'Components',
               subtitle: 'Components are reusable UI elements in a design system that helps to create consistent, intuitive experiences across products.',
-            },
-          },
-          <DaffioRoute>{
-            path: '**',
-            component: DaffioDocsPageComponent,
-            resolve: {
-              doc: daffioDocsDesignComponentDocResolver,
-            },
-            data: {
-              sidebarMode: DaffSidebarModeEnum.SideFixed,
-            },
-          },
-        ],
-      },
-      {
-        path: 'behaviors',
-        children: [
-          {
-            path: '',
-            pathMatch: 'full',
-            component: DaffioDocsDesignComponentOverviewPageComponent,
-            resolve: {
-              components: daffioDocsDesignComponentListResolverFactory('behaviors'),
-            },
-            data: {
-              title: 'Behaviors',
-              subtitle: 'Behaviors are reusable, composable traits for building UI components that enforce consistent inputs, types, and patterns across both Daffodil and custom components.',
             },
           },
           <DaffioRoute>{

--- a/libs/design/tree/src/tree-item/tree-item.directive.ts
+++ b/libs/design/tree/src/tree-item/tree-item.directive.ts
@@ -1,14 +1,18 @@
 /* eslint-disable quote-props */
 
 import {
+  computed,
   Directive,
-  Inject,
-  Input,
-  DOCUMENT,
+  effect,
+  inject,
+  input,
+  untracked,
 } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 
 import { DaffTreeNotifierService } from '../tree/tree-notifier.service';
 import { DaffTreeFlatNode } from '../utils/flatten-tree';
+import { daffTreeOpenAncestors } from '../utils/open-ancestors';
 
 /**
  * The `DaffTreeItemDirective` marks elements as tree child nodes that interact with the parent tree structure.
@@ -34,89 +38,86 @@ import { DaffTreeFlatNode } from '../utils/flatten-tree';
   selector: '[daffTreeItem]',
   host: {
     'class': 'daff-tree-item',
-    '[class.selected]': 'selected',
-    '[class.parent]': 'isParent',
-    '[class.open]': 'open',
-    '[attr.id]': 'id',
-    '[attr.aria-expanded]': 'ariaExpanded',
-    '[style.--depth]': 'depth',
+    '[class.selected]': 'selected()',
+    '[class.parent]': 'isParent()',
+    '[class.open]': 'open()',
+    '[attr.id]': 'id()',
+    '[attr.aria-expanded]': 'ariaExpanded()',
+    '[style.--depth]': 'depth()',
     '(keydown.escape)': 'onEscape()',
     '(click)': 'onClick()',
   },
 })
 export class DaffTreeItemDirective {
-  private isParent = false;
+  private document = inject(DOCUMENT);
+  private treeNotifier = inject(DaffTreeNotifierService);
+
+  /**
+   * The {@link DaffTreeFlatNode} associated with this specific tree item.
+   */
+  readonly node = input.required<DaffTreeFlatNode>();
+
+  /**
+   * Whether or not the tree item is the currently active item.
+   * Note that there is no requirement that there only be one active item at a time.
+   *
+   * When a tree item becomes selected, all of its ancestor nodes
+   * will be automatically opened so that the selected item is visible.
+   */
+  readonly selected = input(false);
 
   /**
    * The html `id` of the tree item. This is derived from the {@link DaffTreeData}.
-   *
    */
-  private id: string;
+  protected readonly id = computed(() => 'tree-' + this.node().id);
+
+  /**
+   * A property indicating the depth of the tree.
+   */
+  protected readonly depth = computed(() => this.node().level);
+
+  /**
+   * Whether or not this node has children.
+   */
+  protected readonly isParent = computed(() => this.node().hasChildren);
+
+  /**
+   * Indicates whether or not the tree is `open`.
+   */
+  protected readonly open = computed(() => this.node()._treeRef.open);
 
   /**
    * Accessibility property, notifying users about whether
    * or not the tree item is open.
    */
-  private ariaExpanded: string;
+  protected readonly ariaExpanded = computed(() => {
+    const node = this.node();
+    return node.hasChildren ? (node._treeRef.open ? 'true' : 'false') : undefined;
+  });
 
-  /**
-   * A property indicating the depth of the tree.
-   */
-  private depth: number;
-
-  /**
-   * Indicates whether or not the tree is `open`.
-   */
-  private open = false;
-
-  /**
-   * The {@link DaffTreeFlatNode} associated with this specific tree item.
-   */
-  private _node: DaffTreeFlatNode;
-
-  /**
-   * The {@link DaffTreeFlatNode} associated with this specific tree item.
-   */
-  @Input()
-  get node() {
-    return this._node;
-  };
-  set node(val: DaffTreeFlatNode) {
-    this._node = val;
-    this.id = 'tree-' + this._node.id;
-    this.depth = this._node.level;
-    this.isParent = this._node.hasChildren;
-    this.open = this._node._treeRef.open;
-
-    if(this._node.hasChildren) {
-      this.ariaExpanded = this._node._treeRef.open ? 'true' : 'false';
-    }
+  constructor() {
+    effect(() => {
+      if(this.selected()) {
+        const node = untracked(this.node);
+        daffTreeOpenAncestors(node._treeRef);
+        this.treeNotifier.notify();
+      }
+    });
   }
-
-  /**
-   * Whether or not the tree item is the currently active item.
-   * Note that there is no requirement that there only be one active item at a time.
-   */
-  @Input() selected = false;
-
-  constructor(
-    @Inject(DOCUMENT) private document: any,
-    private treeNotifier: DaffTreeNotifierService,
-  ) {}
 
   /**
    * @docs-private
    */
   onEscape() {
-    this.toggleParent(this.node);
+    this.toggleParent(this.node());
   }
 
   /**
    * @docs-private
    */
   onClick() {
-    if(this.node.hasChildren) {
-      this.toggleTree(this.node);
+    if(this.node().hasChildren) {
+      this.toggleTree(this.node());
     }
     this.treeNotifier.notify();
   }

--- a/libs/design/tree/src/tree-item/tree-item.directive.ts
+++ b/libs/design/tree/src/tree-item/tree-item.directive.ts
@@ -1,5 +1,6 @@
 /* eslint-disable quote-props */
 
+import { DOCUMENT } from '@angular/common';
 import {
   computed,
   Directive,
@@ -8,7 +9,6 @@ import {
   input,
   untracked,
 } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
 
 import { DaffTreeNotifierService } from '../tree/tree-notifier.service';
 import { DaffTreeFlatNode } from '../utils/flatten-tree';

--- a/libs/design/tree/src/tree/specs/defaults.spec.ts
+++ b/libs/design/tree/src/tree/specs/defaults.spec.ts
@@ -33,7 +33,7 @@ describe('@daffodil/design/tree | DaffTreeComponent | Defaults', () => {
   });
 
   it('should have sane defaults', () => {
-    expect(component.flatTree).toEqual([]);
-    expect(component.tree).toEqual(undefined);
+    expect(component.flatTree()).toEqual([]);
+    expect(component.tree()).toEqual(undefined);
   });
 });

--- a/libs/design/tree/src/tree/specs/render-modes.spec.ts
+++ b/libs/design/tree/src/tree/specs/render-modes.spec.ts
@@ -1,6 +1,6 @@
 import {
   Component,
-  Input,
+  signal,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -15,7 +15,7 @@ import { DaffTreeComponent } from '../tree.component';
 
 @Component({
   template: `
-    <ul daff-tree [tree]="data" [renderMode]="renderMode">
+    <ul daff-tree [tree]="data()" [renderMode]="renderMode()">
       <ng-template #daffTreeItemWithChildrenTpl let-node>
           <button daffTreeItem [node]="node">{{ node.title }} </button>
       </ng-template>
@@ -31,8 +31,8 @@ import { DaffTreeComponent } from '../tree.component';
   ],
 })
 class WrapperComponent {
-  @Input() data: DaffTreeData<any>;
-  @Input() renderMode: DaffTreeRenderMode;
+  data = signal<DaffTreeData<any>>(undefined);
+  renderMode = signal<DaffTreeRenderMode>(undefined);
 }
 
 
@@ -62,25 +62,25 @@ describe('@daffodil/design/tree | DaffTreeComponent | renderModes', () => {
   });
 
   it('should render two nodes when renderMode is `not-in-dom`', () => {
-    wrapper.data = { title: 'Root', url: '', id: '', items: [
+    wrapper.data.set({ title: 'Root', url: '', id: '', items: [
       { title: 'Child A', url: '', id: '', items: [
         { title: 'Child Aa', url: '', id: '', items: [], data: {}},
       ], data: {}},
       { title: 'Child B', url: '', id: '', items: [], data: {}},
-    ], data: {}};
-    wrapper.renderMode = 'not-in-dom';
+    ], data: {}});
+    wrapper.renderMode.set('not-in-dom');
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('li')).length).toEqual(2);
   });
 
   it('should render three nodes when renderMode is `in-dom`', () => {
-    wrapper.data = { title: 'Root', url: '', id: '', items: [
+    wrapper.data.set({ title: 'Root', url: '', id: '', items: [
       { title: 'Child A', url: '', id: '', items: [
         { title: 'Child Aa', url: '', id: '', items: [], data: {}},
       ], data: {}},
       { title: 'Child B', url: '', id: '', items: [], data: {}},
-    ], data: {}};
-    wrapper.renderMode = 'in-dom';
+    ], data: {}});
+    wrapper.renderMode.set('in-dom');
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('li')).length).toEqual(3);
   });

--- a/libs/design/tree/src/tree/specs/simple.spec.ts
+++ b/libs/design/tree/src/tree/specs/simple.spec.ts
@@ -1,6 +1,6 @@
 import {
   Component,
-  Input,
+  signal,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -13,14 +13,14 @@ import { DaffTreeComponent } from '../tree.component';
 
 @Component({
   template: `
-    <ul daff-tree [tree]="data"></ul>
+    <ul daff-tree [tree]="data()"></ul>
   `,
   imports: [
     DaffTreeComponent,
   ],
 })
 class WrapperComponent {
-  @Input() data: DaffTreeData<any>;
+  data = signal<DaffTreeData<any>>(undefined);
 }
 
 describe('@daffodil/design/tree | DaffTreeComponent | Simple', () => {
@@ -54,7 +54,7 @@ describe('@daffodil/design/tree | DaffTreeComponent | Simple', () => {
   });
 
   it('should render nothing within the tree when data is provided with no templates', () => {
-    wrapper.data = { title: '', url: '', id: '', items: [], data: {}};
+    wrapper.data.set({ title: '', url: '', id: '', items: [], data: {}});
     fixture.detectChanges();
 
     expect(el).toBeTruthy();

--- a/libs/design/tree/src/tree/specs/with-template.spec.ts
+++ b/libs/design/tree/src/tree/specs/with-template.spec.ts
@@ -1,6 +1,6 @@
 import {
   Component,
-  Input,
+  signal,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -14,7 +14,7 @@ import { DaffTreeComponent } from '../tree.component';
 
 @Component({
   template: `
-    <ul daff-tree [tree]="data">
+    <ul daff-tree [tree]="data()">
       <ng-template #daffTreeItemWithChildrenTpl let-node>
           <button daffTreeItem [node]="node">{{ node.title }} </button>
       </ng-template>
@@ -30,7 +30,7 @@ import { DaffTreeComponent } from '../tree.component';
   ],
 })
 class WrapperComponent {
-  @Input() data: DaffTreeData<any>;
+  data = signal<DaffTreeData<any>>(undefined);
 }
 
 
@@ -60,23 +60,23 @@ describe('@daffodil/design/tree - DaffTreeComponent | withTemplate', () => {
   });
 
   it('should render something when data and templates are provided', () => {
-    wrapper.data = { title: 'Root', url: '', id: '', items: [
+    wrapper.data.set({ title: 'Root', url: '', id: '', items: [
       { title: 'Child A', url: '', id: '', items: [
         { title: 'Child Aa', url: '', id: '', items: [], data: {}},
       ], data: {}},
       { title: 'Child B', url: '', id: '', items: [], data: {}},
-    ], data: {}};
+    ], data: {}});
     fixture.detectChanges();
     expect(fixture.debugElement.query(By.css('li')).componentInstance instanceof DaffTreeComponent).toBeTrue();
   });
 
   it('should render the same number of items as there are tree branches', () => {
-    wrapper.data = { title: 'Root', url: '', id: '', items: [
+    wrapper.data.set({ title: 'Root', url: '', id: '', items: [
       { title: 'Child A', url: '', id: '', items: [
         { title: 'Child Aa', url: '', id: '', items: [], data: {}},
       ], data: {}},
       { title: 'Child B', url: '', id: '', items: [], data: {}},
-    ], data: {}};
+    ], data: {}});
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('li')).length).toEqual(3);
   });

--- a/libs/design/tree/src/tree/tree.component.html
+++ b/libs/design/tree/src/tree/tree.component.html
@@ -1,7 +1,7 @@
-@for (node of flatTree; track node.id) {
+@for (node of flatTree(); track node.id) {
 	<li [attr.aria-level]="node.level" [class.hidden]="!node.visible">
 		<ng-container
-			*ngTemplateOutlet="node.hasChildren ? withChildrenTemplate : treeItemTemplate; context: { $implicit: node }">
+			*ngTemplateOutlet="node.hasChildren ? withChildrenTemplate() : treeItemTemplate(); context: { $implicit: node }">
 		</ng-container>
 	</li>
 }

--- a/libs/design/tree/src/tree/tree.component.ts
+++ b/libs/design/tree/src/tree/tree.component.ts
@@ -3,11 +3,11 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
-  ContentChild,
-  Input,
-  OnChanges,
-  OnInit,
-  SimpleChanges,
+  computed,
+  contentChild,
+  inject,
+  input,
+  signal,
   TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
@@ -17,11 +17,7 @@ import { DaffArticleEncapsulatedDirective } from '@daffodil/design';
 import { DaffTreeNotifierService } from './tree-notifier.service';
 import { DaffTreeData } from '../interfaces/tree-data';
 import { DaffTreeRenderMode } from '../interfaces/tree-render-mode';
-import { DaffTreeUi } from '../interfaces/tree-ui';
-import {
-  DaffTreeFlatNode,
-  flattenTree,
-} from '../utils/flatten-tree';
+import { flattenTree } from '../utils/flatten-tree';
 import { hydrateTree } from '../utils/hydrate-tree';
 
 /**
@@ -63,7 +59,9 @@ import { hydrateTree } from '../utils/hydrate-tree';
     NgTemplateOutlet,
   ],
 })
-export class DaffTreeComponent implements OnInit, OnChanges {
+export class DaffTreeComponent {
+  private notifier = inject(DaffTreeNotifierService);
+
   /**
    * The rendering mode for nodes in the tree.
    *
@@ -73,12 +71,26 @@ export class DaffTreeComponent implements OnInit, OnChanges {
    * but there may be use-cases (like SEO) where having the tree in the DOM
    * is relevant.
    */
-  @Input() renderMode: DaffTreeRenderMode;
+  readonly renderMode = input<DaffTreeRenderMode>();
+
+  /**
+   * The tree data you would like to render.
+   */
+  readonly tree = input<DaffTreeData<unknown>>();
 
   /**
    * The internal tree element.
    */
-  private _tree: DaffTreeUi<unknown> = undefined;
+  private _tree = computed(() => {
+    const tree = this.tree();
+    return tree ? hydrateTree(tree) : undefined;
+  });
+
+  /**
+   * A revision counter incremented by notifications from tree items.
+   * Used to trigger re-flattening when tree item state changes.
+   */
+  readonly _revision = signal(0);
 
   /**
    * @docs-private
@@ -86,57 +98,29 @@ export class DaffTreeComponent implements OnInit, OnChanges {
    * The flattened tree data. For debugging purposes, you can iterate through this if you want to inspect
    * the resulting array structure we computed to render the tree.
    */
-  public flatTree: DaffTreeFlatNode[] = [];
-
-  /**
-   * The tree data you would like to render.
-   */
-  @Input() tree: DaffTreeData<unknown>;
+  readonly flatTree = computed(() => {
+    this._revision();
+    const tree = this._tree();
+    return tree ? flattenTree(tree, this.renderMode() === 'not-in-dom') : [];
+  });
 
   /**
    * The template used to render tree-nodes that themselves have children.
    *
    * @docs-private
    */
-  @ContentChild('daffTreeItemWithChildrenTpl', { static: true })
-  withChildrenTemplate: TemplateRef<any>;
+  readonly withChildrenTemplate = contentChild<TemplateRef<any>>('daffTreeItemWithChildrenTpl');
 
   /**
    * The template used to render tree-nodes that have no children.
    *
    * @docs-private
    */
-  @ContentChild('daffTreeItemTpl', { static: true }) treeItemTemplate: TemplateRef<any>;
+  readonly treeItemTemplate = contentChild<TemplateRef<any>>('daffTreeItemTpl');
 
-  /**
-   * @docs-private
-   */
-  constructor(private notifier: DaffTreeNotifierService) {}
-
-  /**
-   * @docs-private
-   */
-  ngOnChanges(changes: SimpleChanges): void {
-    if(!changes.tree.currentValue) {
-      this._tree = undefined;
-      this.flatTree = [];
-      return;
-    }
-
-    if(changes.renderMode && !changes.tree) {
-      this.flatTree = flattenTree(this._tree, changes.renderMode.currentValue === 'not-in-dom');
-    } else if(changes.renderMode || changes.tree) {
-      this._tree = hydrateTree(changes.tree?.currentValue ?? this.tree);
-      this.flatTree = flattenTree(this._tree, (changes.renderMode?.currentValue ?? this.renderMode) === 'not-in-dom');
-    }
-  }
-
-  /**
-   * @docs-private
-   */
-  ngOnInit(): void {
+  constructor() {
     this.notifier.notice$.subscribe(() => {
-      this.flatTree = flattenTree(this._tree, this.renderMode === 'not-in-dom');
+      this._revision.update((r) => r + 1);
     });
   }
 }

--- a/libs/design/tree/src/tree/tree.component.ts
+++ b/libs/design/tree/src/tree/tree.component.ts
@@ -20,6 +20,8 @@ import { DaffTreeRenderMode } from '../interfaces/tree-render-mode';
 import { flattenTree } from '../utils/flatten-tree';
 import { hydrateTree } from '../utils/hydrate-tree';
 
+let daffTreeId = 0;
+
 /**
  * The `DaffTreeComponent` allows you to render tree structures as interactable UI.
  *
@@ -74,6 +76,13 @@ export class DaffTreeComponent {
   readonly renderMode = input<DaffTreeRenderMode>();
 
   /**
+   * A unique identifier for the tree instance.
+   * Used as a prefix for all node IDs in the tree.
+   * If not provided, an auto-incrementing number is used.
+   */
+  readonly id = input<string>(`${daffTreeId++}`);
+
+  /**
    * The tree data you would like to render.
    */
   readonly tree = input<DaffTreeData<unknown>>();
@@ -83,7 +92,7 @@ export class DaffTreeComponent {
    */
   private _tree = computed(() => {
     const tree = this.tree();
-    return tree ? hydrateTree(tree) : undefined;
+    return tree ? hydrateTree(tree, this.id()) : undefined;
   });
 
   /**

--- a/libs/design/tree/src/utils/hydrate-tree.spec.ts
+++ b/libs/design/tree/src/utils/hydrate-tree.spec.ts
@@ -47,4 +47,51 @@ describe('@daffodil/design/tree - hydrateTree', () => {
       expect(uiCount).toEqual(dataCount);
     });
   });
+
+  describe('node IDs', () => {
+    it('should use the treeId as the root node ID when provided', () => {
+      const data = { title: 'Root', url: '', id: 'root', items: [], data: {}};
+      const uiTree = hydrateTree(data, 'my-tree');
+      expect(uiTree.id).toEqual('my-tree');
+    });
+
+    it('should fall back to the data id for the root node when treeId is not provided', () => {
+      const data = { title: 'Root', url: '', id: 'root', items: [], data: {}};
+      const uiTree = hydrateTree(data);
+      expect(uiTree.id).toEqual('root');
+    });
+
+    it('should fall back to the data title for the root node when treeId and id are nullish', () => {
+      const data = { title: 'Root', url: '', id: undefined, items: [], data: {}};
+      const uiTree = hydrateTree(data);
+      expect(uiTree.id).toEqual('Root');
+    });
+
+    it('should prefix child node IDs with their parent ID', () => {
+      const data = { title: 'Root', url: '', id: 'root', items: [
+        { title: 'Child A', url: '', id: 'a', items: [], data: {}},
+      ], data: {}};
+      const uiTree = hydrateTree(data, 'my-tree');
+      expect(uiTree.items[0].id).toEqual('my-tree.a');
+    });
+
+    it('should build nested IDs through the full ancestor chain', () => {
+      const data = { title: 'Root', url: '', id: 'root', items: [
+        { title: 'Child A', url: '', id: 'a', items: [
+          { title: 'Child B', url: '', id: 'b', items: [], data: {}},
+        ], data: {}},
+      ], data: {}};
+      const uiTree = hydrateTree(data, 'my-tree');
+      expect(uiTree.items[0].id).toEqual('my-tree.a');
+      expect(uiTree.items[0].items[0].id).toEqual('my-tree.a.b');
+    });
+
+    it('should use the title as fallback for child IDs when id is nullish', () => {
+      const data = { title: 'Root', url: '', id: undefined, items: [
+        { title: 'Child A', url: '', id: undefined, items: [], data: {}},
+      ], data: {}};
+      const uiTree = hydrateTree(data, 'my-tree');
+      expect(uiTree.items[0].id).toEqual('my-tree.Child A');
+    });
+  });
 });

--- a/libs/design/tree/src/utils/hydrate-tree.ts
+++ b/libs/design/tree/src/utils/hydrate-tree.ts
@@ -3,7 +3,7 @@ import { DaffTreeData } from '../interfaces/tree-data';
 import { DaffTreeUi } from '../interfaces/tree-ui';
 
 export const daffDataTreeToUiTree = <T>(data: DaffTreeData<T>, parent: DaffTreeUi<T>, open: boolean = false): DaffTreeUi<T> => ({
-  id: data.id ?? data.title,
+  id: parent ? `${parent.id}.${data.id ?? data.title}` : (data.id ?? data.title),
   title: data.title,
   url: data.url,
   data: data.data,
@@ -16,11 +16,19 @@ export const daffDataTreeToUiTree = <T>(data: DaffTreeData<T>, parent: DaffTreeU
  * This function translates the original data given to us by the client
  * to the internal representation of the tree used by the {@link DaffTreeComponent}
  */
-export const hydrateTree = <T>(data: DaffTreeData<T>): DaffTreeUi<T> => {
-  const tree = daffDataTreeToUiTree(data, undefined, true);
+export const hydrateTree = <T>(data: DaffTreeData<T>, treeId?: string): DaffTreeUi<T> => {
+  const root: DaffTreeUi<T> = {
+    id: treeId ?? (data.id ?? data.title),
+    title: data.title,
+    url: data.url,
+    data: data.data,
+    open: true,
+    parent: undefined,
+    items: [],
+  };
 
   let treeStack = [
-    tree,
+    root,
   ];
 
   traverse(data, (el) => {
@@ -33,5 +41,5 @@ export const hydrateTree = <T>(data: DaffTreeData<T>): DaffTreeUi<T> => {
     return el;
   }, 'items');
 
-  return tree;
+  return root;
 };

--- a/libs/design/tree/src/utils/open-ancestors.ts
+++ b/libs/design/tree/src/utils/open-ancestors.ts
@@ -1,5 +1,5 @@
-import { DaffTreeUi } from '../interfaces/tree-ui';
 import { walkUp } from './walk-up';
+import { DaffTreeUi } from '../interfaces/tree-ui';
 
 /**
  * Open all ancestor nodes of the given node so that it becomes visible in the tree.

--- a/libs/design/tree/src/utils/open-ancestors.ts
+++ b/libs/design/tree/src/utils/open-ancestors.ts
@@ -1,0 +1,12 @@
+import { DaffTreeUi } from '../interfaces/tree-ui';
+import { walkUp } from './walk-up';
+
+/**
+ * Open all ancestor nodes of the given node so that it becomes visible in the tree.
+ */
+export const daffTreeOpenAncestors = <T>(node: DaffTreeUi<T>): void => {
+  walkUp(node, (ancestor) => {
+    ancestor.open = true;
+    return ancestor;
+  });
+};


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior

### Design

  - The sidebar navigation tree does not auto-expand to reveal the currently active page. On initial render and on every page change, all parent nodes are collapsed, hiding the active item.                                          
  - The tree component and tree item directive use legacy @Input()/@ContentChild() decorators and OnChanges/OnInit lifecycle hooks with manual change detection. 

### Daffio

  - The sidebar body component is destroyed and recreated on every route navigation, even when the sidebar registration hasn't changed. This causes unnecessary re-initialization and loss of tree expansion state.
  - The storefront and design docs routes share a factory function (daffioDocsDesignRoutesFactory) that takes a section string and extra routes, coupling them unnecessarily. 
 
Fixes: #2931 
Part of: #4327 

## New behavior

### Design

  - Tree auto-expands ancestors of selected nodes. When a tree item's selected input becomes true, all ancestor nodes are automatically opened via the new `daffTreeOpenAncestors` utility, making the active page visible in the sidebar.
  - Tree component and directive use signals. @Input() replaced with input()/input.required(), @ContentChild with contentChild(), derived state with computed(), and side-effects with effect(). The tree component uses a _revision signal to trigger re-flattening instead of manual markForCheck(). 
  
 ### Daffio

  - Sidebar body component persists across navigations. activeRegistration$ now uses distinctUntilChanged on the registration id, preventing unnecessary component destruction. The nav list composable (useDaffioNavList) uses DaffRouterDataService instead of ActivatedRoute so it receives updated route data even when the component isn't recreated.
  - Storefront routes are independent. The route factory is replaced with two plain route arrays: daffioDocsDesignRoutes and daffioDocsStorefrontRoutes. Storefront routes no longer include the behaviors section and the design examples are no longer shared on both areas.  

## Breaking change?

- [x] Yes
- [ ] No

## Additional context
<!-- Any other relevant information -->