### PR TITLE
feat(design)!: convert `@daffodil/design/toast` to use signals

### DIFF
--- a/libs/design/toast/src/service/toast.service.spec.ts
+++ b/libs/design/toast/src/service/toast.service.spec.ts
@@ -12,10 +12,12 @@ import {
   DaffFocusStackService,
   DAFF_PREFIX_SUFFIX_DIRECTIVES,
 } from '@daffodil/design';
+import {
+  DaffToastService,
+  DaffToast,
+} from '@daffodil/design/toast';
 
 import { DaffToastPositionService } from './position.service';
-import { DaffToastService } from './toast.service';
-import { DaffToast } from '../interfaces/toast';
 import { DaffToastTemplateComponent } from '../toast/toast-template.component';
 import { DaffToastComponent } from '../toast/toast.component';
 import { DaffToastActionsDirective } from '../toast-actions/toast-actions.directive';

--- a/libs/design/toast/src/toast-actions/toast-actions.directive.spec.ts
+++ b/libs/design/toast/src/toast-actions/toast-actions.directive.spec.ts
@@ -21,7 +21,7 @@ import { DaffToastActionsDirective } from './toast-actions.directive';
 })
 class WrapperComponent {}
 
-describe('DaffToastActionsDirective', () => {
+describe('@daffodil/design/toast | DaffToastActionsDirective', () => {
   let wrapper: WrapperComponent;
   let de: DebugElement;
   let fixture: ComponentFixture<WrapperComponent>;
@@ -46,9 +46,9 @@ describe('DaffToastActionsDirective', () => {
     expect(wrapper).toBeTruthy();
   });
 
-  describe('[daffToastActions]', () => {
-    it('should add a class of `daff-toast__actions` to its host element', () => {
-      expect(de.nativeElement.classList.contains('daff-toast__actions')).toEqual(true);
-    });
+  it('should add a class of `daff-toast__actions` to its host element', () => {
+    expect(de.classes).toEqual(jasmine.objectContaining({
+      'daff-toast__actions': true,
+    }));
   });
 });

--- a/libs/design/toast/src/toast-actions/toast-actions.directive.ts
+++ b/libs/design/toast/src/toast-actions/toast-actions.directive.ts
@@ -1,10 +1,9 @@
-/* eslint-disable quote-props */
 import { Directive } from '@angular/core';
 
 @Directive({
   selector: '[daffToastActions]',
   host: {
-    'class': 'daff-toast__actions',
+    class: 'daff-toast__actions',
   },
 })
 

--- a/libs/design/toast/src/toast-message/toast-message.directive.spec.ts
+++ b/libs/design/toast/src/toast-message/toast-message.directive.spec.ts
@@ -21,7 +21,7 @@ import { DaffToastMessageDirective } from './toast-message.directive';
 })
 class WrapperComponent {}
 
-describe('DaffToastMessageDirective', () => {
+describe('@daffodil/design/toast | DaffToastMessageDirective', () => {
   let wrapper: WrapperComponent;
   let de: DebugElement;
   let fixture: ComponentFixture<WrapperComponent>;
@@ -46,9 +46,9 @@ describe('DaffToastMessageDirective', () => {
     expect(wrapper).toBeTruthy();
   });
 
-  describe('[daffToastMessage]', () => {
-    it('should add a class of `daff-toast__message` to its host element', () => {
-      expect(de.nativeElement.classList.contains('daff-toast__message')).toEqual(true);
-    });
+  it('should add a class of `daff-toast__message` to its host element', () => {
+    expect(de.classes).toEqual(jasmine.objectContaining({
+      'daff-toast__message': true,
+    }));
   });
 });

--- a/libs/design/toast/src/toast/toast.component.html
+++ b/libs/design/toast/src/toast/toast.component.html
@@ -1,4 +1,4 @@
-@if (_prefix) {
+@if (_prefix()) {
   <ng-content select="[daffPrefix]"></ng-content>
 }
 <div class="daff-toast__details">

--- a/libs/design/toast/src/toast/toast.component.spec.ts
+++ b/libs/design/toast/src/toast/toast.component.spec.ts
@@ -12,9 +12,9 @@ import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
 
 import { DaffStatus } from '@daffodil/design';
+import { DaffToast } from '@daffodil/design/toast';
 
 import { DaffToastComponent } from './toast.component';
-import { DaffToast } from '../interfaces/toast';
 
 @Component ({
   template: `
@@ -33,7 +33,7 @@ class WrapperComponent {
   toast = signal<DaffToast>(undefined);
 }
 
-describe('DaffToastComponent', () => {
+describe('@daffodil/design/toast | DaffToastComponent', () => {
   let fixture: ComponentFixture<WrapperComponent>;
   let de: DebugElement;
   let wrapper: WrapperComponent;
@@ -65,12 +65,10 @@ describe('DaffToastComponent', () => {
     expect(wrapper).toBeTruthy();
   });
 
-  describe('<daff-toast>', () => {
-    it('should add a class of "daff-toast" to the host element', () => {
-      expect(de.classes).toEqual(jasmine.objectContaining({
-        'daff-toast': true,
-      }));
-    });
+  it('should add a class of "daff-toast" to the host element', () => {
+    expect(de.classes).toEqual(jasmine.objectContaining({
+      'daff-toast': true,
+    }));
   });
 
   it('should take status as an input', () => {

--- a/libs/design/toast/src/toast/toast.component.ts
+++ b/libs/design/toast/src/toast/toast.component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable quote-props */
 import {
   ConfigurableFocusTrap,
   ConfigurableFocusTrapFactory,
@@ -6,13 +5,13 @@ import {
 import {
   Component,
   ElementRef,
-  ContentChild,
   ViewEncapsulation,
   ChangeDetectionStrategy,
   AfterViewInit,
   AfterContentInit,
-  Input,
   OnDestroy,
+  contentChild,
+  input,
 } from '@angular/core';
 
 import {
@@ -35,7 +34,7 @@ import { DaffToastActionsDirective } from '../toast-actions/toast-actions.direct
 @Component({
   selector: 'daff-toast',
   templateUrl: './toast.component.html',
-  styleUrls: ['./toast.component.scss'],
+  styleUrl: './toast.component.scss',
   hostDirectives: [
     { directive: DaffArticleEncapsulatedDirective },
     {
@@ -44,7 +43,7 @@ import { DaffToastActionsDirective } from '../toast-actions/toast-actions.direct
     },
   ],
   host: {
-    'class': 'daff-toast',
+    class: 'daff-toast',
     '(keydown.escape)': 'onEscape()',
   },
   encapsulation: ViewEncapsulation.None,
@@ -54,20 +53,20 @@ export class DaffToastComponent implements AfterContentInit, AfterViewInit, OnDe
   /**
    * @docs-private
    */
-  @ContentChild(DaffToastActionsDirective) _actions: DaffToastActionsDirective;
+  _actions = contentChild(DaffToastActionsDirective);
 
   /**
    * @docs-private
    */
-  @ContentChild(DaffPrefixDirective) _prefix: DaffPrefixDirective;
+  _prefix = contentChild(DaffPrefixDirective);
 
-  @Input() toast: DaffToast;
+  toast = input.required<DaffToast>();
 
   /**
    * @docs-private
    */
   onEscape() {
-    this.toast.dismiss();
+    this.toast().dismiss();
   }
 
   private _focusTrap: ConfigurableFocusTrap;
@@ -83,7 +82,7 @@ export class DaffToastComponent implements AfterContentInit, AfterViewInit, OnDe
    * @docs-private
    */
   ngAfterContentInit() {
-    if(daffToastChangesFocus(this.toast)) {
+    if(daffToastChangesFocus(this.toast())) {
       this._focusTrap = this._focusTrapFactory.create(
         this._elementRef.nativeElement,
       );
@@ -94,7 +93,7 @@ export class DaffToastComponent implements AfterContentInit, AfterViewInit, OnDe
    * @docs-private
    */
   ngAfterViewInit() {
-    if(daffToastChangesFocus(this.toast)) {
+    if(daffToastChangesFocus(this.toast())) {
       this._focusStack.push();
       this._focusTrap.focusFirstTabbableElementWhenReady();
     }
@@ -104,7 +103,7 @@ export class DaffToastComponent implements AfterContentInit, AfterViewInit, OnDe
    * @docs-private
    */
   ngOnDestroy() {
-    if(daffToastChangesFocus(this.toast)) {
+    if(daffToastChangesFocus(this.toast())) {
       this._focusTrap.destroy();
     }
   }


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4327

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `DaffToastComponent.toast` is now a required signal input. Read its value by calling it as a function (`toast()`) instead of accessing the property directly, and provide it via `[toast]` binding as it is now required.

## Additional context
<!-- Any other relevant information -->