### PR TITLE
feat(design)!: convert `@daffodil/design/tag` to use signals

### DIFF
--- a/libs/design/tag/src/tag/specs/defaults.spec.ts
+++ b/libs/design/tag/src/tag/specs/defaults.spec.ts
@@ -51,7 +51,7 @@ describe('@daffodil/design/tag | DaffTagComponent | Defaults', () => {
   });
 
   it('should set dismissible to false by default', () => {
-    expect(component.dismissible).toBeFalse();
+    expect(component.dismissible()).toBeFalse();
   });
 
   it('should set disabled to false by default', () => {

--- a/libs/design/tag/src/tag/specs/usage.spec.ts
+++ b/libs/design/tag/src/tag/specs/usage.spec.ts
@@ -72,7 +72,7 @@ describe('@daffodil/design/tag | DaffTagComponent | Usage', () => {
 
   describe('dismissible property', () => {
     it('should take dismissible as an input', () => {
-      expect(component.dismissible).toEqual(wrapper.dismissible());
+      expect(component.dismissible()).toEqual(wrapper.dismissible());
     });
 
     it('should not show close button when dismissible is false', () => {

--- a/libs/design/tag/src/tag/tag.component.html
+++ b/libs/design/tag/src/tag/tag.component.html
@@ -1,10 +1,10 @@
-@if (_prefix) {
+@if (_prefix()) {
   <ng-content select="[daffPrefix]"></ng-content>
 }
 <div class="daff-tag__label">
   <ng-content></ng-content>
 </div>
-@if (dismissible) {
+@if (dismissible()) {
   <button class="daff-tag__close-icon" (click)="onCloseTag($event)" aria-label="Dismiss" [attr.tabindex]="disabled ? -1 : null">
     <fa-icon [icon]="faTimes" [fixedWidth]="true"></fa-icon>
   </button>

--- a/libs/design/tag/src/tag/tag.component.ts
+++ b/libs/design/tag/src/tag/tag.component.ts
@@ -2,10 +2,10 @@ import {
   booleanAttribute,
   ChangeDetectionStrategy,
   Component,
-  ContentChild,
-  EventEmitter,
+  contentChild,
   Input,
-  Output,
+  input,
+  output,
   ViewEncapsulation,
 } from '@angular/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -51,6 +51,7 @@ import { DaffTagSizableDirective } from './tag-sizable.directive';
     },
     {
       directive: DaffStatusableDirective,
+      inputs: ['status'],
     },
     {
       directive: DaffDisableableDirective,
@@ -62,7 +63,7 @@ import { DaffTagSizableDirective } from './tag-sizable.directive';
   host: {
     class: 'daff-tag',
     '[attr.aria-disabled]': 'disabled ? true : null',
-    '[class.dismissible]': 'dismissible',
+    '[class.dismissible]': 'dismissible()',
   },
   imports: [
     FaIconComponent,
@@ -78,7 +79,7 @@ export class DaffTagComponent implements DaffDisableable {
   /**
    * @docs-private
    */
-  @ContentChild(DaffPrefixDirective, { static: true }) _prefix: DaffPrefixDirective;
+  _prefix = contentChild(DaffPrefixDirective);
 
   /**
    * @docs-private
@@ -106,12 +107,12 @@ export class DaffTagComponent implements DaffDisableable {
    * Whether the tag can be dismissed by the user.
    * Displays a close icon if `true`.
    */
-  @Input({ transform: booleanAttribute }) dismissible = false;
+  dismissible = input(false, { transform: booleanAttribute });
 
   /**
    * Emits when the tag is closed.
    */
-  @Output() closeTag: EventEmitter<void> = new EventEmitter();
+  closeTag = output<void>();
 
   /**
    * @docs-private


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `@daffodil/design/tag` now exposes the `DaffTagComponent` `dismissible` input as a signal rather than a plain property. Template bindings (`[dismissible]="..."`) continue to work unchanged. Programmatic reads must invoke the signal: `tag.dismissible` → `tag.dismissible()`. `dismissible` is now read-only and can no longer be assigned imperatively (`tag.dismissible = true` is no longer supported).

## Additional context
<!-- Any other relevant information -->