### PR TITLE
ci: allow overriding release version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,11 @@ on:
         type: boolean
         required: false
         default: false
+      release-as:
+        description: 'Force a specific version (e.g. 0.92.3 to graduate an RC).'
+        type: string
+        required: false
+        default: ''
 
 env:
   NPM_VERSION: 11
@@ -22,6 +27,13 @@ jobs:
       matrix:
         node: [22.21.x]
     steps:
+      - name: Override release-as
+        if: inputs.release-as != ''
+        run: |
+          jq --arg v "${{ inputs.release-as }}" '. + {"release-as": $v}' \
+            release-please-config.json > /tmp/rpc.json && \
+            mv /tmp/rpc.json release-please-config.json
+
       - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.GRAYCORE_GITHUB_TOKEN }}


### PR DESCRIPTION
should allow reverting back to stable release although its a shame the dev has to hardcode the version number

claude coded

## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->