### PR TITLE
build(design): add import/no-cycle rule

### DIFF
--- a/libs/design/eslint.config.mjs
+++ b/libs/design/eslint.config.mjs
@@ -14,6 +14,20 @@ export default defineConfig([
 		},
 	},
 	{
+		files: ['**/*.ts'],
+		ignores: ['**/*.spec.ts'],
+		settings: {
+			'import/resolver': {
+				node: {
+					extensions: ['.ts', '.js'],
+				},
+			},
+		},
+		rules: {
+			'import/no-cycle': ['warn', { ignoreExternal: true }],
+		},
+	},
+	{
 		files: ['**/*.component.ts', '**/*.container.ts', '**/*.directive.ts'],
 		plugins: {
 			'daff-docs': daffDocsPlugin,


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [x] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, we allow cycles in our typescript code. We should generally try to prevent this.

Part of: #4593 

## New behavior
This lints ( and uncovers) the cycles in @daffodil/design as a warning.

## Breaking change?

- [ ] Yes
- [x] No

## Additional context

This adds some perf hit (it's a ~5s additional time spend linting, which sucks):

```
/home/damien/graycore/daffodil/libs/design/breadcrumb/src/breadcrumb-render/breadcrumb-render.type.ts
  1:1  warning  Dependency cycle via ./breadcrumb/breadcrumb.component:1  import/no-cycle

/home/damien/graycore/daffodil/libs/design/breadcrumb/src/breadcrumb-render/to-render-type.ts
  1:1  warning  Dependency cycle via ./breadcrumb/breadcrumb.component:1  import/no-cycle

/home/damien/graycore/daffodil/libs/design/breadcrumb/src/breadcrumb.module.ts
  3:1  warning  Dependency cycle via ../breadcrumb-render/breadcrumb-render.type:32=>../public_api:1  import/no-cycle

/home/damien/graycore/daffodil/libs/design/breadcrumb/src/breadcrumb.ts
  1:1  warning  Dependency cycle via ../breadcrumb-render/breadcrumb-render.type:32=>../public_api:1  import/no-cycle

/home/damien/graycore/daffodil/libs/design/breadcrumb/src/breadcrumb/breadcrumb.component.ts
  32:1  warning  Dependency cycle via ../public_api:1  import/no-cycle

/home/damien/graycore/daffodil/libs/design/breadcrumb/src/public_api.ts
  1:1  warning  Dependency cycle via ../breadcrumb-render/breadcrumb-render.type:32  import/no-cycle

/home/damien/graycore/daffodil/libs/design/modal/src/modal/interfaces/modal.ts
  4:1  warning  Dependency cycle via ../service/modal.service:34  import/no-cycle

/home/damien/graycore/daffodil/libs/design/modal/src/modal/modal.component.ts
  34:1  warning  Dependency cycle detected  import/no-cycle

/home/damien/graycore/daffodil/libs/design/modal/src/service/modal.service.ts
  16:1  warning  Dependency cycle via ../modal.component:4  import/no-cycle

/home/damien/graycore/daffodil/libs/design/radio/src/cva/radio-cva.directive.ts
  14:1  warning  Dependency cycle detected  import/no-cycle

/home/damien/graycore/daffodil/libs/design/radio/src/registry/radio-registry.ts
  4:1  warning  Dependency cycle detected  import/no-cycle

/home/damien/graycore/daffodil/libs/design/src/core/roving-tab-index/roving-tab-index-boundary.directive.ts
  11:1  warning  Dependency cycle detected  import/no-cycle

/home/damien/graycore/daffodil/libs/design/src/core/roving-tab-index/roving-tab-index.directive.ts
  9:1  warning  Dependency cycle detected  import/no-cycle

  ```