### PR TITLE
fix(core): `provideDaffApolloHeaderProviders` doesn't return new headers

### DIFF
--- a/libs/core/graphql/src/apollo/header/provider.spec.ts
+++ b/libs/core/graphql/src/apollo/header/provider.spec.ts
@@ -1,0 +1,62 @@
+import { HttpHeaders } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import {
+  ApolloLink,
+  gql,
+} from '@apollo/client';
+import { Apollo } from 'apollo-angular';
+import {
+  ApolloTestingController,
+  ApolloTestingModule,
+} from 'apollo-angular/testing';
+
+import { DAFF_APOLLO_REQUEST_HANDLERS } from '../request-handler.provider';
+import { provideDaffApolloHeaderProviders } from './provider';
+import { DaffApolloHeaderProvider } from './type';
+
+describe('@daffodil/core/graphql | provideDaffApolloHeaderProviders', () => {
+  let apollo: Apollo;
+  let controller: ApolloTestingController;
+  let operation: ApolloLink.Operation;
+  let handlers: Array<ApolloLink.RequestHandler>;
+  let forward: jasmine.Spy<ApolloLink.ForwardFunction>;
+  let firstProvider: DaffApolloHeaderProvider;
+  let secondProvider: DaffApolloHeaderProvider;
+  const query = gql`{ Operation(test: string) { name }}`;
+
+  beforeEach(() => {
+    firstProvider = () => new HttpHeaders({ 'X-First-Header': 'first-value' });
+    secondProvider = () => new HttpHeaders({ 'X-Second-Header': 'second-value' });
+
+    TestBed.configureTestingModule({
+      imports: [
+        ApolloTestingModule,
+      ],
+      providers: [
+        provideDaffApolloHeaderProviders(firstProvider, secondProvider),
+      ],
+    });
+
+    controller = TestBed.inject(ApolloTestingController);
+    apollo = TestBed.inject(Apollo);
+    handlers = TestBed.inject(DAFF_APOLLO_REQUEST_HANDLERS);
+
+    forward = jasmine.createSpy('forward');
+
+    apollo.query({ query }).subscribe();
+    operation = controller.expectOne(query).operation;
+  });
+
+  it('should set headers from a single provider onto the operation context', () => {
+    handlers[0](operation, forward);
+
+    expect(operation.getContext().headers.get('X-First-Header')).toEqual('first-value');
+  });
+
+  it('should set headers from multiple providers onto the operation context', () => {
+    handlers[0](operation, forward);
+
+    expect(operation.getContext().headers.get('X-First-Header')).toEqual('first-value');
+    expect(operation.getContext().headers.get('X-Second-Header')).toEqual('second-value');
+  });
+});

--- a/libs/core/graphql/src/apollo/header/provider.ts
+++ b/libs/core/graphql/src/apollo/header/provider.ts
@@ -21,13 +21,13 @@ export const provideDaffApolloHeaderProviders = (...providers: Array<DaffApolloH
         operation.setContext({
           headers: providers.reduce((acc, provider) => {
             const headers = runInInjectionContext(injector, provider);
-            headers.keys().forEach((key) => {
+            return headers.keys().reduce((a, key) => {
               const val = headers.getAll(key);
               if (val) {
-                acc.append(key, val);
+                return acc.append(key, val);
               }
-            });
-            return acc;
+              return a;
+            }, acc);
           }, getApolloOperationHeaders(operation)),
         });
         return forward(operation);


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

the new headers aren't returned; `append` is immutable

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->