### PR TITLE
feat(design)!: remove default theme variables from scss 'theme' export

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -251,7 +251,6 @@
             "stylePreprocessorOptions": {
               "includePaths": [
                 "apps/daffio/src/scss",
-                "dist/design/scss",
                 "dist/docs/src/scss"
               ]
             },
@@ -366,7 +365,6 @@
             "stylePreprocessorOptions": {
               "includePaths": [
                 "apps/daffio/src/scss",
-                "dist/design/scss",
                 "dist/docs/src/scss"
               ]
             },

--- a/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents.component.scss
+++ b/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents.component.scss
@@ -1,4 +1,4 @@
-@use 'typography' as t;
+@use '@daffodil/design/scss/typography' as t;
 
 // stylelint-disable selector-class-pattern
 :host {

--- a/apps/daffio/src/scss/styles.scss
+++ b/apps/daffio/src/scss/styles.scss
@@ -1,9 +1,10 @@
 // DO NOT IMPORT THIS FILE ANYWHERE ELSE
 
 @use 'sass:meta';
-@use 'global';
-@use 'theme' as daff-theme;
+@use '@daffodil/design/scss/global';
+@use '@daffodil/design/scss/theme' as daff-theme;
 @use './component-themes' as daffio-components;
+@use '@daffodil/design/scss/theming/default' as daff-default-theme;
 
 // @daffodil/branding
 @use '@daffodil/branding/scss/component-themes' as branding;
@@ -17,10 +18,10 @@
 
 	@include meta.load-css('highlight.js/scss/a11y-light');
 
-	@include branding.daff-branding-theme(daff-theme.$theme);
-	@include daff-theme.daff-component-themes(daff-theme.$theme);
-	@include daffio-components.component-themes(daff-theme.$theme);
-	@include docs.daff-docs-component-themes(daff-theme.$theme);
+	@include branding.daff-branding-theme(daff-default-theme.$theme);
+	@include daff-theme.daff-component-themes(daff-default-theme.$theme);
+	@include daffio-components.component-themes(daff-default-theme.$theme);
+	@include docs.daff-docs-component-themes(daff-default-theme.$theme);
 }
 
 .daff-theme-dark {
@@ -29,10 +30,10 @@
 
 	@include meta.load-css('highlight.js/scss/a11y-dark');
 
-	@include branding.daff-branding-theme(daff-theme.$theme-dark);
-	@include daff-theme.daff-component-themes(daff-theme.$theme-dark);
-	@include daffio-components.component-themes(daff-theme.$theme-dark);
-	@include docs.daff-docs-component-themes(daff-theme.$theme-dark);
+	@include branding.daff-branding-theme(daff-default-theme.$theme-dark);
+	@include daff-theme.daff-component-themes(daff-default-theme.$theme-dark);
+	@include daffio-components.component-themes(daff-default-theme.$theme-dark);
+	@include docs.daff-docs-component-themes(daff-default-theme.$theme-dark);
 }
 
 body {

--- a/apps/daffio/src/scss/styles.scss
+++ b/apps/daffio/src/scss/styles.scss
@@ -4,7 +4,7 @@
 @use '@daffodil/design/scss/global';
 @use '@daffodil/design/scss/theme' as daff-theme;
 @use './component-themes' as daffio-components;
-@use '@daffodil/design/scss/theming/default' as daff-default-theme;
+@use '@daffodil/design/scss/theme/default' as daff-default-theme;
 
 // @daffodil/branding
 @use '@daffodil/branding/scss/component-themes' as branding;

--- a/libs/design/button/src/button/raised/raised-theme.scss
+++ b/libs/design/button/src/button/raised/raised-theme.scss
@@ -1,6 +1,6 @@
 @use '../../../../scss/theming' as *;
 
-@mixin daff-raised-button-theme-variant($base-color) {
+@mixin daff-raised-button-theme-variant($theme, $base-color) {
 	@if daff-contrast-ratio($base-color, daff-text-contrast($base-color)) < 4.5 {
 		@error 'Button Initial State: ' + map.get(a11y.$wcag-aa-errors, 'text-contrast');
 	}
@@ -37,39 +37,39 @@
 	$neutral: daff-get-palette($theme, neutral);
 
 	.daff-raised-button {
-		@include daff-raised-button-theme-variant(daff-color($neutral, 20));
+		@include daff-raised-button-theme-variant($theme, daff-color($neutral, 20));
 
 		&.daff-primary {
-			@include daff-raised-button-theme-variant(daff-color($primary));
+			@include daff-raised-button-theme-variant($theme, daff-color($primary));
 		}
 
 		&.daff-secondary {
-			@include daff-raised-button-theme-variant(daff-color($secondary));
+			@include daff-raised-button-theme-variant($theme, daff-color($secondary));
 		}
 
 		&.daff-tertiary {
-			@include daff-raised-button-theme-variant(daff-color($tertiary));
+			@include daff-raised-button-theme-variant($theme, daff-color($tertiary));
 		}
 
 		&.daff-dark {
-			@include daff-raised-button-theme-variant($black);
+			@include daff-raised-button-theme-variant($theme, $black);
 		}
 
 		&.daff-light {
-			@include daff-raised-button-theme-variant($white);
+			@include daff-raised-button-theme-variant($theme, $white);
 		}
 
 		&.daff-theme {
-			@include daff-raised-button-theme-variant($base);
+			@include daff-raised-button-theme-variant($theme, $base);
 		}
 
 		&.daff-theme-contrast {
-			@include daff-raised-button-theme-variant($base-contrast);
+			@include daff-raised-button-theme-variant($theme, $base-contrast);
 		}
 
 		&[disabled],
 		&.daff-disabled {
-			@include daff-raised-button-theme-variant(daff-color($neutral, 30));
+			@include daff-raised-button-theme-variant($theme, daff-color($neutral, 30));
 			color: daff-color($neutral, 50);
 
 			&::after {
@@ -78,15 +78,15 @@
 		}
 
 		&.daff-warn {
-			@include daff-raised-button-theme-variant(daff-color($warn));
+			@include daff-raised-button-theme-variant($theme, daff-color($warn));
 		}
 
 		&.daff-critical {
-			@include daff-raised-button-theme-variant(daff-color($critical));
+			@include daff-raised-button-theme-variant($theme, daff-color($critical));
 		}
 
 		&.daff-success {
-			@include daff-raised-button-theme-variant(daff-color($success));
+			@include daff-raised-button-theme-variant($theme, daff-color($success));
 		}
 	}
 }

--- a/libs/design/guides/getting-started.md
+++ b/libs/design/guides/getting-started.md
@@ -49,15 +49,16 @@ There is a minimal required global style for the Daffodil Design System to opera
 > For more information on our approach to these kinds of styles, see the [Global Styles guide.](/libs/design/guides/foundations/global-styles.md)
 
 ## Add a theme
-A theme must be configured in order for Daffodil Design components to work properly.
+A theme must be configured in order for Daffodil Design components to work properly. Daffodil Design provides a default theme, but it is not automatically configured and must be added to your styles.
 
-The `daff-component-themes` mixin includes styles for all components. The example below demonstrates how to use Daffodil Design's default theme, where the `$theme` variable is the default configured theme. The mixin is included in the `html` selector to ensure that component styles are applied across the entire application.
+The `daff-component-themes` mixin includes styles for all components. The example below demonstrates how to add the default theme, where the `$theme` variable is the default configured theme. The mixin is included in the `html` selector to ensure that component styles are applied across the entire application.
 
 ```scss
 @use '@daffodil/design/scss/theme' as daff-theme;
+@use '@daffodil/design/scss/theme/default' as daff-default-theme;
 
 html {
-	@include daff-theme.daff-component-themes(daff-theme.$theme);
+	@include daff-theme.daff-component-themes(daff-default-theme.$theme);
 }
 ```
 

--- a/libs/design/guides/theming/introduction.md
+++ b/libs/design/guides/theming/introduction.md
@@ -4,19 +4,20 @@ Daffodil's extensible theming architecture allows you to customize our component
 ## Theming basics
 Daffodil Design is built with [Sass](https://sass-lang.com/), so you should be familiar with CSS and Sass fundamentals such as variables, functions, and mixins.
 
-A theme must be configured in order for Daffodil components to render correctly.
+A theme must be configured in order for Daffodil components to render correctly. Daffodil Design provides a default theme, but it is not included automatically and must be added to your styles.
 
 ## Set up a theme
 Configure a theme using the `daff-component-themes` mixin. This mixin includes styles for all components.
 
-The example below demonstrates how to use Daffodil Design’s default theme.
+The example below demonstrates how to add Daffodil Design’s default theme.
 
 Add it to your `styles.scss` file to apply styles globally:
 
 ```scss
 @use '@daffodil/design/scss/theme' as daff-theme;
+@use '@daffodil/design/scss/theme/default' as daff-default-theme;
 
-@include daff-theme.daff-component-themes(daff-theme.$theme);
+@include daff-theme.daff-component-themes(daff-default-theme.$theme);
 ```
 
 ## Next steps

--- a/libs/design/guides/theming/modes.md
+++ b/libs/design/guides/theming/modes.md
@@ -2,23 +2,24 @@
 Daffodil Design supports light and dark modes out of the box, allowing you to easily switch between them without additional configuration.
 
 ## Enable modes with the default theme
-To enable light and dark mode using Daffodil’s default theme:
+Daffodil’s default theme is not automatically configured and must be added to your styles. To enable light and dark mode with it:
 
-1. Add the `daff-component-themes` mixin with `$theme` and `$theme-dark` variables to the `.daff-theme-light` and `.daff-theme-dark` classes.
+1. Add the `daff-component-themes` mixin with the `$theme` and `$theme-dark` variables to the `.daff-theme-light` and `.daff-theme-dark` classes.
 
 ```scss
 @use '@daffodil/design/scss/theme' as daff-theme;
+@use '@daffodil/design/scss/theme/default' as daff-default-theme;
 
 .daff-theme-light {
-	@include daff-theme.daff-component-themes(daff-theme.$theme);
+	@include daff-theme.daff-component-themes(daff-default-theme.$theme);
 }
 
 .daff-theme-dark {
-	@include daff-theme.daff-component-themes(daff-theme.$theme-dark);
+	@include daff-theme.daff-component-themes(daff-default-theme.$theme-dark);
 }
 ```
 
-> The `$theme` and `$theme-dark` variables are based on Daffodil Design's default theme. Learn how to customize your own theme [here](/libs/design/guides/theming/custom-theme.md).
+> The `$theme` and `$theme-dark` variables are based on Daffodil Design's default theme. Learn how to customize your own theme [here](/libs/design/guides/theming/customize-your-own-theme.md).
 
 2. Add `DAFF_THEME_INITIALIZER` to the `providers` array of your root component.
 

--- a/libs/design/package.json
+++ b/libs/design/package.json
@@ -57,6 +57,9 @@
     "./scss/global": {
       "sass": "./scss/global.scss"
     },
+    "./scss/theme/default": {
+      "sass": "./scss/theming/default/_index.scss"
+    },
     "./scss/theme": {
       "sass": "./scss/theme.scss"
     },

--- a/libs/design/scss/theme/default.scss
+++ b/libs/design/scss/theme/default.scss
@@ -1,0 +1,15 @@
+// This file only exists for builds inside the Daffodil monorepo. Consumers of
+// the published package never load it.
+//
+// Externally, `@daffodil/design/scss/theme/default` resolves through the `sass`
+// condition of the `exports` map in package.json, which points straight at
+// `scss/theming/default/_index.scss`.
+//
+// Inside the monorepo there is no `node_modules/@daffodil/design`, so the
+// specifier instead resolves via the root tsconfig `paths` mapping
+// (`@daffodil/*` -> `dist/*`). That mapping bypasses `exports` entirely, leaving
+// Angular's Sass importer to fall back to joining the remaining specifier
+// segments onto the package root verbatim. `scss/theme/default` therefore has to
+// exist as a real file for the monorepo apps to resolve it.
+
+@forward '../theming/default';

--- a/libs/design/scss/theming/_index.scss
+++ b/libs/design/scss/theming/_index.scss
@@ -5,7 +5,6 @@
 @forward 'configure-palette';
 @forward 'create-theme/create-theme';
 @forward 'light-dark';
-@forward './default/index';
 @forward 'get-palette';
 @forward 'get-base-color';
 @forward 'get-theme-mode';

--- a/libs/design/scss/theming/_index.scss
+++ b/libs/design/scss/theming/_index.scss
@@ -5,7 +5,7 @@
 @forward 'configure-palette';
 @forward 'create-theme/create-theme';
 @forward 'light-dark';
-@forward 'daff-theme';
+@forward './default/index';
 @forward 'get-palette';
 @forward 'get-base-color';
 @forward 'get-theme-mode';

--- a/libs/design/scss/theming/default/_daff-theme.scss
+++ b/libs/design/scss/theming/default/_daff-theme.scss
@@ -1,7 +1,7 @@
-@use 'configure-palette';
-@use './create-theme/create-theme';
-@use 'color-palettes' as palette;
-@use '../core';
+@use '../configure-palette';
+@use '../create-theme/create-theme';
+@use '../color-palettes' as palette;
+@use '../../core';
 
 $primary: configure-palette.daff-configure-palette(palette.$daff-blue, 60);
 $secondary: configure-palette.daff-configure-palette(palette.$daff-purple, 60);

--- a/libs/design/scss/theming/default/_index.scss
+++ b/libs/design/scss/theming/default/_index.scss
@@ -1,0 +1,1 @@
+@forward 'daff-theme';


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
Currently, we expose many theme variables unexpectedly (like `$tertiary`).

Fixes: #4640
Part of: # <!-- Keeps issue open -->

## New behavior
We no longer expose these variables by default.

## Breaking change?

- [x] Yes
- [ ] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->