### PR TITLE
fix: add missing key fields to graphql fragments and queries

### DIFF
--- a/libs/cart/driver/magento/src/queries/fragments/cart-item.ts
+++ b/libs/cart/driver/magento/src/queries/fragments/cart-item.ts
@@ -25,6 +25,7 @@ export const cartItemFragment = gql`
 		uid
     product {
       ...cartItemProduct
+      uid
     }
     quantity
     prices {

--- a/libs/cart/driver/magento/src/queries/fragments/cart-totals.ts
+++ b/libs/cart/driver/magento/src/queries/fragments/cart-totals.ts
@@ -13,7 +13,9 @@ export const cartTotalsFragment = gql`
         selected_shipping_method {
           ...selectedShippingMethod
         }
+        street
       }
+      street
     }
     prices {
       ...prices

--- a/libs/cart/driver/magento/src/queries/fragments/cart.ts
+++ b/libs/cart/driver/magento/src/queries/fragments/cart.ts
@@ -21,6 +21,7 @@ export const cartFragment = gql`
         selected_shipping_method {
           ...selectedShippingMethod
         }
+        street
       }
       available_shipping_methods {
         amount {
@@ -32,15 +33,19 @@ export const cartFragment = gql`
         carrier_title
         method_title
       }
+      street
     }
     items {
       ...cartItem
+      uid
     }
     available_payment_methods {
       ...availablePaymentMethod
+      code
     }
     selected_payment_method {
       ...selectedPaymentMethod
+      code
     }
     applied_coupons {
       ...cartCoupon

--- a/libs/cart/driver/magento/src/queries/get-selected-payment-method/query.ts
+++ b/libs/cart/driver/magento/src/queries/get-selected-payment-method/query.ts
@@ -15,6 +15,7 @@ export const getSelectedPaymentMethod = (extraCartFragments: DocumentNode[] = []
     cart(cart_id: $cartId) {
       selected_payment_method {
         ...selectedPaymentMethod
+        code
       }
       ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }

--- a/libs/cart/driver/magento/src/queries/get-selected-shipping-method/query.ts
+++ b/libs/cart/driver/magento/src/queries/get-selected-shipping-method/query.ts
@@ -17,6 +17,7 @@ export const getSelectedShippingMethod = (extraCartFragments: DocumentNode[] = [
         selected_shipping_method {
           ...selectedShippingMethod
         }
+        street
       }
       ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }

--- a/libs/cart/driver/magento/src/queries/get-shipping-address/query.ts
+++ b/libs/cart/driver/magento/src/queries/get-shipping-address/query.ts
@@ -15,6 +15,7 @@ export const getShippingAddress = (extraCartFragments: DocumentNode[] = []) => g
     cart(cart_id: $cartId) {
       shipping_addresses {
         ...cartAddress
+        street
       }
       email
       ${daffBuildFragmentNameSpread(...extraCartFragments)}

--- a/libs/cart/driver/magento/src/queries/list-items/query.ts
+++ b/libs/cart/driver/magento/src/queries/list-items/query.ts
@@ -15,6 +15,7 @@ export const listCartItems = (extraCartFragments: DocumentNode[] = []) => gql<Ma
     cart(cart_id: $cartId) {
       items {
         ...cartItem
+        uid
       }
       ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }

--- a/libs/cart/driver/magento/src/queries/list-payment-methods/query.ts
+++ b/libs/cart/driver/magento/src/queries/list-payment-methods/query.ts
@@ -15,6 +15,7 @@ export const listPaymentMethods = (extraCartFragments: DocumentNode[] = []) => g
     cart(cart_id: $cartId) {
       available_payment_methods {
         ...availablePaymentMethod
+        code
       }
       ${daffBuildFragmentNameSpread(...extraCartFragments)}
     }

--- a/libs/cart/driver/magento/src/queries/list-shipping-methods/query.ts
+++ b/libs/cart/driver/magento/src/queries/list-shipping-methods/query.ts
@@ -20,6 +20,8 @@ export const listShippingMethods = (extraCartFragments: DocumentNode[] = []) => 
 				street
         available_shipping_methods {
           ...availableShippingMethod
+          carrier_code
+          method_code
         }
       }
       ${daffBuildFragmentNameSpread(...extraCartFragments)}

--- a/libs/category/driver/magento/src/queries/get-category-and-products.ts
+++ b/libs/category/driver/magento/src/queries/get-category-and-products.ts
@@ -21,6 +21,7 @@ query ${DAFF_MAGENTO_GET_CATEGORY_AND_PRODUCTS_QUERY_NAME}($categoryFilters: Cat
 {
   categoryList(filters: $categoryFilters) {
 		...categoryTree
+  uid
     ${daffBuildFragmentNameSpread(...extraCategoryFragments)}
 	}
 	products(filter: $productFilter, search: $search, pageSize: $pageSize, currentPage: $currentPage, sort: $sort)
@@ -28,6 +29,7 @@ query ${DAFF_MAGENTO_GET_CATEGORY_AND_PRODUCTS_QUERY_NAME}($categoryFilters: Cat
 		total_count
 		items {
 			...product
+   uid
       ${daffBuildFragmentNameSpread(...extraProductFragments)}
 		}
 		page_info {

--- a/libs/navigation/driver/magento/src/queries/fragments/category-node/category-node.spec.ts
+++ b/libs/navigation/driver/magento/src/queries/fragments/category-node/category-node.spec.ts
@@ -92,6 +92,7 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
         query TestQuery {
           categoryList {
             ...recursiveCategoryNode
+            uid
           }
         }
         ${fragment}
@@ -134,6 +135,7 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
         query TestQuery {
           categoryList {
             ...recursiveCategoryNode
+            uid
           }
         }
         ${fragment}
@@ -176,6 +178,7 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
         query TestQuery {
           categoryList {
             ...recursiveCategoryNode
+            uid
           }
         }
         ${fragment}

--- a/libs/navigation/driver/magento/src/queries/get-category-tree.ts
+++ b/libs/navigation/driver/magento/src/queries/get-category-tree.ts
@@ -15,6 +15,7 @@ export function daffMagentoGetCategoryTree(depth: number = 3, extraFragments: Ar
     query ${DAFF_MAGENTO_GET_CATEGORY_TREE_QUERY_NAME}($filters: CategoryFilterInput!){
       categoryList(filters: $filters) {
         ...recursiveCategoryNode
+        uid
       }
     }
     ${getCategoryNodeFragment(depth, extraFragments)}

--- a/libs/product-composite/driver/magento/src/fragments/bundled-product.ts
+++ b/libs/product-composite/driver/magento/src/fragments/bundled-product.ts
@@ -38,6 +38,7 @@ fragment magentoBundledProduct on BundleProduct {
 						}
 					}
 				}
+    uid
 			}
 		}
 	}

--- a/libs/product-configurable/driver/magento/src/fragments/configurable-product.ts
+++ b/libs/product-configurable/driver/magento/src/fragments/configurable-product.ts
@@ -16,6 +16,7 @@ export const magentoConfigurableProductFragment = (extraVariantFragments: Array<
 				label
 				value_index
 			}
+   uid
 		}
 		variants {
 			${daffBuildFragmentNameSpread(...extraVariantFragments)}
@@ -42,8 +43,10 @@ export const magentoConfigurableProductFragment = (extraVariantFragments: Array<
 					url
 					label
 				}
+    uid
 			}
 		}
+  uid
   }
 ${daffBuildFragmentDefinition(...extraVariantFragments)}
 `;

--- a/libs/product/driver/magento/src/queries/fragments/product-page.ts
+++ b/libs/product/driver/magento/src/queries/fragments/product-page.ts
@@ -16,6 +16,7 @@ export const magentoProductPageFragment = gql`
 		description {
 			html
 		}
+    uid
 	}
   ${magentoProductFragment}
 `;

--- a/libs/product/driver/magento/src/queries/fragments/product.ts
+++ b/libs/product/driver/magento/src/queries/fragments/product.ts
@@ -14,6 +14,7 @@ export const magentoProductFragment = gql`
 		short_description {
 			html
 		}
+    uid
 	}
   ${magentoProductPreviewFragment}
 `;

--- a/libs/product/driver/magento/src/queries/get-all-products.ts
+++ b/libs/product/driver/magento/src/queries/get-all-products.ts
@@ -16,6 +16,7 @@ export const getAllProducts = (extraProductFragments: DocumentNode[] = []) => gq
       total_count
       items {
         ...magentoProductPage
+        uid
         ${daffBuildFragmentNameSpread(...extraProductFragments)}
       }
       page_info {

--- a/libs/product/driver/magento/src/queries/get-product-by-url/query.ts
+++ b/libs/product/driver/magento/src/queries/get-product-by-url/query.ts
@@ -17,6 +17,7 @@ export const getProductByUrl = (extraProductFragments: DocumentNode[] = []) => g
 		route(url: $url) {
       ... on ProductInterface {
         ...magentoProductPage
+        uid
         ${daffBuildFragmentNameSpread(...extraProductFragments)}
       }
     }

--- a/libs/product/driver/magento/src/queries/get-product.ts
+++ b/libs/product/driver/magento/src/queries/get-product.ts
@@ -19,6 +19,7 @@ export const getProduct = (extraProductFragments: DocumentNode[] = []) => gql`
     }){
       items {
         ...magentoProductPage
+        uid
         ${daffBuildFragmentNameSpread(...extraProductFragments)}
       }
     }

--- a/libs/product/integration-tests/driver/magento/custom-fields.spec.ts
+++ b/libs/product/integration-tests/driver/magento/custom-fields.spec.ts
@@ -37,6 +37,7 @@ interface MyMagentoProduct extends MagentoProduct {
 const myProductFragment = gql`
   fragment MyProductFragment on ProductInterface {
     updated_at
+    uid
   }
 `;
 

--- a/libs/related-products/driver/magento/src/queries/fragments/related-products.ts
+++ b/libs/related-products/driver/magento/src/queries/fragments/related-products.ts
@@ -11,8 +11,10 @@ export const magentoRelatedProductsFragment = (extraProductFragments: DocumentNo
   fragment relatedProducts on ProductInterface {
     related_products {
       ...magentoProductPreview
+      uid
       ${daffBuildFragmentNameSpread(...extraProductFragments)}
     }
+    uid
 	}
 	${magentoProductPreviewFragment}
   ${daffBuildFragmentDefinition(...extraProductFragments)}

--- a/libs/reviews/driver/magento/src/queries/get-product-reviews.ts
+++ b/libs/reviews/driver/magento/src/queries/get-product-reviews.ts
@@ -23,6 +23,7 @@ export const getProductReviews = gql`
             ...magentoSearchResultPageInfo
           }
         }
+        uid
       }
     }
   }

--- a/libs/search-category/driver/magento/src/queries/category-search.ts
+++ b/libs/search-category/driver/magento/src/queries/category-search.ts
@@ -13,6 +13,7 @@ export const categorySearch = () => gql`
     }, pageSize: $pageSize) {
       items {
         ...categoryTree
+        uid
       }
     }
   }

--- a/libs/search-category/driver/magento/src/queries/fragments/category-result.ts
+++ b/libs/search-category/driver/magento/src/queries/fragments/category-result.ts
@@ -10,6 +10,7 @@ export const magentoSearchCategoryResultFragment = gql`
 		products {
 			items {
 				sku
+    uid
 			}
 		}
   }

--- a/libs/search-product/driver/magento/src/queries/product-incremental.ts
+++ b/libs/search-product/driver/magento/src/queries/product-incremental.ts
@@ -17,6 +17,7 @@ export const daffSearchProductIncrementalQuery = (extraProductFragments: Documen
     products(search: $search, pageSize: $pageSize) {
       items {
         ...product
+        uid
         ${daffBuildFragmentNameSpread(...extraProductFragments)}
       }
 		  total_count

--- a/libs/search-product/driver/magento/src/queries/product-search.ts
+++ b/libs/search-product/driver/magento/src/queries/product-search.ts
@@ -25,6 +25,7 @@ export const productSearch = (extraProductFragments: DocumentNode[] = []) => gql
     products(filter: $filter, search: $search, pageSize: $pageSize, currentPage: $currentPage, sort: $sort) {
       items {
         ...product
+        uid
         ${daffBuildFragmentNameSpread(...extraProductFragments)}
       }
       page_info {

--- a/libs/upsell-products/driver/magento/src/queries/fragments/upsell-products.ts
+++ b/libs/upsell-products/driver/magento/src/queries/fragments/upsell-products.ts
@@ -11,8 +11,10 @@ export const magentoUpsellProductsFragment = (extraProductFragments: DocumentNod
   fragment upsellProducts on ProductInterface {
     upsell_products {
       ...magentoProductPreview
+      uid
       ${daffBuildFragmentNameSpread(...extraProductFragments)}
     }
+    uid
 	}
 	${magentoProductPreviewFragment}
   ${daffBuildFragmentDefinition(...extraProductFragments)}


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
I used an eslint plugin (that's not quite ready to merge but does work) to auto add these. The one caveat is that the plugin cannot tell if a key field is added by a fragment or not so it adds them to basically all queries. Should be okay since they will just get merged by apollo and its better safe than sorry