### PR TITLE
feat(design)!: convert `@daffodil/design/menu` to use signals

### DIFF
--- a/libs/design/menu/src/menu-activator/menu-activator.component.ts
+++ b/libs/design/menu/src/menu-activator/menu-activator.component.ts
@@ -3,7 +3,6 @@ import {
   computed,
   Directive,
   input,
-  Input,
   OnDestroy,
   signal,
   TemplateRef,
@@ -55,7 +54,7 @@ export class DaffMenuActivatorDirective implements OnDestroy {
   /**
    * The menu content to display when activated.
    */
-  @Input() daffMenuActivator: Type<unknown> | TemplateRef<unknown>;
+  daffMenuActivator = input<Type<unknown> | TemplateRef<unknown>>();
 
   /**
    * An optional ID for the activator.
@@ -122,6 +121,6 @@ export class DaffMenuActivatorDirective implements OnDestroy {
    */
   onClick(event: MouseEvent) {
     event.preventDefault();
-    this.service.open(this.viewContainerRef, this.daffMenuActivator, { menuId: this.menuId(), xPosition: this.xPosition(), yPosition: this.yPosition() });
+    this.service.open(this.viewContainerRef, this.daffMenuActivator(), { menuId: this.menuId(), xPosition: this.xPosition(), yPosition: this.yPosition() });
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: #4327

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `@daffodil/design/menu` now exposes the `DaffMenuActivatorDirective` `daffMenuActivator` input as a signal rather than a plain property. Template bindings (`[daffMenuActivator]="..."`) continue to work unchanged. Programmatic reads must invoke the signal: `activator.daffMenuActivator` → `activator.daffMenuActivator()`. `daffMenuActivator` is now read-only and can no longer be assigned imperatively (`activator.daffMenuActivator = menu` is no longer supported).
## Additional context
<!-- Any other relevant information -->