### PR TITLE
fix(navigation): ensure fragment fields on leaf nodes in magento

### DIFF
--- a/libs/navigation/driver/magento/src/queries/fragments/category-node/category-node.spec.ts
+++ b/libs/navigation/driver/magento/src/queries/fragments/category-node/category-node.spec.ts
@@ -17,6 +17,13 @@ import { CategoryNode } from '@daffodil/navigation/driver/magento';
 
 import { getCategoryNodeFragment } from './category-node';
 
+type CategoryNodeWithExtraField = CategoryNode & {
+  extra_field: string;
+  children?: Array<CategoryNode & {
+    extra_field: string;
+  }>;
+};
+
 const generateMagentoCategoryTree = (id: CategoryNode['uid']): CategoryNode => ({
   __typename: 'CategoryTree',
   uid: id,
@@ -193,6 +200,75 @@ describe('Navigation | Driver | Magento | getCategoryNodeFragment', () => {
       const op = controller.expectOne('TestQuery');
 
       op.flushData({ categoryList: depth3NavigationTree });
+    });
+  });
+
+  describe('when extra fragments are provided', () => {
+    const extraFragment = gql`
+      fragment extraFragment on CategoryTree {
+        extra_field
+      }
+    `;
+
+    let query: DocumentNode;
+    let response: Observable<Apollo.QueryResult<{categoryList: CategoryNodeWithExtraField}>>;
+    let extraFieldNavigationTree: CategoryNodeWithExtraField;
+
+    beforeEach(() => {
+      const fragment = getCategoryNodeFragment(1, [extraFragment]);
+
+      query = gql`
+        query TestQuery {
+          categoryList {
+            ...recursiveCategoryNode
+          }
+        }
+        ${fragment}
+      `;
+
+      extraFieldNavigationTree = {
+        ...generateMagentoCategoryTree('2'),
+        extra_field: 'root value',
+        children_count: 1,
+        children: [{
+          ...childlessNavigationTree,
+          extra_field: 'child value',
+        }],
+      };
+
+      response = apollo.query({ query });
+    });
+
+    it('should spread the extra fragments into every level of the tree, including the deepest', () => {
+      const depth = 3;
+      const fragment = getCategoryNodeFragment(depth, [extraFragment]);
+
+      let selectionSet = (<any>fragment.definitions[0]).selectionSet;
+      let levels = 0;
+
+      while (selectionSet) {
+        expect(selectionSet.selections.some(selection =>
+          selection.kind === 'FragmentSpread' && selection.name.value === 'extraFragment',
+        )).toBeTrue();
+        levels++;
+        selectionSet = selectionSet.selections.find(selection =>
+          selection.kind === 'Field' && selection.name.value === 'children',
+        )?.selectionSet;
+      }
+
+      expect(levels).toEqual(depth + 1);
+    });
+
+    it('should query extra fragment fields on the deepest nodes of the tree', done => {
+      response.subscribe(resp => {
+        expect(resp.data.categoryList.extra_field).toEqual('root value');
+        expect(resp.data.categoryList.children[0].extra_field).toEqual('child value');
+        done();
+      });
+
+      const op = controller.expectOne('TestQuery');
+
+      op.flushData({ categoryList: extraFieldNavigationTree });
     });
   });
 

--- a/libs/navigation/driver/magento/src/queries/fragments/category-node/category-node.ts
+++ b/libs/navigation/driver/magento/src/queries/fragments/category-node/category-node.ts
@@ -33,14 +33,18 @@ const categoryNodeFragment = `
  */
 //todo: use nested fragments when this bug is fixed: https://github.com/magento/magento2/issues/31086
 export function getCategoryNodeFragment(depth: number = 3, extraFragments: Array<DocumentNode> = []): DocumentNode {
+  const extraFragmentSpread = daffBuildFragmentNameSpread(...extraFragments);
   const fragmentBody = new Array(depth).fill(null).reduce(acc => `
     ${categoryNodeFragment}
     children_count
     children {
       ${acc}
     }
-    ${daffBuildFragmentNameSpread(...extraFragments)}
-  `, categoryNodeFragment);
+    ${extraFragmentSpread}
+  `, `
+    ${categoryNodeFragment}
+    ${extraFragmentSpread}
+  `);
 
   return gql`
     fragment recursiveCategoryNode on CategoryTree {


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type

- [x] Bug fix

## Current behavior

`getCategoryNodeFragment` builds the recursive `CategoryTree` selection with a reduce, spreading extra fragments (registered via `DAFF_NAVIGATION_MAGENTO_DRIVER_EXTRA_FRAGMENTS`) into each wrapper iteration but not into the reduce seed. The seed is the deepest selection set, so a depth-N query ends up with N+1 selection sets and only N extra fragment spreads. Fields contributed by extra fragments are never requested at the deepest tier of the tree, and any navigation tree transforms reading those fields get `undefined` for the bottom-level nodes.

This regressed in #2889, which inlined the node fields to work around magento/magento2#31086. Before that change the spread lived inside the named `categoryNode` fragment, which the seed referenced, so every level got it.

Fixes: #

## New behavior

The extra fragment spread is computed once and included in both the reduce seed and each wrapper iteration, so every generated `CategoryTree` selection set requests the extra fragment fields, including the deepest one. `daffBuildFragmentNameSpread` returns an empty string when no extra fragments are registered, so the default case produces the same query as before.

I added two regression tests. One walks the generated fragment AST and asserts the spread is present at every nesting level (depth + 1 levels), and one runs a query through the Apollo testing controller and asserts a field contributed by an extra fragment survives on the deepest child node.

## Breaking change?

- [ ] Yes
- [x] No

