### PR TITLE
feat(design)!: convert `@daffodil/design/text-snippet` to use signals

### DIFF
--- a/libs/design/text-snippet/src/text-snippet.component.html
+++ b/libs/design/text-snippet/src/text-snippet.component.html
@@ -1,7 +1,7 @@
-@if (html) {
-  <div class="daff-text-snippet__content daff-text-snippet__html" #htmlEl [class.condensed]="condensed" [innerHtml]="html"></div>
+@if (html()) {
+  <div class="daff-text-snippet__content daff-text-snippet__html" #htmlEl [class.condensed]="condensed()" [innerHtml]="html()"></div>
 } @else {
-  <div class="daff-text-snippet__content daff-text-snippet__ngcontent" #contentEl [class.condensed]="condensed">
+  <div class="daff-text-snippet__content daff-text-snippet__ngcontent" #contentEl [class.condensed]="condensed()">
     <ng-content></ng-content>
   </div>
 }
@@ -9,7 +9,7 @@
   class="daff-text-snippet__toggle"
   [attr.aria-expanded]="ariaExpanded()"
   (click)="toggleSnippet()">
-    @if (condensed) {
+    @if (condensed()) {
       Show more
     } @else {
       Show less

--- a/libs/design/text-snippet/src/text-snippet.component.spec.ts
+++ b/libs/design/text-snippet/src/text-snippet.component.spec.ts
@@ -9,14 +9,11 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DAFF_UNDERLINE_BUTTON_COMPONENTS } from '@daffodil/design/button';
-
-import { DaffTextSnippetComponent } from './text-snippet.component';
+import { DaffTextSnippetComponent } from '@daffodil/design/text-snippet';
 
 @Component({
   template: '<daff-text-snippet [condensed]="condensed" [html]="html">content</daff-text-snippet>',
   imports: [
-    DAFF_UNDERLINE_BUTTON_COMPONENTS,
     DaffTextSnippetComponent,
   ],
 })
@@ -30,7 +27,7 @@ describe('@daffodil/design/text-snippet | DaffTextSnippetComponent', () => {
   let fixture: ComponentFixture<WrapperComponent>;
   let wrapper: WrapperComponent;
   let component: DaffTextSnippetComponent;
-  let componentDe: DebugElement;
+  let de: DebugElement;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -44,12 +41,18 @@ describe('@daffodil/design/text-snippet | DaffTextSnippetComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(WrapperComponent);
     wrapper = fixture.componentInstance;
-    componentDe = fixture.debugElement.query(By.css('daff-text-snippet'));
-    component = componentDe.componentInstance;
+    de = fixture.debugElement.query(By.css('daff-text-snippet'));
+    component = de.componentInstance;
   });
 
   it('should create', () => {
     expect(fixture).toBeTruthy();
+  });
+
+  it('should add a class of "daff-text-snippet" to the host element', () => {
+    expect(de.classes).toEqual(jasmine.objectContaining({
+      'daff-text-snippet': true,
+    }));
   });
 
   it('should pass through any html as `innerHtml` on the `html` div inside the component', () => {
@@ -91,7 +94,7 @@ describe('@daffodil/design/text-snippet | DaffTextSnippetComponent', () => {
 
   describe('condensed property', () => {
     it('should set condensed to true by default', () => {
-      expect(component.condensed).toEqual(true);
+      expect(component.condensed()).toEqual(true);
     });
   });
 
@@ -99,7 +102,7 @@ describe('@daffodil/design/text-snippet | DaffTextSnippetComponent', () => {
     wrapper.condensed = true;
     fixture.detectChanges();
 
-    expect(componentDe.query(By.css('.daff-text-snippet__content')).classes.condensed).toBeTruthy();
+    expect(de.query(By.css('.daff-text-snippet__content')).classes.condensed).toBeTruthy();
   });
 
   it('should set aria-expanded to true when text snippet is not condensed', () => {

--- a/libs/design/text-snippet/src/text-snippet.component.ts
+++ b/libs/design/text-snippet/src/text-snippet.component.ts
@@ -1,62 +1,60 @@
 import {
   Component,
-  Input,
   ChangeDetectionStrategy,
-  EventEmitter,
-  Output,
   ElementRef,
-  ViewChild,
+  input,
+  model,
+  output,
+  viewChild,
 } from '@angular/core';
 
 @Component({
   selector: 'daff-text-snippet',
   templateUrl: './text-snippet.component.html',
-  styleUrls: ['./text-snippet.component.scss'],
+  styleUrl: './text-snippet.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'daff-text-snippet',
   },
 })
 export class DaffTextSnippetComponent {
-
   /**
    * Whether or not the component should render a condensed version of the content.
    */
-  @Input() condensed = true;
+  condensed = model(true);
 
   /**
    * The HTML content to render inside the snippet.
    */
-  @Input() html = '';
+  html = input('');
 
   /**
    * @docs-private
    */
   ariaExpanded() {
-    return !this.condensed ? true : false;
+    return !this.condensed() ? true : false;
   }
 
   /**
    * @docs-private
    */
-  @ViewChild('contentEl', { read: ElementRef }) contentRef: ElementRef;
+  contentRef = viewChild('contentEl', { read: ElementRef });
 
   /**
    * @docs-private
    */
-  @ViewChild('htmlEl', { read: ElementRef }) htmlRef: ElementRef;
+  htmlRef = viewChild('htmlEl', { read: ElementRef });
 
   /**
    * An output event that can be used to track the state of the component externally.
    */
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() toggle: EventEmitter<boolean> = new EventEmitter();
+  toggled = output<boolean>();
 
   /**
    * @docs-private
    */
   toggleSnippet() {
-    this.condensed = !this.condensed;
-    this.toggle.emit(this.condensed);
+    this.condensed.set(!this.condensed());
+    this.toggled.emit(this.condensed());
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `@daffodil/design/text-snippet` now exposes the `DaffTextSnippetComponent` inputs as signals rather than plain properties, and renames the `toggle` output to `toggled`. Template bindings (`[condensed]="..."`, `[html]="..."`) continue to work unchanged.

## Additional context
<!-- Any other relevant information -->