### PR TITLE
feat(design)!: convert `DaffOpenableDirective` to use signals

### DIFF
--- a/libs/design/accordion/src/accordion/accordion-item/accordion-item.component.html
+++ b/libs/design/accordion/src/accordion/accordion-item/accordion-item.component.html
@@ -1,6 +1,6 @@
 <button type="button" class="daff-accordion-item__header"
   (click)="toggle()"
-  [attr.aria-expanded]="open"
+  [attr.aria-expanded]="open()"
   [attr.aria-controls]="contentId"
   [id]="itemId"
   [disabled]="disabled"

--- a/libs/design/accordion/src/accordion/accordion-item/accordion-item.component.spec.ts
+++ b/libs/design/accordion/src/accordion/accordion-item/accordion-item.component.spec.ts
@@ -37,7 +37,7 @@ describe('@daffodil/design/accordion | DaffAccordionItemComponent | Defaults', (
   });
 
   it('should be collapsed by default', () => {
-    expect(component.open).toEqual(false);
+    expect(component.open()).toEqual(false);
   });
 });
 
@@ -107,7 +107,6 @@ describe('@daffodil/design/accordion | DaffAccordionItemComponent | Usage', () =
     fixture.detectChanges();
 
     expect(accordionItemHeader.nativeElement.attributes['aria-expanded'].value).toEqual('true');
-
   });
 
   it('should set aria-expanded to false if open is false', () => {
@@ -115,28 +114,27 @@ describe('@daffodil/design/accordion | DaffAccordionItemComponent | Usage', () =
     fixture.detectChanges();
 
     expect(accordionItemHeader.nativeElement.attributes['aria-expanded'].value).toEqual('false');
-
   });
 
   it('should set open to true if initiallyExpanded is true', () => {
     wrapper.initiallyExpandedValue.set(true);
     fixture.detectChanges();
 
-    expect(daffAccordionItem.open).toBeTrue();
+    expect(daffAccordionItem.open()).toBeTrue();
   });
 
   it('should set open to false if initiallyExpanded is false', () => {
     wrapper.initiallyExpandedValue.set(false);
     fixture.detectChanges();
 
-    expect(daffAccordionItem.open).toBeFalse();
+    expect(daffAccordionItem.open()).toBeFalse();
   });
 
   it('should set open to false if initiallyExpanded is undefined', () => {
     wrapper.initiallyExpandedValue.set(undefined);
     fixture.detectChanges();
 
-    expect(daffAccordionItem.open).toBeFalse();
+    expect(daffAccordionItem.open()).toBeFalse();
   });
 
   describe('when accordion header is clicked', () => {

--- a/libs/design/accordion/src/accordion/accordion-item/accordion-item.component.ts
+++ b/libs/design/accordion/src/accordion/accordion-item/accordion-item.component.ts
@@ -84,7 +84,7 @@ export class DaffAccordionItemComponent implements OnInit, DaffOpenable, DaffDis
    * @docs-private
    */
   ngOnInit() {
-    this.openDirective.open = this.initiallyExpanded ? this.initiallyExpanded : this.openDirective.open;
+    this.openDirective.open.update(() => this.initiallyExpanded ? this.initiallyExpanded : this.openDirective.open()) ;
   }
 
   /**

--- a/libs/design/select/src/select/select.component.ts
+++ b/libs/design/select/src/select/select.component.ts
@@ -148,7 +148,7 @@ export class DaffSelectComponent<T = unknown> extends DaffFormFieldControl<strin
    * @docs-private
    */
   get isOpen() {
-    return this.openDirective.open;
+    return this.openDirective.open();
   }
 
   /**
@@ -300,8 +300,8 @@ export class DaffSelectComponent<T = unknown> extends DaffFormFieldControl<strin
     event?.preventDefault();
     event?.stopPropagation();
 
-    if (!this.openDirective.open) {
-      this.openDirective.open = true;
+    if (!this.openDirective.open()) {
+      this.openDirective.open.set(true);
 
       if (this._value) {
         this._highlighted = this.options.findIndex((v) => v === this._value);
@@ -360,8 +360,8 @@ export class DaffSelectComponent<T = unknown> extends DaffFormFieldControl<strin
     event?.preventDefault();
     event?.stopPropagation();
 
-    if (this.openDirective.open) {
-      this.openDirective.open = false;
+    if (this.openDirective.open()) {
+      this.openDirective.open.set(false);
       this.cd.markForCheck();
 
       // do we actually have to dispose and recreate the overlay every time we want to close the dropdown?

--- a/libs/design/sidebar/src/sidebar-viewport/sidebar-viewport.component.ts
+++ b/libs/design/sidebar/src/sidebar-viewport/sidebar-viewport.component.ts
@@ -215,7 +215,7 @@ export class DaffSidebarViewportComponent implements AfterContentChecked, OnDest
   private updateAnimationState() {
     this._animationState = {
       value: getSidebarViewportAnimationState(
-        this.sidebars.reduce((acc: boolean, sidebar) => acc || isViewportContentShifted(sidebar.mode, sidebar.open), false),
+        this.sidebars.reduce((acc: boolean, sidebar) => acc || isViewportContentShifted(sidebar.mode, sidebar.open()), false),
       ),
       params: { shift: this._shift },
     };

--- a/libs/design/sidebar/src/sidebar-viewport/utils/backdrop-interactable.ts
+++ b/libs/design/sidebar/src/sidebar-viewport/utils/backdrop-interactable.ts
@@ -6,5 +6,5 @@ import { DaffSidebarComponent } from '../../sidebar/sidebar.component';
  * Determines, given a list of sidebars, whether or not the backdrop is interactable (typically clickable).
  */
 export const sidebarViewportBackdropInteractable = (sidebars: QueryList<DaffSidebarComponent>): boolean => sidebars.reduce(
-  (acc: boolean, sidebar) => ((sidebar.mode === 'over' || sidebar.mode === 'under') && sidebar.open) || acc,
+  (acc: boolean, sidebar) => ((sidebar.mode === 'over' || sidebar.mode === 'under') && sidebar.open()) || acc,
   false);

--- a/libs/design/sidebar/src/sidebar-viewport/utils/content-pad.ts
+++ b/libs/design/sidebar/src/sidebar-viewport/utils/content-pad.ts
@@ -9,7 +9,7 @@ import { DaffSidebarComponent } from '../../sidebar/sidebar.component';
  */
 export const isSidebarViewportContentPadded = (sidebars: QueryList<DaffSidebarComponent>, side: DaffSidebarSide): boolean =>
   sidebars.reduce((acc: boolean, sidebar) => {
-    if(!(sidebar.mode === DaffSidebarModeEnum.SideFixed && sidebar.open)) {
+    if(!(sidebar.mode === DaffSidebarModeEnum.SideFixed && sidebar.open())) {
       return acc || false;
     }
 

--- a/libs/design/sidebar/src/sidebar-viewport/utils/content-shift.ts
+++ b/libs/design/sidebar/src/sidebar-viewport/utils/content-shift.ts
@@ -10,7 +10,7 @@ export const isViewportContentShifted = (mode: DaffSidebarMode, open: boolean): 
  */
 export const sidebarViewportContentShift = (sidebars: QueryList<DaffSidebarComponent>): number =>
   sidebars.reduce((acc: number, sidebar) => {
-    if(!isViewportContentShifted(sidebar.mode, sidebar.open)) {
+    if(!isViewportContentShifted(sidebar.mode, sidebar.open())) {
       return acc;
     }
 

--- a/libs/design/sidebar/src/sidebar/sidebar.component.spec.ts
+++ b/libs/design/sidebar/src/sidebar/sidebar.component.spec.ts
@@ -213,7 +213,7 @@ describe('DaffSidebarComponent | Usage', () => {
   });
 
   it('should be able to bind to the input `open`', () => {
-    expect(component.open).toEqual(false);
+    expect(component.open()).toEqual(false);
   });
 });
 

--- a/libs/design/sidebar/src/sidebar/sidebar.component.ts
+++ b/libs/design/sidebar/src/sidebar/sidebar.component.ts
@@ -77,7 +77,7 @@ export class DaffSidebarComponent implements DaffOpenable {
    */
   @HostBinding('@transformSidebar') get transformSidebar() {
     return {
-      value: getAnimationState(this.openDirective.open, this.mode),
+      value: getAnimationState(this.openDirective.open(), this.mode),
       params: { width: getSidebarAnimationWidth(this.side, this.width) },
     };
   }

--- a/libs/design/src/core/openable/openable.directive.ts
+++ b/libs/design/src/core/openable/openable.directive.ts
@@ -1,11 +1,11 @@
 import {
   Directive,
   EventEmitter,
-  Input,
   OnChanges,
   Output,
   SimpleChanges,
   isDevMode,
+  model,
 } from '@angular/core';
 
 import { DaffOpenable } from './openable';
@@ -59,17 +59,17 @@ import { DaffOpenableStateError } from './utils/state-error';
 @Directive({
   selector: '[daffOpenable]',
   host: {
-    '[class.daff-open]': 'open',
+    '[class.daff-open]': 'open()',
   },
 })
 
 export class DaffOpenableDirective implements DaffOpenable, OnChanges {
   /** Controls whether the component is open. */
-  @Input() open = false;
+  open = model(false);
 
   private _setOpen(v: boolean) {
     if(!this.stateless) {
-      this.open = v;
+      this.open.set(v);
     }
   }
 
@@ -111,7 +111,7 @@ export class DaffOpenableDirective implements DaffOpenable, OnChanges {
    * Open or close the component, depending on if it's currently open or not
    */
   toggle() {
-    const state = !this.open;
+    const state = !this.open();
 
     this._setOpen(state);
 
@@ -126,7 +126,7 @@ export class DaffOpenableDirective implements DaffOpenable, OnChanges {
      * Throw an error if open is set in a component that is not stateless
      */
     if(changes.open.currentValue && !this.stateless) {
-      this.open = changes.open.previousValue;
+      this.open.set(changes.open.previousValue);
 
       if(isDevMode()) {
         throw new Error(DaffOpenableStateError);

--- a/libs/design/src/core/openable/openable.ts
+++ b/libs/design/src/core/openable/openable.ts
@@ -1,9 +1,11 @@
+import { Signal } from '@angular/core';
+
 /**
  * An interface for giving a component the ability to display an open UI.
  */
 export interface DaffOpenable {
   /** Whether a component is open or not */
-  open: boolean;
+  open: Signal<boolean>;
 
   /** Reveal the component */
   reveal: () => void;

--- a/libs/design/src/core/openable/specs/states.directive.spec.ts
+++ b/libs/design/src/core/openable/specs/states.directive.spec.ts
@@ -112,7 +112,7 @@ describe('@daffodil/design | DaffOpenableDirective | States', () => {
 
     fixture.detectChanges();
 
-    expect(statelessComponent.openDirective.open).toEqual(false);
-    expect(statelessComponent.openDirective.open).toEqual(wrapper.statelessOpen);
+    expect(statelessComponent.openDirective.open()).toEqual(false);
+    expect(statelessComponent.openDirective.open()).toEqual(wrapper.statelessOpen);
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: #4327 

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `DaffOpenableDirective` now exposes `open` as a signal rather than a plain property. Template bindings (`[open]="isOpen"`) continue to work, but any programmatic access
must go through the signal API:

- Reads must invoke the signal: `directive.open` → `directive.open()`,
  `sidebar.open` → `sidebar.open()`.
- Writes must use `.set()` / `.update()`: `directive.open = true` →
  `directive.open.set(true)`, and conditional updates become
  `directive.open.update(() => ...)`.

The `DaffOpenable` interface now types `open` as `Signal<boolean>`. Any code that reads
or assigns `open` directly — from tests, components, or implementations of
`DaffOpenable` — must be updated accordingly.

## Additional context
<!-- Any other relevant information -->