### PR TITLE
feat(design)!: convert `@daffodil/design/form-field` to use signals

### DIFF
--- a/libs/design/form-field/src/action/action.directive.spec.ts
+++ b/libs/design/form-field/src/action/action.directive.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffFormFieldActionDirective } from './action.directive';
+import { DaffFormFieldActionDirective } from '@daffodil/design/form-field';
 
 @Component({
   template: `

--- a/libs/design/form-field/src/form-field/form-field.component.html
+++ b/libs/design/form-field/src/form-field/form-field.component.html
@@ -1,41 +1,41 @@
 <ng-content />
 
-@if (isFixed) {
+@if (isFixed()) {
   <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
 }
 <div class="daff-form-field__wrapper">
 	<div class="daff-form-field__control">
-		@if (_prefix) {
+		@if (_prefix()) {
 			<ng-content select="[daffPrefix]"></ng-content>
 		}
 		<div class="daff-form-field__inner">
-			@if (!isFixed) {
+			@if (!isFixed()) {
 				<ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
 			}
 			<ng-content></ng-content>
 		</div>
-		@if (_suffix) {
+		@if (_suffix()) {
 			<ng-content select="[daffSuffix]"></ng-content>
 		}
-		@if (_action && !isFixed) {
+		@if (_action() && !isFixed()) {
 			<ng-container *ngTemplateOutlet="actionTemplate"></ng-container>
 		}
 	</div>
-	@if ((_action && isFixed)) {
+	@if ((_action() && isFixed())) {
 		<ng-container *ngTemplateOutlet="actionTemplate"></ng-container>
 	}
 </div>
 @if (hasHint()) {
 	<div
 		class="daff-form-field__hint-wrapper"
-		[id]="hintId">
+		[id]="hintId()">
 		<ng-content select="daff-hint"></ng-content>
 	</div>
 }
 @if (hasErrorMessage()) {
 	<div
 		class="daff-form-field__error-wrapper"
-		[id]="errorMessageId">
+		[id]="errorMessageId()">
 		<ng-content select="daff-error-message"></ng-content>
 	</div>
 }
@@ -45,14 +45,14 @@
 </ng-template>
 
 <ng-template #labelTemplate>
-  @if (_formLabelDirective) {
+  @if (_formLabelDirective()) {
     <ng-content select="label[daffFormLabel]"></ng-content>
-  } @else if(_formFieldLabelDirective) {
+  } @else if(_formFieldLabelDirective()) {
     <label class="daff-form-field__label"
-      [attr.for]="autoLabelId"
-      [attr.id]="customId">
+      [attr.for]="autoLabelId()"
+      [attr.id]="customId()">
       <ng-content select="daff-form-label"></ng-content>
-			@if (_control.required) {
+			@if (_control().required) {
 			<span aria-hidden="true">*</span>
 			}
     </label>

--- a/libs/design/form-field/src/form-field/form-field.component.spec.ts
+++ b/libs/design/form-field/src/form-field/form-field.component.spec.ts
@@ -56,7 +56,7 @@ describe('@daffodil/design/form-field | DaffFormFieldComponent | Defaults', () =
     wrapper = fixture.componentInstance;
     de = fixture.debugElement.query(By.css('daff-form-field'));
     component = de.componentInstance;
-    control = component._control;
+    control = component._control();
 
     fixture.detectChanges();
   });
@@ -71,9 +71,8 @@ describe('@daffodil/design/form-field | DaffFormFieldComponent | Defaults', () =
     }));
   });
 
-
   it('should have a generated id', () => {
-    expect(component.id).toMatch('daff-form-field-[0-9]*');
+    expect(component.id()).toMatch('daff-form-field-[0-9]*');
   });
 
   it('should have a generated id for the hint', () => {
@@ -89,6 +88,6 @@ describe('@daffodil/design/form-field | DaffFormFieldComponent | Defaults', () =
   });
 
   it('should set fluid as the default appearance', () => {
-    expect(component.appearance).toEqual('fluid');
+    expect(component.appearance()).toEqual('fluid');
   });
 });

--- a/libs/design/form-field/src/form-field/form-field.component.ts
+++ b/libs/design/form-field/src/form-field/form-field.component.ts
@@ -2,15 +2,17 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   Component,
   ViewEncapsulation,
-  ContentChild,
   AfterContentInit,
   AfterContentChecked,
   ChangeDetectorRef,
   ChangeDetectionStrategy,
-  Input,
   AfterViewInit,
   isDevMode,
   ElementRef,
+  input,
+  contentChild,
+  signal,
+  computed,
 } from '@angular/core';
 
 import {
@@ -53,17 +55,17 @@ export const DaffFormFieldMissingControlMessage = 'A DaffFormFieldComponent must
   ],
   host: {
     class: 'daff-form-field',
-    '[class.is-native-select]': 'isNativeSelect',
-    '[class.has-prefix]': '_prefix',
-    '[class.has-suffix]': '_suffix',
-    '[class.has-action]': '_action',
-    '[class.daff-error]': 'isError',
-    '[class.daff-disabled]': 'isDisabled',
-    '[class.daff-valid]': 'isValid',
+    '[class.is-native-select]': 'isNativeSelect()',
+    '[class.has-prefix]': '_prefix()',
+    '[class.has-suffix]': '_suffix()',
+    '[class.has-action]': '_action()',
+    '[class.daff-error]': 'isError()',
+    '[class.daff-disabled]': 'isDisabled()',
+    '[class.daff-valid]': 'isValid()',
     '[class.daff-focused]': 'isFocused',
     '[class.daff-raised]': 'isRaised',
-    '[class.fluid]': 'appearance === "fluid"',
-    '[class.fixed]': 'appearance === "fixed"',
+    '[class.fluid]': 'appearance() === "fluid"',
+    '[class.fixed]': 'appearance() === "fixed"',
   },
   hostDirectives: [
     {
@@ -74,50 +76,52 @@ export const DaffFormFieldMissingControlMessage = 'A DaffFormFieldComponent must
 })
 export class DaffFormFieldComponent implements AfterContentInit, AfterContentChecked, AfterViewInit {
   /** @docs-private */
-  get isNativeSelect() {
-    return this._control.controlType === 'native-select';
-  }
+  isNativeSelect = computed(() => this._control()?.controlType === 'native-select');
 
-  constructor(private cd: ChangeDetectorRef, public elementRef: ElementRef) {}
-
-  /** @docs-private */
-  @ContentChild(DaffPrefixDirective) _prefix: DaffPrefixDirective;
+  constructor(
+    private cd: ChangeDetectorRef,
+    public elementRef: ElementRef,
+  ) {}
 
   /** @docs-private */
-  @ContentChild(DaffSuffixDirective) _suffix: DaffSuffixDirective;
+  _prefix = contentChild(DaffPrefixDirective);
+
+  /** @docs-private */
+  _suffix = contentChild(DaffSuffixDirective);
 
   /**
    * @docs-private
    *
    * The child form control that the form field manages.
    */
-  @ContentChild(DaffFormFieldControl) _control: DaffFormFieldControl<unknown>;
+  _control = contentChild(DaffFormFieldControl);
 
   /**
    * @docs-private
+   *
    * @deprecated Deprecated in version 0.86.0. Will be removed in version 1.0.0.
    */
-  @ContentChild(DaffFormLabelDirective) _formLabelDirective: DaffFormLabelDirective;
+  _formLabelDirective = contentChild(DaffFormLabelDirective);
 
   /**
    * @docs-private
    */
-  @ContentChild(DaffFormFieldLabelDirective) _formFieldLabelDirective: DaffFormFieldLabelDirective;
+  _formFieldLabelDirective = contentChild(DaffFormFieldLabelDirective);
 
   /**
    * @docs-private
    */
-  @ContentChild(DaffFormFieldActionDirective) _action: DaffFormFieldActionDirective;
+  _action = contentChild(DaffFormFieldActionDirective);
 
   /**
    * @docs-private
    */
-  @ContentChild(DaffHintComponent) private _hint: DaffHintComponent;
+  private _hint = contentChild(DaffHintComponent);
 
   /**
    * @docs-private
    */
-  @ContentChild(DaffErrorMessageComponent) private _error: DaffErrorMessageComponent;
+  private _error = contentChild(DaffErrorMessageComponent);
 
   /**
    * @docs-private
@@ -125,7 +129,7 @@ export class DaffFormFieldComponent implements AfterContentInit, AfterContentChe
    * Tracking property to keep a record of whether or not the
    * form field should be marked as error.
    */
-  isError = false;
+  isError = signal(false);
 
   /**
    * @docs-private
@@ -133,7 +137,7 @@ export class DaffFormFieldComponent implements AfterContentInit, AfterContentChe
    * Tracking property to keep a record of whether or not the
    * form field contains any user input.
    */
-  isFilled = false;
+  isFilled = signal(false);
 
   /**
    * @docs-private
@@ -141,7 +145,7 @@ export class DaffFormFieldComponent implements AfterContentInit, AfterContentChe
    * Tracking property to keep a record of whether or not the
    * form field should be marked as disabled.
    */
-  isDisabled = false;
+  isDisabled = signal(false);
 
   /**
    * @docs-private
@@ -149,7 +153,7 @@ export class DaffFormFieldComponent implements AfterContentInit, AfterContentChe
    * Tracking property to keep a record of whether or not the
    * form field should be marked as valid.
    */
-  isValid = false;
+  isValid = signal(false);
 
   /**
    * @docs-private
@@ -157,40 +161,28 @@ export class DaffFormFieldComponent implements AfterContentInit, AfterContentChe
    * Determines whether or not the form field should display its focused state.
    */
   get isFocused() {
-    return this._control?.focused;
+    return this._control()?.focused;
   }
 
   /**
    * @docs-private
    */
   get isRaised() {
-    return this._control?.raised || this.isFilled;
+    return this._control()?.raised || this.isFilled();
   }
-
-  private _appearance: DaffFormFieldApperanace = DaffFormFieldApperanaceEnum.Fluid;
 
   /**
    * The appearance of the form field. Defaults to `fluid`.
    */
-  @Input()
-  get appearance() {
-    return this._appearance;
-  }
-
-  set appearance(value: DaffFormFieldApperanace) {
-    if(value === null || value === undefined || <unknown>value === '') {
-      this._appearance = DaffFormFieldApperanaceEnum.Fluid;
-    } else {
-      this._appearance = value;
-    }
-  };
+  appearance = input(DaffFormFieldApperanaceEnum.Fluid, {
+    transform: (value: DaffFormFieldApperanace | '' | null | undefined) =>
+      value || DaffFormFieldApperanaceEnum.Fluid,
+  });
 
   /**
    * @docs-private
    */
-  get isFixed() {
-    return this._appearance === DaffFormFieldApperanaceEnum.Fixed;
-  }
+  isFixed = computed(() => this.appearance() === DaffFormFieldApperanaceEnum.Fixed);
 
   /**
    * The unique id of the form field. Defaults to an autogenerated value. When using this,
@@ -198,45 +190,37 @@ export class DaffFormFieldComponent implements AfterContentInit, AfterContentChe
    *
    * It gets assigned to the `for` attribute on the `<label>` inside of the form field.
    */
-  @Input() id = 'daff-form-field-' + ++daffFormFieldId;
+  id = input('daff-form-field-' + ++daffFormFieldId);
 
   /**
    * @docs-private
    */
-  hasHint() {
-    return this._hint ? true : false;
-  }
+  hasHint = computed(() => !!this._hint());
 
   /**
    * @docs-private
    */
-  hintId = this.id + '-hint';
+  hintId = computed(() => this.id() + '-hint');
 
   /**
    * @docs-private
    */
-  hasErrorMessage() {
-    return this._error ? true : false;
-  }
+  hasErrorMessage = computed(() => !!this._error());
 
   /**
    * @docs-private
    */
-  errorMessageId = this.id + '-error';
+  errorMessageId = computed(() => this.id() + '-error');
 
   /**
    * @docs-private
    */
-  get autoLabelId() {
-    return this._control.supportsAutoLabelling ? this.id : null;
-  }
+  autoLabelId = computed(() => this._control()?.supportsAutoLabelling ? this.id() : null);
 
   /**
    * @docs-private
    */
-  get customId() {
-    return this._control.supportsAutoLabelling ? null : this.id;
-  }
+  customId = computed(() => this._control()?.supportsAutoLabelling ? null : this.id());
 
   /**
    * @docs-private
@@ -245,18 +229,18 @@ export class DaffFormFieldComponent implements AfterContentInit, AfterContentChe
    */
   ngAfterViewInit() {
     if (isDevMode()) {
-      if (!this._formFieldLabelDirective && this._control.supportsAutoLabelling && !(this._control.id)) {
+      if (!this._formFieldLabelDirective() && this._control()?.supportsAutoLabelling && !(this._control()?.id)) {
         console.warn(
-          `Accessibility Warning: The form field with id "${this.id}" uses a control that supports auto-labelling, but no <daff-form-label> component was found.\n\n` +
+          `Accessibility Warning: The form field with id "${this.id()}" uses a control that supports auto-labelling, but no <daff-form-label> component was found.\n\n` +
           `1. Add a <daff-form-label> component (recommended)\n` +
           `2. OR manually set an 'id' on your input and matching 'for' attribute on your <label>.\n\n` +
           `Why this matters: Proper labelling ensures assistive technologies can identify form fields correctly.`,
         );
       }
 
-      if(this._suffix && this._action && !this.isFixed) {
+      if(this._suffix() && this._action() && !this.isFixed()) {
         console.warn(
-          `UI consideration for form field with id "${this.id}":\n\n` + `In a fluid appearance, avoid using suffix alongside an action.`,
+          `UI consideration for form field with id "${this.id()}":\n\n` + `In a fluid appearance, avoid using suffix alongside an action.`,
         );
       };
     }
@@ -266,7 +250,7 @@ export class DaffFormFieldComponent implements AfterContentInit, AfterContentChe
    * Validates whether or not the form field is in a "usable" state.
    */
   private _validateFormControl() {
-    if (!this._control) {
+    if (!this._control()) {
       throw new Error(DaffFormFieldMissingControlMessage);
     }
   }
@@ -281,11 +265,11 @@ export class DaffFormFieldComponent implements AfterContentInit, AfterContentChe
   ngAfterContentInit() {
     this._validateFormControl();
 
-    this._control.stateChanges?.subscribe(({ focused, filled, disabled, error, valid }) => {
-      this.isFilled = filled;
-      this.isError = error;
-      this.isDisabled = disabled;
-      this.isValid = valid;
+    this._control()?.stateChanges?.subscribe(({ filled, disabled, error, valid }) => {
+      this.isFilled.set(filled);
+      this.isError.set(error);
+      this.isDisabled.set(disabled);
+      this.isValid.set(valid);
 
       this.cd.markForCheck();
     });

--- a/libs/design/form-field/src/specs/usage.spec.ts
+++ b/libs/design/form-field/src/specs/usage.spec.ts
@@ -67,7 +67,7 @@ describe('@daffodil/design | DaffFormFieldComponent | Usage', () => {
 
     de = fixture.debugElement.query(By.css('daff-form-field'));
     component = de.componentInstance;
-    control = component._control;
+    control = component._control();
     patchElementFocus(fixture.debugElement.query(By.css('input')).nativeElement);
   });
 
@@ -76,12 +76,12 @@ describe('@daffodil/design | DaffFormFieldComponent | Usage', () => {
   });
 
   it('should allow a custom id to be set', () => {
-    expect(component.id).toEqual(wrapper.id());
+    expect(component.id()).toEqual(wrapper.id());
   });
 
   describe('setting the appearance of a form field', () => {
     it('should take appearance as an input', () => {
-      expect(component.appearance).toEqual(wrapper.appearance());
+      expect(component.appearance()).toEqual(wrapper.appearance());
     });
 
     it('should add a class of "fluid" to the host element when appearance="fluid"', () => {

--- a/libs/design/form-field/src/specs/without-control.spec.ts
+++ b/libs/design/form-field/src/specs/without-control.spec.ts
@@ -5,7 +5,8 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 
-import { DAFF_FORM_FIELD_COMPONENTS } from '../form-field';
+import { DAFF_FORM_FIELD_COMPONENTS } from '@daffodil/design/form-field';
+
 import { DaffFormFieldMissingControlMessage } from '../form-field/form-field.component';
 
 @Component({ template: `

--- a/libs/design/input/src/input.component.ts
+++ b/libs/design/input/src/input.component.ts
@@ -63,7 +63,7 @@ export class DaffInputComponent extends DaffFormFieldControl<string> implements 
    * @docs-private
    */
   get _id() {
-    return this.formField?.id;
+    return this.formField?.id();
   };
 
   /**
@@ -112,9 +112,9 @@ export class DaffInputComponent extends DaffFormFieldControl<string> implements 
    */
   get ariaDescribedBy() {
     if(this.formField.hasErrorMessage()) {
-      return this.formField.errorMessageId;
+      return this.formField.errorMessageId();
     } else if(this.formField.hasHint()) {
-      return this.formField.hintId;
+      return this.formField.hintId();
     } else {
       return null;
     }

--- a/libs/design/input/src/specs/with-form-field.spec.ts
+++ b/libs/design/input/src/specs/with-form-field.spec.ts
@@ -62,11 +62,11 @@ describe('@daffodil/design | DaffInputComponent | With Form Field', () => {
   });
 
   it('should set the control type to native-input', () => {
-    expect(formField._control.controlType).toEqual('native-input');
+    expect(formField._control().controlType).toEqual('native-input');
   });
 
   it('should set the input id to the form field id', () => {
-    expect(componentDE.attributes.id).toEqual(formField.id);
+    expect(componentDE.attributes.id).toEqual(formField.id());
   });
 
   it('should set required to false', () => {
@@ -94,7 +94,7 @@ describe('@daffodil/design | DaffInputComponent | With Form Field', () => {
       wrapper.id.set('test-2');
       fixture.detectChanges();
 
-      expect(formField.id).toEqual('test-2');
+      expect(formField.id()).toEqual('test-2');
       expect(componentDE.attributes.id).toEqual('test-2');
     });
   });

--- a/libs/design/native-select/src/native-select/native-select.component.ts
+++ b/libs/design/native-select/src/native-select/native-select.component.ts
@@ -69,7 +69,7 @@ export class DaffNativeSelectComponent extends DaffFormFieldControl<string> impl
    * Implemented as part of DaffFormFieldControl.
    */
   get _id() {
-    return this.formField?.id;
+    return this.formField?.id();
   };
 
   constructor(
@@ -93,9 +93,9 @@ export class DaffNativeSelectComponent extends DaffFormFieldControl<string> impl
    */
   get ariaDescribedBy() {
     if(this.formField.hasErrorMessage()) {
-      return this.formField.errorMessageId;
+      return this.formField.errorMessageId();
     } else if(this.formField.hasHint()) {
-      return this.formField.hintId;
+      return this.formField.hintId();
     } else {
       return null;
     }

--- a/libs/design/native-select/src/native-select/specs/with-form-field.spec.ts
+++ b/libs/design/native-select/src/native-select/specs/with-form-field.spec.ts
@@ -70,7 +70,7 @@ describe('@daffodil/design | DaffNativeSelectComponent | With Form Field', () =>
   });
 
   it('should set the native select id to the form field id', () => {
-    expect(componentDE.attributes.id).toEqual(formField.id);
+    expect(componentDE.attributes.id).toEqual(formField.id());
   });
 
 
@@ -99,7 +99,7 @@ describe('@daffodil/design | DaffNativeSelectComponent | With Form Field', () =>
       wrapper.id.set('test-2');
       fixture.detectChanges();
 
-      expect(formField.id).toEqual('test-2');
+      expect(formField.id()).toEqual('test-2');
       expect(componentDE.attributes.id).toEqual('test-2');
     });
   });

--- a/libs/design/select/src/select/select.component.ts
+++ b/libs/design/select/src/select/select.component.ts
@@ -177,7 +177,7 @@ export class DaffSelectComponent<T = unknown> extends DaffFormFieldControl<strin
       throw new Error('DaffSelectComponent needs to be used with the DaffFormFieldComponent.');
     }
 
-    this.ariaLabelledBy = this.formField.id;
+    this.ariaLabelledBy = this.formField.id();
 
     this.openDirective.stateless = false;
 

--- a/libs/design/select/src/specs/with-form-field.spec.ts
+++ b/libs/design/select/src/specs/with-form-field.spec.ts
@@ -61,7 +61,7 @@ describe('@daffodil/design/select | DaffSelectComponent | With Form Field', () =
   });
 
   it('should set the control type to custom-select', () => {
-    expect(formField._control.controlType).toEqual('custom-select');
+    expect(formField._control().controlType).toEqual('custom-select');
   });
 
   it('should set required to false', () => {

--- a/libs/design/textarea/src/specs/with-form-field.spec.ts
+++ b/libs/design/textarea/src/specs/with-form-field.spec.ts
@@ -63,11 +63,11 @@ describe('@daffodil/design/textarea | DaffTextareaComponent | With Form Field', 
   });
 
   it('should set the control type to native-textarea', () => {
-    expect(formField._control.controlType).toEqual('native-textarea');
+    expect(formField._control().controlType).toEqual('native-textarea');
   });
 
   it('should set the textarea id to the form field id', () => {
-    expect(component.internalId).toEqual(formField.id);
+    expect(component.internalId).toEqual(formField.id());
   });
 
   it('should set required to false', () => {
@@ -105,7 +105,7 @@ describe('@daffodil/design/textarea | DaffTextareaComponent | With Form Field', 
       wrapper.id.set('test-2');
       fixture.detectChanges();
 
-      expect(formField.id).toEqual('test-2');
+      expect(formField.id()).toEqual('test-2');
       expect(component.internalId).toEqual('test-2');
     });
   });

--- a/libs/design/textarea/src/textarea.component.ts
+++ b/libs/design/textarea/src/textarea.component.ts
@@ -57,7 +57,7 @@ export class DaffTextareaComponent extends DaffFormFieldControl<string> implemen
   focused = false;
 
   private get _id() {
-    return this.formField?.id;
+    return this.formField?.id();
   };
 
   /**
@@ -128,9 +128,9 @@ export class DaffTextareaComponent extends DaffFormFieldControl<string> implemen
    */
   get ariaDescribedBy() {
     if(this.formField.hasErrorMessage()) {
-      return this.formField.errorMessageId;
+      return this.formField.errorMessageId();
     } else if(this.formField.hasHint()) {
-      return this.formField.hintId;
+      return this.formField.hintId();
     } else {
       return null;
     }


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327

## New behavior
This doesn't touch the `DaffFormFieldControl` portion since that's a bigger conversion. Aiming to keep this specific PR small and easily reviewable.

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `@daffodil/design/form-field` now exposes all `DaffFormFieldComponent` inputs (`appearance` and `id`) as signals rather than plain properties. Template bindings continue to work, but any programmatic access must go through the signal API:

- Reads must invoke the signal: `formField.appearance` → `formField.appearance()`, `formField.id` → `formField.id()`.

Inputs are now read-only and can no longer be assigned imperatively (`formField.appearance = 'fixed'` is no longer supported).

## Additional context
<!-- Any other relevant information -->