### PR TITLE
feat(design)!: convert `@daffodil/design/list` to use signals

### DIFF
--- a/libs/design/list/README.md
+++ b/libs/design/list/README.md
@@ -58,6 +58,16 @@ Use `<daff-nav-list>` with anchor elements to create a list of links. This is us
 
 <daff-docs-example-viewer example="nav-list"></daff-docs-example-viewer>
 
+### Active items
+Use the `active` property to highlight the item in a `<daff-nav-list>` that matches the current page.
+
+```html
+<daff-nav-list aria-label="Sidebar links">
+  <a href="/dashboard" daff-list-item [active]="true">Dashboard</a>
+  <a href="/orders" daff-list-item>Orders</a>
+</daff-nav-list>
+```
+
 ### Multi-line lists
 For list items that contain multiple lines of text, use the `[daffListItemTitle]` element to identify the primary title. Additional supporting content can be added using `<div>` or `<p>` elements.
 

--- a/libs/design/list/src/list-item-title/list-item-title.directive.spec.ts
+++ b/libs/design/list/src/list-item-title/list-item-title.directive.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffListItemTitleDirective } from './list-item-title.directive';
+import { DaffListItemTitleDirective } from '@daffodil/design/list';
 
 @Component({
   template: `<div daffListItemTitle>Title</div>`,
@@ -19,7 +19,7 @@ import { DaffListItemTitleDirective } from './list-item-title.directive';
 })
 class WrapperComponent {}
 
-describe('DaffListItemTitleDirective', () => {
+describe('@daffodil/design/list | DaffListItemTitleDirective', () => {
   let fixture: ComponentFixture<WrapperComponent>;
   let de: DebugElement;
   let wrapper: WrapperComponent;

--- a/libs/design/list/src/list-item-title/list-item-title.directive.ts
+++ b/libs/design/list/src/list-item-title/list-item-title.directive.ts
@@ -1,6 +1,5 @@
 import { Directive } from '@angular/core';
 
-/* eslint-disable quote-props */
 /**
  * Used to identify the primary title of a list item within a multi-line list.
  *
@@ -12,7 +11,7 @@ import { Directive } from '@angular/core';
 @Directive({
   selector: '[daffListItemTitle]',
   host: {
-    'class': 'daff-list-item__title',
+    class: 'daff-list-item__title',
   },
 })
 

--- a/libs/design/list/src/list-item/list-item.component.html
+++ b/libs/design/list/src/list-item/list-item.component.html
@@ -1,4 +1,4 @@
-@if(_prefix) {
+@if(_prefix()) {
   <ng-content select="[daffPrefix]"></ng-content>
 }
 <div class="daff-list-item__content">

--- a/libs/design/list/src/list-item/list-item.component.spec.ts
+++ b/libs/design/list/src/list-item/list-item.component.spec.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   DebugElement,
+  signal,
 } from '@angular/core';
 import {
   waitForAsync,
@@ -9,18 +10,20 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffListItemComponent } from './list-item.component';
+import { DaffListItemComponent } from '@daffodil/design/list';
 
 @Component({
   template: `
     <daff-list-item>List Item</daff-list-item>
-    <a daff-list-item>List Item</a>
+    <a daff-list-item [active]="active()">List Item</a>
   `,
   imports: [
     DaffListItemComponent,
   ],
 })
-class WrapperComponent {}
+class WrapperComponent {
+  active = signal(false);
+}
 
 describe('@daffodil/design/list | DaffListItemComponent', () => {
   let wrapper: WrapperComponent;
@@ -65,5 +68,16 @@ describe('@daffodil/design/list | DaffListItemComponent', () => {
 
   it('should not have a role applied if it is used with an anchor element', () => {
     expect(anchorDE.nativeElement.role).toBe(null);
+  });
+
+  it('should not add the "active" class by default', () => {
+    expect(itemDE.classes['active']).toBeFalsy();
+  });
+
+  it('should add the "active" class when `active` is set', () => {
+    fixture.componentInstance.active.set(true);
+    fixture.detectChanges();
+
+    expect(anchorDE.classes['active']).toBe(true);
   });
 });

--- a/libs/design/list/src/list-item/list-item.component.ts
+++ b/libs/design/list/src/list-item/list-item.component.ts
@@ -1,14 +1,13 @@
 import {
   Component,
   ChangeDetectionStrategy,
-  ContentChild,
   ElementRef,
-  Input,
+  contentChild,
+  input,
 } from '@angular/core';
 
 import { DaffPrefixDirective } from '@daffodil/design';
 
-/* eslint-disable quote-props */
 /**
  * Individual items within a list.
  *
@@ -24,8 +23,8 @@ import { DaffPrefixDirective } from '@daffodil/design';
     'a[daff-list-item]',
   templateUrl: './list-item.component.html',
   host: {
-    'class': 'daff-list-item',
-    '[class.active]': 'active',
+    class: 'daff-list-item',
+    '[class.active]': 'active()',
     '[attr.role]': 'this._isAnchor ? null : "listitem"',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -33,12 +32,12 @@ import { DaffPrefixDirective } from '@daffodil/design';
 
 export class DaffListItemComponent {
   /** Whether an item in a `<daff-nav-list>` is the currently active item. */
-  @Input() active = false;
+  active = input(false);
 
   /**
    * @docs-private
    */
-  @ContentChild(DaffPrefixDirective) _prefix: DaffPrefixDirective;
+  _prefix = contentChild(DaffPrefixDirective);
 
   constructor(private elementRef: ElementRef) {}
 

--- a/libs/design/list/src/list/list.component.spec.ts
+++ b/libs/design/list/src/list/list.component.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffListComponent } from './list.component';
+import { DaffListComponent } from '@daffodil/design/list';
 
 @Component({
   template: `

--- a/libs/design/list/src/list/list.component.ts
+++ b/libs/design/list/src/list/list.component.ts
@@ -6,7 +6,6 @@ import {
 
 import { DaffArticleEncapsulatedDirective } from '@daffodil/design';
 
-/* eslint-disable quote-props */
 /**
  * A standard list used for grouping generic content.
  *
@@ -23,8 +22,8 @@ import { DaffArticleEncapsulatedDirective } from '@daffodil/design';
   template: '<ng-content></ng-content>',
   styleUrls: ['./list.component.scss'],
   host: {
-    'class': 'daff-list',
-    'role': 'list',
+    class: 'daff-list',
+    role: 'list',
   },
   hostDirectives: [{
     directive: DaffArticleEncapsulatedDirective,

--- a/libs/design/list/src/nav-list/nav-list.component.spec.ts
+++ b/libs/design/list/src/nav-list/nav-list.component.spec.ts
@@ -9,11 +9,11 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffNavListComponent } from './nav-list.component';
+import { DaffNavListComponent } from '@daffodil/design/list';
 
 @Component({
   template: `
-    <daff-list [mode]="mode"></daff-list>
+    <daff-list></daff-list>
     <daff-nav-list></daff-nav-list>
   `,
   imports: [

--- a/libs/design/list/src/nav-list/nav-list.component.ts
+++ b/libs/design/list/src/nav-list/nav-list.component.ts
@@ -6,7 +6,6 @@ import {
 
 import { DaffArticleEncapsulatedDirective } from '@daffodil/design';
 
-/* eslint-disable quote-props */
 /**
  * A navigation list intended for use with anchor elements (`<a>`).
  *
@@ -23,8 +22,8 @@ import { DaffArticleEncapsulatedDirective } from '@daffodil/design';
   template: '<ng-content></ng-content>',
   styleUrl: './nav-list.component.scss',
   host: {
-    'class': 'daff-nav-list',
-    'role': 'navigation',
+    class: 'daff-nav-list',
+    role: 'navigation',
   },
   hostDirectives: [
     {


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327
## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `@daffodil/design/list` now exposes the `DaffListItemComponent` `active` input as a signal rather than a plain property.

- Template bindings (`[active]="..."`) continue to work unchanged.
- Programmatic reads must invoke the signal: `listItem.active` → `listItem.active()`.
- `active` is now read-only and can no longer be assigned imperatively (`listItem.active = true` is no longer supported).

## Additional context
<!-- Any other relevant information -->