### PR TITLE
build(branding): revise scss export format

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -252,7 +252,6 @@
               "includePaths": [
                 "apps/daffio/src/scss",
                 "dist/design/scss",
-                "dist/branding/src/scss",
                 "dist/docs/src/scss"
               ]
             },
@@ -368,7 +367,6 @@
               "includePaths": [
                 "apps/daffio/src/scss",
                 "dist/design/scss",
-                "dist/branding/src/scss",
                 "dist/docs/src/scss"
               ]
             },

--- a/apps/daffio/src/scss/styles.scss
+++ b/apps/daffio/src/scss/styles.scss
@@ -6,7 +6,7 @@
 @use './component-themes' as daffio-components;
 
 // @daffodil/branding
-@use 'daff-branding-theme' as branding;
+@use '@daffodil/branding/scss/component-themes' as branding;
 
 // @daffodil/docs
 @use 'daff-docs-theme' as docs;

--- a/libs/branding/package.json
+++ b/libs/branding/package.json
@@ -26,5 +26,13 @@
   "devDependencies": {
     "@daffodil/design": "0.0.0-PLACEHOLDER"
   },
-  "description": "Reusable branding components including copyright, logos, and theming assets. Part of the Daffodil ecommerce framework."
+  "description": "Reusable branding components including copyright, logos, and theming assets. Part of the Daffodil ecommerce framework.",
+  "exports": {
+    "./scss/theme": {
+      "sass": "./scss/theme.scss"
+    },
+    "./scss/component-themes": {
+      "sass": "./scss/component-themes.scss"
+    }
+  }
 }

--- a/libs/branding/scss/component-themes.scss
+++ b/libs/branding/scss/component-themes.scss
@@ -1,4 +1,4 @@
-@use '../lib/logo/logo-theme' as logo;
+@use '../src/lib/logo/logo-theme' as logo;
 
 @mixin daff-branding-theme($theme) {
   @include logo.daff-logo-theme($theme);

--- a/libs/branding/scss/theme.scss
+++ b/libs/branding/scss/theme.scss
@@ -1,5 +1,4 @@
-@use 'theme' as daff-theme;
-@forward 'theme';
+@use '@daffodil/design/scss/theme' as daff-theme;
 
 $primary: daff-theme.daff-configure-palette(daff-theme.$daff-blue, 60);
 $secondary: daff-theme.daff-configure-palette(daff-theme.$daff-purple, 60);

--- a/libs/branding/src/lib/logo/logo-theme.scss
+++ b/libs/branding/src/lib/logo/logo-theme.scss
@@ -1,5 +1,4 @@
-@use '../../scss/branding-theme';
-@use 'theme' as daff-theme;
+@use '@daffodil/design/scss/theme' as daff-theme;
 
 @mixin daff-logo-theme($theme) {
 	$neutral: daff-theme.daff-get-palette($theme, neutral);


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [x] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, `@daffodil/branding` (the internal package), exposes its scss imports via `includePaths` in the `angular.json`. Since https://github.com/graycoreio/daffodil/pull/4375 (many thanks @joannalauu ) we no longer need to do this.

Part of: #4640

## New behavior
We remove the `includePaths` and solely rely on the native scss importer / Karma plugin.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->