### PR TITLE
fix(design): apply article styles to articles nested in encapsulated components

### DIFF
--- a/libs/design/article/src/article/_stops-article-cascade.scss
+++ b/libs/design/article/src/article/_stops-article-cascade.scss
@@ -1,6 +1,10 @@
 @mixin stopsArticleCascade($selector...) {
 	#{$selector} {
-		&:not(.daff-ae *, .daff-ae) {
+		// `.daff-ae` only stops the cascade when it sits between the element and
+		// the article. Anchoring it to `.daff-article` keeps article styles
+		// working when an article is nested inside an encapsulated component.
+		// `:where` keeps the anchored selector from raising specificity.
+		&:not(.daff-ae, :where(.daff-article .daff-ae *)) {
 			@content;
 		}
 	}


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
`stopsArticleCascade` emitted `:not(.daff-ae *, .daff-ae)`, where `.daff-ae *` is not attached to `.daff-article` — it excluded any element with a `.daff-ae` ancestor anywhere in the chain, not just one sitting between the element and its article. Because many components apply `DaffArticleEncapsulatedDirective` as a host directive, placing a `daff-article` inside one of them removes the article's heading, paragraph, and link styles.

Fixes: #4662

## New behavior
`:where` keeps the `.daff-article` selector at zero specificity

```
<daff-callout class="daff-ae">  <!-- matched by .daff-ae -->
  <daff-article>
    <a> <!-- so this matches ".daff-ae *" -->
```

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->