### PR TITLE
fix(design): remove duplicate component theme injections

### DIFF
--- a/libs/design/scss/theme.scss
+++ b/libs/design/scss/theme.scss
@@ -84,7 +84,6 @@
 	@include stroked-button.daff-stroked-button-theme($theme);
 	@include underline-button.daff-underline-button-theme($theme);
 
-	@include callout.daff-callout-theme($theme);
 	@include card-base.daff-card-base-theme($theme);
 	@include stroked-card.daff-stroked-card-theme($theme);
 
@@ -98,8 +97,6 @@
 	@include spinner.daff-spinner-theme($theme);
 	@include progress-bar.daff-progress-bar-theme($theme);
 
-	@include accordion.daff-accordion-theme($theme);
-	@include article.daff-article-theme($theme);
 	@include callout.daff-callout-theme($theme);
 	@include hero.daff-hero-theme($theme);
 	@include list.daff-list-theme($theme);
@@ -113,7 +110,6 @@
 	@include navbar.daff-navbar-theme($theme);
 	@include notification.daff-notification-theme($theme);
 	@include paginator.daff-paginator-theme($theme);
-	@include progress-bar.daff-progress-bar-theme($theme);
 	@include sidebar.daff-sidebar-theme($theme);
 	@include switch.daff-switch-theme($theme);
 	@include tabs.daff-tabs-theme($theme);


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
`daff-component-themes` included the callout, progress-bar, article, and accordion themes twice, so every rule from both themes was emitted twice into the compiled stylesheet.

Fixes: #4635

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->