### PR TITLE
fix(design): break dependency cycle in DaffRovingTabIndexDirective

### DIFF
--- a/libs/design/src/core/roving-tab-index/public_api.ts
+++ b/libs/design/src/core/roving-tab-index/public_api.ts
@@ -1,2 +1,6 @@
 export { DaffRovingTabIndexDirective } from './roving-tab-index.directive';
 export { DaffRovingTabIndexBoundaryDirective } from './roving-tab-index-boundary.directive';
+export {
+  DAFF_ROVING_TAB_INDEX_BOUNDARY,
+  DaffRovingTabIndexBoundary,
+} from './roving-tab-index-boundary.token';

--- a/libs/design/src/core/roving-tab-index/roving-tab-index-boundary.directive.ts
+++ b/libs/design/src/core/roving-tab-index/roving-tab-index-boundary.directive.ts
@@ -7,6 +7,10 @@ import {
   input,
 } from '@angular/core';
 
+import {
+  DAFF_ROVING_TAB_INDEX_BOUNDARY,
+  DaffRovingTabIndexBoundary,
+} from './roving-tab-index-boundary.token';
 import { DaffRovingTabIndexService } from './roving-tab-index-group.service';
 import { DaffRovingTabIndexDirective } from './roving-tab-index.directive';
 
@@ -22,10 +26,16 @@ import { DaffRovingTabIndexDirective } from './roving-tab-index.directive';
   },
   hostDirectives: [
     CdkTrapFocus,
-    forwardRef(() => DaffRovingTabIndexDirective),
+    DaffRovingTabIndexDirective,
+  ],
+  providers: [
+    {
+      provide: DAFF_ROVING_TAB_INDEX_BOUNDARY,
+      useExisting: forwardRef(() => DaffRovingTabIndexBoundaryDirective),
+    },
   ],
 })
-export class DaffRovingTabIndexBoundaryDirective {
+export class DaffRovingTabIndexBoundaryDirective implements DaffRovingTabIndexBoundary {
   /**
    * Don't touch this directly. Use `_uniqueId`.
    */

--- a/libs/design/src/core/roving-tab-index/roving-tab-index-boundary.token.ts
+++ b/libs/design/src/core/roving-tab-index/roving-tab-index-boundary.token.ts
@@ -1,0 +1,20 @@
+import {
+  InjectionToken,
+  Signal,
+} from '@angular/core';
+
+/**
+ * The public shape of an RTI boundary, exposed to descendant RTI targets.
+ */
+export interface DaffRovingTabIndexBoundary {
+  /**
+   * The name of the group defined by this boundary.
+   */
+  readonly effectiveBoundary: Signal<string>;
+}
+
+/**
+ * Allows RTI targets to inject their nearest ancestor boundary without
+ * creating a circular import with the boundary directive.
+ */
+export const DAFF_ROVING_TAB_INDEX_BOUNDARY = new InjectionToken<DaffRovingTabIndexBoundary>('DaffRovingTabIndexBoundary');

--- a/libs/design/src/core/roving-tab-index/roving-tab-index.directive.ts
+++ b/libs/design/src/core/roving-tab-index/roving-tab-index.directive.ts
@@ -1,12 +1,16 @@
 import {
   computed,
   Directive,
+  Inject,
   input,
   Optional,
   SkipSelf,
 } from '@angular/core';
 
-import { DaffRovingTabIndexBoundaryDirective } from './roving-tab-index-boundary.directive';
+import {
+  DAFF_ROVING_TAB_INDEX_BOUNDARY,
+  DaffRovingTabIndexBoundary,
+} from './roving-tab-index-boundary.token';
 import { DaffRovingTabIndexService } from './roving-tab-index-group.service';
 
 /**
@@ -47,7 +51,7 @@ export class DaffRovingTabIndexDirective {
 
   constructor(
     private service: DaffRovingTabIndexService,
-    @Optional() @SkipSelf() private parent: DaffRovingTabIndexBoundaryDirective,
+    @Optional() @SkipSelf() @Inject(DAFF_ROVING_TAB_INDEX_BOUNDARY) private parent: DaffRovingTabIndexBoundary,
   ) {}
 
   /**


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, there's a import loop in [DaffRovingTabIndexDirective](https://github.com/graycoreio/daffodil/blob/develop/libs/design/src/core/roving-tab-index/roving-tab-index.directive.ts#L9).

Fixes: #4593 

## New behavior
There is no more cycle. The cycle is acyclitized with a shared injection token.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->