### PR TITLE
feat(design)!: convert `@daffodil/design/progress-bar` to use signals

### DIFF
--- a/libs/design/progress-bar/src/progress-bar-label/progress-bar-label.directive.spec.ts
+++ b/libs/design/progress-bar/src/progress-bar-label/progress-bar-label.directive.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffProgressBarLabelDirective } from './progress-bar-label.directive';
+import { DaffProgressBarLabelDirective } from '@daffodil/design/progress-bar';
 
 @Component({
   template: `<daff-progress-bar-label>Label</daff-progress-bar-label>`,

--- a/libs/design/progress-bar/src/progress-bar.component.html
+++ b/libs/design/progress-bar/src/progress-bar.component.html
@@ -1,4 +1,4 @@
-@if (_label) {
+@if (_label()) {
 	<div class="daff-progress-bar__label"
 		[attr.id]="id">
 		<ng-content select="daff-progress-bar-label"></ng-content>
@@ -8,9 +8,9 @@
 	role="progressbar"
 	aria-valuemin="0"
 	aria-valuemax="100"
-	[attr.aria-valuenow]="ariaValueNow"
-	[attr.aria-labelledby]="ariaLabelledBy">
-	@if (indeterminate) {
+	[attr.aria-valuenow]="ariaValueNow()"
+	[attr.aria-labelledby]="ariaLabelledBy()">
+	@if (indeterminate()) {
 		<div class="daff-progress-bar__fill indeterminate-bar" aria-hidden="true"></div>
 	} @else {
 		<div class="daff-progress-bar__fill determinate-bar"

--- a/libs/design/progress-bar/src/progress-bar.component.ts
+++ b/libs/design/progress-bar/src/progress-bar.component.ts
@@ -1,12 +1,11 @@
 import {
   Component,
-  Input,
   ChangeDetectionStrategy,
-  Output,
-  EventEmitter,
-  ChangeDetectorRef,
   booleanAttribute,
-  ContentChild,
+  input,
+  output,
+  computed,
+  contentChild,
 } from '@angular/core';
 
 import { DaffColorableDirective } from '@daffodil/design';
@@ -30,7 +29,7 @@ let daffProgressBarId = 0;
 @Component({
   selector: 'daff-progress-bar',
   templateUrl: './progress-bar.component.html',
-  styleUrls: ['./progress-bar.component.scss'],
+  styleUrl: './progress-bar.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [
     {
@@ -40,51 +39,40 @@ let daffProgressBarId = 0;
   ],
   host: {
     class: 'daff-progress-bar',
-    '[class.indeterminate]': 'indeterminate',
+    '[class.indeterminate]': 'indeterminate()',
   },
 })
 export class DaffProgressBarComponent {
   constructor(
-    private _changeDetectorRef: ChangeDetectorRef,
     private colorable: DaffColorableDirective,
   ) {
     this.colorable.defaultColor = 'primary';
   }
 
-  private _percentage = 0;
-
   /**
    * @docs-private
    */
-  @ContentChild(DaffProgressBarLabelDirective) _label: DaffProgressBarLabelDirective;
+  _label = contentChild(DaffProgressBarLabelDirective);
 
   /**
    * Sets the percentage completion of the progression,
    * expressed as a whole number between 0 and 100.
    */
-  @Input() get percentage(): number {
-    return this._percentage;
-  };
-  set percentage(val: number) {
-    this._percentage = clamp(val, 0, 100);
-    this._changeDetectorRef.markForCheck();
-  }
+  percentage = input(0, { transform: (val: number) => clamp(val, 0, 100) });
 
   /**
    * @docs-private
    */
-  get ariaValueNow() {
-    return this.indeterminate ? null : this.percentage;
-  }
+  ariaValueNow = computed(() => this.indeterminate() ? null : this.percentage());
 
   /**
    * @docs-private
    */
-  get ariaLabelledBy() {
-    if(!this.ariaLabel && this.id) {
+  ariaLabelledBy = computed(() => {
+    if(!this.ariaLabel() && this.id) {
       return this.id;
     }
-  }
+  });
 
   /**
    * @docs-private
@@ -96,7 +84,7 @@ export class DaffProgressBarComponent {
   /**
    * An `aria-label` for the progress bar.
    */
-  @Input('aria-label') ariaLabel = '';
+  ariaLabel = input('', { alias: 'aria-label' });
 
   /**
    * Property to set the animation of a progress bar to
@@ -104,7 +92,7 @@ export class DaffProgressBarComponent {
    *
    * See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
    **/
-  @Input({ transform: booleanAttribute }) indeterminate = false;
+  indeterminate = input(false, { transform: booleanAttribute });
 
   /**
    * @docs-private
@@ -112,14 +100,14 @@ export class DaffProgressBarComponent {
    * Returns the transform style for the determinate progress bar.
    */
   _determinateBarTransform(): string {
-    return `scaleX(${this.percentage / 100})`;
+    return `scaleX(${this.percentage() / 100})`;
   }
 
   /**
    * An event that emits each time the progression reaches 100%
    * and the animation is finished.
    */
-  @Output() finished: EventEmitter<void> = new EventEmitter();
+  finished = output<void>();
 
   /**
    * @docs-private
@@ -127,7 +115,7 @@ export class DaffProgressBarComponent {
    * Handles the CSS transition end event.
    */
   onTransitionEnd(event: TransitionEvent): void {
-    if (event.propertyName === 'transform' && this.percentage === 100) {
+    if (event.propertyName === 'transform' && this.percentage() === 100) {
       this.finished.emit();
     }
   }

--- a/libs/design/progress-bar/src/specs/defaults.spec.ts
+++ b/libs/design/progress-bar/src/specs/defaults.spec.ts
@@ -10,8 +10,8 @@ import {
 import { By } from '@angular/platform-browser';
 
 import {
+  DAFF_PROGRESS_BAR_COMPONENTS,
   DaffProgressBarComponent,
-  DaffProgressBarLabelDirective,
 } from '@daffodil/design/progress-bar';
 
 @Component({
@@ -21,8 +21,7 @@ import {
 	</daff-progress-bar>
   `,
   imports: [
-    DaffProgressBarComponent,
-    DaffProgressBarLabelDirective,
+    DAFF_PROGRESS_BAR_COMPONENTS,
   ],
 })
 class WrapperComponent {}
@@ -68,7 +67,7 @@ describe('@daffodil/design/progress-bar | DaffProgressBarComponent | Defaults', 
   });
 
   it('should be unfilled by default', () => {
-    expect(component.percentage).toEqual(0);
+    expect(component.percentage()).toEqual(0);
   });
 
   describe('color property', () => {

--- a/libs/design/progress-bar/src/specs/usage.spec.ts
+++ b/libs/design/progress-bar/src/specs/usage.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffPalette } from '@daffodil/design';
+import { DaffColor } from '@daffodil/design';
 import { DaffProgressBarComponent } from '@daffodil/design/progress-bar';
 
 @Component({
@@ -28,7 +28,7 @@ import { DaffProgressBarComponent } from '@daffodil/design/progress-bar';
   ],
 })
 class WrapperComponent {
-  color = signal<DaffPalette>(undefined);
+  color = signal<DaffColor>(undefined);
   percentage = signal<number>(undefined);
   ariaLabel = signal<string>(undefined);
   id: string;
@@ -70,14 +70,14 @@ describe('@daffodil/design/progress-bar | DaffProgressBarComponent | Usage', () 
     wrapper.percentage.set(20);
     fixture.detectChanges();
 
-    expect(component.percentage).toEqual(20);
+    expect(component.percentage()).toEqual(20);
   });
 
   it('should be able to take `aria-label` as an input', () =>{
     wrapper.ariaLabel.set('file upload');
     fixture.detectChanges();
 
-    expect(component.ariaLabel).toEqual('file upload');
+    expect(component.ariaLabel()).toEqual('file upload');
   });
 
   it('should add a class of `indeterminate` to the host when indeterminate is true', () => {


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `@daffodil/design/progress-bar` now exposes the `DaffProgressBarComponent` inputs `percentage`, `aria-label`, and `indeterminate` as signals rather than plain properties. Template bindings (`[percentage]="..."`, `[indeterminate]="..."`, etc.) continue to work unchanged. Programmatic reads must invoke the signal: `progressBar.percentage` → `progressBar.percentage()`, `progressBar.ariaLabel` → `progressBar.ariaLabel()`. These inputs are now read-only and can no longer be assigned imperatively (`progressBar.percentage = 50` is no longer supported).

## Additional context
<!-- Any other relevant information -->