### PR TITLE
feat(design)!: convert `@daffodil/design/switch` to use signals

### DIFF
--- a/libs/design/switch/src/switch/specs/usage.spec.ts
+++ b/libs/design/switch/src/switch/specs/usage.spec.ts
@@ -62,7 +62,7 @@ describe('@daffodil/design/switch | DaffSwitchComponent | Usage', () => {
 
   describe('checked property', () => {
     it('should take `checked` as an input', () => {
-      expect(component.checked).toEqual(wrapper.checked());
+      expect(component.checked()).toEqual(wrapper.checked());
     });
 
     it('should add a class of "checked" to the host element when checked is true', () => {
@@ -88,7 +88,7 @@ describe('@daffodil/design/switch | DaffSwitchComponent | Usage', () => {
 
   describe('labelPosition property', () => {
     it('should take `labelPosition` as an input', () => {
-      expect(component.labelPosition).toEqual(wrapper.labelPosition());
+      expect(component.labelPosition()).toEqual(wrapper.labelPosition());
     });
 
     it('should add a class of "left" to the host element when labelPosition="left"', () => {

--- a/libs/design/switch/src/switch/switch.component.html
+++ b/libs/design/switch/src/switch/switch.component.html
@@ -1,4 +1,4 @@
-<label class="daff-switch__label" [id]="labelId" [for]="id">
+<label class="daff-switch__label" [id]="labelId" [for]="id()">
   <ng-content></ng-content>
 </label>
 
@@ -7,7 +7,7 @@
   role="switch"
   (click)="onToggle()"
   [attr.disabled]="disabled ? '' : null"
-  [attr.aria-checked]="checked ? true : false"
+  [attr.aria-checked]="checked() ? true : false"
   [attr.aria-labelledby]="labelId"
-  [attr.id]="id">
+  [attr.id]="id()">
 </button>

--- a/libs/design/switch/src/switch/switch.component.spec.ts
+++ b/libs/design/switch/src/switch/switch.component.spec.ts
@@ -13,7 +13,6 @@ import {
   DaffSwitchComponent,
 } from '@daffodil/design/switch';
 
-
 @Component({
   template: `
     <daff-switch>Wifi</daff-switch>
@@ -64,10 +63,10 @@ describe('@daffodil/design/switch | DaffSwitchComponent | Defaults', () => {
   });
 
   it('should have a generated id for the switch control', () => {
-    expect(component.id).toMatch('daff-switch-[0-9]*');
+    expect(component.id()).toMatch('daff-switch-[0-9]*');
   });
 
   it('should set `left` as the default labelPosition', () => {
-    expect(component.labelPosition).toEqual('left');
+    expect(component.labelPosition()).toEqual('left');
   });
 });

--- a/libs/design/switch/src/switch/switch.component.ts
+++ b/libs/design/switch/src/switch/switch.component.ts
@@ -1,11 +1,11 @@
-/* eslint-disable quote-props */
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
   Component,
-  EventEmitter,
   Input,
-  Output,
+  input,
+  model,
+  output,
 } from '@angular/core';
 
 import {
@@ -33,9 +33,8 @@ export type DaffSwitchSize = DaffSizeSmallType;
  */
 @Component({
   selector: 'daff-switch',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './switch.component.html',
-  styleUrls: ['./switch.component.scss'],
+  styleUrl: './switch.component.scss',
   hostDirectives: [
     {
       directive: DaffSizableDirective,
@@ -47,19 +46,20 @@ export type DaffSwitchSize = DaffSizeSmallType;
     },
   ],
   host: {
-    'class': 'daff-switch',
-    '[class.checked]': 'checked',
-    '[class.left]': 'labelPosition === "left"',
-    '[class.right]': 'labelPosition === "right"',
-    '[class.top]': 'labelPosition === "top"',
-    '[class.bottom]': 'labelPosition === "bottom"',
+    class: 'daff-switch',
+    '[class.checked]': 'checked()',
+    '[class.left]': 'labelPosition() === "left"',
+    '[class.right]': 'labelPosition() === "right"',
+    '[class.top]': 'labelPosition() === "top"',
+    '[class.bottom]': 'labelPosition() === "bottom"',
   },
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DaffSwitchComponent extends DaffSizableDirective<DaffSwitchSize> implements DaffDisableable {
   /**
    * The position of the label relative to the switch.
    */
-  @Input() labelPosition: DaffSwitchLabelPosition = DaffSwitchLabelPositionEnum.LEFT;
+  labelPosition = input<DaffSwitchLabelPosition>(DaffSwitchLabelPositionEnum.LEFT);
 
   constructor(private disabledDirective: DaffDisableableDirective) {
     super();
@@ -78,7 +78,7 @@ export class DaffSwitchComponent extends DaffSizableDirective<DaffSwitchSize> im
   /**
    * Current state of switch (on/off).
    */
-  @Input() checked = false;
+  checked = model(false);
 
   /**
    * @docs-private
@@ -91,20 +91,20 @@ export class DaffSwitchComponent extends DaffSizableDirective<DaffSwitchSize> im
    *
    * It gets assigned to the `for` attribute on the `<label>` inside of the switch.
    */
-  @Input() id = 'daff-switch-' + switchIncrementalId++;
+  id = input('daff-switch-' + switchIncrementalId++);
 
   /**
    * Output event triggered when the switch has been toggled.
    */
-  @Output() toggled = new EventEmitter<boolean>();
+  toggled = output<boolean>();
 
   /**
    * @docs-private
    */
   onToggle() {
     if (!this.disabled) {
-      this.checked = !this.checked;
-      this.toggled.emit(this.checked);
+      this.checked.set(!this.checked());
+      this.toggled.emit(this.checked());
     }
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `@daffodil/design/switch` now exposes the `DaffSwitchComponent` inputs as signals rather than plain properties. Template bindings (`[checked]="..."`, `[labelPosition]="..."`, `[id]="..."`, `[disabled]="..."`) continue to work unchanged.

## Additional context
<!-- Any other relevant information -->