### PR TITLE
feat(design)!: convert `@daffodil/design/paginator` to use signals

### DIFF
--- a/libs/design/paginator/src/paginator/paginator.component.html
+++ b/libs/design/paginator/src/paginator/paginator.component.html
@@ -1,23 +1,23 @@
-@if (!linkMode) {
+@if (!linkMode()) {
   <button type="button" class="daff-paginator__previous"
-    [disabled]="_disablePrev"
+    [disabled]="_disablePrev()"
     tabindex="0"
     attr.aria-label="Go to Previous Page"
     (click)="_onNotifyPrevPageChange()">
     <fa-icon [icon]="faChevronLeft" size="sm"></fa-icon> Previous
   </button>
 }
-@if (linkMode) {
-  @if (!_disablePrev) {
+@if (linkMode()) {
+  @if (!_disablePrev()) {
     <a class="daff-paginator__previous"
       attr.aria-label="Go to Previous Page"
-      [routerLink]="url"
+      [routerLink]="url()"
       queryParamsHandling="merge"
-      [queryParams]="_buildPageQueryParams(currentPage - 1)">
+      [queryParams]="_buildPageQueryParams(currentPage() - 1)">
       <fa-icon [icon]="faChevronLeft" size="sm"></fa-icon><span>Previous</span>
     </a>
   }
-  @if (_disablePrev) {
+  @if (_disablePrev()) {
     <span class="daff-paginator__previous disabled"
       attr.aria-label="Go to Previous Page"
       [attr.disabled]="true">
@@ -26,7 +26,7 @@
   }
 }
 
-@if (!linkMode) {
+@if (!linkMode()) {
   <button type="button" class="daff-paginator__page-link"
     [class.selected]="_isSelected(1)"
     tabindex="0"
@@ -36,9 +36,9 @@
   </button>
 }
 
-@if (linkMode) {
+@if (linkMode()) {
   <a class="daff-paginator__page-link"
-    [routerLink]="url"
+    [routerLink]="url()"
     [queryParams]="_buildPageQueryParams(1)"
     queryParamsHandling="merge"
     [class.selected]="_isSelected(1)"
@@ -47,13 +47,13 @@
   </a>
 }
 
-@if (_showFirstEllipsis) {
+@if (_showFirstEllipsis()) {
   <span class="daff-paginator__ellipsis">...</span>
 }
 
-@for (pageNumber of _numberOfPagesArray; track pageNumber) {
+@for (pageNumber of _numberOfPagesArray(); track pageNumber) {
   @if (_showNumber(pageNumber)) {
-    @if (!linkMode) {
+    @if (!linkMode()) {
       <button type="button" class="daff-paginator__page-link"
         [class.selected]="_isSelected(pageNumber)"
         [attr.data-page-number]="pageNumber"
@@ -64,10 +64,10 @@
         <span>{{ pageNumber }}</span>
       </button>
     }
-    @if (linkMode) {
+    @if (linkMode()) {
       <a class="daff-paginator__page-link"
         [attr.data-page-number]="pageNumber"
-        [routerLink]="url"
+        [routerLink]="url()"
         [queryParams]="_buildPageQueryParams(pageNumber)"
         queryParamsHandling="merge"
         [class.selected]="_isSelected(pageNumber)"
@@ -78,53 +78,53 @@
   }
 }
 
-@if (_showLastEllipsis) {
+@if (_showLastEllipsis()) {
   <span class="daff-paginator__ellipsis">...</span>
 }
 
-@if (!(numberOfPages < 2)) {
-  @if (!linkMode) {
+@if (!(numberOfPages() < 2)) {
+  @if (!linkMode()) {
     <button type="button" class="daff-paginator__page-link"
-      [class.selected]="_isSelected(numberOfPages)"
+      [class.selected]="_isSelected(numberOfPages())"
       tabindex="0"
-      attr.aria-label="Go To Page {{numberOfPages}}"
-      (click)="_onNotifyPageChange(numberOfPages)">
-        <span>{{ numberOfPages }}</span>
+      attr.aria-label="Go To Page {{numberOfPages()}}"
+      (click)="_onNotifyPageChange(numberOfPages())">
+        <span>{{ numberOfPages() }}</span>
     </button>
   }
-  @if (linkMode) {
+  @if (linkMode()) {
     <a class="daff-paginator__page-link"
-      [routerLink]="url"
-      [queryParams]="_buildPageQueryParams(numberOfPages)"
+      [routerLink]="url()"
+      [queryParams]="_buildPageQueryParams(numberOfPages())"
       queryParamsHandling="merge"
-      [class.selected]="_isSelected(numberOfPages)"
-      attr.aria-label="Go to Page {{numberOfPages}}">
-        <span>{{ numberOfPages }}</span>
+      [class.selected]="_isSelected(numberOfPages())"
+      attr.aria-label="Go to Page {{numberOfPages()}}">
+        <span>{{ numberOfPages() }}</span>
     </a>
   }
 }
 
-@if (!linkMode) {
+@if (!linkMode()) {
   <button class="daff-paginator__next"
-    [disabled]="_disableNext"
+    [disabled]="_disableNext()"
     tabindex="0"
     attr.aria-label="Go to Next Page"
     (click)="_onNotifyNextPageChange()">
     Next <fa-icon [icon]="faChevronRight" size="sm"></fa-icon>
   </button>
 }
-@if (linkMode) {
-  @if (!_disableNext) {
+@if (linkMode()) {
+  @if (!_disableNext()) {
     <a class="daff-paginator__next"
-      [routerLink]="url"
+      [routerLink]="url()"
       attr.aria-label="Go to Next Page"
       queryParamsHandling="merge"
-      [queryParams]="_buildPageQueryParams(currentPage + 1)">
+      [queryParams]="_buildPageQueryParams(currentPage() + 1)">
       <span>Next</span><fa-icon [icon]="faChevronRight" size="sm"></fa-icon>
     </a>
   }
 
-  @if (_disableNext) {
+  @if (_disableNext()) {
     <span class="daff-paginator__next disabled"
       attr.aria-label="Go to Next Page"
       [attr.disabled]="true">

--- a/libs/design/paginator/src/paginator/paginator.component.spec.ts
+++ b/libs/design/paginator/src/paginator/paginator.component.spec.ts
@@ -17,7 +17,8 @@ import {
   RouterModule,
 } from '@angular/router';
 
-import { DaffPaginatorComponent } from './paginator.component';
+import { DaffPaginatorComponent } from '@daffodil/design/paginator';
+
 import {
   DaffPaginatorNumberOfPagesErrorMessage,
   DaffPaginatorPageOutOfRangeErrorMessage,
@@ -25,7 +26,6 @@ import {
 
 @Component({
   template: '',
-  standalone: false,
 })
 class TestComponent {}
 
@@ -102,29 +102,29 @@ describe('@daffodil/design/paginator | DaffPaginatorComponent', () => {
   });
 
   it('should be able to take currentPage as input', () => {
-    expect(component.currentPage).toEqual(wrapper.currentPageValue());
+    expect(component.currentPage()).toEqual(wrapper.currentPageValue());
   });
 
   it('should be able to take linkMode as input', () => {
-    expect(component.linkMode).toEqual(wrapper.linkModeValue());
+    expect(component.linkMode()).toEqual(wrapper.linkModeValue());
   });
 
   it('should be able to take url as input', () => {
-    expect(component.url).toEqual(wrapper.urlValue());
+    expect(component.url()).toEqual(wrapper.urlValue());
   });
 
   it('should be able to take queryParam as input', () => {
-    expect(component.queryParam).toEqual(wrapper.queryParamValue());
+    expect(component.queryParam()).toEqual(wrapper.queryParamValue());
   });
 
   it('should be able to take numberOfPages as input', () => {
-    expect(component.numberOfPages).toEqual(wrapper.numberOfPagesValue());
+    expect(component.numberOfPages()).toEqual(wrapper.numberOfPagesValue());
   });
 
   it('should show page numbers within one of the current page', () => {
     const paginatorText = fixture.debugElement.query(By.css('daff-paginator')).nativeElement.innerText;
-    const lesserPage = component.currentPage - 1;
-    const greaterPage = component.currentPage + 1;
+    const lesserPage = component.currentPage() - 1;
+    const greaterPage = component.currentPage() + 1;
 
     expect(paginatorText.includes(lesserPage)).toBeTruthy();
     expect(paginatorText.includes(greaterPage)).toBeTruthy();

--- a/libs/design/paginator/src/paginator/paginator.component.ts
+++ b/libs/design/paginator/src/paginator/paginator.component.ts
@@ -1,15 +1,13 @@
-/* eslint-disable quote-props */
 import {
   Component,
-  Input,
-  Output,
-  EventEmitter,
-  OnChanges,
   ChangeDetectionStrategy,
+  input,
+  output,
+  computed,
 } from '@angular/core';
 import {
   Params,
-  RouterModule,
+  RouterLink,
 } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import {
@@ -26,19 +24,19 @@ const visiblePageRange = 2;
 
 @Component({
   selector: 'daff-paginator',
-  styleUrls: ['./paginator.component.scss'],
   templateUrl: './paginator.component.html',
+  styleUrl: './paginator.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    'class': 'daff-paginator',
-    'role': 'navigation',
+    class: 'daff-paginator',
+    role: 'navigation',
   },
   imports: [
     FaIconComponent,
-    RouterModule,
+    RouterLink,
   ],
 })
-export class DaffPaginatorComponent implements OnChanges {
+export class DaffPaginatorComponent {
   /**
    * @docs-private
    */
@@ -54,87 +52,76 @@ export class DaffPaginatorComponent implements OnChanges {
    *
    * For example, if the `numberOfPages` is dynamically changed to a value less than the `currentPage`, the paginator will break.
    */
-  @Input() numberOfPages: number;
+  numberOfPages = input.required<number>();
 
   /**
    * The currently selected page.
    */
-  @Input() currentPage: number;
+  currentPage = input.required<number>();
 
   /**
    * Replace the paginator buttons with links. `url` is required if using this mode.
    */
-  @Input() linkMode = false;
+  linkMode = input(false);
 
   /**
    * The url to which to navigate if the paginator is in link mode.
    * This paginator component will set the page query param.
    */
-  @Input() url?: string;
+  url = input<string>();
 
   /**
    * The query param to which the paginator component will set the current page value in link mode.
    */
-  @Input() queryParam = 'page';
-
-  /**
-   * @docs-private
-   */
-  _numberOfPagesArray: number[];
+  queryParam = input('page');
 
   /**
    * Emits when the current page changes with the new current page.
    */
-  @Output() notifyPageChange: EventEmitter<any> = new EventEmitter();
+  notifyPageChange = output<any>();
+
+  /**
+   * @docs-private
+   */
+  _numberOfPagesArray = computed<number[]>(() => {
+    const numberOfPages = this.numberOfPages();
+
+    if(numberOfPages < 1) {
+      throw new Error(DaffPaginatorNumberOfPagesErrorMessage);
+    } else if(numberOfPages < this.currentPage()) {
+      throw new Error(DaffPaginatorPageOutOfRangeErrorMessage);
+    }
+
+    return numberOfPages < 2 ? [] : Array(numberOfPages-2).fill(numberOfPages-2).map((x,i)=>i+2);
+  });
 
   /**
    * Determines when ellipsis after the first page number should show.
    *
    * @docs-private
    */
-  get _showFirstEllipsis(): boolean {
-    return this.currentPage >= visiblePageRange+2;
-  }
+  _showFirstEllipsis = computed<boolean>(() => this.currentPage() >= visiblePageRange+2);
 
   /**
    * Determines when ellipsis before the final page number should show.
    *
    * @docs-private
    */
-  get _showLastEllipsis(): boolean {
-    return this.currentPage < (this.numberOfPages - visiblePageRange);
-  }
+  _showLastEllipsis = computed<boolean>(() => this.currentPage() < (this.numberOfPages() - visiblePageRange));
 
   /**
    * Determines when the Previous button should be disabled.
    *
    * @docs-private
    */
-  get _disablePrev(): boolean {
-    return this.currentPage === 1;
-  }
+  _disablePrev = computed<boolean>(() => this.currentPage() === 1);
 
   /**
    * Determines when the Next button should be disabled.
    *
    * @docs-private
    */
-  get _disableNext(): boolean {
-    return this.currentPage === this.numberOfPages;
-  }
-
-  /**
-   * @docs-private
-   */
-  ngOnChanges() {
-    if(this.numberOfPages < 1) {
-      throw new Error(DaffPaginatorNumberOfPagesErrorMessage);
-    } else if(this.numberOfPages < this.currentPage) {
-      throw new Error(DaffPaginatorPageOutOfRangeErrorMessage);
-    }
-
-    this._numberOfPagesArray = this.numberOfPages < 2 ? [] : Array(this.numberOfPages-2).fill(this.numberOfPages-2).map((x,i)=>i+2);
-  }
+  _disableNext = computed<boolean>(() => this.currentPage() === this.numberOfPages());
 
   /**
    * Emits the previous page number through notifyPageChange Output.
@@ -142,7 +129,7 @@ export class DaffPaginatorComponent implements OnChanges {
    * @docs-private
    */
   _onNotifyPrevPageChange() {
-    this.notifyPageChange.emit(this.currentPage - 1);
+    this.notifyPageChange.emit(this.currentPage() - 1);
   }
 
   /**
@@ -151,7 +138,7 @@ export class DaffPaginatorComponent implements OnChanges {
    * @docs-private
    */
   _onNotifyNextPageChange() {
-    this.notifyPageChange.emit(this.currentPage + 1);
+    this.notifyPageChange.emit(this.currentPage() + 1);
   }
 
   /**
@@ -169,7 +156,7 @@ export class DaffPaginatorComponent implements OnChanges {
    * @docs-private
    */
   _isSelected(page: number): boolean {
-    return page === this.currentPage;
+    return page === this.currentPage();
   }
 
   /**
@@ -179,9 +166,9 @@ export class DaffPaginatorComponent implements OnChanges {
    * @docs-private
    */
   _showNumber(pageNumber: number): boolean {
-    return Math.abs(this.currentPage - pageNumber) < visiblePageRange
-      || (this.currentPage <= visiblePageRange && pageNumber <= 2*visiblePageRange)
-      || (this.currentPage > this.numberOfPages - visiblePageRange && pageNumber > this.numberOfPages - 2*visiblePageRange);
+    return Math.abs(this.currentPage() - pageNumber) < visiblePageRange
+      || (this.currentPage() <= visiblePageRange && pageNumber <= 2*visiblePageRange)
+      || (this.currentPage() > this.numberOfPages() - visiblePageRange && pageNumber > this.numberOfPages() - 2*visiblePageRange);
   }
 
   /**
@@ -189,7 +176,7 @@ export class DaffPaginatorComponent implements OnChanges {
    */
   _buildPageQueryParams(page: number): Params {
     return {
-      [this.queryParam]: page,
+      [this.queryParam()]: page,
     };
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `@daffodil/design/paginator` now exposes the `DaffPaginatorComponent` inputs `numberOfPages`, `currentPage`, `linkMode`, `url`, and `queryParam` as signals rather than plain properties. Template bindings (`[numberOfPages]="..."`, etc.) continue to work unchanged. Programmatic reads must invoke the signal: `paginator.currentPage` → `paginator.currentPage()`, `paginator.numberOfPages` → `paginator.numberOfPages()`, etc. These inputs are now read-only and can no longer be assigned imperatively.

## Additional context
<!-- Any other relevant information -->