### PR TITLE
feat(design)!: convert `@daffodil/design/notification` to use signals

### DIFF
--- a/libs/design/notification/src/notification/notification.component.html
+++ b/libs/design/notification/src/notification/notification.component.html
@@ -1,4 +1,4 @@
-@if (_prefix) {
+@if (_prefix()) {
   <ng-content select="[daffPrefix]"></ng-content>
 }
 <div class="daff-notification__body">
@@ -6,11 +6,11 @@
     <ng-content select="[daffNotificationTitle]"></ng-content>
     <ng-content select="[daffNotificationMessage]"></ng-content>
   </div>
-  @if (_actions) {
+  @if (_actions()) {
     <ng-content select="[daffNotificationActions]"></ng-content>
   }
 </div>
-@if (dismissible) {
+@if (dismissible()) {
   <button class="daff-notification__close-icon" (click)="onCloseNotification($event)">
     <fa-icon [icon]="faTimes" [fixedWidth]="true"></fa-icon>
   </button>

--- a/libs/design/notification/src/notification/notification.component.spec.ts
+++ b/libs/design/notification/src/notification/notification.component.spec.ts
@@ -73,11 +73,11 @@ describe('@daffodil/design/notification | DaffNotificationComponent', () => {
 
   describe('the dismissible property', () => {
     it('should take dismissible as an input', () => {
-      expect(component.dismissible).toEqual(wrapper.dismissible());
+      expect(component.dismissible()).toEqual(wrapper.dismissible());
     });
 
     it('should set dismissible to false by default', () => {
-      expect(component.dismissible).toBeFalse();
+      expect(component.dismissible()).toBeFalse();
     });
 
     describe('when dismissible is set to false', () => {

--- a/libs/design/notification/src/notification/notification.component.ts
+++ b/libs/design/notification/src/notification/notification.component.ts
@@ -1,12 +1,10 @@
-/* eslint-disable quote-props */
 import {
   Component,
-  Input,
-  ContentChild,
   ViewEncapsulation,
   ChangeDetectionStrategy,
-  Output,
-  EventEmitter,
+  input,
+  output,
+  contentChild,
 } from '@angular/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
@@ -42,7 +40,7 @@ import { DaffNotificationActionsDirective } from '../notification-actions/notifi
 @Component({
   selector: 'daff-notification',
   templateUrl: './notification.component.html',
-  styleUrls: ['./notification.component.scss'],
+  styleUrl: './notification.component.scss',
   hostDirectives: [
     { directive: DaffArticleEncapsulatedDirective },
     {
@@ -55,9 +53,9 @@ import { DaffNotificationActionsDirective } from '../notification-actions/notifi
     },
   ],
   host: {
-    'class': 'daff-notification',
-    '[class.dismissible]': 'dismissible',
-    'tabindex': '0',
+    class: 'daff-notification',
+    '[class.dismissible]': 'dismissible()',
+    tabindex: '0',
     '[attr.role]': 'role',
   },
   encapsulation: ViewEncapsulation.None,
@@ -76,12 +74,12 @@ export class DaffNotificationComponent {
   /**
    * @docs-private
    */
-  @ContentChild(DaffPrefixDirective) _prefix: DaffPrefixDirective;
+  _prefix = contentChild(DaffPrefixDirective);
 
   /**
    * @docs-private
    */
-  @ContentChild(DaffNotificationActionsDirective) _actions: DaffNotificationActionsDirective;
+  _actions = contentChild(DaffNotificationActionsDirective);
 
   /**
    * @docs-private
@@ -96,7 +94,7 @@ export class DaffNotificationComponent {
   /** Whether the notification can be dismissed by the user.
    * Displays a close icon if `true`.
    */
-  @Input() dismissible = false;
+  dismissible = input(false);
 
   constructor(
     private statusDirective: DaffStatusableDirective,
@@ -108,7 +106,7 @@ export class DaffNotificationComponent {
   /**
    * Emits when the notification is closed.
    */
-  @Output() closeNotification: EventEmitter<void> = new EventEmitter();
+  closeNotification = output<void>();
 
   /**
    * @docs-private


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `@daffodil/design/notification` now exposes the `DaffNotificationComponent` `dismissible` input as a signal rather than a plain property. Template bindings (`[dismissible]="..."`) continue to work unchanged. Programmatic reads must invoke the signal: `notification.dismissible` → `notification.dismissible()`. `dismissible` is now read-only and can no longer be assigned imperatively (`notification.dismissible = true` is no longer supported).

## Additional context
<!-- Any other relevant information -->