### PR TITLE
feat(design)!: convert `DaffDisableableDirective` to use signals

### DIFF
--- a/libs/design/accordion/src/accordion/accordion-item/accordion-item.component.ts
+++ b/libs/design/accordion/src/accordion/accordion-item/accordion-item.component.ts
@@ -70,7 +70,7 @@ export class DaffAccordionItemComponent implements OnInit, DaffOpenable, DaffDis
    * Internal function to access the disabled property of the DaffDisableableDirective
    */
   get disabled() {
-    return this.disabledDirective.disabled;
+    return this.disabledDirective.disabled();
   }
 
   constructor(

--- a/libs/design/button/src/button/button-base.directive.ts
+++ b/libs/design/button/src/button/button-base.directive.ts
@@ -80,7 +80,7 @@ export class DaffButtonBaseDirective implements DaffDisableable {
    * The disabled state of the button.
    */
   get disabled() {
-    return this.disabledDirective.disabled;
+    return this.disabledDirective.disabled();
   }
 
   /**

--- a/libs/design/src/core/disableable/disableable.directive.spec.ts
+++ b/libs/design/src/core/disableable/disableable.directive.spec.ts
@@ -55,7 +55,7 @@ describe('@daffodil/design | DaffDisableableDirective', () => {
   });
 
   it('should take disabled as an input', () => {
-    expect(directive.disabled).toEqual(wrapper.disabled());
+    expect(directive.disabled()).toEqual(wrapper.disabled());
   });
 
   it('should add a class of "daff-disabled" to the host element when disabled is true', () => {

--- a/libs/design/src/core/disableable/disableable.directive.ts
+++ b/libs/design/src/core/disableable/disableable.directive.ts
@@ -1,6 +1,6 @@
 import {
   Directive,
-  Input,
+  model,
 } from '@angular/core';
 
 /**
@@ -9,12 +9,12 @@ import {
 @Directive({
   selector: '[daffDisableable]',
   host: {
-    '[class.daff-disabled]': 'disabled',
+    '[class.daff-disabled]': 'disabled()',
   },
 })
 export class DaffDisableableDirective {
   /**
    * Whether the component is disabled.
    */
-  @Input() disabled = false;
+  disabled = model(false);
 }

--- a/libs/design/switch/src/switch/switch.component.ts
+++ b/libs/design/switch/src/switch/switch.component.ts
@@ -69,10 +69,10 @@ export class DaffSwitchComponent extends DaffSizableDirective<DaffSwitchSize> im
    * Whether the switch is disabled.
    */
   @Input() get disabled() {
-    return this.disabledDirective.disabled;
+    return this.disabledDirective.disabled();
   }
   set disabled(value: any) {
-    this.disabledDirective.disabled = coerceBooleanProperty(value);
+    this.disabledDirective.disabled.set(coerceBooleanProperty(value));
   }
 
   /**

--- a/libs/design/tabs/src/tabs/tab/tab.component.ts
+++ b/libs/design/tabs/src/tabs/tab/tab.component.ts
@@ -57,7 +57,7 @@ export class DaffTabComponent implements DaffDisableable {
    * Whether the tab is disabled.
    */
   get disabled() {
-    return this.disabledDirective.disabled;
+    return this.disabledDirective.disabled();
   }
 
   /**

--- a/libs/design/tag/src/tag/tag.component.ts
+++ b/libs/design/tag/src/tag/tag.component.ts
@@ -86,7 +86,7 @@ export class DaffTagComponent implements DaffDisableable {
    * Internal function to access the disabled property of the DaffDisableableDirective.
    */
   get disabled() {
-    return this.disabledDirective.disabled;
+    return this.disabledDirective.disabled();
   }
 
   /**


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `DaffDisableableDirective` now exposes `disabled` as a signal (`model`) rather than a plain property. Template bindings (`[disabled]="..."`) continue to work unchanged. Programmatic reads must invoke the signal: `directive.disabled` → `directive.disabled()`. Imperative writes must use `set`: `directive.disabled = true` → `directive.disabled.set(true)`.

## Additional context
<!-- Any other relevant information -->