### PR TITLE
fix(design)!: scope callout body paragraph margins to direct children

### DIFF
--- a/libs/design/callout/src/callout/callout.component.scss
+++ b/libs/design/callout/src/callout/callout.component.scss
@@ -52,7 +52,7 @@
 			margin-top: 48px;
 		}
 
-		p {
+		> p {
 			&:first-of-type {
 				margin-top: 0;
 			}


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4616

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `DaffCalloutComponent` no longer resets the margins of paragraphs nested inside child components within `[daffCalloutBody]`. Previously the first and last `<p>` under the body received `margin-top: 0` and `margin-bottom: 0` at any depth. The reset now applies only to paragraphs that are direct children of `[daffCalloutBody]`. If you relied on the old behavior to flatten spacing in nested content, apply those margins in your own styles.

## Additional context
<!-- Any other relevant information -->