### PR TITLE
fix(daffio): apply correct label class for multi-word api roles

### DIFF
--- a/apps/daffio/src/app/docs/api/components/api-list-section/api-list-section.component.html
+++ b/apps/daffio/src/app/docs/api/components/api-list-section/api-list-section.component.html
@@ -3,7 +3,7 @@
     <div class="daffio-api-list-section__item-name">{{ childDoc.title }}</div>
     <div class="daffio-api-list-section__label-wrapper">
       <daffio-docs-api-item-label
-				[type]="((childDoc.role | daffDocsApiRoleTagLabel) || childDoc.docType).toLowerCase()"
+				[type]="childDoc.role || childDoc.docType.toLowerCase()"
 				class="daffio-api-list-section__item-label">
 				{{ (childDoc.role | daffDocsApiRoleTagLabel) || childDoc.docType }}
 			</daffio-docs-api-item-label>

--- a/apps/daffio/src/app/docs/api/components/fragments/base/base.component.html
+++ b/apps/daffio/src/app/docs/api/components/fragments/base/base.component.html
@@ -8,7 +8,7 @@
 	}
 	<div class="daffio-docs-api-base-fragment__label-wrapper">
 		@if (!child()) {
-			<daffio-docs-api-item-label [type]="(doc().role | daffDocsApiRoleTagLabel).toLowerCase()">
+			<daffio-docs-api-item-label [type]="doc().role">
 				{{ doc().role | daffDocsApiRoleTagLabel }}
 			</daffio-docs-api-item-label>
 		}


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
`[type]="(role | daffDocsApiRoleTagLabel).toLowerCase()"` ran the kebab-case role through the human-readable label pipe ('model-factory' → 'Model Factory') and then lowercased it to 'model factory' (with a space). When applied as a class, that split into two separate classes (model and factory)

Fixes: #4374

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->