### PR TITLE
ci: specify npm publish tag for prelease and release candidates

### DIFF
--- a/.github/actions/compute-npm-tag/.gitignore
+++ b/.github/actions/compute-npm-tag/.gitignore
@@ -1,0 +1,1 @@
+dist/*.spec.js

--- a/.github/actions/compute-npm-tag/action.yml
+++ b/.github/actions/compute-npm-tag/action.yml
@@ -1,0 +1,10 @@
+name: "Compute npm publish tag"
+author: "Graycore"
+description: "Computes the npm publish tag from package.json. Prerelease versions (those containing '-') publish under 'next', otherwise 'latest'."
+outputs:
+  npm_tag:
+    description: "The computed npm publish tag ('next' for prereleases, 'latest' otherwise)"
+
+runs:
+  using: "node24"
+  main: "dist/main.js"

--- a/.github/actions/compute-npm-tag/dist/main.js
+++ b/.github/actions/compute-npm-tag/dist/main.js
@@ -1,0 +1,16 @@
+// .github/actions/compute-npm-tag/src/main.ts
+var import_fs = require("fs");
+var import_path = require("path");
+
+// .github/actions/compute-npm-tag/src/compute-npm-tag.ts
+var computeNpmTag = (version) => version.includes("-") ? "next" : "latest";
+
+// .github/actions/compute-npm-tag/src/main.ts
+var workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+var pkgJson = JSON.parse((0, import_fs.readFileSync)((0, import_path.join)(workspace, "package.json"), "utf-8"));
+var tag = computeNpmTag(pkgJson.version);
+var outputFile = process.env.GITHUB_OUTPUT;
+if (outputFile) {
+  (0, import_fs.appendFileSync)(outputFile, `npm_tag=${tag}
+`);
+}

--- a/.github/actions/compute-npm-tag/jasmine.json
+++ b/.github/actions/compute-npm-tag/jasmine.json
@@ -1,0 +1,8 @@
+{
+  "spec_dir": ".github/actions/compute-npm-tag/dist",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/.github/actions/compute-npm-tag/project.json
+++ b/.github/actions/compute-npm-tag/project.json
@@ -1,0 +1,28 @@
+{
+	"name": "compute-npm-tag",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": ".github/actions/compute-npm-tag",
+	"projectType": "application",
+	"targets": {
+		"build": {
+			"executor": "nx:run-commands",
+			"outputs": ["{projectRoot}/dist/main.js"],
+			"options": {
+				"command": "npx esbuild .github/actions/compute-npm-tag/src/main.ts --bundle --platform=node --outfile=.github/actions/compute-npm-tag/dist/main.js"
+			}
+		},
+		"test": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["build-test"],
+			"options": {
+				"command": "npx jasmine --config=.github/actions/compute-npm-tag/jasmine.json"
+			}
+		},
+		"build-test": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "npx esbuild .github/actions/compute-npm-tag/src/*.spec.ts --bundle --platform=node --outdir=.github/actions/compute-npm-tag/dist"
+			}
+		}
+	}
+}

--- a/.github/actions/compute-npm-tag/src/compute-npm-tag.spec.ts
+++ b/.github/actions/compute-npm-tag/src/compute-npm-tag.spec.ts
@@ -1,0 +1,27 @@
+import { computeNpmTag } from './compute-npm-tag';
+
+describe('computeNpmTag', () => {
+  it('returns "latest" for a stable version', () => {
+    expect(computeNpmTag('1.2.3')).toBe('latest');
+  });
+
+  it('returns "latest" for a zero-major stable version', () => {
+    expect(computeNpmTag('0.92.2')).toBe('latest');
+  });
+
+  it('returns "next" for a release-candidate version', () => {
+    expect(computeNpmTag('1.0.0-rc.1')).toBe('next');
+  });
+
+  it('returns "next" for a prerelease version', () => {
+    expect(computeNpmTag('2.0.0-alpha.0')).toBe('next');
+  });
+
+  it('returns "next" for a beta version', () => {
+    expect(computeNpmTag('0.93.0-beta.4')).toBe('next');
+  });
+
+  it('returns "next" for a build-metadata-only prerelease', () => {
+    expect(computeNpmTag('1.0.0-0')).toBe('next');
+  });
+});

--- a/.github/actions/compute-npm-tag/src/compute-npm-tag.ts
+++ b/.github/actions/compute-npm-tag/src/compute-npm-tag.ts
@@ -1,0 +1,12 @@
+/**
+ * The set of npm distribution tags this action emits.
+ */
+export type NpmTag = 'latest' | 'next';
+
+/**
+ * Computes the npm publish tag for a given semver version.
+ * Prerelease versions (those containing a `-`, e.g. `1.0.0-rc.1`) publish under `next`;
+ * stable versions publish under `latest`.
+ */
+export const computeNpmTag = (version: string): NpmTag =>
+  version.includes('-') ? 'next' : 'latest';

--- a/.github/actions/compute-npm-tag/src/main.ts
+++ b/.github/actions/compute-npm-tag/src/main.ts
@@ -1,0 +1,16 @@
+import {
+  appendFileSync,
+  readFileSync,
+} from 'fs';
+import { join } from 'path';
+
+import { computeNpmTag } from './compute-npm-tag';
+
+const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+const pkgJson = JSON.parse(readFileSync(join(workspace, 'package.json'), 'utf-8'));
+const tag = computeNpmTag(pkgJson.version);
+
+const outputFile = process.env.GITHUB_OUTPUT;
+if (outputFile) {
+  appendFileSync(outputFile, `npm_tag=${tag}\n`);
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,7 @@ jobs:
       - uses: graycoreio/github-actions/set-versions-from-root@main
 
       - id: compute-npm-tag
-        shell: bash
-        name: Compute npm publish tag
-        run: cat package.json | jq -r .version | grep -q '-' && echo "npm_tag=next" >> ${GITHUB_OUTPUT} || echo "npm_tag=latest" >> ${GITHUB_OUTPUT}
+        uses: graycoreio/daffodil/.github/actions/compute-npm-tag@develop
 
       - run: npx nx run-many -t publish -- --tag $NPM_TAG
         if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,5 +47,12 @@ jobs:
 
       - uses: graycoreio/github-actions/set-versions-from-root@main
 
-      - run: npx nx run-many -t publish
+      - id: compute-npm-tag
+        shell: bash
+        name: Compute npm publish tag
+        run: cat package.json | jq -r .version | grep -q '-' && echo "npm_tag=next" >> ${GITHUB_OUTPUT} || echo "npm_tag=latest" >> ${GITHUB_OUTPUT}
+
+      - run: npx nx run-many -t publish -- --tag $NPM_TAG
         if: github.event.workflow_run.conclusion == 'success'
+        env:
+          NPM_TAG: ${{ steps.compute-npm-tag.outputs.npm_tag }}

--- a/.github/workflows/test-commerce-schematic.yml
+++ b/.github/workflows/test-commerce-schematic.yml
@@ -97,7 +97,6 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           use-stamp-cache: true
-          working-directory: ${{ github.workspace }}
 
       - uses: graycoreio/daffodil/.github/actions/setup-nx-remote-cache@develop
         with:
@@ -142,7 +141,7 @@ jobs:
         run: |
           npx nx run-many \
             -t publish \
-            --projects="${{ steps.daff-deps.outputs.packages }},@daffodil/commerce"
+            --projects="${{ steps.daff-deps.outputs.packages }},@daffodil/commerce" -- --tag latest
 
       - name: Compute test directory
         id: test-dir


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [x] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

`npm publish` does not specify a tag, which is now invalid behavior on npm v11. this also breaks the commerce tests

## New behavior

we specify the tag to which to publish

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->