### PR TITLE
feat(design): support `light` and `dark` colors in callout and hero

### DIFF
--- a/libs/design-examples/callout/src/callout-theming/callout-theming.component.ts
+++ b/libs/design-examples/callout/src/callout-theming/callout-theming.component.ts
@@ -36,8 +36,8 @@ export class CalloutThemingExampleComponent {
     { value: 'primary', label: 'Primary' },
     { value: 'secondary', label: 'Secondary' },
     { value: 'tertiary', label: 'Tertiary' },
-    { value: 'white', label: 'White' },
-    { value: 'black', label: 'Black' },
+    { value: 'light', label: 'Light' },
+    { value: 'dark', label: 'Dark' },
     { value: 'theme', label: 'Theme' },
     { value: 'theme-contrast', label: 'Theme Contrast' },
   ];

--- a/libs/design-examples/hero/src/hero-theming/hero-theming.component.ts
+++ b/libs/design-examples/hero/src/hero-theming/hero-theming.component.ts
@@ -36,8 +36,8 @@ export class HeroThemingExampleComponent {
     { value: 'primary', label: 'Primary' },
     { value: 'secondary', label: 'Secondary' },
     { value: 'tertiary', label: 'Tertiary' },
-    { value: 'white', label: 'White' },
-    { value: 'black', label: 'Black' },
+    { value: 'light', label: 'Light' },
+    { value: 'dark', label: 'Dark' },
     { value: 'theme', label: 'Theme' },
     { value: 'theme-contrast', label: 'Theme Contrast' },
   ];

--- a/libs/design/callout/src/callout-theme.scss
+++ b/libs/design/callout/src/callout-theme.scss
@@ -57,11 +57,21 @@
 			@include daff-callout-theme-variant($base-contrast);
 		}
 
+		// remove when `DaffColorEnum.Black` is removed in v1.0.0
 		&.daff-black {
 			@include daff-callout-theme-variant($black);
 		}
 
+		// remove when `DaffColorEnum.White` is removed in v1.0.0
 		&.daff-white {
+			@include daff-callout-theme-variant($white);
+		}
+
+		&.daff-dark {
+			@include daff-callout-theme-variant($black);
+		}
+
+		&.daff-light {
 			@include daff-callout-theme-variant($white);
 		}
 	}

--- a/libs/design/hero/src/hero-theme.scss
+++ b/libs/design/hero/src/hero-theme.scss
@@ -57,11 +57,21 @@
 			@include daff-hero-theme-variant($base-contrast);
 		}
 
+		// remove when `DaffColorEnum.Black` is removed in v1.0.0
 		&.daff-black {
 			@include daff-hero-theme-variant($black);
 		}
 
+		// remove when `DaffColorEnum.White` is removed in v1.0.0
 		&.daff-white {
+			@include daff-hero-theme-variant($white);
+		}
+
+		&.daff-dark {
+			@include daff-hero-theme-variant($black);
+		}
+
+		&.daff-light {
 			@include daff-hero-theme-variant($white);
 		}
 	}


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
`daff-light` and `daff-dark` now theme the callout and hero the same way `daff-white` and `daff-black` do, so both components work with the non-deprecated members of `DaffColorEnum`. The deprecated `daff-white` and `daff-black` styles are kept and marked for removal in v1.0.0.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->