### PR TITLE
fix(design): apply card and select hover styles only on hover

### DIFF
--- a/libs/design/card/src/card/stroked/stroked-theme.scss
+++ b/libs/design/card/src/card/stroked/stroked-theme.scss
@@ -13,9 +13,11 @@
 	}
 
 	@media (hover: hover) {
-		.daff-card__wrapper {
-			&::after {
-				opacity: 1;
+		&:hover {
+			.daff-card__wrapper {
+				&::after {
+					opacity: 1;
+				}
 			}
 		}
 	}
@@ -107,33 +109,23 @@
 			}
 
 			&.daff-primary {
-				@include linkable-stroked-card-theme-variant(
-					daff-color($primary)
-				);
+				@include linkable-stroked-card-theme-variant(daff-color($primary));
 			}
 
 			&.daff-secondary {
-				@include linkable-stroked-card-theme-variant(
-					daff-color($secondary)
-				);
+				@include linkable-stroked-card-theme-variant(daff-color($secondary));
 			}
 
 			&.daff-tertiary {
-				@include linkable-stroked-card-theme-variant(
-					daff-color($tertiary)
-				);
+				@include linkable-stroked-card-theme-variant(daff-color($tertiary));
 			}
 
 			&.daff-dark {
-				@include linkable-stroked-card-theme-variant(
-					daff-color($neutral, 90)
-				);
+				@include linkable-stroked-card-theme-variant(daff-color($neutral, 90));
 			}
 
 			&.daff-light {
-				@include linkable-stroked-card-theme-variant(
-					daff-color($neutral, 20)
-				);
+				@include linkable-stroked-card-theme-variant(daff-color($neutral, 20));
 			}
 		}
 	}

--- a/libs/design/select/src/select-theme.scss
+++ b/libs/design/select/src/select-theme.scss
@@ -63,7 +63,9 @@
 				}
 
 				@media (hover: hover) {
-					background-color: daff-color($neutral, 90);
+					&:hover {
+						background-color: daff-color($neutral, 90);
+					}
 				}
 
 				&.highlighted {


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
https://github.com/graycoreio/daffodil/commit/922e73fdc9f7505823150e6a7a994420e056c557's updates to add ``@media (hover: hover)` blocks missed adding the `&:hover` selector for the card and select component. 

Fixes: # <!-- Closes issue on merge -->
Part of: # <!-- Keeps issue open -->

## New behavior
<!-- Describe the changes -->

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->