### PR TITLE
feat(design): rename light and dark mode mixins

### DIFF
--- a/apps/daffio/src/app/content/home/components/home-callout-commerce/home-callout-commerce-theme.scss
+++ b/apps/daffio/src/app/content/home/components/home-callout-commerce/home-callout-commerce-theme.scss
@@ -11,7 +11,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daffio-home-callout-commerce {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&__video {
 				box-shadow: 0 0 1.5rem 0 rgba($black, 0.4);
 			}
@@ -23,7 +23,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&__video {
 				border: thin solid daff-color($neutral, 80);
 				box-shadow: 0 0 1.5rem 0 rgba($black, 0.2);

--- a/apps/daffio/src/app/content/home/components/home-callout-sponsors/home-callout-sponsors-theme.scss
+++ b/apps/daffio/src/app/content/home/components/home-callout-sponsors/home-callout-sponsors-theme.scss
@@ -14,14 +14,14 @@
 			color: $base-contrast;
 		}
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&__logo,
 			&__link {
 				background: daff-color($neutral, 10);
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&__logo,
 			&__link {
 				background: daff-color($neutral, 90);

--- a/apps/daffio/src/app/content/home/components/home-hero/home-hero-theme.scss
+++ b/apps/daffio/src/app/content/home/components/home-hero/home-hero-theme.scss
@@ -10,11 +10,11 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daffio-home-hero {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			background: url('/assets/hero-bg.svg');
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			background: url('/assets/hero-bg-dark.svg');
 		}
 

--- a/apps/daffio/src/app/core/footer/docs-footer/docs-footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/docs-footer/docs-footer-theme.scss
@@ -7,7 +7,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daffio-docs-footer {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			border-top: 1px solid daff-color($neutral, 20);
 
 			&__copyright {
@@ -23,7 +23,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			border-top: 1px solid daff-color($neutral, 80);
 
 			&__copyright {

--- a/apps/daffio/src/app/core/footer/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/footer/footer/footer-theme.scss
@@ -8,7 +8,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daffio-footer {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			border-top: 1px solid daff-color($neutral, 20);
 
 			&__copyright {
@@ -24,7 +24,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			border-top: 1px solid daff-color($neutral, 80);
 
 			&__copyright {

--- a/apps/daffio/src/app/core/header/components/header/header-theme.scss
+++ b/apps/daffio/src/app/core/header/components/header/header-theme.scss
@@ -14,7 +14,7 @@
 		}
 	}
 
-	@include light($mode) {
+	@include daff-light-mode($mode) {
 		.daffio-header {
 			&.bordered {
 				.daffio-header__navbar {
@@ -30,7 +30,7 @@
 		}
 	}
 
-	@include dark($mode) {
+	@include daff-dark-mode($mode) {
 		.daffio-header {
 			&.bordered {
 				.daffio-header__navbar {

--- a/apps/daffio/src/app/core/sidebar/components/docs/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/sidebar/components/docs/footer/footer-theme.scss
@@ -6,7 +6,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daffio-docs-sidebar-footer {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			border-top: 1px solid daff-color($neutral, 20);
 
 			&::after {
@@ -14,7 +14,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			border-top: 1px solid daff-color($neutral, 90);
 
 			&::after {

--- a/apps/daffio/src/app/core/sidebar/components/marketing/footer/footer-theme.scss
+++ b/apps/daffio/src/app/core/sidebar/components/marketing/footer/footer-theme.scss
@@ -6,7 +6,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daffio-marketing-sidebar-footer {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			background: daff-color($neutral, 20);
 
 			&:hover {
@@ -14,7 +14,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			background: daff-color($neutral, 90);
 
 			&:hover {

--- a/apps/daffio/src/app/docs/api/components/api-item-label/api-item-label-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-item-label/api-item-label-theme.scss
@@ -18,7 +18,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daffio-docs-api-item-label {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			// Angular Framework
 			&.component {
 				@include type-theming(daff-color($primary, 90));
@@ -115,7 +115,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			// Angular Framework
 			&.component {
 				@include type-theming(daff-color($primary, 10), 0.1);

--- a/apps/daffio/src/app/docs/api/components/api-list-section/api-list-section-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-list-section/api-list-section-theme.scss
@@ -25,7 +25,7 @@
 			}
 		}
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&__item {
 				&::after {
 					background: rgba(daff-color($neutral, 20), 0.5);
@@ -33,7 +33,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&__item {
 				&::after {
 					background: rgba(daff-color($neutral, 80), 0.5);

--- a/apps/daffio/src/app/docs/api/components/api-list/api-list-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-list/api-list-theme.scss
@@ -16,7 +16,7 @@
 			}
 		}
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&__package-wrapper {
 				border-bottom: 1px solid daff-color($neutral, 20);
 			}
@@ -30,7 +30,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&__package-wrapper {
 				border-bottom: 1px solid daff-color($neutral, 80);
 			}

--- a/apps/daffio/src/app/docs/api/components/api-package/api-package-theme.scss
+++ b/apps/daffio/src/app/docs/api/components/api-package/api-package-theme.scss
@@ -15,7 +15,7 @@
 				}
 			}
 
-			@include light($mode) {
+			@include daff-light-mode($mode) {
 				&__subpackage-name {
 					a {
 						&:hover {
@@ -25,7 +25,7 @@
 				}
 			}
 
-			@include dark($mode) {
+			@include daff-dark-mode($mode) {
 				&__subpackage-name {
 					a {
 						&:hover {

--- a/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer-theme.scss
+++ b/apps/daffio/src/app/docs/components/doc-viewer/doc-viewer-theme.scss
@@ -5,7 +5,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daffio-doc-viewer {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&__toc-links {
 				border-top: 1px solid daff-color($neutral, 30);
 			}
@@ -19,7 +19,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&__toc-links {
 				border-top: 1px solid daff-color($neutral, 70);
 			}

--- a/apps/daffio/src/app/docs/components/member-heading/member-heading-theme.scss
+++ b/apps/daffio/src/app/docs/components/member-heading/member-heading-theme.scss
@@ -8,7 +8,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daffio-docs-member-heading {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&.property {
 				.daffio-docs-member-heading__name {
 					background-color: daff-color($primary, 10);
@@ -31,7 +31,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&.property {
 				.daffio-docs-member-heading__name {
 					background-color: daff-color($primary, 90);

--- a/apps/daffio/src/app/docs/components/scroll-to-top/scroll-to-top-theme.scss
+++ b/apps/daffio/src/app/docs/components/scroll-to-top/scroll-to-top-theme.scss
@@ -6,7 +6,7 @@
 
 	.daffio-docs-scroll-to-top {
 		&__button {
-			@include light($mode) {
+			@include daff-light-mode($mode) {
 				color: daff-color($neutral, 80);
 
 				&:hover {
@@ -14,7 +14,7 @@
 				}
 			}
 
-			@include dark($mode) {
+			@include daff-dark-mode($mode) {
 				color: daff-color($neutral, 40);
 
 				&:hover {

--- a/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents-theme.scss
+++ b/apps/daffio/src/app/docs/components/table-of-contents/table-of-contents-theme.scss
@@ -7,7 +7,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daffio-docs-table-of-contents-link {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			color: daff-color($neutral, 80);
 
 			&:hover {
@@ -15,7 +15,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			color: daff-color($neutral, 40);
 
 			&:hover {

--- a/libs/branding/src/lib/logo/logo-theme.scss
+++ b/libs/branding/src/lib/logo/logo-theme.scss
@@ -5,11 +5,11 @@
 	$mode: daff-theme.daff-get-theme-mode($theme);
 
 	.daff-branding-logo {
-		@include daff-theme.light($mode) {
+		@include daff-theme.daff-light-mode($mode) {
 			fill: daff-theme.daff-color($neutral, 90);
 		}
 
-		@include daff-theme.dark($mode) {
+		@include daff-theme.daff-dark-mode($mode) {
 			fill: daff-theme.daff-color($neutral, 10);
 		}
 	}

--- a/libs/design/accordion/src/accordion-theme.scss
+++ b/libs/design/accordion/src/accordion-theme.scss
@@ -7,7 +7,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-accordion-item {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			border-top: 1px solid daff-color($neutral, 20);
 
 			&:last-child {
@@ -23,7 +23,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			border-top: 1px solid daff-color($neutral, 80);
 
 			&:last-child {

--- a/libs/design/article/src/article-theme.scss
+++ b/libs/design/article/src/article-theme.scss
@@ -14,7 +14,7 @@
 	$table-border-dark: daff-color($neutral, 80);
 
 	.daff-article {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			color: $text-color-light;
 
 			@include stopsArticleCascade(a) {
@@ -98,7 +98,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			color: $text-color-dark;
 
 			@include stopsArticleCascade(a) {

--- a/libs/design/badge/src/badge-theme.scss
+++ b/libs/design/badge/src/badge-theme.scss
@@ -51,7 +51,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-badge {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			@include daff-badge-color-light-variants(
 				(
 					'primary': $primary,
@@ -125,7 +125,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			background: daff-color($neutral, 80);
 			color: daff-color($neutral, 20);
 

--- a/libs/design/breadcrumb/src/breadcrumb-theme.scss
+++ b/libs/design/breadcrumb/src/breadcrumb-theme.scss
@@ -6,12 +6,12 @@
 
 	.daff-breadcrumb__item {
 		a, .daff-breadcrumb__menu-activator {
-			@include light($mode) {
+			@include daff-light-mode($mode) {
 				color: daff-color($neutral, 80);
 				text-decoration-color: daff-color($neutral, 80);
 			}
 
-			@include dark($mode) {
+			@include daff-dark-mode($mode) {
 				color: daff-color($neutral, 30);
 				text-decoration-color: daff-color($neutral, 30);
 			}

--- a/libs/design/button/src/button/basic/button-theme.scss
+++ b/libs/design/button/src/button/basic/button-theme.scss
@@ -43,7 +43,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-button {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			@include daff-button-theme-variant(
 				daff-color($neutral, 10),
 				daff-color($neutral, 20),
@@ -131,7 +131,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			@include daff-button-theme-variant(
 				daff-color($neutral, 90),
 				daff-color($neutral, 80),

--- a/libs/design/button/src/button/flat/flat-theme.scss
+++ b/libs/design/button/src/button/flat/flat-theme.scss
@@ -30,7 +30,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-flat-button {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			@include daff-flat-button-theme-variant(
 				$base-contrast,
 			);
@@ -96,7 +96,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			@include daff-flat-button-theme-variant(
 				$base-contrast,
 			);

--- a/libs/design/button/src/button/icon/icon-theme.scss
+++ b/libs/design/button/src/button/icon/icon-theme.scss
@@ -41,7 +41,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-icon-button {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			@include daff-icon-button-theme-variant(
 				daff-color($neutral, 50),
 				daff-color($neutral, 60),
@@ -129,7 +129,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			@include daff-icon-button-theme-variant(
 				daff-color($neutral, 50),
 				daff-color($neutral, 40),

--- a/libs/design/button/src/button/stroked/stroked-theme.scss
+++ b/libs/design/button/src/button/stroked/stroked-theme.scss
@@ -46,7 +46,7 @@
 			}
 		}
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&.daff-primary {
 				@include daff-stroked-button-theme-variant(
 					daff-color($primary)
@@ -98,7 +98,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&.daff-primary {
 				@include daff-stroked-button-theme-variant(
 					daff-color($primary, 40)

--- a/libs/design/button/src/button/underline/underline-theme.scss
+++ b/libs/design/button/src/button/underline/underline-theme.scss
@@ -24,7 +24,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-underline-button {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			@include daff-underline-button-theme-variant(
 				daff-color($neutral, 70)
 			);
@@ -80,7 +80,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			@include daff-underline-button-theme-variant(
 				daff-color($neutral, 40)
 			);

--- a/libs/design/callout/src/callout-theme.scss
+++ b/libs/design/callout/src/callout-theme.scss
@@ -17,7 +17,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-callout {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			@include daff-callout-theme-variant(daff-color($neutral, 10));
 
 			&.daff-primary {
@@ -33,7 +33,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			@include daff-callout-theme-variant(daff-color($neutral, 90));
 
 			&.daff-primary {

--- a/libs/design/card/src/card-base-theme.scss
+++ b/libs/design/card/src/card-base-theme.scss
@@ -54,7 +54,7 @@
 	}
 
 	.daff-card {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			@include daff-basic-card-theme-variant(daff-color($neutral, 10));
 
 			&.daff-primary {
@@ -70,7 +70,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			@include daff-basic-card-theme-variant(daff-color($neutral, 90));
 
 			&.daff-primary {
@@ -117,7 +117,7 @@
 		}
 
 		&.daff-card {
-			@include light($mode) {
+			@include daff-light-mode($mode) {
 				@include daff-linkable-card-theme-variant(daff-color($neutral, 20));
 
 				&.daff-primary {
@@ -149,7 +149,7 @@
 				}
 			}
 
-			@include dark($mode) {
+			@include daff-dark-mode($mode) {
 				@include daff-linkable-card-theme-variant(daff-color($neutral, 80));
 
 				&.daff-primary {

--- a/libs/design/card/src/card/stroked/stroked-theme.scss
+++ b/libs/design/card/src/card/stroked/stroked-theme.scss
@@ -63,7 +63,7 @@
 			@include stroked-card-theme-variant(daff-color($neutral, 20));
 		}
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			@include stroked-card-theme-variant(daff-color($neutral, 20));
 			color: $base-contrast;
 
@@ -77,7 +77,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			@include stroked-card-theme-variant(daff-color($neutral, 90));
 			color: $base-contrast;
 
@@ -94,14 +94,14 @@
 
 	a {
 		&.daff-stroked-card {
-			@include light($mode) {
+			@include daff-light-mode($mode) {
 				@include linkable-stroked-card-theme-variant(
 					daff-color($neutral, 20),
 					0.2
 				);
 			}
 
-			@include dark($mode) {
+			@include daff-dark-mode($mode) {
 				@include linkable-stroked-card-theme-variant(
 					daff-color($neutral, 90),
 					0.2

--- a/libs/design/form-field/src/form-field-theme.scss
+++ b/libs/design/form-field/src/form-field-theme.scss
@@ -12,7 +12,7 @@
 
 	// stylelint-disable selector-class-pattern
 	.daff-form-field {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			.daff-form-field__control {
 				border: 1px solid daff-color($neutral);
 				color: daff-color($neutral);
@@ -30,7 +30,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			.daff-form-field__control {
 				border: 1px solid daff-color($neutral, 40);
 				color: daff-color($neutral, 40);

--- a/libs/design/form/src/hint/hint-theme.scss
+++ b/libs/design/form/src/hint/hint-theme.scss
@@ -7,11 +7,11 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-hint {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			color: daff-color($neutral, 80);
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			color: daff-color($neutral, 30);
 		}
 

--- a/libs/design/guides/theming/customize-your-own-theme.md
+++ b/libs/design/guides/theming/customize-your-own-theme.md
@@ -2,7 +2,7 @@
 Daffodil allows you to define custom themes to match your brand’s visual style. This involves creating custom color palettes, configuring them, and applying them to your application.
 
 ## Create custom palettes
-Create a palettes file with Sass maps that include hues from `10` to `100` in increments of 10. These palettes will be used for `$primary`, `$secondary`, and `$tertiary` colors.
+Create a palettes file with Sass maps that include hues from `10` to `100` in increments of 10. Create a palette for each color your theme needs. Primary, secondary, and tertiary are required. Neutral and the status colors are optional and fall back to Daffodil's defaults.
 
 **Example:**
 ```scss
@@ -41,6 +41,8 @@ $app-secondary-dark: daff-theme.daff-configure-palette(palette.$app-green, 50);
 $app-tertiary-dark: daff-theme.daff-configure-palette(palette.$app-purple, 50);
 ```
 
+> Use a lighter hue for dark mode so colors stay legible against a dark background. Daffodil's default theme uses `60` for light mode and `50` for dark mode.
+
 ## Define themes
 Use the `daff-create-theme` function to define light and dark themes. This function accepts a single map parameter with configuration options.
 
@@ -62,16 +64,19 @@ Use the `daff-create-theme` function to define light and dark themes. This funct
 | -------- | ----------- |
 | `'mode'` | Theme mode (`light` or `dark`). Defaults to `light` if not provided |
 | `'neutral'` | The neutral color palette |
-| `'info'` | The informational color palette |
+| `'informational'` | The informational color palette |
 | `'warn'` | The warning color palette |
 | `'critical'` | The critical/error color palette |
 | `'success'` | The success color palette |
 | `'text-color-default'` | The default text color |
 | `'text-color-inverse'` | The inverse text color |
 
-**Example with required parameters only:**
+Define a light and a dark theme so your app can support both modes.
+
+**Example with required keys only:**
 
 ```scss
+// app-theme.scss
 @use '@daffodil/design/scss/theme' as daff-theme;
 @use 'app-color-palettes' as palette; // your palettes file
 
@@ -79,17 +84,29 @@ $app-primary: daff-theme.daff-configure-palette(palette.$app-blue, 60);
 $app-secondary: daff-theme.daff-configure-palette(palette.$app-green, 60);
 $app-tertiary: daff-theme.daff-configure-palette(palette.$app-purple, 60);
 
-$theme: daff-theme.daff-create-theme((
-  'mode': 'light'
+$app-primary-dark: daff-theme.daff-configure-palette(palette.$app-blue, 50);
+$app-secondary-dark: daff-theme.daff-configure-palette(palette.$app-green, 50);
+$app-tertiary-dark: daff-theme.daff-configure-palette(palette.$app-purple, 50);
+
+$theme-light: daff-theme.daff-create-theme((
+  'mode': 'light',
   'primary': $app-primary,
   'secondary': $app-secondary,
   'tertiary': $app-tertiary,
 ));
+
+$theme-dark: daff-theme.daff-create-theme((
+  'mode': 'dark',
+  'primary': $app-primary-dark,
+  'secondary': $app-secondary-dark,
+  'tertiary': $app-tertiary-dark,
+));
 ```
 
-**Example with optional parameters:**
+**Example with optional keys:**
 
 ```scss
+// app-theme.scss
 @use '@daffodil/design/scss/theme' as daff-theme;
 @use 'app-color-palettes' as palette; // your palettes file
 
@@ -102,6 +119,7 @@ $theme: daff-theme.daff-create-theme((
   'primary': $app-primary,
   'secondary': $app-secondary,
   'tertiary': $app-tertiary,
+  'neutral': daff-theme.daff-configure-palette(palette.$app-neutral, 60),
   'informational': daff-theme.daff-configure-palette(palette.$app-blue, 40),
   'warn': daff-theme.daff-configure-palette(palette.$app-orange, 40),
   'critical': daff-theme.daff-configure-palette(palette.$app-red, 40),
@@ -112,7 +130,7 @@ $theme: daff-theme.daff-create-theme((
 ```
 
 ## Apply themes
-Finally, include your custom themes in your global styles.scss file:
+Include your themes in your global `styles.scss` file the same way you would the default theme, using your own theme variables in place of Daffodil's:
 
 ```scss
 @use '@daffodil/design/scss/theme' as daff-theme;
@@ -126,3 +144,5 @@ Finally, include your custom themes in your global styles.scss file:
   @include daff-theme.daff-component-themes(app-theme.$theme-dark);
 }
 ```
+
+Switching between the two also requires `DAFF_THEME_INITIALIZER`. See [light and dark modes](/libs/design/guides/theming/modes.md) for the full setup.

--- a/libs/design/guides/theming/introduction.md
+++ b/libs/design/guides/theming/introduction.md
@@ -20,8 +20,10 @@ Add it to your `styles.scss` file to apply styles globally:
 @include daff-theme.daff-component-themes(daff-default-theme.$theme);
 ```
 
+> This applies the light theme only. To support both light and dark modes, see the [modes](/libs/design/guides/theming/modes.md) documentation.
+
 ## Next steps
 To learn more about theming, see:
 
-- [Light and dark modes](/libs/design/guides/theming/modes.md)
+- [Modes](/libs/design/guides/theming/modes.md)
 - [Customize your own theme](/libs/design/guides/theming/customize-your-own-theme.md)

--- a/libs/design/guides/theming/modes.md
+++ b/libs/design/guides/theming/modes.md
@@ -35,6 +35,58 @@ import { DAFF_THEME_INITIALIZER } from '@daffodil/design';
 class AppModule {}
 ```
 
+## Support both modes in your own components
+Your own components can respond to light and dark mode the same way Daffodil Design's components do. Use the `daff-light-mode` and `daff-dark-mode` mixins to set the styles for each mode.
+
+| Mixin | Description |
+| -------- | ----------- |
+| `daff-light-mode` | Styles that only apply in light mode |
+| `daff-dark-mode` | Styles that only apply in dark mode |
+
+1. Create a theme file for your component. Get the mode with the `daff-get-theme-mode` function, then add the styles for each mode.
+
+```scss
+// custom-component-theme.scss
+@use '@daffodil/design/scss/theme' as daff-theme;
+
+@mixin custom-component-theme($theme) {
+	$neutral: daff-theme.daff-get-palette($theme, neutral);
+	$mode: daff-theme.daff-get-theme-mode($theme);
+
+	.custom-component {
+		@include daff-theme.daff-light-mode($mode) {
+			background: daff-theme.daff-color($neutral, 10);
+			color: daff-theme.daff-color($neutral, 90);
+		}
+
+		@include daff-theme.daff-dark-mode($mode) {
+			background: daff-theme.daff-color($neutral, 90);
+			color: daff-theme.daff-color($neutral, 10);
+		}
+	}
+}
+```
+
+2. Add your component's theme next to `daff-component-themes` in your styles, using `$theme` for light mode and `$theme-dark` for dark mode.
+
+```scss
+@use '@daffodil/design/scss/theme' as daff-theme;
+@use '@daffodil/design/scss/theme/default' as daff-default-theme;
+@use 'custom-component-theme';
+
+.daff-theme-light {
+	@include daff-theme.daff-component-themes(daff-default-theme.$theme);
+	@include custom-component-theme.custom-component-theme(daff-default-theme.$theme);
+}
+
+.daff-theme-dark {
+	@include daff-theme.daff-component-themes(daff-default-theme.$theme-dark);
+	@include custom-component-theme.custom-component-theme(daff-default-theme.$theme-dark);
+}
+```
+
+> Only add the styles that change between light and dark mode to your theme file. Styles that stay the same, like layout and spacing, belong in your component's stylesheet.
+
 ## Configure a theme toggle
 Use the [theme toggle](/libs/storefront/theme-toggle/README.md) component from `@daffodil/storefront/theme-toggle` to add a button that toggles between light and dark modes.
 

--- a/libs/design/hero/src/hero-theme.scss
+++ b/libs/design/hero/src/hero-theme.scss
@@ -17,7 +17,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-hero {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			@include daff-hero-theme-variant(daff-color($neutral, 10));
 
 			&.daff-primary {
@@ -33,7 +33,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			@include daff-hero-theme-variant(daff-color($neutral, 90));
 
 			&.daff-primary {

--- a/libs/design/list/src/list-theme.scss
+++ b/libs/design/list/src/list-theme.scss
@@ -18,7 +18,7 @@
 				background-color: $base;
 			}
 
-			@include light($mode) {
+			@include daff-light-mode($mode) {
 				&.active {
 					&::after {
 						background-color: rgba(daff-color($neutral, 20), 0.5);
@@ -34,7 +34,7 @@
 				}
 			}
 
-			@include dark($mode) {
+			@include daff-dark-mode($mode) {
 				&.active {
 					&::after {
 						background-color: rgba(daff-color($neutral, 20), 0.08);

--- a/libs/design/media-gallery/src/media-gallery-theme.scss
+++ b/libs/design/media-gallery/src/media-gallery-theme.scss
@@ -8,7 +8,7 @@
 	.daff-media-gallery {
 		$root: &;
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			.daff-thumbnail {
 				background: daff-color($neutral, 20);
 
@@ -18,7 +18,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			.daff-thumbnail {
 				background: daff-color($neutral, 70);
 

--- a/libs/design/menu/src/menu-theme.scss
+++ b/libs/design/menu/src/menu-theme.scss
@@ -7,7 +7,7 @@
 	$base-contrast: daff-get-base-color($theme, base-contrast);
 	$mode: daff-get-theme-mode($theme);
 
-	@include light($mode) {
+	@include daff-light-mode($mode) {
 		.daff-menu {
 			background: $base;
 			box-shadow: 0 0 1.5rem rgb($black, 0.12);
@@ -29,7 +29,7 @@
 		}
 	}
 
-	@include dark($mode) {
+	@include daff-dark-mode($mode) {
 		.daff-menu {
 			background: $base;
 			box-shadow: 0 0 1.5rem rgb($black, 0.12);

--- a/libs/design/notification/src/notification-theme.scss
+++ b/libs/design/notification/src/notification-theme.scss
@@ -12,7 +12,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-notification {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			background: daff-color($neutral, 10);
 			border: 1px solid daff-color($neutral, 20);
 			color: $base-contrast;
@@ -58,7 +58,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			background: daff-color($neutral, 90);
 			border: 1px solid daff-color($neutral, 80);
 			color: $base-contrast;

--- a/libs/design/paginator/src/paginator-theme.scss
+++ b/libs/design/paginator/src/paginator-theme.scss
@@ -14,7 +14,7 @@
 			color: $base-contrast;
 		}
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&__page-link {
 				@media (hover: hover) {
 					&:hover {
@@ -32,7 +32,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&__page-link {
 				@media (hover: hover) {
 					&:hover {

--- a/libs/design/progress-bar/src/progress-bar-theme.scss
+++ b/libs/design/progress-bar/src/progress-bar-theme.scss
@@ -18,13 +18,13 @@
 			color: daff-text-contrast($base);
 		}
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			#{$root}__track {
 				background: daff-color($neutral, 30);
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			#{$root}__track {
 				background: daff-color($neutral, 80);
 			}

--- a/libs/design/scss/state/skeleton/_mixins.scss
+++ b/libs/design/scss/state/skeleton/_mixins.scss
@@ -7,14 +7,14 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-skeleton {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&::before,
 			::before {
 				background: daff-color($neutral, 20);
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&::before,
 			::before {
 				background: daff-color($neutral, 90);

--- a/libs/design/scss/theming/_get-theme-mode.scss
+++ b/libs/design/scss/theming/_get-theme-mode.scss
@@ -17,7 +17,7 @@
 /// 	@use '@daffodil/design/scss/theme' as daff-theme;
 ///
 /// 	@mixin custom-content-theme($theme) {
-/// 		$mode: daff-get-theme-mode($theme);
+/// 		$mode: daff-theme.daff-get-theme-mode($theme);
 /// 	}
 ///
 

--- a/libs/design/scss/theming/_light-dark.scss
+++ b/libs/design/scss/theming/_light-dark.scss
@@ -11,16 +11,16 @@
 /// 	@mixin custom-content-theme($theme) {
 /// 		$mode: daff-theme.daff-get-theme-mode($theme);
 ///
-/// 		@include daff-theme.light($mode) {
+/// 		@include daff-theme.daff-light-mode($mode) {
 /// 			color: blue;
 ///
-///   		.class {
-///   			background: white;
-///				}
-///	 		}
+/// 			.class {
+/// 				background: white;
+/// 			}
+/// 		}
 /// 	}
 ///
-@mixin light($mode) {
+@mixin daff-light-mode($mode) {
 	@if $mode == 'light' {
 		@content;
 	}
@@ -39,16 +39,41 @@
 /// 	@mixin custom-content-theme($theme) {
 /// 		$mode: daff-theme.daff-get-theme-mode($theme);
 ///
-/// 		@include daff-theme.dark($mode) {
+/// 		@include daff-theme.daff-dark-mode($mode) {
 /// 			color: white;
 ///
-///   		.class {
-///   			background: blue;
-///				}
-///	 		}
+/// 			.class {
+/// 				background: blue;
+/// 			}
+/// 		}
 /// 	}
-@mixin dark($mode) {
+///
+@mixin daff-dark-mode($mode) {
 	@if $mode == 'dark' {
+		@content;
+	}
+}
+
+/// @deprecated Use `daff-light-mode` instead.
+///
+/// @group Theming
+///
+/// @alias daff-light-mode
+///
+@mixin light($mode) {
+	@include daff-light-mode($mode) {
+		@content;
+	}
+}
+
+/// @deprecated Use `daff-dark-mode` instead.
+///
+/// @group Theming
+///
+/// @alias daff-dark-mode
+///
+@mixin dark($mode) {
+	@include daff-dark-mode($mode) {
 		@content;
 	}
 }

--- a/libs/design/select/src/select-theme.scss
+++ b/libs/design/select/src/select-theme.scss
@@ -14,7 +14,7 @@
 	.daff-select {
 		$root: '.daff-select';
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&.disabled {
 				#{$root}__field {
 					color: daff-color($neutral, 50);
@@ -44,7 +44,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&.disabled {
 				#{$root}__field {
 					color: daff-color($neutral, 70);

--- a/libs/design/switch/src/switch-theme.scss
+++ b/libs/design/switch/src/switch-theme.scss
@@ -21,7 +21,7 @@
 			}
 		}
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			&__toggle {
 				background-color: daff-color($neutral, 30);
 
@@ -37,7 +37,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			&__toggle {
 				background-color: daff-color($neutral, 70);
 

--- a/libs/design/tabs/src/tabs-theme.scss
+++ b/libs/design/tabs/src/tabs-theme.scss
@@ -6,7 +6,7 @@
 	$base-contrast: daff-get-base-color($theme, base-contrast);
 	$mode: daff-get-theme-mode($theme);
 
-	@include light($mode) {
+	@include daff-light-mode($mode) {
 		.daff-tabs {
 			&__tab-list {
 				&::after {
@@ -25,7 +25,7 @@
 		}
 	}
 
-	@include dark($mode) {
+	@include daff-dark-mode($mode) {
 		.daff-tabs {
 			&__tab-list {
 				&::after {

--- a/libs/design/tag/src/tag-theme.scss
+++ b/libs/design/tag/src/tag-theme.scss
@@ -15,7 +15,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-tag {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			background: daff-color($neutral, 20);
 			color: $black;
 
@@ -123,7 +123,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			background: daff-color($neutral, 80);
 			color: daff-color($neutral, 20);
 

--- a/libs/design/toast/src/toast-theme.scss
+++ b/libs/design/toast/src/toast-theme.scss
@@ -12,7 +12,7 @@
 	$mode: daff-get-theme-mode($theme);
 
 	.daff-toast {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			background: daff-color($neutral, 10);
 			box-shadow: 0 -16px 24px -4px rgba($black, 0.04),
 				0 8px 24px -4px rgba($black, 0.1);
@@ -62,7 +62,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			background: daff-color($neutral, 90);
 			box-shadow: 0 -16px 24px -4px rgba($black, 0.04),
 				0 8px 24px -4px rgba($black, 0.1);

--- a/libs/design/tree/src/tree-theme.scss
+++ b/libs/design/tree/src/tree-theme.scss
@@ -11,7 +11,7 @@
 	.daff-tree-item {
 		$root: &;
 
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			background-color: $base;
 			color: daff-color($neutral, 90);
 
@@ -35,7 +35,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			background-color: $base;
 			color: daff-color($neutral, 20);
 

--- a/libs/docs/src/example-viewer/example-viewer-theme.scss
+++ b/libs/docs/src/example-viewer/example-viewer-theme.scss
@@ -14,7 +14,7 @@
 	$background-dark: daff-color($neutral, 90);
 
 	.daff-docs-example-viewer-code {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			border: $border-light;
 
 			&__nav {
@@ -31,7 +31,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			border: $border-dark;
 
 			&__nav {
@@ -58,7 +58,7 @@
 	}
 
 	.daff-docs-example-viewer-preview {
-		@include light($mode) {
+		@include daff-light-mode($mode) {
 			border: $border-light;
 
 			&__viewport-controls {
@@ -67,7 +67,7 @@
 			}
 		}
 
-		@include dark($mode) {
+		@include daff-dark-mode($mode) {
 			border: $border-dark;
 
 			&__viewport-controls {

--- a/libs/storefront/carousel/src/carousel-theme.scss
+++ b/libs/storefront/carousel/src/carousel-theme.scss
@@ -5,7 +5,7 @@
 	$base-contrast: daff-get-base-color($theme, base-contrast);
 	$mode: daff-get-theme-mode($theme);
 
-	@include light($mode) {
+	@include daff-light-mode($mode) {
 		.daff-sf-carousel {
 			&__button {
 				color: $base-contrast;
@@ -30,7 +30,7 @@
 		}
 	}
 
-	@include dark($mode) {
+	@include daff-dark-mode($mode) {
 		.daff-sf-carousel {
 			&__button {
 				color: $base-contrast;


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4634 

## New behavior
Rename the `light` and `dark` mixins to `daff-light-mode` and `daff-dark-mode` to match the naming used across the rest of the theming API. The old mixins are kept as deprecated aliases, and all internal usage are updated to the new names. The `light` and `dark` mixins should be removed in v1.0.0.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->