### PR TITLE
feat(design)!: convert `@daffodil/design/image` to use signals

### DIFF
--- a/libs/design-examples/image/src/load-image/load-image.component.html
+++ b/libs/design-examples/image/src/load-image/load-image.component.html
@@ -3,7 +3,7 @@
   alt="Ergonomic Bronze Pants T-Shirt"
   [width]="934"
   [height]="934"
-  (load)="load()"
+  (loaded)="load()"
 >
 </daff-image>
 

--- a/libs/design/image/src/image/image.component.html
+++ b/libs/design/image/src/image/image.component.html
@@ -1,6 +1,6 @@
 <img class="daff-image"
-	[ngSrc]="src"
-	[alt]="alt"
+	[ngSrc]="src()"
+	[alt]="alt()"
 	fill
-	[priority]="priority"
-	(load)="load.emit" />
+	[priority]="priority()"
+	(load)="loaded.emit()" />

--- a/libs/design/image/src/image/image.component.spec.ts
+++ b/libs/design/image/src/image/image.component.spec.ts
@@ -10,10 +10,16 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffImageComponent } from './image.component';
+import { DaffImageComponent } from '@daffodil/design/image';
 
 @Component({
-  template: `<daff-image [src]="src()" [alt]="alt()" [width]="width()" [height]="height()" [skeleton]="skeleton()" [priority]="priority()"></daff-image>`,
+  template: `
+    <daff-image
+      [src]="src()"
+      [alt]="alt()"
+      [width]="width()"
+      [height]="height()">
+    </daff-image>`,
   imports: [
     DaffImageComponent,
   ],
@@ -24,12 +30,9 @@ class WrapperComponent {
   alt = signal('image');
   width = signal(100);
   height = signal(100);
-  skeleton = signal(false);
-  priority = signal(false);
 }
 
-describe('@daffodil/design/image | DaffImageComponent', () => {
-  let wrapper: WrapperComponent;
+describe('@daffodil/design/image | DaffImageComponent | Defaults', () => {
   let component: DaffImageComponent;
   let de: DebugElement;
   let fixture: ComponentFixture<WrapperComponent>;
@@ -45,7 +48,6 @@ describe('@daffodil/design/image | DaffImageComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);
-    wrapper = fixture.componentInstance;
     de = fixture.debugElement.query(By.css('daff-image'));
     component = de.componentInstance;
 
@@ -56,82 +58,7 @@ describe('@daffodil/design/image | DaffImageComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should be able to take `src` as an input', () => {
-    wrapper.src.set('/assets/image.svg');
-    fixture.detectChanges();
-
-    expect(component.src).toEqual('/assets/image.svg');
-  });
-
-  it('should be able to take `alt` as an input', () => {
-    wrapper.alt.set('alt tag');
-    fixture.detectChanges();
-
-    expect(component.alt).toEqual('alt tag');
-  });
-
-  it('should be able to take `width` as an input', () => {
-    wrapper.width.set(100);
-    fixture.detectChanges();
-
-    expect(component.width).toEqual(100);
-  });
-
-  it('should be able to take `height` as an input', () => {
-    wrapper.height.set(100);
-    fixture.detectChanges();
-
-    expect(component.height).toEqual(100);
-  });
-
-  it('should take skeleton as an input', () => {
-    wrapper.skeleton.set(true);
-    fixture.detectChanges();
-
-    expect(de.nativeElement.classList.contains('daff-skeleton')).toEqual(true);
-  });
-
-  it('should take priority as an input', () => {
-    wrapper.priority.set(true);
-    fixture.detectChanges();
-
-    expect(component.priority()).toEqual(true);
-  });
-
-  it('should throw an error when src is invalid', () => {
-    wrapper.src.set('');
-    expect(() => fixture.detectChanges()).toThrowError(/src/);
-  });
-
-  it('should throw an error when alt is invalid', () => {
-    wrapper.alt.set('');
-    expect(() => fixture.detectChanges()).toThrowError(/alt/);
-  });
-
-  it('should throw an error when width is invalid', () => {
-    wrapper.width.set(null);
-    expect(() => fixture.detectChanges()).toThrowError(/width/);
-  });
-
-  it('should throw an error when height is invalid', () => {
-    wrapper.height.set(undefined);
-    expect(() => fixture.detectChanges()).toThrowError(/height/);
-  });
-
-  it('should calculate and set `aspect-ratio` on `.daff-image` based on the width and height', () => {
-    wrapper.width.set(300);
-    wrapper.height.set(100);
-
-    fixture.detectChanges();
-
-    expect(de.styles['aspect-ratio']).toEqual('300 / 100');
-  });
-
-  it('sets `max-width` on the host element based on the width', () => {
-    wrapper.width.set(300);
-
-    fixture.detectChanges();
-
-    expect(de.styles['max-width']).toEqual(wrapper.width() + 'px');
+  it('should not be a priority image by default', () => {
+    expect(component.priority()).toEqual(false);
   });
 });

--- a/libs/design/image/src/image/image.component.ts
+++ b/libs/design/image/src/image/image.component.ts
@@ -2,11 +2,9 @@ import { NgOptimizedImage } from '@angular/common';
 import {
   Component,
   ChangeDetectionStrategy,
-  Input,
-  EventEmitter,
-  OnInit,
-  Output,
   input,
+  output,
+  computed,
 } from '@angular/core';
 import {
   DomSanitizer,
@@ -15,25 +13,12 @@ import {
 
 import { DaffSkeletonableDirective } from '@daffodil/design';
 
-const validateProperty = (object: Record<string, any>, prop: string) => {
-  if (object[prop] === null || object[prop] === undefined || object[prop] === '') {
+const validateInput = (prop: string) => <T>(value: T): T => {
+  if (value === null || value === undefined || <unknown>value === '') {
     throw new Error(`DaffImageComponent must have a defined ${prop} attribute.`);
   }
-};
 
-const validateProperties = (object: Record<string, any>, props: string[]) => {
-  const invalidProps = props.filter(prop => {
-    try {
-      validateProperty(object, prop);
-    } catch(e) {
-      return true;
-    }
-    return false;
-  });
-
-  if (invalidProps.length) {
-    throw new Error(`DaffImageComponent must have the ${invalidProps.join(',')} attributes defined.`);
-  }
+  return value;
 };
 
 @Component({
@@ -48,69 +33,33 @@ const validateProperties = (object: Record<string, any>, props: string[]) => {
     },
   ],
   host: {
-    '[style.max-width]': 'width + "px"',
-    '[style.aspect-ratio]': '_aspectRatio',
+    '[style.max-width]': 'width() + "px"',
+    '[style.aspect-ratio]': '_aspectRatio()',
   },
   imports: [
     NgOptimizedImage,
   ],
 })
-export class DaffImageComponent implements OnInit {
-  private _src: string;
-
+export class DaffImageComponent {
   /**
    * The URL of the image.
    */
-  @Input()
-  get src(): string {
-    return this._src;
-  }
-  set src(value: string) {
-    this._src = value;
-    validateProperty(this, 'src');
-  }
-
-  private _alt: string;
+  src = input.required<string, string>({ transform: validateInput('src') });
 
   /**
    * The alternate text for the image.
    */
-  @Input()
-  get alt(): string {
-    return this._alt;
-  }
-  set alt(value: string) {
-    this._alt = value;
-    validateProperty(this, 'alt');
-  }
-
-  private _width: number;
+  alt = input.required<string, string>({ transform: validateInput('alt') });
 
   /**
    * The width of the image.
    */
-  @Input()
-  get width(): number {
-    return this._width;
-  }
-  set width(value: number) {
-    this._width = value;
-    validateProperty(this, 'width');
-  }
-
-  private _height: number;
+  width = input.required<number, number>({ transform: validateInput('width') });
 
   /**
    * The height of the image.
    */
-  @Input()
-  get height(): number {
-    return this._height;
-  }
-  set height(value: number) {
-    this._height = value;
-    validateProperty(this, 'height');
-  }
+  height = input.required<number, number>({ transform: validateInput('height') });
 
   /**
    * Whether the image should be treated as a priority image for loading.
@@ -121,36 +70,31 @@ export class DaffImageComponent implements OnInit {
   /**
    * Emits when the image has loaded.
    */
-  // TODO: rename event to not collide with native event (unless that's intentional)
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() load: EventEmitter<void> = new EventEmitter();
-
-  /**
-   * @docs-private
-   */
-  ngOnInit(): void {
-    validateProperties(this, ['src', 'alt', 'width', 'height']);
-  }
+  loaded = output<void>();
 
   constructor(private sanitizer: DomSanitizer) {}
 
   /**
    * @docs-private
    */
-  get _paddingTop(): any {
-    if (!this.height || !this.width ) {
+  _paddingTop = computed(() => {
+    if (!this.height() || !this.width() ) {
       return undefined;
     }
 
-    return this.sanitizer.bypassSecurityTrustStyle('calc(' + this.height + ' / ' + this.width + ' * 100%)');
-  }
+    return this.sanitizer.bypassSecurityTrustStyle(
+      'calc(' + this.height() + ' / ' + this.width() + ' * 100%)',
+    );
+  });
 
   /**
    * @docs-private
    *
    * The aspect ratio of an image, based on the width and height set by the user.
    */
-  get _aspectRatio(): SafeStyle {
-    return this.sanitizer.bypassSecurityTrustStyle(this.width + ' / ' + this.height);
-  }
+  _aspectRatio = computed<SafeStyle>(
+    () => this.sanitizer.bypassSecurityTrustStyle(
+      this.width() + ' / ' + this.height(),
+    ),
+  );
 }

--- a/libs/design/image/src/image/specs/missing-props.spec.ts
+++ b/libs/design/image/src/image/specs/missing-props.spec.ts
@@ -5,11 +5,13 @@ import {
   TestBed,
 } from '@angular/core/testing';
 
-import { DaffImageComponent } from '../image.component';
+import { DaffImageComponent } from '@daffodil/design/image';
 
 @Component({
   template: `<daff-image></daff-image>`,
-  standalone: false,
+  imports: [
+    DaffImageComponent,
+  ],
 })
 
 class WrapperComponent {
@@ -19,15 +21,12 @@ class WrapperComponent {
   height: number;
 }
 
-describe('DaffImageComponent | Props Validation', () => {
+describe('@daffodil/design/image | DaffImageComponent | Props Validation', () => {
   let fixture: ComponentFixture<WrapperComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        DaffImageComponent,
-      ],
-      declarations: [
         WrapperComponent,
       ],
     })

--- a/libs/design/image/src/image/specs/usage.spec.ts
+++ b/libs/design/image/src/image/specs/usage.spec.ts
@@ -1,0 +1,139 @@
+import {
+  Component,
+  DebugElement,
+  signal,
+} from '@angular/core';
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { DaffImageComponent } from '@daffodil/design/image';
+
+@Component({
+  template: `
+    <daff-image
+      [src]="src()"
+      [alt]="alt()"
+      [width]="width()"
+      [height]="height()"
+      [skeleton]="skeleton()"
+      [priority]="priority()">
+    </daff-image>`,
+  imports: [
+    DaffImageComponent,
+  ],
+})
+
+class WrapperComponent {
+  src = signal('assets/image.svg');
+  alt = signal('image');
+  width = signal(100);
+  height = signal(100);
+  skeleton = signal(false);
+  priority = signal(false);
+}
+
+describe('@daffodil/design/image | DaffImageComponent | Usage', () => {
+  let wrapper: WrapperComponent;
+  let component: DaffImageComponent;
+  let de: DebugElement;
+  let fixture: ComponentFixture<WrapperComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        WrapperComponent,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WrapperComponent);
+    wrapper = fixture.componentInstance;
+    de = fixture.debugElement.query(By.css('daff-image'));
+    component = de.componentInstance;
+  });
+
+  it('should be able to take `src` as an input', () => {
+    wrapper.src.set('/assets/image.svg');
+    fixture.detectChanges();
+
+    expect(component.src()).toEqual('/assets/image.svg');
+  });
+
+  it('should be able to take `alt` as an input', () => {
+    wrapper.alt.set('alt tag');
+    fixture.detectChanges();
+
+    expect(component.alt()).toEqual('alt tag');
+  });
+
+  it('should be able to take `width` as an input', () => {
+    wrapper.width.set(100);
+    fixture.detectChanges();
+
+    expect(component.width()).toEqual(100);
+  });
+
+  it('should be able to take `height` as an input', () => {
+    wrapper.height.set(100);
+    fixture.detectChanges();
+
+    expect(component.height()).toEqual(100);
+  });
+
+  it('should take skeleton as an input', () => {
+    wrapper.skeleton.set(true);
+    fixture.detectChanges();
+
+    expect(de.nativeElement.classList.contains('daff-skeleton')).toEqual(true);
+  });
+
+  it('should take priority as an input', () => {
+    wrapper.priority.set(true);
+    fixture.detectChanges();
+
+    expect(component.priority()).toEqual(true);
+  });
+
+  it('should throw an error when src is invalid', () => {
+    wrapper.src.set('');
+    expect(() => fixture.detectChanges()).toThrowError(/src/);
+  });
+
+  it('should throw an error when alt is invalid', () => {
+    wrapper.alt.set('');
+    expect(() => fixture.detectChanges()).toThrowError(/alt/);
+  });
+
+  it('should throw an error when width is invalid', () => {
+    wrapper.width.set(null);
+    expect(() => fixture.detectChanges()).toThrowError(/width/);
+  });
+
+  it('should throw an error when height is invalid', () => {
+    wrapper.height.set(undefined);
+    expect(() => fixture.detectChanges()).toThrowError(/height/);
+  });
+
+  it('should calculate and set `aspect-ratio` on `.daff-image` based on the width and height', () => {
+    wrapper.width.set(300);
+    wrapper.height.set(100);
+
+    fixture.detectChanges();
+
+    expect(de.styles['aspect-ratio']).toEqual('300 / 100');
+  });
+
+  it('sets `max-width` on the host element based on the width', () => {
+    wrapper.width.set(300);
+
+    fixture.detectChanges();
+
+    expect(de.styles['max-width']).toEqual(wrapper.width() + 'px');
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE:  `@daffodil/design/image` now exposes the `DaffImageComponent` inputs `src`, `alt`, `width`, and `height` as signals rather than plain properties, and renames the `load` output to `loaded`.

- Input template bindings (`[src]`, `[alt]`, etc.) continue to work unchanged.
- Programmatic reads must invoke the signal: `image.src` → `image.src()`, `image.width` → `image.width()`, etc.
- Inputs are now read-only and can no longer be assigned imperatively (`image.src = '/image/test.jpg'` is no longer supported).

## Additional context
<!-- Any other relevant information -->