### PR TITLE
ci: select angular version from @angular/core version in package.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,6 @@ on:
       cache-mode:
         required: true
         type: string
-      angular-versions:
-        required: false
-        type: string
-        default: '^20'
-        description: "Comma-separated Angular version constraints (e.g. '^19,^20')"
     secrets:
       NX_KEY:
         required: true
@@ -153,7 +148,6 @@ jobs:
     with:
       ref: ${{ inputs.ref && inputs.ref || github.sha }}
       node-versions: '22.21.x'
-      angular-versions: ${{ inputs.angular-versions }}
     secrets:
       NX_KEY: ${{ secrets.NX_KEY }}
       AZURE_NX_CACHE_READONLY_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING || secrets.AZURE_NX_CACHE_READONLY_CONNECTION_STRING }}

--- a/.github/workflows/test-commerce-schematic.yml
+++ b/.github/workflows/test-commerce-schematic.yml
@@ -14,8 +14,7 @@ on:
       angular-versions:
         required: false
         type: string
-        default: '^20'
-        description: "Comma-separated Angular version constraints (e.g. '^19,^20')"
+        description: "Comma-separated Angular version constraints (e.g. '^19,^20'). Defaults to the @angular/core version in package.json."
     secrets:
       NX_KEY:
         required: true
@@ -41,6 +40,12 @@ jobs:
           fetch-depth: 100
           ref: ${{ inputs.ref && inputs.ref || github.sha }}
 
+      - name: Get Angular version from package.json
+        id: package-angular-version
+        run: |
+          VERSION=$(jq -r '.dependencies["@angular/core"]' package.json | sed 's/\.[0-9]*\.[0-9]*//')
+          echo "angular-versions=${VERSION}" >> "$GITHUB_OUTPUT"
+
       - run: git fetch origin ${{ github.base_ref }}
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
@@ -59,7 +64,7 @@ jobs:
         id: matrix
         with:
           changed-files: ${{ steps.changed.outputs.files }}
-          angular-versions: ${{ inputs.angular-versions }}
+          angular-versions: ${{ inputs.angular-versions || steps.package-angular-version.outputs.angular-versions }}
           node-versions: ${{ inputs.node-versions }}
 
   test:

--- a/.github/workflows/test-commerce-schematic.yml
+++ b/.github/workflows/test-commerce-schematic.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get Angular version from package.json
         id: package-angular-version
         run: |
-          VERSION=$(jq -r '.dependencies["@angular/core"]' package.json | sed 's/\.[0-9]*\.[0-9]*//')
+          VERSION=$(jq -r '.dependencies["@angular/core"]' package.json | sed -E 's/\.[0-9]+\.[0-9]+//g; s/ *\|\| */,/g')
           echo "angular-versions=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - run: git fetch origin ${{ github.base_ref }}


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [x] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, we don't allow people to adjust the version of Angular used in the commerce schematic tests. This makes upgrading Angular fail CI. We'd like to allow PRs to adjust Angular version during upgrades.

@griest024 tried this in https://github.com/graycoreio/daffodil/pull/4445 but it didn't work as expected.


Fixes: # 4444

## New behavior
We now base the angular version used in the workflow on the angular version in the `package.json` of the calling branches state. I also handled what I think will happen in the future, where we allow a range of Angular version with something like:

```
    "@angular/core": "^20.0.0 || ^21.0.0",
```


## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->