### PR TITLE
fix(driver): provideMagentoDriver crashes when options is an InjectionToken

### DIFF
--- a/libs/driver/magento/src/features/transfer-state.ts
+++ b/libs/driver/magento/src/features/transfer-state.ts
@@ -6,10 +6,8 @@ import {
   type EnvironmentProviders,
   type StateKey,
 } from '@angular/core';
-import {
-  ApolloCache,
-  NormalizedCacheObject,
-} from '@apollo/client/cache';
+import { NormalizedCacheObject } from '@apollo/client/cache';
+import { Apollo } from 'apollo-angular';
 
 import { createSingleInjectionToken } from '@daffodil/core';
 
@@ -41,24 +39,20 @@ export const withDaffDriverMagentoTransferState = <T extends StateKey<any> = Sta
  * Holds the logic for hydrating the Apollo cache with the server's transferred state.
  * It is recommended to use {@link withDaffDriverMagentoTransferState} with {@link provideMagentoDriver}
  * to provide this functionality automatically.
- *
- * @param cache The Apollo cache instance.
  */
-export const provideDaffDriverMagentoTransferState = (cache: ApolloCache<NormalizedCacheObject>): EnvironmentProviders => makeEnvironmentProviders([
+export const provideDaffDriverMagentoTransferState = (): EnvironmentProviders => makeEnvironmentProviders([
   provideAppInitializer(() => {
+    const cache = inject(Apollo).client.cache;
     const transferState = inject(TransferState);
     const stateKey = inject(DAFF_DRIVER_MAGENTO_TRANSFER_STATE_KEY);
     const hasStateKey = transferState.hasKey(stateKey);
     if (hasStateKey) {
-      // reads the serialized cache
       const state = transferState.get<NormalizedCacheObject>(
         stateKey,
         null,
       );
-        // and puts it in the Apollo
       cache.restore(state);
     } else {
-      // serializes the cache and puts it under a key
       transferState.onSerialize(stateKey, () => cache.extract());
     }
   }),

--- a/libs/driver/magento/src/provider.spec.ts
+++ b/libs/driver/magento/src/provider.spec.ts
@@ -1,0 +1,18 @@
+import { InjectionToken } from '@angular/core';
+
+import {
+  DaffMagentoDriverConfig,
+  provideMagentoDriver,
+} from './provider';
+
+describe('@daffodil/driver/magento | provideMagentoDriver', () => {
+  describe('when options is an InjectionToken', () => {
+    const CONFIG_TOKEN = new InjectionToken<DaffMagentoDriverConfig>('test config');
+
+    it('should not throw when registering providers', () => {
+      expect(() => {
+        provideMagentoDriver(CONFIG_TOKEN);
+      }).not.toThrow();
+    });
+  });
+});

--- a/libs/driver/magento/src/provider.ts
+++ b/libs/driver/magento/src/provider.ts
@@ -48,23 +48,24 @@ export interface DaffMagentoDriverConfig extends HttpOptions {
  * @param endpoint - The Magento store domain (e.g. "https://www.my-store.com/graphql") or an injection token for a string or function that returns a string
  */
 export function provideMagentoDriver(options: DaffMagentoDriverConfig | InjectionToken<DaffMagentoDriverConfig>, ...features: Array<MagentoDriverFeature>): EnvironmentProviders {
-  const opts: DaffMagentoDriverConfig = {
-    possibleTypes: MAGENTO_POSSIBLE_TYPES.possibleTypes,
-    typePolicies,
-    ...(options instanceof InjectionToken ? inject(options) : options),
-  };
-  const cache = new InMemoryCache({ typePolicies: opts.typePolicies, possibleTypes: opts.possibleTypes });
   const providers = [
     ...features.flatMap(({ ɵproviders }) => ɵproviders),
-    provideApollo(() => ({
-      ...inject(DAFF_DRIVER_MAGENTO_EXTRA_APOLLO_OPTIONS),
-      link: from([
-        ...inject(DAFF_APOLLO_REQUEST_HANDLERS),
-        onError(inject(DAFF_DRIVER_MAGENTO_ERROR_HANDLER)),
-        inject(HttpLink).create(opts),
-      ]),
-      cache,
-    })),
+    provideApollo(() => {
+      const opts: DaffMagentoDriverConfig = {
+        possibleTypes: MAGENTO_POSSIBLE_TYPES.possibleTypes,
+        typePolicies,
+        ...(options instanceof InjectionToken ? inject(options) : options),
+      };
+      return {
+        ...inject(DAFF_DRIVER_MAGENTO_EXTRA_APOLLO_OPTIONS),
+        link: from([
+          ...inject(DAFF_APOLLO_REQUEST_HANDLERS),
+          onError(inject(DAFF_DRIVER_MAGENTO_ERROR_HANDLER)),
+          inject(HttpLink).create(opts),
+        ]),
+        cache: new InMemoryCache({ typePolicies: opts.typePolicies, possibleTypes: opts.possibleTypes }),
+      };
+    }),
     provideDaffDriverHttpClientCacheService(DaffDriverHttpClientCacheMagentoService),
 
     // enable caching by default
@@ -73,7 +74,7 @@ export function provideMagentoDriver(options: DaffMagentoDriverConfig | Injectio
   ];
 
   if (features.find(({ ɵkind }) => ɵkind === MagentoDriverFeatureKind.TransferState)) {
-    providers.push(provideDaffDriverMagentoTransferState(cache));
+    providers.push(provideDaffDriverMagentoTransferState());
   }
 
   return makeEnvironmentProviders(providers);


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
I was testing the `@daffodil/commerce` demo schematic. When I loaded the resulting app, I got the error:

> The `InjectionToken DEMO_MAGENTO_DRIVER_CONFIG` token injection failed. `inject()` function must be called from an injection context such as a constructor, a factory function, a field initializer, or a function used with `runInInjectionContext

## New behavior

Now, when using the `provideMagentoDriver` with an InjectionToken, it no longer errors.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->