### PR TITLE
docs(design): clarify `light` and `dark` color behavior

### DIFF
--- a/libs/design/progress-bar/README.md
+++ b/libs/design/progress-bar/README.md
@@ -61,7 +61,7 @@ Use an indeterminate progress bar when the percentage of completion is unknown o
 ### Colors
 The default color is `primary`. Use the `color` property to change a progress bar's color.
 
-> `theme`, `white`, and `black` should be used with caution to ensure that there is sufficient contrast.
+> `theme`, `light`, and `dark` should be used with caution to ensure that there is sufficient contrast.
 
 <daff-docs-example-viewer example="progress-bar-themes"></daff-docs-example-viewer>
 

--- a/libs/design/src/core/colorable/colorable.ts
+++ b/libs/design/src/core/colorable/colorable.ts
@@ -35,12 +35,20 @@ export enum DaffColorEnum {
   Tertiary = 'tertiary',
 
   /**
-   * A light color that does not change based on the theme.
+   * A light color.
+   *
+   * This does not track the theme mode. An element with this color stays light
+   * in both light and dark mode. Use `Theme` or `ThemeContrast` instead for a
+   * color that flips with the mode.
    */
   Light = 'light',
 
   /**
-   * A dark color that does not change based on the theme.
+   * A dark color.
+   *
+   * This does not track the theme mode. An element with this color stays dark
+   * in both light and dark mode. Use `Theme` or `ThemeContrast` instead for a
+   * color that flips with the mode.
    */
   Dark = 'dark',
 


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [x] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
Note in the `DaffColorEnum` docs that `Light` and `Dark` stay fixed across theme modes, and point to `Theme` and `ThemeContrast` for a color that flips with the mode. The progress bar README referred to `white` and `black`, which it never supported; name `light` and `dark` instead.

## Breaking change?

- [ ] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->