### PR TITLE
fix(design): use DaffDisableableDirective in tag component

### DIFF
--- a/libs/design-examples/tag/src/disabled-tag/disabled-tag.component.html
+++ b/libs/design-examples/tag/src/disabled-tag/disabled-tag.component.html
@@ -1,3 +1,3 @@
-<daff-tag disabled="true">
+<daff-tag [disabled]="true">
   Brand: Nike
 </daff-tag>

--- a/libs/design/tag/src/tag/tag.component.scss
+++ b/libs/design/tag/src/tag/tag.component.scss
@@ -53,8 +53,7 @@
 	border-radius: 0.25rem;
 	position: relative;
 
-	&[disabled],
-	&.disabled {
+	&.daff-disabled {
 		cursor: not-allowed;
 		opacity: 0.5;
 

--- a/libs/design/tag/src/tag/tag.component.ts
+++ b/libs/design/tag/src/tag/tag.component.ts
@@ -14,6 +14,8 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import {
   DaffArticleEncapsulatedDirective,
   DaffColorableDirective,
+  DaffDisableable,
+  DaffDisableableDirective,
   DaffPrefixDirective,
   DaffStatusableDirective,
 } from '@daffodil/design';
@@ -50,13 +52,16 @@ import { DaffTagSizableDirective } from './tag-sizable.directive';
       directive: DaffStatusableDirective,
       inputs: ['status'],
     },
+    {
+      directive: DaffDisableableDirective,
+      inputs: ['disabled'],
+    },
   ],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'daff-tag',
     '[attr.aria-disabled]': 'disabled ? true : null',
-    '[attr.disabled]': 'disabled',
     '[class.dismissible]': 'dismissible',
   },
   imports: [
@@ -64,7 +69,7 @@ import { DaffTagSizableDirective } from './tag-sizable.directive';
     DaffPrefixDirective,
   ],
 })
-export class DaffTagComponent {
+export class DaffTagComponent implements DaffDisableable {
   /**
    * @docs-private
    */
@@ -77,17 +82,11 @@ export class DaffTagComponent {
 
   /**
    * @docs-private
+   *
+   * Internal function to access the disabled property of the DaffDisableableDirective.
    */
-  _disabled = false;
-
-  /**
-   * The disabled state of the tag.
-   */
-  @Input() get disabled() {
-    return this._disabled;
-  }
-  set disabled(value: any) {
-    this._disabled = coerceBooleanProperty(value);
+  get disabled() {
+    return this.disabledDirective.disabled;
   }
 
   private _dismissible = false;
@@ -113,7 +112,7 @@ export class DaffTagComponent {
    * Internal handler for the close icon click.
    */
   onCloseTag(event: Event) {
-    if (this._disabled) {
+    if (this.disabled) {
       return;
     }
     this.closeTag.emit();
@@ -121,6 +120,7 @@ export class DaffTagComponent {
 
   constructor(
     private size: DaffTagSizableDirective,
+    private disabledDirective: DaffDisableableDirective,
   ) {
     /**
      * Sets the default size of a tag to medium.


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4537

## New behavior
Replaces the tag's disabled input with the `DaffDisableableDirective`, so the disabled state is now driven by the `daff-disabled` class instead of the disabled attribute.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->