### PR TITLE
feat(core,content,category,product)!: allow validators to narrow type

### DIFF
--- a/libs/category/driver/magento/src/queries/resolve-url/validator.ts
+++ b/libs/category/driver/magento/src/queries/resolve-url/validator.ts
@@ -2,11 +2,19 @@ import { GraphQlApolloValidator } from '@daffodil/core/graphql';
 
 import { MagentoCategoryUrlResolverResponse } from './response.type';
 
-export const magentoCategoryGetByUrlValidator: GraphQlApolloValidator<MagentoCategoryUrlResolverResponse>
-	= (response) => {
-	  if (!response.data?.route?.uid) {
-	    throw new Error('The platform did not respond with a category.');
-	  }
+interface Shape {
+  data: { route: { uid: true } };
+}
+type ValidatorFn = GraphQlApolloValidator<MagentoCategoryUrlResolverResponse, Shape>;
 
-	  return response;
-	};
+const isValid = (
+  response: Parameters<ValidatorFn>[0],
+): response is ReturnType<ValidatorFn> => !!response.data?.route?.uid;
+
+export const magentoCategoryGetByUrlValidator: ValidatorFn = (response) => {
+  if (isValid(response)) {
+    return response;
+  }
+
+  throw new Error('The platform did not respond with a category.');
+};

--- a/libs/content/driver/magento/src/validators/get-page.ts
+++ b/libs/content/driver/magento/src/validators/get-page.ts
@@ -1,4 +1,3 @@
-import { Apollo } from 'apollo-angular';
 
 import { DaffContentInvalidAPIResponseError } from '@daffodil/content/driver';
 import { validateFieldPresence } from '@daffodil/core';
@@ -6,14 +5,30 @@ import { GraphQlApolloValidator } from '@daffodil/core/graphql';
 
 import { MagentoContentGetPageResponse } from '../queries/public_api';
 
-export const validateMagentoContentGetPageResponse: GraphQlApolloValidator<MagentoContentGetPageResponse> = (response: Apollo.QueryResult<MagentoContentGetPageResponse>) => {
+interface Shape {
+  data: {
+    route: {
+      type: true;
+      content: true;
+      title: true;
+      identifier: true;
+    };
+  };
+}
+type ValidatorFn = GraphQlApolloValidator<MagentoContentGetPageResponse, Shape>;
+
+const isValid = (
+  response: Parameters<ValidatorFn>[0],
+): response is ReturnType<ValidatorFn> => validateFieldPresence<any>(response.data?.route, 'content', 'title', 'identifier');
+
+export const validateMagentoContentGetPageResponse: ValidatorFn = (response) => {
   if (response.data?.route?.type === 'CMS_PAGE') {
-    if (validateFieldPresence<any>(response.data.route, 'content', 'title', 'identifier')) {
+    if (isValid(response)) {
       return response;
-    } else {
-      throw new DaffContentInvalidAPIResponseError('The page response does not contain required fields.');
     }
-  } else {
-    throw new DaffContentInvalidAPIResponseError('Get page response does not contain a page.');
+
+    throw new DaffContentInvalidAPIResponseError('The page response does not contain required fields.');
   }
+
+  throw new DaffContentInvalidAPIResponseError('Get page response does not contain a page.');
 };

--- a/libs/content/driver/magento/src/validators/get-schema-page.ts
+++ b/libs/content/driver/magento/src/validators/get-schema-page.ts
@@ -1,4 +1,3 @@
-import { Apollo } from 'apollo-angular';
 
 import { DaffContentInvalidAPIResponseError } from '@daffodil/content/driver';
 import { validateFieldPresence } from '@daffodil/core';
@@ -6,14 +5,30 @@ import { GraphQlApolloValidator } from '@daffodil/core/graphql';
 
 import { MagentoContentGetSchemaPageResponse } from '../queries/public_api';
 
-export const validateMagentoContentGetSchemaPageResponse: GraphQlApolloValidator<MagentoContentGetSchemaPageResponse> = (response: Apollo.QueryResult<MagentoContentGetSchemaPageResponse>) => {
+interface Shape {
+  data: {
+    route: {
+      type: true;
+      content_schema_json: true;
+      title: true;
+      identifier: true;
+    };
+  };
+}
+type ValidatorFn = GraphQlApolloValidator<MagentoContentGetSchemaPageResponse, Shape>;
+
+const isValid = (
+  response: Parameters<ValidatorFn>[0],
+): response is ReturnType<ValidatorFn> => validateFieldPresence<any>(response.data?.route, 'content_schema_json', 'title', 'identifier');
+
+export const validateMagentoContentGetSchemaPageResponse: ValidatorFn = (response) => {
   if (response.data?.route?.type === 'CMS_PAGE') {
-    if (validateFieldPresence<any>(response.data.route, 'content_schema_json', 'title', 'identifier')) {
+    if (isValid(response)) {
       return response;
-    } else {
-      throw new DaffContentInvalidAPIResponseError('The page response does not contain required fields.');
     }
-  } else {
-    throw new DaffContentInvalidAPIResponseError('Get page response does not contain a page.');
+
+    throw new DaffContentInvalidAPIResponseError('The page response does not contain required fields.');
   }
+
+  throw new DaffContentInvalidAPIResponseError('Get page response does not contain a page.');
 };

--- a/libs/core/graphql/src/apollo/validator/type.ts
+++ b/libs/core/graphql/src/apollo/validator/type.ts
@@ -1,9 +1,17 @@
 import { Apollo } from 'apollo-angular';
 
+export type ValidatedResponse<T, Shape> = {
+  [K in keyof T]: K extends keyof Shape
+    ? Shape[K] extends true
+      ? NonNullable<T[K]>
+      : ValidatedResponse<NonNullable<T[K]>, Shape[K]>
+    : T[K];
+};
+
 /**
  * A validator for a GraphQL Apollo response.
  * Throws errors to indicate that the response is not valid.
  * Returns the response and throws no errors to indicate that the response
  * is valid as far as this particular validator is concerned.
  */
-export type GraphQlApolloValidator<T> = (response: Apollo.QueryResult<T>) => Apollo.QueryResult<T>;
+export type GraphQlApolloValidator<T, Shape> = (response: Apollo.QueryResult<T>) => ValidatedResponse<Apollo.QueryResult<T>, Shape>;

--- a/libs/product/driver/magento/src/product.service.ts
+++ b/libs/product/driver/magento/src/product.service.ts
@@ -30,6 +30,7 @@ import { getAllProducts } from './queries/get-all-products';
 import { getProduct } from './queries/get-product';
 import {
   getProductByUrl,
+  magentoProductGetAllValidator,
   magentoProductGetByUrlValidator,
 } from './queries/public_api';
 import { DaffMagentoProductsTransformer } from './transforms/product-transformers';
@@ -92,6 +93,7 @@ export class DaffMagentoProductService implements DaffProductServiceInterface {
         ...this.extraPageFragments,
       ]),
     }).pipe(
+      map(magentoProductGetAllValidator),
       map(result => this.magentoProductsTransformer.transformManyMagentoProducts(result.data.products.items, this.config.baseMediaUrl)),
     );
   }

--- a/libs/product/driver/magento/src/queries/get-all-products/validator.ts
+++ b/libs/product/driver/magento/src/queries/get-all-products/validator.ts
@@ -1,0 +1,21 @@
+import { GraphQlApolloValidator } from '@daffodil/core/graphql';
+import { DaffProductInvalidAPIResponseError } from '@daffodil/product/driver';
+
+import { MagentoGetProductResponse } from '../../models/public_api';
+
+interface Shape {
+  data: { products: { items: true } };
+}
+type ValidatorFn = GraphQlApolloValidator<MagentoGetProductResponse, Shape>;
+
+const isValid = (
+  response: Parameters<ValidatorFn>[0],
+): response is ReturnType<ValidatorFn> => !!response.data?.products?.items;
+
+export const magentoProductGetAllValidator: ValidatorFn = (response) => {
+  if (isValid(response)) {
+    return response;
+  }
+
+  throw new DaffProductInvalidAPIResponseError('The platform did not respond with  products.');
+};

--- a/libs/product/driver/magento/src/queries/get-product-by-url/validator.ts
+++ b/libs/product/driver/magento/src/queries/get-product-by-url/validator.ts
@@ -3,11 +3,19 @@ import { DaffProductInvalidAPIResponseError } from '@daffodil/product/driver';
 
 import { MagentoProductGetByUrlReponse } from './response.type';
 
-export const magentoProductGetByUrlValidator: GraphQlApolloValidator<MagentoProductGetByUrlReponse>
-	= (response) => {
-	  if (!response.data?.route?.sku) {
-	    throw new DaffProductInvalidAPIResponseError('The platform did not respond with a product.');
-	  }
+interface Shape {
+  data: { route: { sku: true } };
+}
+type ValidatorFn = GraphQlApolloValidator<MagentoProductGetByUrlReponse, Shape>;
 
-	  return response;
-	};
+const isValid = (
+  response: Parameters<ValidatorFn>[0],
+): response is ReturnType<ValidatorFn> => !!response.data?.route?.sku;
+
+export const magentoProductGetByUrlValidator: ValidatorFn = (response) => {
+  if (isValid(response)) {
+    return response;
+  }
+
+  throw new DaffProductInvalidAPIResponseError('The platform did not respond with a product.');
+};

--- a/libs/product/driver/magento/src/queries/public_api.ts
+++ b/libs/product/driver/magento/src/queries/public_api.ts
@@ -3,3 +3,4 @@ export * from './get-product-by-url/public_api';
 export * from './get-all-products';
 export * from './get-filter-types';
 export * from './fragments/public_api';
+export { magentoProductGetAllValidator } from './get-all-products/validator';


### PR DESCRIPTION
BREAKING CHANGE: `GraphQlApolloValidator` now requires 2 type params

## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->