### PR TITLE
feat(design): add configurable menu position and scrollable overflow

### DIFF
--- a/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.html
+++ b/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.html
@@ -1,12 +1,12 @@
 <daff-container size="lg">
   <div class="daffio-doc-viewer__sidebar-activators">
-    <button class="daffio-doc-viewer__button" (click)="open()">
+    <button class="daffio-doc-viewer__menu-button" (click)="open()">
       <fa-icon [icon]="faBars"></fa-icon>
       <div>Menu</div>
     </button>
 
     @if (toc.length > 0) {
-      <button class="daffio-doc-viewer__button" [daffMenuActivator]="tocMenu" xPosition="before" #activator="daffMenuActivator">
+      <button class="daffio-doc-viewer__toc-button" [daffMenuActivator]="tocMenu" xPosition="before" #activator="daffMenuActivator">
         <div>On this page</div>
         <span class="daffio-doc-viewer__button-icon" [class.open]="activator.isOpen()"></span>
       </button>

--- a/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.html
+++ b/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.html
@@ -6,7 +6,7 @@
     </button>
 
     @if (toc.length > 0) {
-      <button class="daffio-doc-viewer__button" [daffMenuActivator]="tocMenu" #activator="daffMenuActivator">
+      <button class="daffio-doc-viewer__button" [daffMenuActivator]="tocMenu" xPosition="before" #activator="daffMenuActivator">
         <div>On this page</div>
         <span class="daffio-doc-viewer__button-icon" [class.open]="activator.isOpen()"></span>
       </button>

--- a/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.scss
+++ b/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer.component.scss
@@ -5,6 +5,18 @@
 	display: block;
 }
 
+@mixin button-base() {
+	@include daff.clickable();
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 1;
+	gap: 0.5rem;
+	background: var(--daff-theme);
+	border: 0;
+	color: var(--daff-theme-contrast);
+}
+
 .daffio-doc-viewer {
 	&__grid {
 		padding: 1.5rem;
@@ -80,6 +92,7 @@
 		border-bottom: 1px solid rgb(var(--daff-theme-contrast-rgb), 0.1);
 		font-size: 1rem;
 		line-height: 1rem;
+		padding: 0 1rem;
 		position: sticky;
 		top: var(--daff-sidebar-side-fixed-top-shift);
 		height: 3rem;
@@ -92,17 +105,17 @@
 		}
 	}
 
-	&__button {
-		@include daff.clickable();
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		flex-grow: 1;
-		gap: 0.5rem;
-		background: var(--daff-theme);
-		border: 0;
-		color: var(--daff-theme-contrast);
-		padding: 1rem 1.5rem;
+	&__menu-button,
+	&__toc-button {
+		@include button-base();
+	}
+
+	&__menu-button {
+		padding: 1rem 0;
+	}
+
+	&__toc-button {
+		padding: 1rem 0;
 	}
 
 	&__button-icon {

--- a/libs/design-examples/menu/src/basic-menu/menu-content/menu-content.component.html
+++ b/libs/design-examples/menu/src/basic-menu/menu-content/menu-content.component.html
@@ -11,4 +11,48 @@
     <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
     Contact Us
   </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
 </daff-menu>

--- a/libs/design-examples/menu/src/menu-with-position/menu-content/menu-content.component.html
+++ b/libs/design-examples/menu/src/menu-with-position/menu-content/menu-content.component.html
@@ -1,0 +1,14 @@
+<daff-menu>
+  <a href="#" daff-menu-item>
+    <fa-icon [icon]="faUser" [fixedWidth]="true" daffPrefix></fa-icon>
+    My Account
+  </a>
+  <a href="#" daff-menu-item>
+    <fa-icon [icon]="faInfo" [fixedWidth]="true" daffPrefix></fa-icon>
+    Help
+  </a>
+  <button daff-menu-item>
+    <fa-icon [icon]="faEnvelope" [fixedWidth]="true" daffPrefix></fa-icon>
+    Contact Us
+  </button>
+</daff-menu>

--- a/libs/design-examples/menu/src/menu-with-position/menu-content/menu-content.component.ts
+++ b/libs/design-examples/menu/src/menu-with-position/menu-content/menu-content.component.ts
@@ -1,0 +1,27 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import {
+  faEnvelope,
+  faInfo,
+  faUser,
+} from '@fortawesome/free-solid-svg-icons';
+
+import { DaffMenuModule } from '@daffodil/design/menu';
+
+@Component({
+  selector: 'menu-with-position-content',
+  templateUrl: './menu-content.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DaffMenuModule,
+    FaIconComponent,
+  ],
+})
+export class MenuWithPositionContentExampleComponent {
+  faUser = faUser;
+  faInfo = faInfo;
+  faEnvelope = faEnvelope;
+}

--- a/libs/design-examples/menu/src/menu-with-position/menu-with-position.component.html
+++ b/libs/design-examples/menu/src/menu-with-position/menu-with-position.component.html
@@ -1,0 +1,28 @@
+<div class="menu-with-position__options">
+  <daff-form-field>
+    <daff-form-label>Vertical</daff-form-label>
+    <daff-select [options]="yPositions" [formControl]="yPositionControl">
+      <ng-template daffSelectOption let-option="option">
+        {{ option.label }}
+      </ng-template>
+    </daff-select>
+  </daff-form-field>
+
+  <daff-form-field>
+    <daff-form-label>Horizontal</daff-form-label>
+    <daff-select [options]="xPositions" [formControl]="xPositionControl">
+      <ng-template daffSelectOption let-option="option">
+        {{ option.label }}
+      </ng-template>
+    </daff-select>
+  </daff-form-field>
+</div>
+
+<button
+  daff-button
+  color="theme"
+  [daffMenuActivator]="menu"
+  [xPosition]="xPositionControl.value?.value"
+  [yPosition]="yPositionControl.value?.value">
+  Account
+</button>

--- a/libs/design-examples/menu/src/menu-with-position/menu-with-position.component.scss
+++ b/libs/design-examples/menu/src/menu-with-position/menu-with-position.component.scss
@@ -1,0 +1,20 @@
+:host {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 1rem;
+}
+
+.menu-with-position {
+	&__options {
+		display: flex;
+		justify-content: center;
+		gap: 0.5rem;
+		width: 100%;
+
+		daff-form-field {
+			max-width: 10rem;
+			width: 100%;
+		}
+	}
+}

--- a/libs/design-examples/menu/src/menu-with-position/menu-with-position.component.ts
+++ b/libs/design-examples/menu/src/menu-with-position/menu-with-position.component.ts
@@ -1,0 +1,45 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import {
+  ReactiveFormsModule,
+  UntypedFormControl,
+} from '@angular/forms';
+
+import { DaffButtonComponent } from '@daffodil/design/button';
+import { DAFF_FORM_FIELD_COMPONENTS } from '@daffodil/design/form-field';
+import { DAFF_MENU_COMPONENTS } from '@daffodil/design/menu';
+import { DAFF_SELECT_COMPONENTS } from '@daffodil/design/select';
+
+import { MenuWithPositionContentExampleComponent } from './menu-content/menu-content.component';
+
+@Component({
+  selector: 'menu-with-position-example',
+  templateUrl: './menu-with-position.component.html',
+  styleUrl: './menu-with-position.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DaffButtonComponent,
+    DAFF_FORM_FIELD_COMPONENTS,
+    DAFF_SELECT_COMPONENTS,
+    DAFF_MENU_COMPONENTS,
+    ReactiveFormsModule,
+  ],
+})
+export class MenuWithPositionExampleComponent {
+  public menu = MenuWithPositionContentExampleComponent;
+
+  xPositions = [
+    { value: 'after', label: 'After' },
+    { value: 'before', label: 'Before' },
+  ];
+
+  yPositions = [
+    { value: 'below', label: 'Below' },
+    { value: 'above', label: 'Above' },
+  ];
+
+  xPositionControl: UntypedFormControl = new UntypedFormControl(this.xPositions[0]);
+  yPositionControl: UntypedFormControl = new UntypedFormControl(this.yPositions[0]);
+}

--- a/libs/design-examples/menu/src/provider.ts
+++ b/libs/design-examples/menu/src/provider.ts
@@ -15,5 +15,9 @@ export const provideDaffDesignMenuExamplesContent = () => makeEnvironmentProvide
     id: 'menu-with-id',
     component: () => import('./menu-with-id/menu-with-id.component').then(c => c.MenuWithIdExampleComponent),
   },
+  {
+    id: 'menu-with-position',
+    component: () => import('./menu-with-position/menu-with-position.component').then(c => c.MenuWithPositionExampleComponent),
+  },
 ));
 

--- a/libs/design-examples/menu/src/public_api.ts
+++ b/libs/design-examples/menu/src/public_api.ts
@@ -1,4 +1,5 @@
 export { BasicMenuExampleComponent } from './basic-menu/basic-menu.component';
 export { MenuWithIconToggleExampleComponent } from './menu-with-icon-toggle/menu-with-icon-toggle.component';
 export { MenuWithIdExampleComponent } from './menu-with-id/menu-with-id.component';
+export { MenuWithPositionExampleComponent } from './menu-with-position/menu-with-position.component';
 export { provideDaffDesignMenuExamplesContent } from './provider';

--- a/libs/design/menu/README.md
+++ b/libs/design/menu/README.md
@@ -81,6 +81,11 @@ Menus generate a unique id automatically. To set your own, add an `id` to the ac
 
 <daff-docs-example-viewer example="menu-with-id"></daff-docs-example-viewer>
 
+### Customize menu positions
+By default a menu opens below its activator, aligned to its left edge. Set `yPosition` (`below` or `above`) on the activator to control whether it drops down or rises up, and `xPosition` (`after` or `before`) to align the menu's left or right edge with the activator. The menu stays anchored to the activator and scrolls in place when its content is taller than the available space.
+
+<daff-docs-example-viewer example="menu-with-position"></daff-docs-example-viewer>
+
 ## Accessibility
 Menu follows the [Menu and Menubar WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/).
 

--- a/libs/design/menu/src/config/menu-config.ts
+++ b/libs/design/menu/src/config/menu-config.ts
@@ -1,5 +1,10 @@
 import { createConfigInjectionToken } from '@daffodil/core';
 
+import {
+  DaffMenuXPosition,
+  DaffMenuYPosition,
+} from '../helpers/menu-position';
+
 /**
  * Configuration for a menu instance.
  */
@@ -8,10 +13,22 @@ export interface DaffMenuConfig {
    * A unique identifier for the menu instance.
    */
   menuId?: string;
+
+  /**
+   * The horizontal alignment of the menu relative to its activator. Defaults to `after`.
+   */
+  xPosition?: DaffMenuXPosition;
+
+  /**
+   * The vertical position of the menu relative to its activator. Defaults to `below`.
+   */
+  yPosition?: DaffMenuYPosition;
 }
 
 const daffMenuConfigDefault: DaffMenuConfig = {
   menuId: '',
+  xPosition: 'after',
+  yPosition: 'below',
 };
 
 export const {

--- a/libs/design/menu/src/helpers/create-overlay.spec.ts
+++ b/libs/design/menu/src/helpers/create-overlay.spec.ts
@@ -5,23 +5,22 @@ import { daffMenuCreateOverlay } from './create-overlay';
 describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
   let overlay: any;
   let positionStrategy: any;
-  let element: ElementRef;
-
-  const rect = {
-    top: 100,
-    bottom: 140,
-    left: 0,
-    right: 50,
-    width: 50,
-    height: 40,
-  };
 
   const config = () => overlay.create.calls.mostRecent().args[0];
-  const position = () => positionStrategy.withPositions.calls.mostRecent().args[0][0];
+  const positions = () => positionStrategy.withPositions.calls.mostRecent().args[0];
+  const position = () => positions()[0];
+
+  // Builds an activator whose rect and viewport height can be varied to exercise the
+  // proximity-based side resolution. The default sits with ample room on every side.
+  const elementAt = (rect: Partial<DOMRect> = {}, innerHeight = 1000): ElementRef =>
+    new ElementRef(<any>{
+      getBoundingClientRect: () => (<DOMRect>{ top: 100, bottom: 140, left: 0, right: 50, width: 50, height: 40, ...rect }),
+      ownerDocument: { defaultView: { innerHeight }},
+    });
 
   beforeEach(() => {
     positionStrategy = {};
-    for (const method of ['flexibleConnectedTo', 'withFlexibleDimensions', 'withPush', 'withPositions']) {
+    for (const method of ['flexibleConnectedTo', 'withFlexibleDimensions', 'withPush', 'withViewportMargin', 'withPositions']) {
       positionStrategy[method] = jasmine.createSpy(method).and.returnValue(positionStrategy);
     }
 
@@ -32,14 +31,10 @@ describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
         block: jasmine.createSpy('block').and.returnValue('block'),
       },
     };
-
-    element = new ElementRef(<any>{
-      getBoundingClientRect: () => rect,
-    });
   });
 
   it('should default to the after/below position', () => {
-    daffMenuCreateOverlay(overlay, element);
+    daffMenuCreateOverlay(overlay, elementAt());
 
     expect(position()).toEqual(jasmine.objectContaining({
       originX: 'start',
@@ -49,37 +44,71 @@ describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
     }));
   });
 
-  describe('when yPosition is below', () => {
-    beforeEach(() => {
-      daffMenuCreateOverlay(overlay, element, 'after', 'below');
-    });
+  it('should scope a pane class so the menu can dissolve its wrapper and scroll', () => {
+    daffMenuCreateOverlay(overlay, elementAt());
 
-    it('should drop the menu from the activator bottom edge', () => {
+    expect(config().panelClass).toBe('daff-menu-overlay');
+  });
+
+  it('should let the CDK cap the panel to the viewport on the side it opens', () => {
+    daffMenuCreateOverlay(overlay, elementAt());
+
+    expect(positionStrategy.withFlexibleDimensions).toHaveBeenCalledWith(true);
+  });
+
+  it('should keep the menu anchored rather than pushing it off the activator', () => {
+    daffMenuCreateOverlay(overlay, elementAt());
+
+    expect(positionStrategy.withPush).toHaveBeenCalledWith(false);
+  });
+
+  it('should keep the menu clear of the viewport edges', () => {
+    daffMenuCreateOverlay(overlay, elementAt());
+
+    expect(positionStrategy.withViewportMargin).toHaveBeenCalledWith(jasmine.any(Number));
+  });
+
+  it('should offer a horizontal fallback so a menu near the side of the viewport flips edges', () => {
+    daffMenuCreateOverlay(overlay, elementAt());
+
+    expect(positions()).toContain(jasmine.objectContaining({ originX: 'end', overlayX: 'end', originY: 'bottom' }));
+  });
+
+  describe('vertical placement', () => {
+    it('should drop below when the activator has room beneath it', () => {
+      daffMenuCreateOverlay(overlay, elementAt({ bottom: 140 }, 1000), 'after', 'below');
+
       expect(position()).toEqual(jasmine.objectContaining({ originY: 'bottom', overlayY: 'top' }));
     });
 
-    it('should cap the height to the space below the activator', () => {
-      expect(config().maxHeight).toBe('calc(100% - 140px)');
-    });
-  });
+    it('should rise above when the activator sits too close to the bottom edge', () => {
+      daffMenuCreateOverlay(overlay, elementAt({ bottom: 995 }, 1000), 'after', 'below');
 
-  describe('when yPosition is above', () => {
-    beforeEach(() => {
-      daffMenuCreateOverlay(overlay, element, 'after', 'above');
-    });
-
-    it('should raise the menu from the activator top edge', () => {
       expect(position()).toEqual(jasmine.objectContaining({ originY: 'top', overlayY: 'bottom' }));
     });
 
-    it('should cap the height to the space above the activator', () => {
-      expect(config().maxHeight).toBe('100px');
+    it('should rise above when the activator has room over it', () => {
+      daffMenuCreateOverlay(overlay, elementAt({ top: 500 }, 1000), 'after', 'above');
+
+      expect(position()).toEqual(jasmine.objectContaining({ originY: 'top', overlayY: 'bottom' }));
+    });
+
+    it('should drop below when the activator sits too close to the top edge', () => {
+      daffMenuCreateOverlay(overlay, elementAt({ top: 5 }, 1000), 'after', 'above');
+
+      expect(position()).toEqual(jasmine.objectContaining({ originY: 'bottom', overlayY: 'top' }));
+    });
+
+    it('should keep the requested side when the viewport height is unknown', () => {
+      daffMenuCreateOverlay(overlay, elementAt({ bottom: 995 }, 0), 'after', 'below');
+
+      expect(position()).toEqual(jasmine.objectContaining({ originY: 'bottom', overlayY: 'top' }));
     });
   });
 
   describe('when xPosition is after', () => {
     it('should line up the left edges', () => {
-      daffMenuCreateOverlay(overlay, element, 'after', 'below');
+      daffMenuCreateOverlay(overlay, elementAt(), 'after', 'below');
 
       expect(position()).toEqual(jasmine.objectContaining({ originX: 'start', overlayX: 'start' }));
     });
@@ -87,7 +116,7 @@ describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
 
   describe('when xPosition is before', () => {
     it('should line up the right edges', () => {
-      daffMenuCreateOverlay(overlay, element, 'before', 'below');
+      daffMenuCreateOverlay(overlay, elementAt(), 'before', 'below');
 
       expect(position()).toEqual(jasmine.objectContaining({ originX: 'end', overlayX: 'end' }));
     });

--- a/libs/design/menu/src/helpers/create-overlay.spec.ts
+++ b/libs/design/menu/src/helpers/create-overlay.spec.ts
@@ -1,3 +1,4 @@
+import { STANDARD_DROPDOWN_BELOW_POSITIONS } from '@angular/cdk/overlay';
 import { ElementRef } from '@angular/core';
 
 import { daffMenuCreateOverlay } from './create-overlay';
@@ -5,20 +6,15 @@ import { daffMenuCreateOverlay } from './create-overlay';
 describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
   let overlay: any;
   let positionStrategy: any;
+  let element: ElementRef;
 
   const config = () => overlay.create.calls.mostRecent().args[0];
   const positions = () => positionStrategy.withPositions.calls.mostRecent().args[0];
   const position = () => positions()[0];
 
-  // Builds an activator whose rect and viewport height can be varied to exercise the
-  // proximity-based side resolution. The default sits with ample room on every side.
-  const elementAt = (rect: Partial<DOMRect> = {}, innerHeight = 1000): ElementRef =>
-    new ElementRef(<any>{
-      getBoundingClientRect: () => (<DOMRect>{ top: 100, bottom: 140, left: 0, right: 50, width: 50, height: 40, ...rect }),
-      ownerDocument: { defaultView: { innerHeight }},
-    });
-
   beforeEach(() => {
+    element = new ElementRef(<any>{});
+
     positionStrategy = {};
     for (const method of ['flexibleConnectedTo', 'withFlexibleDimensions', 'withPush', 'withViewportMargin', 'withPositions']) {
       positionStrategy[method] = jasmine.createSpy(method).and.returnValue(positionStrategy);
@@ -34,7 +30,7 @@ describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
   });
 
   it('should default to the after/below position', () => {
-    daffMenuCreateOverlay(overlay, elementAt());
+    daffMenuCreateOverlay(overlay, element);
 
     expect(position()).toEqual(jasmine.objectContaining({
       originX: 'start',
@@ -45,70 +41,52 @@ describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
   });
 
   it('should scope a pane class so the menu can dissolve its wrapper and scroll', () => {
-    daffMenuCreateOverlay(overlay, elementAt());
+    daffMenuCreateOverlay(overlay, element);
 
     expect(config().panelClass).toBe('daff-menu-overlay');
   });
 
   it('should let the CDK cap the panel to the viewport on the side it opens', () => {
-    daffMenuCreateOverlay(overlay, elementAt());
+    daffMenuCreateOverlay(overlay, element);
 
     expect(positionStrategy.withFlexibleDimensions).toHaveBeenCalledWith(true);
   });
 
   it('should keep the menu anchored rather than pushing it off the activator', () => {
-    daffMenuCreateOverlay(overlay, elementAt());
+    daffMenuCreateOverlay(overlay, element);
 
     expect(positionStrategy.withPush).toHaveBeenCalledWith(false);
   });
 
   it('should keep the menu clear of the viewport edges', () => {
-    daffMenuCreateOverlay(overlay, elementAt());
+    daffMenuCreateOverlay(overlay, element);
 
     expect(positionStrategy.withViewportMargin).toHaveBeenCalledWith(jasmine.any(Number));
   });
 
-  it('should offer a horizontal fallback so a menu near the side of the viewport flips edges', () => {
-    daffMenuCreateOverlay(overlay, elementAt());
+  it('should append the CDK standard dropdown positions as fallbacks after the requested one', () => {
+    daffMenuCreateOverlay(overlay, element);
 
-    expect(positions()).toContain(jasmine.objectContaining({ originX: 'end', overlayX: 'end', originY: 'bottom' }));
+    expect(positions().slice(1)).toEqual(STANDARD_DROPDOWN_BELOW_POSITIONS);
   });
 
   describe('vertical placement', () => {
-    it('should drop below when the activator has room beneath it', () => {
-      daffMenuCreateOverlay(overlay, elementAt({ bottom: 140 }, 1000), 'after', 'below');
+    it('should drop below when below is requested', () => {
+      daffMenuCreateOverlay(overlay, element, 'after', 'below');
 
       expect(position()).toEqual(jasmine.objectContaining({ originY: 'bottom', overlayY: 'top' }));
     });
 
-    it('should rise above when the activator sits too close to the bottom edge', () => {
-      daffMenuCreateOverlay(overlay, elementAt({ bottom: 995 }, 1000), 'after', 'below');
+    it('should rise above when above is requested', () => {
+      daffMenuCreateOverlay(overlay, element, 'after', 'above');
 
       expect(position()).toEqual(jasmine.objectContaining({ originY: 'top', overlayY: 'bottom' }));
-    });
-
-    it('should rise above when the activator has room over it', () => {
-      daffMenuCreateOverlay(overlay, elementAt({ top: 500 }, 1000), 'after', 'above');
-
-      expect(position()).toEqual(jasmine.objectContaining({ originY: 'top', overlayY: 'bottom' }));
-    });
-
-    it('should drop below when the activator sits too close to the top edge', () => {
-      daffMenuCreateOverlay(overlay, elementAt({ top: 5 }, 1000), 'after', 'above');
-
-      expect(position()).toEqual(jasmine.objectContaining({ originY: 'bottom', overlayY: 'top' }));
-    });
-
-    it('should keep the requested side when the viewport height is unknown', () => {
-      daffMenuCreateOverlay(overlay, elementAt({ bottom: 995 }, 0), 'after', 'below');
-
-      expect(position()).toEqual(jasmine.objectContaining({ originY: 'bottom', overlayY: 'top' }));
     });
   });
 
   describe('when xPosition is after', () => {
     it('should line up the left edges', () => {
-      daffMenuCreateOverlay(overlay, elementAt(), 'after', 'below');
+      daffMenuCreateOverlay(overlay, element, 'after', 'below');
 
       expect(position()).toEqual(jasmine.objectContaining({ originX: 'start', overlayX: 'start' }));
     });
@@ -116,7 +94,7 @@ describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
 
   describe('when xPosition is before', () => {
     it('should line up the right edges', () => {
-      daffMenuCreateOverlay(overlay, elementAt(), 'before', 'below');
+      daffMenuCreateOverlay(overlay, element, 'before', 'below');
 
       expect(position()).toEqual(jasmine.objectContaining({ originX: 'end', overlayX: 'end' }));
     });

--- a/libs/design/menu/src/helpers/create-overlay.spec.ts
+++ b/libs/design/menu/src/helpers/create-overlay.spec.ts
@@ -1,0 +1,95 @@
+import { ElementRef } from '@angular/core';
+
+import { daffMenuCreateOverlay } from './create-overlay';
+
+describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
+  let overlay: any;
+  let positionStrategy: any;
+  let element: ElementRef;
+
+  const rect = {
+    top: 100,
+    bottom: 140,
+    left: 0,
+    right: 50,
+    width: 50,
+    height: 40,
+  };
+
+  const config = () => overlay.create.calls.mostRecent().args[0];
+  const position = () => positionStrategy.withPositions.calls.mostRecent().args[0][0];
+
+  beforeEach(() => {
+    positionStrategy = {};
+    for (const method of ['flexibleConnectedTo', 'withFlexibleDimensions', 'withPush', 'withPositions']) {
+      positionStrategy[method] = jasmine.createSpy(method).and.returnValue(positionStrategy);
+    }
+
+    overlay = {
+      create: jasmine.createSpy('create').and.returnValue({}),
+      position: jasmine.createSpy('position').and.returnValue(positionStrategy),
+      scrollStrategies: {
+        block: jasmine.createSpy('block').and.returnValue('block'),
+      },
+    };
+
+    element = new ElementRef(<any>{
+      getBoundingClientRect: () => rect,
+    });
+  });
+
+  it('should default to the after/below position', () => {
+    daffMenuCreateOverlay(overlay, element);
+
+    expect(position()).toEqual(jasmine.objectContaining({
+      originX: 'start',
+      overlayX: 'start',
+      originY: 'bottom',
+      overlayY: 'top',
+    }));
+  });
+
+  describe('when yPosition is below', () => {
+    beforeEach(() => {
+      daffMenuCreateOverlay(overlay, element, 'after', 'below');
+    });
+
+    it('should drop the menu from the activator bottom edge', () => {
+      expect(position()).toEqual(jasmine.objectContaining({ originY: 'bottom', overlayY: 'top' }));
+    });
+
+    it('should cap the height to the space below the activator', () => {
+      expect(config().maxHeight).toBe('calc(100% - 140px)');
+    });
+  });
+
+  describe('when yPosition is above', () => {
+    beforeEach(() => {
+      daffMenuCreateOverlay(overlay, element, 'after', 'above');
+    });
+
+    it('should raise the menu from the activator top edge', () => {
+      expect(position()).toEqual(jasmine.objectContaining({ originY: 'top', overlayY: 'bottom' }));
+    });
+
+    it('should cap the height to the space above the activator', () => {
+      expect(config().maxHeight).toBe('100px');
+    });
+  });
+
+  describe('when xPosition is after', () => {
+    it('should line up the left edges', () => {
+      daffMenuCreateOverlay(overlay, element, 'after', 'below');
+
+      expect(position()).toEqual(jasmine.objectContaining({ originX: 'start', overlayX: 'start' }));
+    });
+  });
+
+  describe('when xPosition is before', () => {
+    it('should line up the right edges', () => {
+      daffMenuCreateOverlay(overlay, element, 'before', 'below');
+
+      expect(position()).toEqual(jasmine.objectContaining({ originX: 'end', overlayX: 'end' }));
+    });
+  });
+});

--- a/libs/design/menu/src/helpers/create-overlay.ts
+++ b/libs/design/menu/src/helpers/create-overlay.ts
@@ -1,7 +1,9 @@
 import {
   ConnectedPosition,
+  HorizontalConnectionPos,
   Overlay,
   OverlayConfig,
+  VerticalConnectionPos,
 } from '@angular/cdk/overlay';
 import { ElementRef } from '@angular/core';
 
@@ -11,52 +13,75 @@ import {
 } from './menu-position';
 
 /**
- * The CDK connected position for a menu. `yPosition` controls whether the menu drops
- * below or rises above the activator; `xPosition` controls which edges line up. The menu
- * stays anchored to the activator, so this is a single placement rather than a set of
- * fallbacks.
+ * How close, in pixels, the activator is allowed to sit to an edge of the viewport before the
+ * menu switches to the opposite side. The menu otherwise stays on its requested side and
+ * scrolls when it's too tall, rather than flipping just because it doesn't fully fit — so this only kicks in when the activator itself is near the edge.
  */
-const daffMenuConnectedPosition = (xPosition: DaffMenuXPosition, yPosition: DaffMenuYPosition): ConnectedPosition => {
-  const x = xPosition === 'before' ? 'end' : 'start';
+const DAFF_MENU_FLIP_THRESHOLD = 128;
 
-  return {
-    originX: x,
-    overlayX: x,
-    originY: yPosition === 'above' ? 'top' : 'bottom',
-    overlayY: yPosition === 'above' ? 'bottom' : 'top',
-  };
+/**
+ * The gap, in pixels, the CDK keeps between the menu and every edge of the viewport so the
+ * panel never sits flush against the screen.
+ */
+const DAFF_MENU_VIEWPORT_MARGIN = 24;
+
+/**
+ * Resolves which side the menu opens on. It keeps the requested `yPosition` unless the
+ * activator is within {@link DAFF_MENU_VIEWPORT_MARGIN} of that side's edge — a menu requested
+ * below an activator that sits too close to the bottom of the viewport opens above instead.
+ * When the viewport height is unknown (e.g. server-side) the requested side is kept as-is.
+ */
+const daffMenuResolveYPosition = (yPosition: DaffMenuYPosition, rect: DOMRect, viewportHeight: number): DaffMenuYPosition => {
+  if (!viewportHeight) {
+    return yPosition;
+  }
+
+  return yPosition === 'above'
+    ? (rect.top < DAFF_MENU_FLIP_THRESHOLD ? 'below' : 'above')
+    : (viewportHeight - rect.bottom < DAFF_MENU_FLIP_THRESHOLD ? 'above' : 'below');
 };
 
 /**
- * The tallest the menu can be without running past the edge of the viewport in the
- * direction it opens, so the panel scrolls in place while staying anchored to the
- * activator. `above` grows upward from the activator's top edge; `below` grows downward
- * from the bottom edge.
+ * The CDK connected positions for a menu, ordered by preference. The menu opens on the given
+ * `yPosition` — `above` rises from the activator's top edge, `below` drops from its bottom —
+ * and the two entries flip only the horizontal edges the menu lines up against, so the CDK can
+ * shift a menu near the left or right of the viewport onto the opposite side without changing
+ * which way it opens.
  */
-function daffMenuMaxHeight(yPosition: DaffMenuYPosition, rect: DOMRect): string {
-  return yPosition === 'above'
-    ? `${rect.top}px`
-    : `calc(100% - ${rect.bottom}px)`;
-}
+const daffMenuConnectedPositions = (xPosition: DaffMenuXPosition, yPosition: DaffMenuYPosition): ConnectedPosition[] => {
+  const preferredX = xPosition === 'before' ? 'end' : 'start';
+  const oppositeX = preferredX === 'end' ? 'start' : 'end';
+  const originY: VerticalConnectionPos = yPosition === 'above' ? 'top' : 'bottom';
+  const overlayY: VerticalConnectionPos = originY === 'top' ? 'bottom' : 'top';
+
+  const at = (x: HorizontalConnectionPos): ConnectedPosition => ({
+    originX: x,
+    overlayX: x,
+    originY,
+    overlayY,
+  });
+
+  return [at(preferredX), at(oppositeX)];
+};
 
 export function daffMenuCreateOverlay(overlay: Overlay, element: ElementRef, xPosition: DaffMenuXPosition = 'after', yPosition: DaffMenuYPosition = 'below', config: OverlayConfig = {}) {
   const rect = element.nativeElement.getBoundingClientRect();
+  const viewportHeight = element.nativeElement.ownerDocument?.defaultView?.innerHeight ?? 0;
+  const resolvedYPosition = daffMenuResolveYPosition(yPosition, rect, viewportHeight);
 
   return overlay.create({
     hasBackdrop: true,
     backdropClass: 'cdk-overlay-transparent-backdrop',
+    panelClass: 'daff-menu-overlay',
     scrollStrategy: overlay.scrollStrategies.block(),
     disposeOnNavigation: true,
-    maxHeight: daffMenuMaxHeight(yPosition, rect),
     positionStrategy: overlay
       .position()
       .flexibleConnectedTo(element)
-      // Use exact positioning so `maxHeight` is applied directly to the panel, and don't
-      // let the CDK push the panel to fit its natural height — both would detach it from
-      // the activator in the chosen direction.
-      .withFlexibleDimensions(false)
+      .withFlexibleDimensions(true)
       .withPush(false)
-      .withPositions([daffMenuConnectedPosition(xPosition, yPosition)]),
+      .withViewportMargin(24)
+      .withPositions(daffMenuConnectedPositions(xPosition, resolvedYPosition)),
     ...config,
   });
 };

--- a/libs/design/menu/src/helpers/create-overlay.ts
+++ b/libs/design/menu/src/helpers/create-overlay.ts
@@ -1,9 +1,8 @@
 import {
   ConnectedPosition,
-  HorizontalConnectionPos,
   Overlay,
   OverlayConfig,
-  VerticalConnectionPos,
+  STANDARD_DROPDOWN_BELOW_POSITIONS,
 } from '@angular/cdk/overlay';
 import { ElementRef } from '@angular/core';
 
@@ -13,75 +12,45 @@ import {
 } from './menu-position';
 
 /**
- * How close, in pixels, the activator is allowed to sit to an edge of the viewport before the
- * menu switches to the opposite side. The menu otherwise stays on its requested side and
- * scrolls when it's too tall, rather than flipping just because it doesn't fully fit — so this only kicks in when the activator itself is near the edge.
+ * The CDK connected position for a menu. `yPosition` controls whether the menu drops
+ * below or rises above the activator; `xPosition` controls which edges line up. The menu
+ * stays anchored to the activator, so this is a single placement rather than a set of
+ * fallbacks.
  */
-const DAFF_MENU_FLIP_THRESHOLD = 128;
+const daffMenuConnectedPosition = (xPosition: DaffMenuXPosition, yPosition: DaffMenuYPosition): ConnectedPosition => {
+  const x = xPosition === 'before' ? 'end' : 'start';
 
-/**
- * The gap, in pixels, the CDK keeps between the menu and every edge of the viewport so the
- * panel never sits flush against the screen.
- */
-const DAFF_MENU_VIEWPORT_MARGIN = 24;
-
-/**
- * Resolves which side the menu opens on. It keeps the requested `yPosition` unless the
- * activator is within {@link DAFF_MENU_VIEWPORT_MARGIN} of that side's edge — a menu requested
- * below an activator that sits too close to the bottom of the viewport opens above instead.
- * When the viewport height is unknown (e.g. server-side) the requested side is kept as-is.
- */
-const daffMenuResolveYPosition = (yPosition: DaffMenuYPosition, rect: DOMRect, viewportHeight: number): DaffMenuYPosition => {
-  if (!viewportHeight) {
-    return yPosition;
-  }
-
-  return yPosition === 'above'
-    ? (rect.top < DAFF_MENU_FLIP_THRESHOLD ? 'below' : 'above')
-    : (viewportHeight - rect.bottom < DAFF_MENU_FLIP_THRESHOLD ? 'above' : 'below');
-};
-
-/**
- * The CDK connected positions for a menu, ordered by preference. The menu opens on the given
- * `yPosition` — `above` rises from the activator's top edge, `below` drops from its bottom —
- * and the two entries flip only the horizontal edges the menu lines up against, so the CDK can
- * shift a menu near the left or right of the viewport onto the opposite side without changing
- * which way it opens.
- */
-const daffMenuConnectedPositions = (xPosition: DaffMenuXPosition, yPosition: DaffMenuYPosition): ConnectedPosition[] => {
-  const preferredX = xPosition === 'before' ? 'end' : 'start';
-  const oppositeX = preferredX === 'end' ? 'start' : 'end';
-  const originY: VerticalConnectionPos = yPosition === 'above' ? 'top' : 'bottom';
-  const overlayY: VerticalConnectionPos = originY === 'top' ? 'bottom' : 'top';
-
-  const at = (x: HorizontalConnectionPos): ConnectedPosition => ({
+  return {
     originX: x,
     overlayX: x,
-    originY,
-    overlayY,
-  });
-
-  return [at(preferredX), at(oppositeX)];
+    originY: yPosition === 'above' ? 'top' : 'bottom',
+    overlayY: yPosition === 'above' ? 'bottom' : 'top',
+  };
 };
 
-export function daffMenuCreateOverlay(overlay: Overlay, element: ElementRef, xPosition: DaffMenuXPosition = 'after', yPosition: DaffMenuYPosition = 'below', config: OverlayConfig = {}) {
-  const rect = element.nativeElement.getBoundingClientRect();
-  const viewportHeight = element.nativeElement.ownerDocument?.defaultView?.innerHeight ?? 0;
-  const resolvedYPosition = daffMenuResolveYPosition(yPosition, rect, viewportHeight);
-
-  return overlay.create({
-    hasBackdrop: true,
-    backdropClass: 'cdk-overlay-transparent-backdrop',
-    panelClass: 'daff-menu-overlay',
-    scrollStrategy: overlay.scrollStrategies.block(),
-    disposeOnNavigation: true,
-    positionStrategy: overlay
-      .position()
-      .flexibleConnectedTo(element)
-      .withFlexibleDimensions(true)
-      .withPush(false)
-      .withViewportMargin(24)
-      .withPositions(daffMenuConnectedPositions(xPosition, resolvedYPosition)),
-    ...config,
-  });
-};
+export const daffMenuCreateOverlay = (
+  overlay: Overlay,
+  element: ElementRef,
+  xPosition: DaffMenuXPosition = 'after',
+  yPosition: DaffMenuYPosition = 'below',
+  config: OverlayConfig = {},
+) => overlay.create({
+  hasBackdrop: true,
+  backdropClass: 'cdk-overlay-transparent-backdrop',
+  panelClass: 'daff-menu-overlay',
+  scrollStrategy: overlay.scrollStrategies.block(),
+  disposeOnNavigation: true,
+  positionStrategy: overlay
+    .position()
+    .flexibleConnectedTo(element)
+    .withFlexibleDimensions(true)
+    .withPush(false)
+    .withViewportMargin(24)
+    .withPositions(
+      [
+        daffMenuConnectedPosition(xPosition, yPosition),
+        ...STANDARD_DROPDOWN_BELOW_POSITIONS,
+      ],
+    ),
+  ...config,
+});

--- a/libs/design/menu/src/helpers/create-overlay.ts
+++ b/libs/design/menu/src/helpers/create-overlay.ts
@@ -16,7 +16,7 @@ import {
  * stays anchored to the activator, so this is a single placement rather than a set of
  * fallbacks.
  */
-function daffMenuConnectedPosition(xPosition: DaffMenuXPosition, yPosition: DaffMenuYPosition): ConnectedPosition {
+const daffMenuConnectedPosition = (xPosition: DaffMenuXPosition, yPosition: DaffMenuYPosition): ConnectedPosition => {
   const x = xPosition === 'before' ? 'end' : 'start';
 
   return {
@@ -25,7 +25,7 @@ function daffMenuConnectedPosition(xPosition: DaffMenuXPosition, yPosition: Daff
     originY: yPosition === 'above' ? 'top' : 'bottom',
     overlayY: yPosition === 'above' ? 'bottom' : 'top',
   };
-}
+};
 
 /**
  * The tallest the menu can be without running past the edge of the viewport in the

--- a/libs/design/menu/src/helpers/create-overlay.ts
+++ b/libs/design/menu/src/helpers/create-overlay.ts
@@ -1,33 +1,62 @@
 import {
+  ConnectedPosition,
   Overlay,
   OverlayConfig,
 } from '@angular/cdk/overlay';
 import { ElementRef } from '@angular/core';
 
-export function daffMenuCreateOverlay(overlay: Overlay, element: ElementRef, config: OverlayConfig = {}) {
+import {
+  DaffMenuXPosition,
+  DaffMenuYPosition,
+} from './menu-position';
+
+/**
+ * The CDK connected position for a menu. `yPosition` controls whether the menu drops
+ * below or rises above the activator; `xPosition` controls which edges line up. The menu
+ * stays anchored to the activator, so this is a single placement rather than a set of
+ * fallbacks.
+ */
+function daffMenuConnectedPosition(xPosition: DaffMenuXPosition, yPosition: DaffMenuYPosition): ConnectedPosition {
+  const x = xPosition === 'before' ? 'end' : 'start';
+
+  return {
+    originX: x,
+    overlayX: x,
+    originY: yPosition === 'above' ? 'top' : 'bottom',
+    overlayY: yPosition === 'above' ? 'bottom' : 'top',
+  };
+}
+
+/**
+ * The tallest the menu can be without running past the edge of the viewport in the
+ * direction it opens, so the panel scrolls in place while staying anchored to the
+ * activator. `above` grows upward from the activator's top edge; `below` grows downward
+ * from the bottom edge.
+ */
+function daffMenuMaxHeight(yPosition: DaffMenuYPosition, rect: DOMRect): string {
+  return yPosition === 'above'
+    ? `${rect.top}px`
+    : `calc(100% - ${rect.bottom}px)`;
+}
+
+export function daffMenuCreateOverlay(overlay: Overlay, element: ElementRef, xPosition: DaffMenuXPosition = 'after', yPosition: DaffMenuYPosition = 'below', config: OverlayConfig = {}) {
+  const rect = element.nativeElement.getBoundingClientRect();
+
   return overlay.create({
     hasBackdrop: true,
     backdropClass: 'cdk-overlay-transparent-backdrop',
     scrollStrategy: overlay.scrollStrategies.block(),
     disposeOnNavigation: true,
+    maxHeight: daffMenuMaxHeight(yPosition, rect),
     positionStrategy: overlay
       .position()
       .flexibleConnectedTo(element)
-      .withPositions([
-        {
-          originX: 'start',
-          originY: 'bottom',
-          overlayX: 'start',
-          overlayY: 'top',
-          offsetY: 0,
-        },
-        {
-          originX: 'start',
-          originY: 'top',
-          overlayX: 'start',
-          overlayY: 'bottom',
-        },
-      ]),
+      // Use exact positioning so `maxHeight` is applied directly to the panel, and don't
+      // let the CDK push the panel to fit its natural height — both would detach it from
+      // the activator in the chosen direction.
+      .withFlexibleDimensions(false)
+      .withPush(false)
+      .withPositions([daffMenuConnectedPosition(xPosition, yPosition)]),
     ...config,
   });
 };

--- a/libs/design/menu/src/helpers/menu-position.ts
+++ b/libs/design/menu/src/helpers/menu-position.ts
@@ -1,0 +1,15 @@
+/**
+ * The horizontal alignment of the menu relative to its activator.
+ *
+ * - `after` lines the menu's left edge up with the activator's left edge.
+ * - `before` lines the menu's right edge up with the activator's right edge.
+ */
+export type DaffMenuXPosition = 'before' | 'after';
+
+/**
+ * The vertical position of the menu relative to its activator.
+ *
+ * - `below` drops the menu down from the activator's bottom edge.
+ * - `above` raises the menu up from the activator's top edge.
+ */
+export type DaffMenuYPosition = 'above' | 'below';

--- a/libs/design/menu/src/menu-activator/menu-activator.component.spec.ts
+++ b/libs/design/menu/src/menu-activator/menu-activator.component.spec.ts
@@ -73,10 +73,70 @@ describe('@daffodil/design/menu | DaffMenuActivatorDirective', () => {
     expect(menuService.open).toHaveBeenCalled();
   });
 
+  it('should open the menu with the default position', () => {
+    const menuService = TestBed.inject(DaffMenuService);
+    spyOn(menuService, 'open');
+
+    de.nativeElement.click();
+
+    expect(menuService.open).toHaveBeenCalledWith(
+      jasmine.anything(),
+      jasmine.anything(),
+      jasmine.objectContaining({ xPosition: 'after', yPosition: 'below' }),
+    );
+  });
+
   it('should focus the button when focus is called', () => {
     const activator = de.injector.get(DaffMenuActivatorDirective);
     activator.focus();
 
     expect(document.activeElement).toEqual(de.nativeElement);
+  });
+});
+
+@Component({
+  template: `
+    <button daffMenuActivator="menu" xPosition="before" yPosition="above"></button>
+    <daff-menu #menu></daff-menu>
+  `,
+  imports: [
+    DaffMenuComponent,
+    DaffMenuActivatorDirective,
+  ],
+})
+class PositionedWrapperComponent {}
+
+describe('@daffodil/design/menu | DaffMenuActivatorDirective | With Custom Position', () => {
+  let fixture: ComponentFixture<PositionedWrapperComponent>;
+  let de: DebugElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        PositionedWrapperComponent,
+      ],
+      providers: [
+        provideTestMenuService(),
+        { provide: DAFF_MENU_CONFIG, useValue: <DaffMenuConfig>{ menuId: 'daff-menu-test' }},
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PositionedWrapperComponent);
+    fixture.detectChanges();
+
+    de = fixture.debugElement.query(By.directive(DaffMenuActivatorDirective));
+  });
+
+  it('should open the menu with the configured position', () => {
+    const menuService = TestBed.inject(DaffMenuService);
+    spyOn(menuService, 'open');
+
+    de.nativeElement.click();
+
+    expect(menuService.open).toHaveBeenCalledWith(
+      jasmine.anything(),
+      jasmine.anything(),
+      jasmine.objectContaining({ xPosition: 'before', yPosition: 'above' }),
+    );
   });
 });

--- a/libs/design/menu/src/menu-activator/menu-activator.component.ts
+++ b/libs/design/menu/src/menu-activator/menu-activator.component.ts
@@ -16,6 +16,10 @@ import {
 } from 'rxjs';
 
 import { daffNextMenuId } from '../config/menu-id';
+import {
+  DaffMenuXPosition,
+  DaffMenuYPosition,
+} from '../helpers/menu-position';
 import { DaffMenuService } from '../services/menu.service';
 
 /**
@@ -55,6 +59,16 @@ export class DaffMenuActivatorDirective implements OnDestroy {
    * When set, the menu's ID is derived as `${id}-menu`.
    */
   id = input<string>();
+
+  /**
+   * The horizontal alignment of the menu relative to the activator. Defaults to `after`.
+   */
+  xPosition = input<DaffMenuXPosition>('after');
+
+  /**
+   * The vertical position of the menu relative to the activator. Defaults to `below`.
+   */
+  yPosition = input<DaffMenuYPosition>('below');
 
   /**
    * The resolved menu ID.
@@ -105,6 +119,6 @@ export class DaffMenuActivatorDirective implements OnDestroy {
    */
   onClick(event: MouseEvent) {
     event.preventDefault();
-    this.service.open(this.viewContainerRef, this.daffMenuActivator, { menuId: this.menuId() });
+    this.service.open(this.viewContainerRef, this.daffMenuActivator, { menuId: this.menuId(), xPosition: this.xPosition(), yPosition: this.yPosition() });
   }
 }

--- a/libs/design/menu/src/menu-item/menu-item.component.spec.ts
+++ b/libs/design/menu/src/menu-item/menu-item.component.spec.ts
@@ -9,7 +9,8 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffMenuItemComponent } from './menu-item.component';
+import { DaffMenuItemComponent } from '@daffodil/design/menu';
+
 import { provideTestMenuService } from '../testing/dummy-service';
 
 @Component({

--- a/libs/design/menu/src/menu-theme.scss
+++ b/libs/design/menu/src/menu-theme.scss
@@ -10,7 +10,7 @@
 	@include light($mode) {
 		.daff-menu {
 			background: $base;
-			box-shadow: 0 0 24px rgb($black, 0.12);
+			box-shadow: 0 0 1.5rem rgb($black, 0.12);
 		}
 
 		.daff-menu-item {
@@ -32,7 +32,7 @@
 	@include dark($mode) {
 		.daff-menu {
 			background: $base;
-			box-shadow: 0 0 24px rgb($black, 0.12);
+			box-shadow: 0 0 1.5rem rgb($black, 0.12);
 		}
 
 		.daff-menu-item {

--- a/libs/design/menu/src/menu/menu.component.scss
+++ b/libs/design/menu/src/menu/menu.component.scss
@@ -1,5 +1,13 @@
 @use '../../../scss/interactions';
 
+.daff-menu-overlay {
+	> * {
+		&:not(.daff-menu) {
+			display: contents;
+		}
+	}
+}
+
 .daff-menu {
 	display: block;
 	min-width: 7rem;

--- a/libs/design/menu/src/menu/menu.component.scss
+++ b/libs/design/menu/src/menu/menu.component.scss
@@ -6,8 +6,8 @@
 	max-width: 20rem;
 	border-radius: 0.25rem;
 	padding: 0.5rem;
+	overflow-y: auto;
 }
-
 
 .daff-menu-item {
 	@include interactions.clickable();

--- a/libs/design/menu/src/menu/menu.component.spec.ts
+++ b/libs/design/menu/src/menu/menu.component.spec.ts
@@ -9,19 +9,19 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { DAFF_MENU_COMPONENTS } from '@daffodil/design/menu';
+
 import { DaffMenuComponent } from './menu.component';
 import {
   DAFF_MENU_CONFIG,
   DaffMenuConfig,
 } from '../config/menu-config';
-import { DaffMenuItemComponent } from '../menu-item/menu-item.component';
 import { provideTestMenuService } from '../testing/dummy-service';
 
 @Component({
   template: `<daff-menu></daff-menu>`,
   imports: [
-    DaffMenuComponent,
-    DaffMenuItemComponent,
+    DAFF_MENU_COMPONENTS,
   ],
 })
 class WrapperComponent {}

--- a/libs/design/menu/src/menu/menu.component.spec.ts
+++ b/libs/design/menu/src/menu/menu.component.spec.ts
@@ -9,9 +9,11 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DAFF_MENU_COMPONENTS } from '@daffodil/design/menu';
+import {
+  DAFF_MENU_COMPONENTS,
+  DaffMenuComponent,
+} from '@daffodil/design/menu';
 
-import { DaffMenuComponent } from './menu.component';
 import {
   DAFF_MENU_CONFIG,
   DaffMenuConfig,

--- a/libs/design/menu/src/menu/specs/usage.spec.ts
+++ b/libs/design/menu/src/menu/specs/usage.spec.ts
@@ -8,16 +8,18 @@ import {
   TestBed,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import {
+  DAFF_MENU_COMPONENTS,
+  DaffMenuComponent,
+} from '@daffodil/design/menu';
 
 import {
   DAFF_MENU_CONFIG,
   DaffMenuConfig,
 } from '../../config/menu-config';
-import { DaffMenuItemComponent } from '../../menu-item/menu-item.component';
 import { DaffMenuService } from '../../services/menu.service';
 import { provideTestMenuService } from '../../testing/dummy-service';
-import { DaffMenuComponent } from '../menu.component';
 
 @Component({
   template: `
@@ -27,8 +29,7 @@ import { DaffMenuComponent } from '../menu.component';
     </daff-menu>
   `,
   imports: [
-    DaffMenuComponent,
-    DaffMenuItemComponent,
+    DAFF_MENU_COMPONENTS,
   ],
 })
 class WrapperComponent {}
@@ -42,7 +43,6 @@ describe('@daffodil/design/menu | DaffMenuComponent | Usage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        NoopAnimationsModule,
         WrapperComponent,
       ],
       providers: [

--- a/libs/design/menu/src/public_api.ts
+++ b/libs/design/menu/src/public_api.ts
@@ -1,5 +1,9 @@
 export { DaffMenuConfig } from './config/menu-config';
 export {
+  DaffMenuXPosition,
+  DaffMenuYPosition,
+} from './helpers/menu-position';
+export {
   DaffMenuService,
   DaffMenuSlot,
 } from './services/menu.service';

--- a/libs/design/menu/src/services/menu.service.ts
+++ b/libs/design/menu/src/services/menu.service.ts
@@ -47,7 +47,7 @@ export class DaffMenuService {
    */
   protected async _createOverlay(activatorElement: ViewContainerRef, component: DaffMenuSlot, config?: DaffMenuConfig) {
     if (!this._overlay) {
-      this._overlay = daffMenuCreateOverlay(this.overlay, activatorElement.element);
+      this._overlay = daffMenuCreateOverlay(this.overlay, activatorElement.element, config?.xPosition, config?.yPosition);
       if(typeof component === 'object' && (<DaffLazyComponent>component)?.import) {
         component = await (<DaffLazyComponent>component).import();
       }


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4202
Fixes: #4533

## New behavior
Add `xPosition` (`before`/`after`) and `yPosition` (`above`/`below`) inputs to the menu activator so a menu can open above or below its activator and align to either edge. Position is threaded through `DaffMenuConfig` into the overlay's connected position and its max-height calculation, so the panel stays anchored to the activator and scrolls its content in place when it is taller than the available space.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->