### PR TITLE
feat(design, design-examples): reposition tag as a filter and selection component

### DIFF
--- a/libs/design-examples/tag/src/basic-tag/basic-tag.component.html
+++ b/libs/design-examples/tag/src/basic-tag/basic-tag.component.html
@@ -1,4 +1,3 @@
 <daff-tag>
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  In Stock
+  Shoes
 </daff-tag>

--- a/libs/design-examples/tag/src/basic-tag/basic-tag.component.ts
+++ b/libs/design-examples/tag/src/basic-tag/basic-tag.component.ts
@@ -2,8 +2,6 @@ import {
   ChangeDetectionStrategy,
   Component,
 } from '@angular/core';
-import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 
 import { DAFF_TAG_COMPONENTS } from '@daffodil/design/tag';
 
@@ -13,9 +11,6 @@ import { DAFF_TAG_COMPONENTS } from '@daffodil/design/tag';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_TAG_COMPONENTS,
-    FaIconComponent,
   ],
 })
-export class BasicTagExampleComponent {
-  faCircleCheck = faCircleCheck;
-}
+export class BasicTagExampleComponent {}

--- a/libs/design-examples/tag/src/colorable-tag/colorable-tag.component.html
+++ b/libs/design-examples/tag/src/colorable-tag/colorable-tag.component.html
@@ -1,39 +1,31 @@
 <daff-tag>
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Default
+  Category: Shoes
 </daff-tag>
 
 <daff-tag color="primary">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Primary
+  Category: Shoes
 </daff-tag>
 
 <daff-tag color="secondary">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Secondary
+  Category: Shoes
 </daff-tag>
 
 <daff-tag color="tertiary">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Tertiary
+  Category: Shoes
 </daff-tag>
 
 <daff-tag color="dark">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Dark
+  Category: Shoes
 </daff-tag>
 
 <daff-tag color="light">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Light
+  Category: Shoes
 </daff-tag>
 
 <daff-tag color="theme">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Theme
+  Category: Shoes
 </daff-tag>
 
 <daff-tag color="theme-contrast">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Theme Contrast
+  Category: Shoes
 </daff-tag>

--- a/libs/design-examples/tag/src/colorable-tag/colorable-tag.component.ts
+++ b/libs/design-examples/tag/src/colorable-tag/colorable-tag.component.ts
@@ -2,8 +2,6 @@ import {
   ChangeDetectionStrategy,
   Component,
 } from '@angular/core';
-import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 
 import { DAFF_TAG_COMPONENTS } from '@daffodil/design/tag';
 
@@ -14,15 +12,13 @@ import { DAFF_TAG_COMPONENTS } from '@daffodil/design/tag';
     :host {
       display: flex;
       flex-wrap: wrap;
-      gap: 8px;
+      gap: 0.5rem;
     }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_TAG_COMPONENTS,
-    FaIconComponent,
   ],
 })
 export class ColorableTagExampleComponent {
-  faCircleCheck = faCircleCheck;
 }

--- a/libs/design-examples/tag/src/disabled-tag/disabled-tag.component.html
+++ b/libs/design-examples/tag/src/disabled-tag/disabled-tag.component.html
@@ -1,3 +1,3 @@
 <daff-tag [disabled]="true">
-  Brand: Nike
+  Department: Men's
 </daff-tag>

--- a/libs/design-examples/tag/src/dismissible-tag/dismissible-tag.component.html
+++ b/libs/design-examples/tag/src/dismissible-tag/dismissible-tag.component.html
@@ -1,5 +1,5 @@
 @if (!isHidden) {
-  <daff-tag dismissible (closeTag)="hideTag()">
+  <daff-tag [dismissible]="true" (closeTag)="hideTag()">
     Brand: Nike
   </daff-tag>
 }

--- a/libs/design-examples/tag/src/dismissible-tag/dismissible-tag.component.ts
+++ b/libs/design-examples/tag/src/dismissible-tag/dismissible-tag.component.ts
@@ -2,8 +2,6 @@ import {
   ChangeDetectionStrategy,
   Component,
 } from '@angular/core';
-import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 
 import { DAFF_TAG_COMPONENTS } from '@daffodil/design/tag';
 
@@ -14,12 +12,9 @@ import { DAFF_TAG_COMPONENTS } from '@daffodil/design/tag';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_TAG_COMPONENTS,
-    FaIconComponent,
   ],
 })
 export class DismissibleTagExampleComponent {
-  faCircleCheck = faCircleCheck;
-
   isHidden = false;
 
   hideTag() {

--- a/libs/design-examples/tag/src/sizable-tag/sizable-tag.component.html
+++ b/libs/design-examples/tag/src/sizable-tag/sizable-tag.component.html
@@ -1,19 +1,14 @@
-<daff-tag>
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Default
+<daff-tag [dismissible]="true" size="sm">
+  <fa-icon daffPrefix [icon]="faTag"></fa-icon>
+  Size: S
 </daff-tag>
 
-<daff-tag size="sm">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Small
+<daff-tag [dismissible]="true" size="md">
+  <fa-icon daffPrefix [icon]="faTag"></fa-icon>
+  Size: M
 </daff-tag>
 
-<daff-tag size="md">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Medium
-</daff-tag>
-
-<daff-tag size="lg">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Large
+<daff-tag [dismissible]="true" size="lg">
+  <fa-icon daffPrefix [icon]="faTag"></fa-icon>
+  Size: L
 </daff-tag>

--- a/libs/design-examples/tag/src/sizable-tag/sizable-tag.component.ts
+++ b/libs/design-examples/tag/src/sizable-tag/sizable-tag.component.ts
@@ -3,7 +3,7 @@ import {
   Component,
 } from '@angular/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
+import { faTag } from '@fortawesome/free-solid-svg-icons';
 
 import { DAFF_TAG_COMPONENTS } from '@daffodil/design/tag';
 
@@ -25,5 +25,5 @@ import { DAFF_TAG_COMPONENTS } from '@daffodil/design/tag';
   ],
 })
 export class SizableTagExampleComponent {
-  faCircleCheck = faCircleCheck;
+  faTag = faTag;
 }

--- a/libs/design-examples/tag/src/statusable-tag/statusable-tag.component.html
+++ b/libs/design-examples/tag/src/statusable-tag/statusable-tag.component.html
@@ -1,19 +1,19 @@
 <daff-tag status="warn">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Warn
+  <fa-icon daffPrefix [icon]="faTriangleExclamation"></fa-icon>
+  Low Stock
 </daff-tag>
 
 <daff-tag status="success">
   <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Success
+  In Stock
 </daff-tag>
 
 <daff-tag status="critical">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Critical
+  <fa-icon daffPrefix [icon]="faCircleXmark"></fa-icon>
+  Out of Stock
 </daff-tag>
 
 <daff-tag status="info">
-  <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
-  Info
+  <fa-icon daffPrefix [icon]="faCircleInfo"></fa-icon>
+  Pre-Order
 </daff-tag>

--- a/libs/design-examples/tag/src/statusable-tag/statusable-tag.component.ts
+++ b/libs/design-examples/tag/src/statusable-tag/statusable-tag.component.ts
@@ -3,7 +3,12 @@ import {
   Component,
 } from '@angular/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCircleCheck,
+  faCircleInfo,
+  faCircleXmark,
+  faTriangleExclamation,
+} from '@fortawesome/free-solid-svg-icons';
 
 import { DAFF_TAG_COMPONENTS } from '@daffodil/design/tag';
 
@@ -25,4 +30,7 @@ import { DAFF_TAG_COMPONENTS } from '@daffodil/design/tag';
 })
 export class StatusableTagExampleComponent {
   faCircleCheck = faCircleCheck;
+  faCircleInfo = faCircleInfo;
+  faCircleXmark = faCircleXmark;
+  faTriangleExclamation = faTriangleExclamation;
 }

--- a/libs/design/tag/README.md
+++ b/libs/design/tag/README.md
@@ -1,8 +1,8 @@
 # Tag
-Tags are compact visual indicators used to display short pieces of information such as status, categories, or labels.
+Tags are interactive indicators and filters that can be edited or removed, used to represent selections, categories, or applied filters.
 
 ## Overview
-Tag supports flexible content projection to allow for various combinations of icons, labels, and interactive elements within a consistent container.
+Tag supports flexible content projection to allow for various combinations of icons, labels, and interactive elements within a consistent container. Tags can be dismissed to remove a selection or filter, making them well suited for filter chips, applied search criteria, and editable selections.
 
 <daff-docs-example-viewer example="basic-tag"></daff-docs-example-viewer>
 
@@ -36,7 +36,7 @@ A tag is composed of a wrapper, an optional prefix, a label, and an optional clo
 - **`<daff-tag>`**: The wrapper component that holds all tag content.
 - **`[daffPrefix]`**: A leading visual, typically an icon, displayed before the label.
 - **Label**: The text content of the tag, projected as a child element.
-- **Close button**: A trailing dismiss button, displayed when `dismissible` is `true`.
+- **Close button**: A trailing remove button, displayed when `dismissible` is `true`.
 
 ## Features
 
@@ -46,7 +46,7 @@ Set `dismissible` to `true` to display a close button. The button emits a `close
 <daff-docs-example-viewer example="dismissible-tag"></daff-docs-example-viewer>
 
 ### Disabled tags
-Set `disabled` to `true` to disable the tag. Disabled tags cannot be dismissed.
+Set `disabled` to `true` to disable the tag. Disabled tags cannot be removed.
 
 <daff-docs-example-viewer example="disabled-tag"></daff-docs-example-viewer>
 
@@ -63,15 +63,19 @@ Use the `color` property to change the color of a tag. Supported colors: `primar
 ### Statuses
 Use the `status` property to convey semantic meaning. Supported statuses: `warn`, `critical`, `info`, `success`.
 
+> **Deprecation notice:**
+>
+> The `status` property is deprecated. Tags are intended for selections, categories, and applied filters, so use the `color` property instead.
+
 <daff-docs-example-viewer example="statusable-tag"></daff-docs-example-viewer>
 
 ## Accessibility
 
 ### Built-in behavior
 - Default tags are not interactive and do not receive focus.
-- Dismissible tags include a focusable close button that can be activated with `Enter` or `Space`.
+- Removable tags include a focusable close button that can be activated with `Enter` or `Space`.
 - Disabled tags expose `aria-disabled="true"` and ignore close button activation.
 
 ### Developer responsibilities
 - Always provide a text label unless the icon is universally understood and accessible.
-- Use the `status` property to communicate semantic meaning, rather than relying on color alone.
+- Communicate meaning through the tag's label or an accessible icon, rather than relying on color alone.

--- a/libs/design/tag/src/tag-theme.scss
+++ b/libs/design/tag/src/tag-theme.scss
@@ -1,3 +1,4 @@
+// stylelint-disable selector-class-pattern
 @use '../../scss/theming' as *;
 
 @mixin daff-tag-theme($theme) {
@@ -18,119 +19,215 @@
 			background: daff-color($neutral, 20);
 			color: $black;
 
+			&::after {
+				background: daff-color($neutral, 30);
+			}
+
 			&.daff-primary {
 				background: daff-color($primary, 10);
 				color: daff-color($primary, 70);
+
+				&::after {
+					background: daff-color($primary, 20);
+				}
 			}
 
 			&.daff-secondary {
 				background: daff-color($secondary, 10);
 				color: daff-color($secondary, 70);
+
+				&::after {
+					background: daff-color($secondary, 20);
+				}
 			}
 
 			&.daff-tertiary {
 				background: daff-color($tertiary, 10);
 				color: daff-color($tertiary, 70);
+
+				&::after {
+					background: daff-color($tertiary, 20);
+				}
 			}
 
 			&.daff-dark {
 				background: daff-color($neutral, 90);
 				color: daff-color($neutral, 10);
+
+				&::after {
+					background: daff-color($neutral, 100);
+				}
 			}
 
 			&.daff-light {
 				background: daff-color($neutral, 10);
 				color: daff-color($neutral, 90);
+
+				&::after {
+					background: daff-color($neutral, 20);
+				}
 			}
 
 			&.daff-theme {
 				background: $white;
 				color: $black;
+
+				&::after {
+					background: daff-color($neutral, 20);
+				}
 			}
 
 			&.daff-theme-contrast {
 				background: $black;
 				color: $white;
+
+				&::after {
+					background: daff-color($neutral, 90);
+				}
 			}
 
 			&.daff-warn {
 				background: daff-color($warn, 10);
 				color: daff-color($warn, 70);
+
+				&::after {
+					background: daff-color($warn, 20);
+				}
 			}
 
 			&.daff-success {
 				background: daff-color($success, 10);
 				color: daff-color($success, 70);
+
+				&::after {
+					background: daff-color($success, 20);
+				}
 			}
 
 			&.daff-critical {
 				background: daff-color($critical, 10);
 				color: daff-color($critical, 70);
+
+				&::after {
+					background: daff-color($critical, 20);
+				}
 			}
 
 			&.daff-info {
 				background: daff-color($info, 10);
-				color: daff-color($info, 70);
+				color: daff-color($info, 90);
+
+				&::after {
+					background: daff-color($info, 20);
+				}
 			}
 		}
 
 		@include dark($mode) {
-			background: daff-color($neutral, 90);
+			background: daff-color($neutral, 80);
 			color: daff-color($neutral, 20);
+
+			&::after {
+				background: daff-color($neutral, 90);
+			}
 
 			&.daff-primary {
 				background: daff-color($primary, 90);
 				color: daff-color($primary, 10);
+
+				&::after {
+					background: daff-color($primary, 100);
+				}
 			}
 
 			&.daff-secondary {
 				background: daff-color($secondary, 90);
 				color: daff-color($secondary, 10);
+
+				&::after {
+					background: daff-color($secondary, 100);
+				}
 			}
 
 			&.daff-tertiary {
 				background: daff-color($tertiary, 90);
 				color: daff-color($tertiary, 10);
+
+				&::after {
+					background: daff-color($tertiary, 100);
+				}
 			}
 
 			&.daff-dark {
 				background: daff-color($neutral, 90);
 				color: daff-color($neutral, 10);
+
+				&::after {
+					background: daff-color($neutral, 100);
+				}
 			}
 
 			&.daff-light {
 				background: daff-color($neutral, 10);
 				color: daff-color($neutral, 90);
+
+				&::after {
+					background: daff-color($neutral, 30);
+				}
 			}
 
 			&.daff-theme {
 				background: $black;
 				color: $white;
+
+				&::after {
+					background: daff-color($neutral, 100);
+				}
 			}
 
 			&.daff-theme-contrast {
 				background: $white;
 				color: $black;
+
+				&::after {
+					background: daff-color($neutral, 20);
+				}
 			}
 
 			&.daff-warn {
 				background: daff-color($warn, 90);
 				color: daff-color($warn, 10);
+
+				&::after {
+					background: daff-color($warn, 100);
+				}
 			}
 
 			&.daff-success {
 				background: daff-color($success, 90);
 				color: daff-color($success, 10);
+
+				&::after {
+					background: daff-color($success, 100);
+				}
 			}
 
 			&.daff-critical {
 				background: daff-color($critical, 90);
 				color: daff-color($critical, 10);
+
+				&::after {
+					background: daff-color($critical, 100);
+				}
 			}
 
 			&.daff-info {
-				background: daff-color($info, 70);
+				background: daff-color($info, 80);
 				color: daff-color($info, 10);
+
+				&::after {
+					background: daff-color($neutral, 80);
+				}
 			}
 		}
 	}

--- a/libs/design/tag/src/tag/specs/defaults.spec.ts
+++ b/libs/design/tag/src/tag/specs/defaults.spec.ts
@@ -1,0 +1,64 @@
+import {
+  Component,
+  DebugElement,
+} from '@angular/core';
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { DaffTagComponent } from '../tag.component';
+
+@Component({
+  template: `
+    <daff-tag>Tag</daff-tag>
+  `,
+  imports: [
+    DaffTagComponent,
+  ],
+})
+class WrapperComponent {}
+
+describe('@daffodil/design/tag | DaffTagComponent | Defaults', () => {
+  let component: DaffTagComponent;
+  let de: DebugElement;
+  let fixture: ComponentFixture<WrapperComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        WrapperComponent,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WrapperComponent);
+    de = fixture.debugElement.query(By.css('daff-tag'));
+    component = de.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have daff-tag class', () => {
+    expect(de.nativeElement.classList.contains('daff-tag')).toBe(true);
+  });
+
+  it('should set dismissible to false by default', () => {
+    expect(component.dismissible).toBeFalse();
+  });
+
+  it('should set disabled to false by default', () => {
+    expect(component.disabled).toBeFalse();
+  });
+
+  it('should default to md size and apply daff-md class', () => {
+    expect(de.nativeElement.classList.contains('daff-md')).toBe(true);
+  });
+});

--- a/libs/design/tag/src/tag/specs/defaults.spec.ts
+++ b/libs/design/tag/src/tag/specs/defaults.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffTagComponent } from '../tag.component';
+import { DaffTagComponent } from '@daffodil/design/tag';
 
 @Component({
   template: `
@@ -58,7 +58,9 @@ describe('@daffodil/design/tag | DaffTagComponent | Defaults', () => {
     expect(component.disabled).toBeFalse();
   });
 
-  it('should default to md size and apply daff-md class', () => {
-    expect(de.nativeElement.classList.contains('daff-md')).toBe(true);
+  it('should set the default size to `md` and add the `.daff-md` class', () => {
+    expect(de.classes).toEqual(jasmine.objectContaining({
+      'daff-md': true,
+    }));
   });
 });

--- a/libs/design/tag/src/tag/specs/usage.spec.ts
+++ b/libs/design/tag/src/tag/specs/usage.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable quote-props */
 import {
   Component,
   DebugElement,
@@ -129,62 +130,76 @@ describe('@daffodil/design/tag | DaffTagComponent | Usage', () => {
   });
 
   describe('status property', () => {
-    it('should accept warn status', () => {
-      wrapper.status.set('warn');
-      fixture.detectChanges();
-
-      expect(de.nativeElement.classList.contains('daff-warn')).toBe(true);
-    });
-
-    it('should accept critical status', () => {
-      wrapper.status.set('critical');
-      fixture.detectChanges();
-
-      expect(de.nativeElement.classList.contains('daff-critical')).toBe(true);
-    });
-
-    it('should accept info status', () => {
+    it('should add a class of ".daff-info" to the host element if status is set to info', () => {
       wrapper.status.set('info');
       fixture.detectChanges();
 
-      expect(de.nativeElement.classList.contains('daff-info')).toBe(true);
+      expect(de.classes).toEqual(jasmine.objectContaining({
+        'daff-info': true,
+      }));
     });
 
-    it('should accept success status', () => {
+    it('should add a class of ".daff-warn" to the host element if status is set to warn', () => {
+      wrapper.status.set('warn');
+      fixture.detectChanges();
+
+      expect(de.classes).toEqual(jasmine.objectContaining({
+        'daff-warn': true,
+      }));
+    });
+
+    it('should add a class of ".daff-critical" to the host element if status is set to critical', () => {
+      wrapper.status.set('critical');
+      fixture.detectChanges();
+
+      expect(de.classes).toEqual(jasmine.objectContaining({
+        'daff-critical': true,
+      }));
+    });
+
+    it('should add a class of ".daff-success" to the host element if status is set to success', () => {
       wrapper.status.set('success');
       fixture.detectChanges();
 
-      expect(de.nativeElement.classList.contains('daff-success')).toBe(true);
+      expect(de.classes).toEqual(jasmine.objectContaining({
+        'daff-success': true,
+      }));
     });
   });
 
   describe('size property', () => {
-    it('should accept sm size and apply daff-sm class', () => {
+    it('should add a class of ".daff-sm" to the host element if size is set to info', () => {
       wrapper.size.set('sm');
       fixture.detectChanges();
 
-      expect(de.nativeElement.classList.contains('daff-sm')).toBe(true);
+      expect(de.classes).toEqual(jasmine.objectContaining({
+        'daff-sm': true,
+      }));
     });
 
-    it('should accept md size and apply daff-md class', () => {
+    it('should add a class of ".daff-md" to the host element if size is set to md', () => {
       wrapper.size.set('md');
       fixture.detectChanges();
 
-      expect(de.nativeElement.classList.contains('daff-md')).toBe(true);
+      expect(de.classes).toEqual(jasmine.objectContaining({
+        'daff-md': true,
+      }));
     });
 
-    it('should accept lg size and apply daff-lg class', () => {
+    it('should add a class of ".daff-lg" to the host element if size is set to lg', () => {
       wrapper.size.set('lg');
       fixture.detectChanges();
 
-      expect(de.nativeElement.classList.contains('daff-lg')).toBe(true);
+      expect(de.classes).toEqual(jasmine.objectContaining({
+        'daff-lg': true,
+      }));
     });
   });
 
   describe('content projection', () => {
     it('should project content inside the tag', () => {
       const projectedContent = de.query(By.css('.daff-tag__label'));
-      expect(projectedContent.nativeElement.textContent.trim()).toBe('Test Tag');
+      expect(projectedContent.nativeElement.textContent.trim()).toBe('Tag');
     });
   });
 
@@ -193,7 +208,9 @@ describe('@daffodil/design/tag | DaffTagComponent | Usage', () => {
       wrapper.dismissible.set(true);
       fixture.detectChanges();
 
-      expect(de.nativeElement.classList.contains('dismissible')).toBe(true);
+      expect(de.classes).toEqual(jasmine.objectContaining({
+        'dismissible': true,
+      }));
     });
 
     it('should not have dismissible class when dismissible is false', () => {

--- a/libs/design/tag/src/tag/specs/usage.spec.ts
+++ b/libs/design/tag/src/tag/specs/usage.spec.ts
@@ -11,9 +11,9 @@ import {
 import { By } from '@angular/platform-browser';
 
 import { DaffStatus } from '@daffodil/design';
+import { DaffTagComponent } from '@daffodil/design/tag';
 
-import { DaffTagSize } from './tag-sizable.directive';
-import { DaffTagComponent } from './tag.component';
+import { DaffTagSize } from '../tag-sizable.directive';
 
 @Component({
   template: `
@@ -23,7 +23,7 @@ import { DaffTagComponent } from './tag.component';
       [status]="status()"
       [size]="size()"
       (closeTag)="onCloseTag()">
-      <div>Test Tag</div>
+        Tag
     </daff-tag>
   `,
   imports: [
@@ -42,7 +42,7 @@ class WrapperComponent {
   }
 }
 
-describe('@daffodil/design/tag | DaffTagComponent', () => {
+describe('@daffodil/design/tag | DaffTagComponent | Usage', () => {
   let wrapper: WrapperComponent;
   let component: DaffTagComponent;
   let de: DebugElement;
@@ -72,10 +72,6 @@ describe('@daffodil/design/tag | DaffTagComponent', () => {
   describe('dismissible property', () => {
     it('should take dismissible as an input', () => {
       expect(component.dismissible).toEqual(wrapper.dismissible());
-    });
-
-    it('should set dismissible to false by default', () => {
-      expect(component.dismissible).toBeFalse();
     });
 
     it('should not show close button when dismissible is false', () => {
@@ -113,10 +109,6 @@ describe('@daffodil/design/tag | DaffTagComponent', () => {
   describe('disabled property', () => {
     it('should take disabled as an input', () => {
       expect(component.disabled).toEqual(wrapper.disabled());
-    });
-
-    it('should set disabled to false by default', () => {
-      expect(component.disabled).toBeFalse();
     });
 
     it('should have disabled property set when disabled is true', () => {
@@ -187,10 +179,6 @@ describe('@daffodil/design/tag | DaffTagComponent', () => {
 
       expect(de.nativeElement.classList.contains('daff-lg')).toBe(true);
     });
-
-    it('should default to md size and apply daff-md class', () => {
-      expect(de.nativeElement.classList.contains('daff-md')).toBe(true);
-    });
   });
 
   describe('content projection', () => {
@@ -201,10 +189,6 @@ describe('@daffodil/design/tag | DaffTagComponent', () => {
   });
 
   describe('host classes', () => {
-    it('should have daff-tag class', () => {
-      expect(de.nativeElement.classList.contains('daff-tag')).toBe(true);
-    });
-
     it('should have dismissible class when dismissible is true', () => {
       wrapper.dismissible.set(true);
       fixture.detectChanges();

--- a/libs/design/tag/src/tag/tag.component.html
+++ b/libs/design/tag/src/tag/tag.component.html
@@ -6,6 +6,6 @@
 </div>
 @if (dismissible) {
   <button class="daff-tag__close-icon" (click)="onCloseTag($event)" aria-label="Dismiss" [attr.tabindex]="disabled ? -1 : null">
-    <fa-icon [icon]="faTimes"></fa-icon>
+    <fa-icon [icon]="faTimes" [fixedWidth]="true"></fa-icon>
   </button>
 }

--- a/libs/design/tag/src/tag/tag.component.scss
+++ b/libs/design/tag/src/tag/tag.component.scss
@@ -1,3 +1,4 @@
+// stylelint-disable selector-class-pattern
 @use '../../../scss/interactions';
 @use '../../../scss/layout';
 @use '../../../scss/typography' as t;
@@ -19,7 +20,7 @@
 
 	&.daff-md {
 		font-size: t.$font-size-base;
-		line-height: 1.25rem;
+		line-height: 1rem;
 		gap: 0.5rem;
 		padding: 0.5rem;
 
@@ -31,35 +32,73 @@
 
 	&.daff-lg {
 		font-size: t.$font-size-md;
-		line-height: 1.5rem;
-		gap: 0.75rem;
+		line-height: 1.25rem;
+		gap: 0.5rem;
 		padding: 0.75rem;
 
 		#{$root}__close-icon {
 			font-size: t.$font-size-md;
-			line-height: 1.5rem;
+			line-height: 1.25rem;
 		}
 	}
 }
-
 
 .daff-tag {
 	$root: &;
 	@include daff-tag-sizes();
 	display: inline-flex;
 	align-items: center;
+	cursor: default;
 	justify-content: center;
 	flex-wrap: nowrap;
 	border-radius: 0.25rem;
 	position: relative;
 
+	&::after {
+		content: '';
+		border-radius: 0.25rem;
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 300ms;
+		z-index: 0;
+	}
+
+	@media (hover: hover) {
+		&:hover {
+			&::after {
+				opacity: 1;
+			}
+		}
+	}
+
 	&.daff-disabled {
 		cursor: not-allowed;
 		opacity: 0.5;
 
+		@media (hover: hover) {
+			&:hover {
+				&::after {
+					opacity: 0;
+				}
+			}
+		}
+
 		#{$root}__close-icon {
 			cursor: not-allowed;
 		}
+	}
+
+	&.dismissible {
+		@include interactions.clickable();
+	}
+
+	#{$root}__label,
+	.daff-prefix,
+	#{$root}__close-icon {
+		z-index: 1;
 	}
 
 	&__close-icon {

--- a/libs/design/tag/src/tag/tag.component.ts
+++ b/libs/design/tag/src/tag/tag.component.ts
@@ -1,5 +1,5 @@
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
   ContentChild,
@@ -17,20 +17,21 @@ import {
   DaffDisableable,
   DaffDisableableDirective,
   DaffPrefixDirective,
+  DaffStatus,
   DaffStatusableDirective,
 } from '@daffodil/design';
 
 import { DaffTagSizableDirective } from './tag-sizable.directive';
 
 /**
- * Contains the tag content: checkmark icon, label, and delete button.
+ * DaffTagComponent is an interactive indicator and filter that can be edited or removed, used to represent selections, categories, or applied filters.
  *
  * @example
  * ```html
- *  <daff-tag [dismissible]="true" (closeTag)="onCloseTag()">
- *    <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
- *    <div>Label</div>
- *  </daff-tag>
+ * <daff-tag [dismissible]="true" (closeTag)="onCloseTag()">
+ *   <fa-icon daffPrefix [icon]="faCircleCheck"></fa-icon>
+ *   Label
+ * </daff-tag>
  * ```
  */
 
@@ -50,7 +51,6 @@ import { DaffTagSizableDirective } from './tag-sizable.directive';
     },
     {
       directive: DaffStatusableDirective,
-      inputs: ['status'],
     },
     {
       directive: DaffDisableableDirective,
@@ -89,17 +89,24 @@ export class DaffTagComponent implements DaffDisableable {
     return this.disabledDirective.disabled;
   }
 
-  private _dismissible = false;
+  /**
+   * @deprecated Deprecated in version 0.93.0.
+   *
+   * Sets the status on the tag.
+   */
+  @Input()
+  get status(): DaffStatus {
+    return this.statusable.status;
+  }
+  set status(value: DaffStatus) {
+    this.statusable.status = value;
+  }
 
-  /** Whether the tag can be dismissed by the user.
+  /**
+   * Whether the tag can be dismissed by the user.
    * Displays a close icon if `true`.
    */
-  @Input() get dismissible() {
-    return this._dismissible;
-  }
-  set dismissible(value: any) {
-    this._dismissible = coerceBooleanProperty(value);
-  }
+  @Input({ transform: booleanAttribute }) dismissible = false;
 
   /**
    * Emits when the tag is closed.
@@ -121,6 +128,7 @@ export class DaffTagComponent implements DaffDisableable {
   constructor(
     private size: DaffTagSizableDirective,
     private disabledDirective: DaffDisableableDirective,
+    private statusable: DaffStatusableDirective,
   ) {
     /**
      * Sets the default size of a tag to medium.


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
- redefine tags as interactive indicators and filters for selections, categories, and applied filters. #4565 should handle usage of feedback indicators, notification counts and status updates instead.
- deprecate the `status` property in favor of `color`. Tags are intended for selections, categories, and applied filters, so use the `color` property instead. `status` used as status updates/indicators should be handled by #4565 instead.
- migrate `dismissible` from `coerceBooleanProperty` to the `booleanAttribute` transform
- add a hover overlay
- render the close icon at a fixed width and refine size line-heights, gaps, and cursor states

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->