### PR TITLE
fix(design): let the card body fill the card

### DIFF
--- a/libs/design/card/src/card-base.scss
+++ b/libs/design/card/src/card-base.scss
@@ -1,8 +1,7 @@
 @use '../../scss/typography' as t;
 @use '../../scss/layout';
 
-$card-border-radius: 8px;
-$card-inner-border-radius: calc(#{$card-border-radius} - 1px);
+$card-border-radius: 0.5rem;
 
 @mixin daff-card-base {
 	display: flex;
@@ -19,6 +18,8 @@ $card-inner-border-radius: calc(#{$card-border-radius} - 1px);
 	.daff-card__wrapper {
 		position: relative;
 		height: 100%;
+		flex: 1 1 auto;
+		min-width: 0;
 
 		&::after {
 			content: '';
@@ -38,7 +39,10 @@ $card-inner-border-radius: calc(#{$card-border-radius} - 1px);
 		flex-direction: column;
 
 		.daff-card__image {
-			border-radius: $card-inner-border-radius $card-inner-border-radius 0 0;
+			border-top-left-radius: inherit;
+			border-top-right-radius: inherit;
+			border-bottom-right-radius: 0;
+			border-bottom-left-radius: 0;
 		}
 	}
 
@@ -51,7 +55,10 @@ $card-inner-border-radius: calc(#{$card-border-radius} - 1px);
 		}
 
 		.daff-card__image {
-			border-radius: $card-inner-border-radius 0 0 $card-inner-border-radius;
+			border-top-left-radius: inherit;
+			border-top-right-radius: 0;
+			border-bottom-right-radius: 0;
+			border-bottom-left-radius: inherit;
 		}
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
`.daff-card__wrapper` had no `flex-grow`, so it sized to its content and left the remainder of the flex line empty. Any card whose image has a definite width, or that has no image at all, got a body narrower than the card — text wrapped early, and on linked cards the hover overlay stopped short of the edge. `min-width: 0` lets the body shrink past its min-content width so a long word pushes the text instead of the image column.

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->