### PR TITLE
feat(design): support nested submenus in menu

### DIFF
--- a/libs/design-examples/menu/src/nested-menu-with-click/menu-content/menu-content.component.html
+++ b/libs/design-examples/menu/src/nested-menu-with-click/menu-content/menu-content.component.html
@@ -1,0 +1,48 @@
+<daff-menu>
+  <button daff-menu-item>
+    <fa-icon [icon]="faPenToSquare" [fixedWidth]="true" daffPrefix></fa-icon>
+    Rename
+  </button>
+
+  <button daff-menu-item trigger="click" [daffMenuActivator]="moreOptionsMenu">
+    <fa-icon [icon]="faGear" [fixedWidth]="true" daffPrefix></fa-icon>
+    More options
+  </button>
+
+  <button daff-menu-item trigger="click" [daffMenuActivator]="manageAccessMenu">
+    <fa-icon [icon]="faUser" [fixedWidth]="true" daffPrefix></fa-icon>
+    Manage access
+  </button>
+
+  <button daff-menu-item>
+    <fa-icon [icon]="faArrowRightFromBracket" [fixedWidth]="true" daffPrefix></fa-icon>
+    Delete
+  </button>
+</daff-menu>
+
+<ng-template #moreOptionsMenu>
+  <daff-menu>
+    <button daff-menu-item>Duplicate</button>
+    <button daff-menu-item>Move to&hellip;</button>
+
+    <button daff-menu-item trigger="click" [daffMenuActivator]="shareMenu">
+      <fa-icon [icon]="faShareNodes" [fixedWidth]="true" daffPrefix></fa-icon>
+      Share
+    </button>
+  </daff-menu>
+</ng-template>
+
+<ng-template #shareMenu>
+  <daff-menu>
+    <button daff-menu-item>Email</button>
+    <button daff-menu-item>Copy link</button>
+  </daff-menu>
+</ng-template>
+
+<ng-template #manageAccessMenu>
+  <daff-menu>
+    <button daff-menu-item>Viewer</button>
+    <button daff-menu-item>Commenter</button>
+    <button daff-menu-item>Editor</button>
+  </daff-menu>
+</ng-template>

--- a/libs/design-examples/menu/src/nested-menu-with-click/menu-content/menu-content.component.ts
+++ b/libs/design-examples/menu/src/nested-menu-with-click/menu-content/menu-content.component.ts
@@ -1,0 +1,31 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import {
+  faArrowRightFromBracket,
+  faGear,
+  faPenToSquare,
+  faShareNodes,
+  faUser,
+} from '@fortawesome/free-solid-svg-icons';
+
+import { DAFF_MENU_COMPONENTS } from '@daffodil/design/menu';
+
+@Component({
+  selector: 'nested-menu-with-click-content',
+  templateUrl: './menu-content.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DAFF_MENU_COMPONENTS,
+    FaIconComponent,
+  ],
+})
+export class NestedMenuWithClickContentExampleComponent {
+  faUser = faUser;
+  faPenToSquare = faPenToSquare;
+  faGear = faGear;
+  faShareNodes = faShareNodes;
+  faArrowRightFromBracket = faArrowRightFromBracket;
+}

--- a/libs/design-examples/menu/src/nested-menu-with-click/nested-menu-with-click.component.html
+++ b/libs/design-examples/menu/src/nested-menu-with-click/nested-menu-with-click.component.html
@@ -1,0 +1,3 @@
+<button daff-button color="theme" [daffMenuActivator]="menu">
+  Document
+</button>

--- a/libs/design-examples/menu/src/nested-menu-with-click/nested-menu-with-click.component.ts
+++ b/libs/design-examples/menu/src/nested-menu-with-click/nested-menu-with-click.component.ts
@@ -1,0 +1,22 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+
+import { DaffButtonComponent } from '@daffodil/design/button';
+import { DAFF_MENU_COMPONENTS } from '@daffodil/design/menu';
+
+import { NestedMenuWithClickContentExampleComponent } from './menu-content/menu-content.component';
+
+@Component({
+  selector: 'nested-menu-with-click-example',
+  templateUrl: './nested-menu-with-click.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DaffButtonComponent,
+    DAFF_MENU_COMPONENTS,
+  ],
+})
+export class NestedMenuWithClickExampleComponent {
+  public menu = NestedMenuWithClickContentExampleComponent;
+}

--- a/libs/design-examples/menu/src/nested-menu/menu-content/menu-content.component.html
+++ b/libs/design-examples/menu/src/nested-menu/menu-content/menu-content.component.html
@@ -1,0 +1,48 @@
+<daff-menu>
+  <button daff-menu-item>
+    <fa-icon [icon]="faPenToSquare" [fixedWidth]="true" daffPrefix></fa-icon>
+    Rename
+  </button>
+
+  <button daff-menu-item [daffMenuActivator]="moreOptionsMenu">
+    <fa-icon [icon]="faGear" [fixedWidth]="true" daffPrefix></fa-icon>
+    More options
+  </button>
+
+  <button daff-menu-item [daffMenuActivator]="manageAccessMenu">
+    <fa-icon [icon]="faUser" [fixedWidth]="true" daffPrefix></fa-icon>
+    Manage access
+  </button>
+
+  <button daff-menu-item>
+    <fa-icon [icon]="faArrowRightFromBracket" [fixedWidth]="true" daffPrefix></fa-icon>
+    Delete
+  </button>
+</daff-menu>
+
+<ng-template #moreOptionsMenu>
+  <daff-menu>
+    <button daff-menu-item>Duplicate</button>
+    <button daff-menu-item>Move to&hellip;</button>
+
+    <button daff-menu-item [daffMenuActivator]="shareMenu">
+      <fa-icon [icon]="faShareNodes" [fixedWidth]="true" daffPrefix></fa-icon>
+      Share
+    </button>
+  </daff-menu>
+</ng-template>
+
+<ng-template #shareMenu>
+  <daff-menu>
+    <button daff-menu-item>Email</button>
+    <button daff-menu-item>Copy link</button>
+  </daff-menu>
+</ng-template>
+
+<ng-template #manageAccessMenu>
+  <daff-menu>
+    <button daff-menu-item>Viewer</button>
+    <button daff-menu-item>Commenter</button>
+    <button daff-menu-item>Editor</button>
+  </daff-menu>
+</ng-template>

--- a/libs/design-examples/menu/src/nested-menu/menu-content/menu-content.component.ts
+++ b/libs/design-examples/menu/src/nested-menu/menu-content/menu-content.component.ts
@@ -1,0 +1,31 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import {
+  faArrowRightFromBracket,
+  faGear,
+  faPenToSquare,
+  faShareNodes,
+  faUser,
+} from '@fortawesome/free-solid-svg-icons';
+
+import { DAFF_MENU_COMPONENTS } from '@daffodil/design/menu';
+
+@Component({
+  selector: 'nested-menu-content',
+  templateUrl: './menu-content.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DAFF_MENU_COMPONENTS,
+    FaIconComponent,
+  ],
+})
+export class NestedMenuContentExampleComponent {
+  faUser = faUser;
+  faPenToSquare = faPenToSquare;
+  faGear = faGear;
+  faShareNodes = faShareNodes;
+  faArrowRightFromBracket = faArrowRightFromBracket;
+}

--- a/libs/design-examples/menu/src/nested-menu/nested-menu.component.html
+++ b/libs/design-examples/menu/src/nested-menu/nested-menu.component.html
@@ -1,0 +1,3 @@
+<button daff-button color="theme" [daffMenuActivator]="menu">
+  Document
+</button>

--- a/libs/design-examples/menu/src/nested-menu/nested-menu.component.ts
+++ b/libs/design-examples/menu/src/nested-menu/nested-menu.component.ts
@@ -1,0 +1,22 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+
+import { DaffButtonComponent } from '@daffodil/design/button';
+import { DAFF_MENU_COMPONENTS } from '@daffodil/design/menu';
+
+import { NestedMenuContentExampleComponent } from './menu-content/menu-content.component';
+
+@Component({
+  selector: 'nested-menu-example',
+  templateUrl: './nested-menu.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DaffButtonComponent,
+    DAFF_MENU_COMPONENTS,
+  ],
+})
+export class NestedMenuExampleComponent {
+  public menu = NestedMenuContentExampleComponent;
+}

--- a/libs/design-examples/menu/src/provider.ts
+++ b/libs/design-examples/menu/src/provider.ts
@@ -12,6 +12,14 @@ export const provideDaffDesignMenuExamplesContent = () => makeEnvironmentProvide
     component: () => import('./menu-with-icon-toggle/menu-with-icon-toggle.component').then(c => c.MenuWithIconToggleExampleComponent),
   },
   {
+    id: 'nested-menu',
+    component: () => import('./nested-menu/nested-menu.component').then(c => c.NestedMenuExampleComponent),
+  },
+  {
+    id: 'nested-menu-with-click',
+    component: () => import('./nested-menu-with-click/nested-menu-with-click.component').then(c => c.NestedMenuWithClickExampleComponent),
+  },
+  {
     id: 'menu-with-id',
     component: () => import('./menu-with-id/menu-with-id.component').then(c => c.MenuWithIdExampleComponent),
   },

--- a/libs/design-examples/menu/src/public_api.ts
+++ b/libs/design-examples/menu/src/public_api.ts
@@ -1,5 +1,7 @@
 export { BasicMenuExampleComponent } from './basic-menu/basic-menu.component';
 export { MenuWithIconToggleExampleComponent } from './menu-with-icon-toggle/menu-with-icon-toggle.component';
+export { NestedMenuExampleComponent } from './nested-menu/nested-menu.component';
+export { NestedMenuWithClickExampleComponent } from './nested-menu-with-click/nested-menu-with-click.component';
 export { MenuWithIdExampleComponent } from './menu-with-id/menu-with-id.component';
 export { MenuWithPositionExampleComponent } from './menu-with-position/menu-with-position.component';
 export { provideDaffDesignMenuExamplesContent } from './provider';

--- a/libs/design/menu/README.md
+++ b/libs/design/menu/README.md
@@ -64,7 +64,7 @@ A menu is composed of an activator, a container, and one or more items:
 </ng-template>
 ```
 
-- **`[daffMenuActivator]`**: A directive attached to a button that triggers the menu to open. The selector doubles as an input for the menu content to display.
+- **`[daffMenuActivator]`**: A directive attached to a button that triggers the menu to open. The selector doubles as an input for the menu content to display. Attach it to a `<daff-menu-item>` to turn that item into the parent of a nested submenu.
 - **`<daff-menu>`**: The container component that holds all menu items.
 - **`<daff-menu-item>`**: A single action or navigation item within the menu. Use with an anchor or button element.
 - **`[daffPrefix]`**: Adds a decorative icon before the menu item content.
@@ -86,6 +86,46 @@ By default a menu opens below its activator, aligned to its left edge. Set `yPos
 
 <daff-docs-example-viewer example="menu-with-position"></daff-docs-example-viewer>
 
+### Nested menu
+A menu item supports the ability to open a submenu. Add `daffMenuActivator` to a `<daff-menu-item>` and point it at a template containing a nested `<daff-menu>`.
+
+```html
+<ng-template #actionsMenu>
+  <daff-menu>
+    <button daff-menu-item>Rename</button>
+
+    <!-- This item opens the submenu below. -->
+    <button daff-menu-item [daffMenuActivator]="moreMenu">
+      More options
+    </button>
+
+    <a href="/settings" daff-menu-item>Settings</a>
+  </daff-menu>
+</ng-template>
+
+<ng-template #moreMenu>
+  <daff-menu>
+    <button daff-menu-item>Duplicate</button>
+    <button daff-menu-item>Archive</button>
+  </daff-menu>
+</ng-template>
+```
+
+By default, a submenu opens on hover. Keyboard users open a submenu with `Enter` or `Right Arrow` regardless of the trigger.
+
+<daff-docs-example-viewer example="nested-menu"></daff-docs-example-viewer>
+
+### Open a submenu on click
+Set `trigger="click"` on the parent item to open its submenu on click instead of on hover.
+
+```html
+<button daff-menu-item trigger="click" [daffMenuActivator]="moreMenu">
+  More options
+</button>
+```
+
+<daff-docs-example-viewer example="nested-menu-with-click"></daff-docs-example-viewer>
+
 ## Accessibility
 Menu follows the [Menu and Menubar WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/).
 
@@ -93,6 +133,7 @@ Menu follows the [Menu and Menubar WAI-ARIA design pattern](https://www.w3.org/W
 - `role="menu"` and `role="menuitem"` on appropriate elements
 - Focus management when menu opens and closes
 - `aria-expanded` on the activator indicating the menu state
+- `aria-haspopup="menu"` on a parent item that reveals a submenu
 
 ### Developer responsibilities
 - Provide a meaningful label on the menu activator
@@ -105,8 +146,10 @@ Keyboard focus is placed on the first item when a menu is opened.
 | Key | Action |
 | --- | ------ |
 | `Enter` / `Space` | Opens the menu when focused on the activator, or activates the focused menu item |
-| `Escape` | Closes the menu and returns focus to the menu activator |
+| `Escape` | Closes the open menu |
 | `Down Arrow` | Moves focus to the next item. If focus is on the last item, focus moves to the first item |
 | `Up Arrow` | Moves focus to the previous item. If focus is on the first item, focus moves to the last item |
+| `Right Arrow` | Opens the current menu's submenu and moves focus to its first item |
+| `Left Arrow` | Closes the current menu if it's a submenu and returns focus to its parent item |
 | `Home` | Moves focus to the first item |
 | `End` | Moves focus to the last item |

--- a/libs/design/menu/src/helpers/create-overlay.spec.ts
+++ b/libs/design/menu/src/helpers/create-overlay.spec.ts
@@ -1,4 +1,7 @@
-import { STANDARD_DROPDOWN_BELOW_POSITIONS } from '@angular/cdk/overlay';
+import {
+  STANDARD_DROPDOWN_ADJACENT_POSITIONS,
+  STANDARD_DROPDOWN_BELOW_POSITIONS,
+} from '@angular/cdk/overlay';
 import { ElementRef } from '@angular/core';
 
 import { daffMenuCreateOverlay } from './create-overlay';
@@ -25,6 +28,7 @@ describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
       position: jasmine.createSpy('position').and.returnValue(positionStrategy),
       scrollStrategies: {
         block: jasmine.createSpy('block').and.returnValue('block'),
+        reposition: jasmine.createSpy('reposition').and.returnValue('reposition'),
       },
     };
   });
@@ -97,6 +101,59 @@ describe('@daffodil/design/menu | daffMenuCreateOverlay', () => {
       daffMenuCreateOverlay(overlay, element, 'before', 'below');
 
       expect(position()).toEqual(jasmine.objectContaining({ originX: 'end', overlayX: 'end' }));
+    });
+  });
+
+  describe('a top-level (non-nested) menu', () => {
+    it('should own a backdrop', () => {
+      daffMenuCreateOverlay(overlay, element);
+
+      expect(config().hasBackdrop).toBe(true);
+    });
+
+    it('should block page scroll', () => {
+      daffMenuCreateOverlay(overlay, element);
+
+      expect(overlay.scrollStrategies.block).toHaveBeenCalled();
+      expect(config().scrollStrategy).toBe('block');
+    });
+  });
+
+  describe('a nested submenu', () => {
+    it('should not own a backdrop', () => {
+      daffMenuCreateOverlay(overlay, element, 'after', 'below', true);
+
+      expect(config().hasBackdrop).toBe(false);
+    });
+
+    it('should reposition rather than block scroll so it tracks its parent item', () => {
+      daffMenuCreateOverlay(overlay, element, 'after', 'below', true);
+
+      expect(overlay.scrollStrategies.reposition).toHaveBeenCalled();
+      expect(config().scrollStrategy).toBe('reposition');
+    });
+
+    it('should use the CDK standard adjacent positions', () => {
+      daffMenuCreateOverlay(overlay, element, 'after', 'below', true);
+
+      expect(positions()).toEqual(STANDARD_DROPDOWN_ADJACENT_POSITIONS);
+    });
+
+    it('should open to the right of the item, top-aligned, as its first choice', () => {
+      daffMenuCreateOverlay(overlay, element, 'after', 'below', true);
+
+      expect(position()).toEqual(jasmine.objectContaining({
+        originX: 'end',
+        overlayX: 'start',
+        originY: 'top',
+        overlayY: 'top',
+      }));
+    });
+
+    it('should fall back to the left side of the item', () => {
+      daffMenuCreateOverlay(overlay, element, 'after', 'below', true);
+
+      expect(positions()).toContain(jasmine.objectContaining({ originX: 'start', overlayX: 'end' }));
     });
   });
 });

--- a/libs/design/menu/src/helpers/create-overlay.ts
+++ b/libs/design/menu/src/helpers/create-overlay.ts
@@ -2,6 +2,7 @@ import {
   ConnectedPosition,
   Overlay,
   OverlayConfig,
+  STANDARD_DROPDOWN_ADJACENT_POSITIONS,
   STANDARD_DROPDOWN_BELOW_POSITIONS,
 } from '@angular/cdk/overlay';
 import { ElementRef } from '@angular/core';
@@ -33,12 +34,13 @@ export const daffMenuCreateOverlay = (
   element: ElementRef,
   xPosition: DaffMenuXPosition = 'after',
   yPosition: DaffMenuYPosition = 'below',
+  nested = false,
   config: OverlayConfig = {},
 ) => overlay.create({
-  hasBackdrop: true,
+  hasBackdrop: !nested,
   backdropClass: 'cdk-overlay-transparent-backdrop',
   panelClass: 'daff-menu-overlay',
-  scrollStrategy: overlay.scrollStrategies.block(),
+  scrollStrategy: nested ? overlay.scrollStrategies.reposition() : overlay.scrollStrategies.block(),
   disposeOnNavigation: true,
   positionStrategy: overlay
     .position()
@@ -47,10 +49,12 @@ export const daffMenuCreateOverlay = (
     .withPush(false)
     .withViewportMargin(24)
     .withPositions(
-      [
-        daffMenuConnectedPosition(xPosition, yPosition),
-        ...STANDARD_DROPDOWN_BELOW_POSITIONS,
-      ],
+      nested
+        ? STANDARD_DROPDOWN_ADJACENT_POSITIONS
+        : [
+          daffMenuConnectedPosition(xPosition, yPosition),
+          ...STANDARD_DROPDOWN_BELOW_POSITIONS,
+        ],
     ),
   ...config,
 });

--- a/libs/design/menu/src/menu-activator/menu-activator.component.spec.ts
+++ b/libs/design/menu/src/menu-activator/menu-activator.component.spec.ts
@@ -1,3 +1,4 @@
+import { InputModalityDetector } from '@angular/cdk/a11y';
 import {
   Component,
   DebugElement,
@@ -8,15 +9,23 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DAFF_MENU_COMPONENTS } from '@daffodil/design/menu';
+import {
+  DAFF_MENU_COMPONENTS,
+  DaffMenuActivatorDirective,
+} from '@daffodil/design/menu';
 
-import { DaffMenuActivatorDirective } from './menu-activator.component';
 import {
   DAFF_MENU_CONFIG,
   DaffMenuConfig,
 } from '../config/menu-config';
 import { DaffMenuService } from '../services/menu.service';
 import { provideTestMenuService } from '../testing/dummy-service';
+
+/**
+ * Hovering only opens a submenu of a menu that's already open, so the stack has to have something
+ * on it before a hover does anything.
+ */
+const openTree = (menuService: DaffMenuService) => menuService.menuStack.push(menuService);
 
 @Component({
   template: `
@@ -98,6 +107,182 @@ describe('@daffodil/design/menu | DaffMenuActivatorDirective', () => {
     activator.focus();
 
     expect(document.activeElement).toEqual(de.nativeElement);
+  });
+
+  it('should open the menu when open() is called', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'open');
+
+    activator.open();
+
+    expect(menuService.open).toHaveBeenCalled();
+  });
+
+  it('should toggle the menu when toggle() is called', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'toggle');
+
+    activator.toggle();
+
+    expect(menuService.toggle).toHaveBeenCalled();
+  });
+
+  it('should not open a top-level menu on hover (it defaults to the click trigger)', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'open');
+
+    activator.onMouseEnter();
+
+    expect(menuService.open).not.toHaveBeenCalled();
+  });
+
+  it('should focus the first item of the menu it opens', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'focusFirstItem');
+
+    activator.open();
+
+    expect(menuService.focusFirstItem).toHaveBeenCalled();
+  });
+
+  it('should not open a submenu on ArrowRight, having no parent menu to open it beside', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'open');
+
+    activator.handleKeydown(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+
+    expect(menuService.open).not.toHaveBeenCalled();
+  });
+
+  it('should report when it takes and loses focus', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService.menuStack, 'setHasFocus');
+
+    activator.setHasFocus(true);
+
+    expect(menuService.menuStack.setHasFocus).toHaveBeenCalledWith(true);
+  });
+});
+
+@Component({
+  template: `
+    <button daff-menu-item [daffMenuActivator]="submenu">Parent</button>
+
+    <ng-template #submenu>
+      <daff-menu>
+        <button daff-menu-item>Child</button>
+      </daff-menu>
+    </ng-template>
+  `,
+  imports: [
+    DAFF_MENU_COMPONENTS,
+  ],
+})
+class NestedWrapperComponent {}
+
+describe('@daffodil/design/menu | DaffMenuActivatorDirective | Nested submenu', () => {
+  let fixture: ComponentFixture<NestedWrapperComponent>;
+  let de: DebugElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NestedWrapperComponent,
+      ],
+      providers: [
+        provideTestMenuService(),
+        { provide: DAFF_MENU_CONFIG, useValue: <DaffMenuConfig>{ menuId: 'daff-menu-test' }},
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NestedWrapperComponent);
+    fixture.detectChanges();
+
+    de = fixture.debugElement.query(By.directive(DaffMenuActivatorDirective));
+  });
+
+  it('should open the submenu on hover (the default trigger for a nested submenu)', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'open');
+    openTree(menuService);
+
+    activator.onMouseEnter();
+
+    expect(menuService.open).toHaveBeenCalled();
+  });
+
+  it('should open the submenu on hover without taking focus off the menu the pointer came from', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'focusFirstItem');
+    openTree(menuService);
+
+    activator.onMouseEnter();
+
+    expect(menuService.focusFirstItem).not.toHaveBeenCalled();
+  });
+
+  it('should not open the submenu on hover before its own menu is open', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'open');
+
+    activator.onMouseEnter();
+
+    expect(menuService.open).not.toHaveBeenCalled();
+  });
+
+  it('should not open the submenu on hover from a touch', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'open');
+    openTree(menuService);
+    spyOnProperty(TestBed.inject(InputModalityDetector), 'mostRecentModality', 'get').and.returnValue('touch');
+
+    activator.onMouseEnter();
+
+    expect(menuService.open).not.toHaveBeenCalled();
+  });
+
+  it('should open the submenu and move focus into it on ArrowRight', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'open');
+    spyOn(menuService, 'focusFirstItem');
+
+    activator.handleKeydown(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+
+    expect(menuService.open).toHaveBeenCalled();
+    expect(menuService.focusFirstItem).toHaveBeenCalledWith('keyboard');
+  });
+
+  it('should move focus into an already open submenu on ArrowRight rather than reopening it', () => {
+    const activator = de.injector.get(DaffMenuActivatorDirective);
+    const menuService = de.injector.get(DaffMenuService);
+    activator.open();
+    spyOn(menuService, 'open');
+    spyOn(menuService, 'focusFirstItem');
+
+    activator.handleKeydown(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+
+    expect(menuService.open).not.toHaveBeenCalled();
+    expect(menuService.focusFirstItem).toHaveBeenCalledWith('keyboard');
+  });
+
+  it('should toggle rather than re-open when a nested parent item is clicked', () => {
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'toggle');
+
+    de.nativeElement.click();
+
+    expect(menuService.toggle).toHaveBeenCalled();
   });
 });
 

--- a/libs/design/menu/src/menu-activator/menu-activator.component.ts
+++ b/libs/design/menu/src/menu-activator/menu-activator.component.ts
@@ -1,7 +1,12 @@
 import {
+  FocusOrigin,
+  InputModalityDetector,
+} from '@angular/cdk/a11y';
+import {
   ChangeDetectorRef,
   computed,
   Directive,
+  Injector,
   input,
   OnDestroy,
   signal,
@@ -10,6 +15,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import {
+  filter,
   Subject,
   takeUntil,
 } from 'rxjs';
@@ -19,10 +25,25 @@ import {
   DaffMenuXPosition,
   DaffMenuYPosition,
 } from '../helpers/menu-position';
+import { DAFF_MENU_ITEM_TOKEN } from '../menu-item/menu-item.token';
+import { DAFF_PARENT_OR_NEW_MENU_STACK_PROVIDER } from '../services/menu-stack';
 import { DaffMenuService } from '../services/menu.service';
 
 /**
+ * How a submenu opens. Keyboard opening (Enter / Right Arrow) always works regardless of the trigger.
+ *
+ * - `hover` opens the submenu on mouse hover of the parent menu item.
+ * This is the default for nested submenus.
+ *
+ * - `click` opens the submenu when the parent item is clicked.
+ * This is the default for top-level menus.
+ */
+export type DaffMenuTrigger = 'hover' | 'click';
+
+/**
  * Directive that triggers the menu to open/close. Applied to the button that activates the menu. The selector doubles as an input for the menu content to display.
+ *
+ * Placing it on a `daff-menu-item` turns that item into the parent of a nested submenu.
  *
  * @example
  * ```html
@@ -35,6 +56,10 @@ import { DaffMenuService } from '../services/menu.service';
   selector: '[daffMenuActivator]',
   host: {
     '(click)': 'onClick($event)',
+    '(keydown)': 'handleKeydown($event)',
+    '(mouseenter)': 'onMouseEnter()',
+    '(focusin)': 'setHasFocus(true)',
+    '(focusout)': 'setHasFocus(false)',
     'aria-haspopup': 'menu',
     '[attr.aria-expanded]': 'ariaExpanded',
     '[attr.aria-controls]': '_open ? menuId() : null',
@@ -42,6 +67,7 @@ import { DaffMenuService } from '../services/menu.service';
   exportAs: 'daffMenuActivator',
   providers: [
     DaffMenuService,
+    DAFF_PARENT_OR_NEW_MENU_STACK_PROVIDER,
   ],
 })
 export class DaffMenuActivatorDirective implements OnDestroy {
@@ -50,6 +76,8 @@ export class DaffMenuActivatorDirective implements OnDestroy {
   private _defaultMenuId = daffNextMenuId();
   protected _open: boolean;
   readonly isOpen = signal(false);
+
+  private _nestedCache?: boolean;
 
   /**
    * The menu content to display when activated.
@@ -73,6 +101,19 @@ export class DaffMenuActivatorDirective implements OnDestroy {
   yPosition = input<DaffMenuYPosition>('below');
 
   /**
+   * How the menu opens in response to the pointer. Defaults to `hover` for nested submenus and
+   * `click` for top-level menus.
+   */
+  trigger = input<DaffMenuTrigger>();
+
+  /**
+   * The resolved pointer trigger, defaulting by nesting when unset.
+   */
+  protected resolvedTrigger = computed<DaffMenuTrigger>(() =>
+    this.trigger() ?? (this._nested ? 'hover' : 'click'),
+  );
+
+  /**
    * The resolved menu ID.
    */
   protected menuId = computed(() => {
@@ -87,10 +128,22 @@ export class DaffMenuActivatorDirective implements OnDestroy {
     return this._open ? 'true' : 'false';
   }
 
+  /**
+   * Whether this activator is nested inside a menu.
+   */
+  private get _nested() {
+    if (this._nestedCache === undefined) {
+      this._nestedCache = !!this.injector.get(DAFF_MENU_ITEM_TOKEN, null, { self: true, optional: true });
+    }
+    return this._nestedCache;
+  }
+
   constructor(
     private service: DaffMenuService,
     private viewContainerRef: ViewContainerRef,
     private cdRef: ChangeDetectorRef,
+    private injector: Injector,
+    private inputModalityDetector: InputModalityDetector,
   ) {
     this.service.open$.pipe(
       takeUntil(this._destroyed$),
@@ -99,6 +152,11 @@ export class DaffMenuActivatorDirective implements OnDestroy {
       this.isOpen.set(this._open);
       this.cdRef.markForCheck();
     });
+
+    this.service.menuStack.hasFocus.pipe(
+      filter((hasFocus) => !hasFocus && !this._nested && !this.service.menuStack.isEmpty()),
+      takeUntil(this._destroyed$),
+    ).subscribe(() => this.service.closeAll());
   }
 
   /**
@@ -118,9 +176,85 @@ export class DaffMenuActivatorDirective implements OnDestroy {
 
   /**
    * @docs-private
+   *
+   * Whether or not this activator holds focus.
+   */
+  setHasFocus(hasFocus: boolean) {
+    if (!this._nested) {
+      this.service.menuStack.setHasFocus(hasFocus);
+    }
+  }
+
+  private _config() {
+    return { menuId: this.menuId(), xPosition: this.xPosition(), yPosition: this.yPosition() };
+  }
+
+  /**
+   * Opens the menu.
+   */
+  open() {
+    this.service.open(this.viewContainerRef, this.daffMenuActivator(), this._config());
+    this.service.focusFirstItem('program');
+  }
+
+  /**
+   * Toggles the menu open or closed.
+   */
+  toggle() {
+    this.service.toggle(this.viewContainerRef, this.daffMenuActivator(), this._config());
+
+    if (this._open) {
+      this.service.focusFirstItem('program');
+    }
+  }
+
+  /**
+   * @docs-private
    */
   onClick(event: MouseEvent) {
     event.preventDefault();
-    this.service.open(this.viewContainerRef, this.daffMenuActivator(), { menuId: this.menuId(), xPosition: this.xPosition(), yPosition: this.yPosition() });
+    if (this._nested) {
+      this.toggle();
+    } else {
+      this.open();
+    }
+  }
+
+  /**
+   * @docs-private
+   *
+   * Opens a submenu when the pointer reaches its parent item, leaving focus where it is.
+   */
+  onMouseEnter() {
+    if (
+      this.resolvedTrigger() === 'hover' &&
+      this.inputModalityDetector.mostRecentModality !== 'touch' &&
+      !this.service.menuStack.isEmpty() &&
+      !this._open
+    ) {
+      this.service.open(this.viewContainerRef, this.daffMenuActivator(), this._config());
+    }
+  }
+
+  /**
+   * @docs-private
+   *
+   * Opens the activator's submenu and moves focus into it.
+   */
+  handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'ArrowRight' && this._nested) {
+      event.preventDefault();
+
+      if (this._open) {
+        this.service.focusFirstItem('keyboard');
+      } else {
+        this._openWithFocus('keyboard');
+      }
+    }
+  }
+
+  private _openWithFocus(origin: FocusOrigin) {
+    this.service.open(this.viewContainerRef, this.daffMenuActivator(), this._config());
+    this.service.focusFirstItem(origin);
   }
 }

--- a/libs/design/menu/src/menu-item/menu-item.component.html
+++ b/libs/design/menu/src/menu-item/menu-item.component.html
@@ -1,4 +1,7 @@
 @if (_prefix) {
   <ng-content select="[daffPrefix]"></ng-content>
 }
-<ng-content></ng-content>
+<div class="daff-menu-item__content"><ng-content></ng-content></div>
+@if (hasSubmenu) {
+  <fa-icon size="sm" [icon]="faChevronRight" class="daff-menu-item__submenu-indicator"></fa-icon>
+}

--- a/libs/design/menu/src/menu-item/menu-item.component.spec.ts
+++ b/libs/design/menu/src/menu-item/menu-item.component.spec.ts
@@ -9,8 +9,12 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DaffMenuItemComponent } from '@daffodil/design/menu';
+import {
+  DAFF_MENU_COMPONENTS,
+  DaffMenuItemComponent,
+} from '@daffodil/design/menu';
 
+import { DaffMenuService } from '../services/menu.service';
 import { provideTestMenuService } from '../testing/dummy-service';
 
 @Component({
@@ -76,5 +80,153 @@ describe('@daffodil/design/menu | DaffMenuItemComponent', () => {
 
   it('should have a role of menuitem', () => {
     expect(de.nativeElement.getAttribute('role')).toBe('menuitem');
+  });
+
+  it('should not report a submenu when it has no activator', () => {
+    expect(component.hasSubmenu).toBe(false);
+  });
+
+  it('should not render a submenu indicator when it has no activator', () => {
+    expect(de.query(By.css('.daff-menu-item__submenu-indicator'))).toBeNull();
+  });
+
+  it('should not set aria-haspopup when it has no activator', () => {
+    expect(de.nativeElement.getAttribute('aria-haspopup')).toBeNull();
+  });
+
+  it('should close every open menu when a leaf item is activated', () => {
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService, 'closeAll');
+
+    component.onClick();
+
+    expect(menuService.closeAll).toHaveBeenCalled();
+  });
+
+  it('should not expose a submenu when it has no activator', () => {
+    expect(component.submenu).toBeNull();
+  });
+
+  it('should step back to the parent menu on ArrowLeft when it is in a submenu', () => {
+    const menuService = de.injector.get(DaffMenuService);
+    (<any>menuService).isNested = true;
+    spyOn(menuService, 'close');
+
+    de.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+
+    expect(menuService.close).toHaveBeenCalled();
+  });
+
+  it('should not close the root menu on ArrowLeft', () => {
+    const menuService = de.injector.get(DaffMenuService);
+    (<any>menuService).isNested = false;
+    spyOn(menuService, 'close');
+
+    de.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+
+    expect(menuService.close).not.toHaveBeenCalled();
+  });
+
+  it('should close an open submenu of its menu once the pointer reaches it', () => {
+    const menuService = de.injector.get(DaffMenuService);
+    menuService.menuStack.push(menuService);
+    spyOn(menuService.menuStack, 'closeSubMenuOf');
+
+    de.nativeElement.dispatchEvent(new MouseEvent('mouseenter'));
+
+    expect(menuService.menuStack.closeSubMenuOf).toHaveBeenCalledWith(menuService);
+  });
+
+  it('should not close anything on hover while no menu is open', () => {
+    const menuService = de.injector.get(DaffMenuService);
+    spyOn(menuService.menuStack, 'closeSubMenuOf');
+
+    de.nativeElement.dispatchEvent(new MouseEvent('mouseenter'));
+
+    expect(menuService.menuStack.closeSubMenuOf).not.toHaveBeenCalled();
+  });
+});
+
+@Component({
+  template: `
+    <button daff-menu-item [daffMenuActivator]="submenu">Parent</button>
+
+    <ng-template #submenu>
+      <daff-menu>
+        <button daff-menu-item>Child</button>
+      </daff-menu>
+    </ng-template>
+  `,
+  imports: [
+    DAFF_MENU_COMPONENTS,
+  ],
+})
+class SubmenuWrapperComponent {}
+
+describe('@daffodil/design/menu | DaffMenuItemComponent | as a submenu parent', () => {
+  let fixture: ComponentFixture<SubmenuWrapperComponent>;
+  let de: DebugElement;
+  let component: DaffMenuItemComponent;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        SubmenuWrapperComponent,
+      ],
+      providers: [
+        provideTestMenuService(),
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SubmenuWrapperComponent);
+    de = fixture.debugElement.query(By.css('[daff-menu-item]'));
+    component = de.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should report that it has a submenu', () => {
+    expect(component.hasSubmenu).toBe(true);
+  });
+
+  it('should render a submenu indicator', () => {
+    expect(de.query(By.css('.daff-menu-item__submenu-indicator'))).not.toBeNull();
+  });
+
+  it('should set aria-haspopup to menu', () => {
+    expect(de.nativeElement.getAttribute('aria-haspopup')).toBe('menu');
+  });
+
+  it('should open its submenu when openSubmenu is called', () => {
+    const activatorService = de.injector.get(DaffMenuService);
+    spyOn(activatorService, 'open');
+
+    component.openSubmenu();
+
+    expect(activatorService.open).toHaveBeenCalled();
+  });
+
+  it('should not close any menu on click (the activator handles opening)', () => {
+    const activatorService = de.injector.get(DaffMenuService);
+    spyOn(activatorService, 'closeAll');
+
+    component.onClick();
+
+    expect(activatorService.closeAll).not.toHaveBeenCalled();
+  });
+
+  it('should expose the submenu it opens', () => {
+    expect(component.submenu).toBe(de.injector.get(DaffMenuService));
+  });
+
+  it('should keep its own submenu open when the pointer reaches it', () => {
+    const parentMenu = TestBed.inject(DaffMenuService);
+    parentMenu.menuStack.push(parentMenu);
+    spyOn(parentMenu.menuStack, 'closeSubMenuOf');
+
+    de.nativeElement.dispatchEvent(new MouseEvent('mouseenter'));
+
+    expect(parentMenu.menuStack.closeSubMenuOf).not.toHaveBeenCalled();
   });
 });

--- a/libs/design/menu/src/menu-item/menu-item.component.ts
+++ b/libs/design/menu/src/menu-item/menu-item.component.ts
@@ -1,19 +1,26 @@
-/* eslint-disable quote-props */
-import { FocusableOption } from '@angular/cdk/a11y';
+import { InputModalityDetector } from '@angular/cdk/a11y';
 import {
   Component,
   ChangeDetectionStrategy,
   ContentChild,
   ElementRef,
+  Optional,
+  Self,
+  SkipSelf,
 } from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 
 import { DaffPrefixDirective } from '@daffodil/design';
 
 import { provideDaffMenuItemToken } from './menu-item.token';
+import { DaffMenuActivatorDirective } from '../menu-activator/menu-activator.component';
 import { DaffMenuService } from '../services/menu.service';
 
 /**
  * Individual clickable items within the menu. Applied to `<button>` or `<a>` elements.
+ *
+ * Add `daffMenuActivator` to make an item the parent of a nested submenu.
  *
  * @example
  * ```
@@ -27,30 +34,120 @@ import { DaffMenuService } from '../services/menu.service';
     'button[daff-menu-item]',
   templateUrl: './menu-item.component.html',
   host: {
-    'class': 'daff-menu-item',
-    'role': 'menuitem',
+    class: 'daff-menu-item',
+    role: 'menuitem',
     '(click)': 'onClick()',
+    '(keydown)': 'handleKeydown($event)',
+    '(mouseenter)': 'onMouseEnter()',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [provideDaffMenuItemToken(DaffMenuItemComponent)],
+  imports: [
+    FaIconComponent,
+  ],
 })
 
-export class DaffMenuItemComponent implements FocusableOption {
+export class DaffMenuItemComponent {
   /**
    * @docs-private
    */
   @ContentChild(DaffPrefixDirective) _prefix: DaffPrefixDirective;
 
+  /**
+   * @docs-private
+   */
+  faChevronRight = faChevronRight;
+
   constructor(
     private _elementRef: ElementRef<HTMLElement>,
-    private _menuService: DaffMenuService,
+    private _inputModalityDetector: InputModalityDetector,
+
+    /**
+     * @docs-private
+     *
+     * The menu that contains a menu item.
+     */
+    @SkipSelf() private _parentMenu: DaffMenuService,
+
+    /**
+     * @docs-private
+     *
+     * The submenu a menu item opens. Present only when a menu item has an activator,
+     * which is what provides the submenu's service on this element.
+     */
+    @Optional() @Self() private _submenu: DaffMenuService | null,
+
+    /**
+     * @docs-private
+     *
+     * Present when a menu item is the parent of a nested submenu.
+     */
+    @Optional() @Self() private _activator: DaffMenuActivatorDirective | null,
   ) {}
+
+  /**
+   * Whether a menu item has a nested submenu.
+   */
+  get hasSubmenu(): boolean {
+    return !!this._activator;
+  }
+
+  /**
+   * @docs-private
+   *
+   * The submenu a menu item opens, if it has one.
+   * The menu panel uses it to tell which of its items a closing submenu belonged to.
+   */
+  get submenu(): DaffMenuService | null {
+    return this._submenu;
+  }
+
+  /**
+   * @docs-private
+   *
+   * Opens a menu item's submenu.
+   */
+  openSubmenu() {
+    this._activator?.open();
+  }
 
   /**
    * @docs-private
    */
   onClick() {
-    this._menuService.close();
+    if (this._activator) {
+      return;
+    }
+    this._parentMenu.closeAll();
+  }
+
+  /**
+   * @docs-private
+   *
+   * Moving the pointer onto an item that has no submenu of its own closes whichever submenu of this menu is open, so a menu never shows two submenus at once.
+   */
+  onMouseEnter() {
+    const menuStack = this._parentMenu.menuStack;
+
+    if (
+      !this.hasSubmenu &&
+      this._inputModalityDetector.mostRecentModality !== 'touch' &&
+      !menuStack.isEmpty()
+    ) {
+      menuStack.closeSubMenuOf(this._parentMenu);
+    }
+  }
+
+  /**
+   * @docs-private
+   *
+   * Steps back out of a submenu, returning focus to the item that opened it.
+   */
+  handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'ArrowLeft' && this._parentMenu.isNested) {
+      event.preventDefault();
+      this._parentMenu.close();
+    }
   }
 
   /**

--- a/libs/design/menu/src/menu/menu-panel.ts
+++ b/libs/design/menu/src/menu/menu-panel.ts
@@ -1,0 +1,24 @@
+import {
+  FocusableOption,
+  FocusOrigin,
+} from '@angular/cdk/a11y';
+
+/**
+ * @docs-private
+ *
+ * The panel a menu's content renders. `DaffMenuService` holds the panel of the menu it opened so
+ * that whatever opened it can decide whether opening should take focus, which keeps the panel from
+ * having to guess. Declared apart from `DaffMenuComponent` so the service can refer to a panel
+ * without importing the component.
+ */
+export interface DaffMenuPanel {
+  /**
+   * Moves focus to the first item in the menu.
+   */
+  focusFirstItem(origin?: FocusOrigin): void;
+
+  /**
+   * Points the menu's keyboard navigation at the given item without moving focus.
+   */
+  setActiveMenuItem(item: FocusableOption): void;
+}

--- a/libs/design/menu/src/menu/menu.component.scss
+++ b/libs/design/menu/src/menu/menu.component.scss
@@ -28,6 +28,11 @@
 	border-radius: 0.25rem;
 	margin: 0;
 	padding: 0.75rem 1rem;
+	text-align: left;
 	text-decoration: none;
 	width: 100%;
+
+	&__content {
+		flex: 1 1 auto;
+	}
 }

--- a/libs/design/menu/src/menu/menu.component.spec.ts
+++ b/libs/design/menu/src/menu/menu.component.spec.ts
@@ -66,12 +66,12 @@ describe('@daffodil/design/menu | DaffMenuComponent | Defaults', () => {
     }));
   });
 
-  it('should have a tabindex of 0', () => {
-    expect(de.nativeElement.tabIndex).toEqual(0);
-  });
-
   it('should have a role of menu', () => {
     expect(de.nativeElement.getAttribute('role')).toBe('menu');
+  });
+
+  it('should set aria-orietnation to vertical', () => {
+    expect(de.nativeElement.getAttribute('aria-orientation')).toBe('vertical');
   });
 
   it('should have an id matching the provided DAFF_MENU_CONFIG menuId', () => {

--- a/libs/design/menu/src/menu/menu.component.ts
+++ b/libs/design/menu/src/menu/menu.component.ts
@@ -1,22 +1,30 @@
 /* eslint-disable quote-props */
 import {
-  ConfigurableFocusTrapFactory,
-  ConfigurableFocusTrap,
   FocusKeyManager,
   FocusableOption,
+  FocusOrigin,
 } from '@angular/cdk/a11y';
 import {
   AfterContentInit,
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
+  contentChildren,
   Inject,
-  QueryList,
-  ContentChildren,
+  Injector,
+  OnDestroy,
   ViewEncapsulation,
 } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import {
+  filter,
+  map,
+  merge,
+  Subject,
+  switchMap,
+  takeUntil,
+} from 'rxjs';
 
+import { DaffMenuPanel } from './menu-panel';
 import {
   DAFF_MENU_CONFIG,
   DaffMenuConfig,
@@ -50,34 +58,46 @@ import { DaffMenuService } from '../services/menu.service';
   selector: 'daff-menu',
   templateUrl: './menu.component.html',
   styleUrl: './menu.component.scss',
-  encapsulation: ViewEncapsulation.None, // Required to allow breadcrumb items to take on `.daff-menu-item` styles
+  // Required to allow breadcrumb items to take on `.daff-menu-item` styles
+  encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'daff-menu',
-    'tabindex': '0',
     'role': 'menu',
+    'aria-orientation': 'vertical',
     '[id]': 'config.menuId',
     '(keydown)': 'handleKeydown($event)',
+    '(focusin)': 'setHasFocus(true)',
+    '(focusout)': 'setHasFocus(false)',
   },
   imports: [
     DaffMenuItemComponent,
   ],
 })
-export class DaffMenuComponent implements AfterContentInit, AfterViewInit {
-  private _focusTrap: ConfigurableFocusTrap;
-  private _keyManager: FocusKeyManager<unknown>;
+export class DaffMenuComponent implements AfterContentInit, OnDestroy, DaffMenuPanel {
+  private _keyManager: FocusKeyManager<FocusableOption>;
+  private _destroyed$ = new Subject<void>();
+
+  /**
+   * The item of the menu whose submenu opened most recently.
+   */
+  private _triggerItem: DaffMenuItemComponent | null = null;
+
   /**
    * @docs-private
    *
    * Content children that provide `DAFF_MENU_ITEM_TOKEN` are treated as menu items.
-   * This includes both `daff-menu-item` components and any custom directives that also provide the token.
    */
-  @ContentChildren(DAFF_MENU_ITEM_TOKEN) private _items: QueryList<FocusableOption>;
+  private _items = contentChildren(DAFF_MENU_ITEM_TOKEN);
+
+  /**
+   * The items that can open a submenu.
+   */
+  private _submenuItems = contentChildren(DaffMenuItemComponent);
 
   constructor(
-    private _focusTrapFactory: ConfigurableFocusTrapFactory,
-    private _elementRef: ElementRef<HTMLElement>,
-    private menuService: DaffMenuService,
+    public menuService: DaffMenuService,
+    private _injector: Injector,
 
     /**
      * @docs-private
@@ -88,13 +108,40 @@ export class DaffMenuComponent implements AfterContentInit, AfterViewInit {
   /**
    * @docs-private
    *
-   * Handles keyboard navigation.
+   * Reports whether this menu holds focus. Open menus close once focus leaves them all.
+   */
+  setHasFocus(hasFocus: boolean) {
+    this.menuService.menuStack.setHasFocus(hasFocus);
+  }
+
+  /**
+   * Moves focus to the first item in the menu.
+   */
+  focusFirstItem(origin: FocusOrigin = 'program') {
+    if (this._items().length > 0) {
+      this._keyManager.setFocusOrigin(origin);
+      this._keyManager.setFirstItemActive();
+    }
+  }
+
+  /**
+   * Points the menu's keyboard navigation at the given item without moving focus.
+   */
+  setActiveMenuItem(item: FocusableOption) {
+    this._keyManager?.updateActiveItem(item);
+  }
+
+  /**
+   * @docs-private
    */
   handleKeydown(event: KeyboardEvent): void {
     switch (event.key) {
       case 'Escape':
         event.preventDefault();
         this.menuService.close();
+        break;
+      case 'Tab':
+        this.menuService.closeAll();
         break;
       case 'ArrowDown':
       case 'ArrowUp':
@@ -110,23 +157,44 @@ export class DaffMenuComponent implements AfterContentInit, AfterViewInit {
    * @docs-private
    */
   ngAfterContentInit() {
-    this._focusTrap = this._focusTrapFactory.create(
-      this._elementRef.nativeElement,
-    );
-
-    this._keyManager = new FocusKeyManager(this._items)
+    this._keyManager = new FocusKeyManager<FocusableOption>(this._items, this._injector)
       .withWrap()
       .withHomeAndEnd();
+
+    this._watchSubmenus();
+    this.menuService.registerPanel(this);
   }
 
   /**
    * @docs-private
    */
-  ngAfterViewInit() {
-    // Set focus to the first menu item when menu opens
-    if (this._items.length > 0) {
-      this._keyManager.setFirstItemActive();
-      this._keyManager.setActiveItem(0);
-    }
+  ngOnDestroy() {
+    this._destroyed$.next();
+    this._destroyed$.complete();
+  }
+
+  /**
+   * Tracks which item's submenu is open, and points the keyboard back at that item once the submenu.
+   */
+  private _watchSubmenus() {
+    toObservable(this._submenuItems, { injector: this._injector }).pipe(
+      switchMap((items) => merge(
+        ...items.filter((item) => !!item.submenu).map((item) => item.submenu.open$.pipe(
+          filter((open) => open),
+          map(() => item),
+        )),
+      )),
+      takeUntil(this._destroyed$),
+    ).subscribe((item) => {
+      this._triggerItem = item;
+    });
+
+    this.menuService.menuStack.closed.pipe(
+      takeUntil(this._destroyed$),
+    ).subscribe(({ item, focusParentTrigger }) => {
+      if (focusParentTrigger && this._triggerItem && item === this._triggerItem.submenu) {
+        this.setActiveMenuItem(this._triggerItem);
+      }
+    });
   }
 }

--- a/libs/design/menu/src/menu/specs/nested.spec.ts
+++ b/libs/design/menu/src/menu/specs/nested.spec.ts
@@ -1,0 +1,428 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Component } from '@angular/core';
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  flush,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { DAFF_MENU_COMPONENTS } from '@daffodil/design/menu';
+
+@Component({
+  template: `
+    <button [daffMenuActivator]="rootMenu" id="activator">Open</button>
+
+    <ng-template #rootMenu>
+      <daff-menu>
+        <button daff-menu-item id="leaf">Leaf</button>
+        <button daff-menu-item [daffMenuActivator]="subMenu" trigger="click" id="parent">Parent</button>
+        <button daff-menu-item id="last">Last</button>
+      </daff-menu>
+    </ng-template>
+
+    <ng-template #subMenu>
+      <daff-menu>
+        <button daff-menu-item id="sub-leaf">Sub leaf</button>
+      </daff-menu>
+    </ng-template>
+  `,
+  imports: [
+    DAFF_MENU_COMPONENTS,
+  ],
+})
+class NestedMenuWrapperComponent {}
+
+const KEY_CODES: Record<string, number> = {
+  Tab: 9,
+  Escape: 27,
+  ArrowLeft: 37,
+  ArrowUp: 38,
+  ArrowRight: 39,
+  ArrowDown: 40,
+};
+
+const keydown = (key: string) => {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true });
+  // `FocusKeyManager` reads the deprecated `keyCode`, which a synthetic event leaves at 0.
+  Object.defineProperty(event, 'keyCode', { get: () => KEY_CODES[key] });
+
+  return event;
+};
+
+describe('@daffodil/design/menu | Nested menu | Usage', () => {
+  let fixture: ComponentFixture<NestedMenuWrapperComponent>;
+  let overlayContainer: OverlayContainer;
+  let overlayContainerElement: HTMLElement;
+
+  const menus = () => overlayContainerElement.querySelectorAll('.daff-menu');
+  const backdrops = () => overlayContainerElement.querySelectorAll('.cdk-overlay-backdrop');
+  const openRoot = () => {
+    fixture.debugElement.query(By.css('#activator')).nativeElement.click();
+    fixture.detectChanges();
+    flush();
+    fixture.detectChanges();
+  };
+  const openSubmenu = () => {
+    (<HTMLElement>overlayContainerElement.querySelector('#parent')).click();
+    fixture.detectChanges();
+    flush();
+    fixture.detectChanges();
+  };
+  const keyEvent = (selector: string, key: string) => {
+    overlayContainerElement.querySelector(selector).dispatchEvent(keydown(key));
+    fixture.detectChanges();
+    flush();
+    fixture.detectChanges();
+  };
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NestedMenuWrapperComponent,
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    overlayContainer = TestBed.inject(OverlayContainer);
+    overlayContainerElement = overlayContainer.getContainerElement();
+    fixture = TestBed.createComponent(NestedMenuWrapperComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    overlayContainer.ngOnDestroy();
+  });
+
+  it('should open the root menu with a backdrop', fakeAsync(() => {
+    openRoot();
+
+    expect(menus().length).toBe(1);
+    expect(backdrops().length).toBe(1);
+  }));
+
+  it('should mark the parent item with aria-haspopup and a submenu indicator', fakeAsync(() => {
+    openRoot();
+
+    const parent = <HTMLElement>overlayContainerElement.querySelector('#parent');
+    expect(parent.getAttribute('aria-haspopup')).toBe('menu');
+    expect(parent.querySelector('.daff-menu-item__submenu-indicator')).not.toBeNull();
+  }));
+
+  it('should open the submenu as a flyout without adding a second backdrop', fakeAsync(() => {
+    openRoot();
+    openSubmenu();
+
+    expect(menus().length).toBe(2);
+    expect(backdrops().length).toBe(1);
+  }));
+
+  it('should reflect the open state on the parent item with aria-expanded', fakeAsync(() => {
+    openRoot();
+    openSubmenu();
+
+    const parent = <HTMLElement>overlayContainerElement.querySelector('#parent');
+    expect(parent.getAttribute('aria-expanded')).toBe('true');
+  }));
+
+  it('should focus the first item of the root menu when it opens', fakeAsync(() => {
+    openRoot();
+
+    expect(document.activeElement).toBe(overlayContainerElement.querySelector('#leaf'));
+  }));
+
+  it('should close the submenu and return focus to the parent item on ArrowLeft', fakeAsync(() => {
+    openRoot();
+    openSubmenu();
+
+    keyEvent('#sub-leaf', 'ArrowLeft');
+
+    expect(menus().length).toBe(1);
+    expect(document.activeElement).toBe(overlayContainerElement.querySelector('#parent'));
+  }));
+
+  it('should point the keyboard back at the parent item once its submenu closes', fakeAsync(() => {
+    openRoot();
+    openSubmenu();
+
+    keyEvent('#sub-leaf', 'Escape');
+    expect(document.activeElement).toBe(overlayContainerElement.querySelector('#parent'));
+
+    keyEvent('#parent', 'ArrowDown');
+
+    expect(document.activeElement).toBe(overlayContainerElement.querySelector('#last'));
+  }));
+
+  it('should close every open menu on Tab so focus can move to the next focusable element after the activator', fakeAsync(() => {
+    openRoot();
+
+    keyEvent('#leaf', 'Tab');
+
+    expect(menus().length).toBe(0);
+  }));
+
+  it('should close all menus when a submenu item is clicked', fakeAsync(() => {
+    openRoot();
+    openSubmenu();
+
+    (<HTMLElement>overlayContainerElement.querySelector('#sub-leaf')).click();
+    fixture.detectChanges();
+    flush();
+
+    expect(menus().length).toBe(0);
+  }));
+
+  it('should close open submenus when the root menu closes', fakeAsync(() => {
+    openRoot();
+    openSubmenu();
+    expect(menus().length).toBe(2);
+
+    (<HTMLElement>backdrops()[0]).click();
+    fixture.detectChanges();
+    flush();
+
+    expect(menus().length).toBe(0);
+  }));
+});
+
+@Component({
+  template: `
+    <button [daffMenuActivator]="rootMenu" id="activator">Open</button>
+
+    <ng-template #rootMenu>
+      <daff-menu>
+        <button daff-menu-item [daffMenuActivator]="subA" trigger="click" id="parentA">A</button>
+        <button daff-menu-item [daffMenuActivator]="subB" trigger="click" id="parentB">B</button>
+      </daff-menu>
+    </ng-template>
+
+    <ng-template #subA>
+      <daff-menu>
+        <button daff-menu-item id="a-leaf">A leaf</button>
+      </daff-menu>
+    </ng-template>
+
+    <ng-template #subB>
+      <daff-menu>
+        <button daff-menu-item id="b-leaf">B leaf</button>
+      </daff-menu>
+    </ng-template>
+  `,
+  imports: [
+    DAFF_MENU_COMPONENTS,
+  ],
+})
+class SiblingSubmenuWrapperComponent {}
+
+describe('@daffodil/design/menu | Nested menu | Sibling submenus', () => {
+  let fixture: ComponentFixture<SiblingSubmenuWrapperComponent>;
+  let overlayContainer: OverlayContainer;
+  let overlayContainerElement: HTMLElement;
+
+  const menus = () => overlayContainerElement.querySelectorAll('.daff-menu');
+  const panes = () => overlayContainerElement.querySelectorAll('.cdk-overlay-pane');
+  const click = (selector: string) => {
+    (<HTMLElement>overlayContainerElement.querySelector(selector)).click();
+    fixture.detectChanges();
+    flush();
+    fixture.detectChanges();
+  };
+  const openRoot = () => {
+    fixture.debugElement.query(By.css('#activator')).nativeElement.click();
+    fixture.detectChanges();
+    flush();
+    fixture.detectChanges();
+  };
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        SiblingSubmenuWrapperComponent,
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    overlayContainer = TestBed.inject(OverlayContainer);
+    overlayContainerElement = overlayContainer.getContainerElement();
+    fixture = TestBed.createComponent(SiblingSubmenuWrapperComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    overlayContainer.ngOnDestroy();
+  });
+
+  it('should close the open submenu when a sibling submenu opens', fakeAsync(() => {
+    openRoot();
+    click('#parentA');
+    expect(menus().length).toBe(2);
+
+    click('#parentB');
+
+    expect(menus().length).toBe(2);
+    expect(overlayContainerElement.querySelector('#a-leaf')).toBeNull();
+    expect(overlayContainerElement.querySelector('#b-leaf')).not.toBeNull();
+  }));
+
+  it('should remove the replaced submenu from the DOM when the menu is dismissed', fakeAsync(() => {
+    openRoot();
+    click('#parentA');
+    click('#parentB');
+
+    (<HTMLElement>overlayContainerElement.querySelector('.cdk-overlay-backdrop')).click();
+    fixture.detectChanges();
+    flush();
+
+    expect(menus().length).toBe(0);
+    expect(panes().length).toBe(0);
+  }));
+});
+
+@Component({
+  template: `
+    <button [daffMenuActivator]="rootMenu" id="activator">Open</button>
+
+    <ng-template #rootMenu>
+      <daff-menu>
+        <button daff-menu-item [daffMenuActivator]="subMenu" id="parent">Parent</button>
+        <button daff-menu-item id="sibling">Sibling</button>
+      </daff-menu>
+    </ng-template>
+
+    <ng-template #subMenu>
+      <daff-menu>
+        <button daff-menu-item id="sub-leaf">Sub leaf</button>
+      </daff-menu>
+    </ng-template>
+  `,
+  imports: [
+    DAFF_MENU_COMPONENTS,
+  ],
+})
+class HoverSubmenuWrapperComponent {}
+
+describe('@daffodil/design/menu | Nested menu | Hover trigger', () => {
+  let fixture: ComponentFixture<HoverSubmenuWrapperComponent>;
+  let overlayContainer: OverlayContainer;
+  let overlayContainerElement: HTMLElement;
+
+  const menus = () => overlayContainerElement.querySelectorAll('.daff-menu');
+  const parent = () => <HTMLElement>overlayContainerElement.querySelector('#parent');
+  const flyoutPane = () => <HTMLElement>menus()[1].closest('.cdk-overlay-pane');
+  const pointer = (element: HTMLElement, event: 'mouseenter' | 'mouseleave') => {
+    element.dispatchEvent(new MouseEvent(event));
+    fixture.detectChanges();
+    flush();
+    fixture.detectChanges();
+  };
+  const openRoot = () => {
+    fixture.debugElement.query(By.css('#activator')).nativeElement.click();
+    fixture.detectChanges();
+    flush();
+    fixture.detectChanges();
+  };
+  const hoverParent = () => pointer(parent(), 'mouseenter');
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HoverSubmenuWrapperComponent,
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    overlayContainer = TestBed.inject(OverlayContainer);
+    overlayContainerElement = overlayContainer.getContainerElement();
+    fixture = TestBed.createComponent(HoverSubmenuWrapperComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    overlayContainer.ngOnDestroy();
+  });
+
+  it('should open the submenu as soon as the pointer reaches the parent item', fakeAsync(() => {
+    openRoot();
+    hoverParent();
+
+    expect(menus().length).toBe(2);
+  }));
+
+  it('should leave focus in the menu the pointer came from', fakeAsync(() => {
+    openRoot();
+    hoverParent();
+
+    expect(document.activeElement).toBe(parent());
+  }));
+
+  it('should keep the submenu open once the pointer leaves it', fakeAsync(() => {
+    openRoot();
+    hoverParent();
+
+    pointer(flyoutPane(), 'mouseleave');
+    pointer(parent(), 'mouseleave');
+
+    expect(menus().length).toBe(2);
+  }));
+
+  it('should close the submenu once the pointer reaches a sibling item', fakeAsync(() => {
+    openRoot();
+    hoverParent();
+
+    pointer(<HTMLElement>overlayContainerElement.querySelector('#sibling'), 'mouseenter');
+
+    expect(menus().length).toBe(1);
+  }));
+});
+
+describe('@daffodil/design/menu | Nested menu | Dismissal', () => {
+  let overlayContainer: OverlayContainer;
+  let overlayContainerElement: HTMLElement;
+
+  const menus = () => overlayContainerElement.querySelectorAll('.daff-menu');
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NestedMenuWrapperComponent,
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    overlayContainer = TestBed.inject(OverlayContainer);
+    overlayContainerElement = overlayContainer.getContainerElement();
+  });
+
+  afterEach(() => {
+    overlayContainer.ngOnDestroy();
+  });
+
+  it('should close every open menu once focus leaves them', async () => {
+    const settle = () => new Promise<void>((resolve) => setTimeout(resolve));
+    const fixture = TestBed.createComponent(NestedMenuWrapperComponent);
+    fixture.detectChanges();
+
+    fixture.debugElement.query(By.css('#activator')).nativeElement.click();
+    fixture.detectChanges();
+    await settle();
+    fixture.detectChanges();
+    expect(menus().length).toBe(1);
+
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+
+    outside.focus();
+    fixture.detectChanges();
+    await settle();
+    fixture.detectChanges();
+
+    expect(menus().length).toBe(0);
+    outside.remove();
+  });
+});

--- a/libs/design/menu/src/menu/specs/usage.spec.ts
+++ b/libs/design/menu/src/menu/specs/usage.spec.ts
@@ -66,7 +66,13 @@ describe('@daffodil/design/menu | DaffMenuComponent | Usage', () => {
     expect(wrapper).toBeTruthy();
   });
 
-  it('should focus the first focusable child when menu is opened', () => {
+  it('should not take focus on its own', () => {
+    expect(document.activeElement).not.toEqual(de.query(By.css('#focused')).nativeElement);
+  });
+
+  it('should focus its first item when asked to', () => {
+    component.focusFirstItem();
+
     expect(document.activeElement).toEqual(de.query(By.css('#focused')).nativeElement);
   });
 
@@ -76,6 +82,7 @@ describe('@daffodil/design/menu | DaffMenuComponent | Usage', () => {
     beforeEach(() => {
       menuService = TestBed.inject(DaffMenuService);
       spyOn(menuService, 'close');
+      spyOn(menuService, 'closeAll');
       spyOn(component['_keyManager'], 'onKeydown');
     });
 
@@ -114,6 +121,28 @@ describe('@daffodil/design/menu | DaffMenuComponent | Usage', () => {
       component.handleKeydown(event);
 
       expect(component['_keyManager'].onKeydown).toHaveBeenCalledWith(event);
+    });
+
+    it('should close every open menu on Tab', () => {
+      component.handleKeydown(new KeyboardEvent('keydown', { key: 'Tab' }));
+
+      expect(menuService.closeAll).toHaveBeenCalled();
+    });
+
+    it('should leave Tab free to move focus on to the next control', () => {
+      const event = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true });
+
+      component.handleKeydown(event);
+
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('should leave the arrow keys that open and leave a submenu to the item that owns them', () => {
+      component.handleKeydown(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+      component.handleKeydown(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+
+      expect(menuService.close).not.toHaveBeenCalled();
+      expect(component['_keyManager'].onKeydown).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/design/menu/src/public_api.ts
+++ b/libs/design/menu/src/public_api.ts
@@ -7,7 +7,10 @@ export {
   DaffMenuService,
   DaffMenuSlot,
 } from './services/menu.service';
-export { DaffMenuActivatorDirective } from './menu-activator/menu-activator.component';
+export {
+  DaffMenuActivatorDirective,
+  DaffMenuTrigger,
+} from './menu-activator/menu-activator.component';
 export { DaffMenuModule } from './menu.module';
 export { DaffMenuComponent } from './menu/menu.component';
 export { DaffMenuItemComponent } from './menu-item/menu-item.component';

--- a/libs/design/menu/src/services/menu-stack.spec.ts
+++ b/libs/design/menu/src/services/menu-stack.spec.ts
@@ -1,0 +1,132 @@
+import {
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+
+import {
+  DaffMenuStack,
+  DaffMenuStackCloseEvent,
+  DaffMenuStackItem,
+} from './menu-stack';
+
+describe('@daffodil/design/menu | DaffMenuStack', () => {
+  let stack: DaffMenuStack;
+  let root: DaffMenuStackItem;
+  let child: DaffMenuStackItem;
+  let grandchild: DaffMenuStackItem;
+  let events: DaffMenuStackCloseEvent[];
+
+  const closedItems = () => events.map(({ item }) => item);
+
+  beforeEach(() => {
+    stack = new DaffMenuStack();
+    root = {};
+    child = {};
+    grandchild = {};
+    events = [];
+
+    stack.closed.subscribe((event) => events.push(event));
+  });
+
+  it('should start out empty', () => {
+    expect(stack.isEmpty()).toBe(true);
+    expect(stack.length()).toBe(0);
+  });
+
+  describe('with a root menu, a submenu, and a submenu of that', () => {
+    beforeEach(() => {
+      stack.push(root);
+      stack.push(child);
+      stack.push(grandchild);
+    });
+
+    it('should report the innermost menu', () => {
+      expect(stack.peek()).toBe(grandchild);
+      expect(stack.length()).toBe(3);
+    });
+
+    it('should close a menu along with everything opened from it, innermost first', () => {
+      stack.close(child);
+
+      expect(closedItems()).toEqual([grandchild, child]);
+      expect(stack.peek()).toBe(root);
+    });
+
+    it('should leave a menu it was never given open', () => {
+      stack.close({});
+
+      expect(closedItems()).toEqual([]);
+      expect(stack.length()).toBe(3);
+    });
+
+    it('should close the submenus of a menu without closing the menu itself', () => {
+      stack.closeSubMenuOf(child);
+
+      expect(closedItems()).toEqual([grandchild]);
+      expect(stack.peek()).toBe(child);
+    });
+
+    it('should report whether closing submenus actually closed anything', () => {
+      expect(stack.closeSubMenuOf(grandchild)).toBe(false);
+      expect(stack.closeSubMenuOf(root)).toBe(true);
+    });
+
+    it('should close every menu', () => {
+      stack.closeAll();
+
+      expect(closedItems()).toEqual([grandchild, child, root]);
+      expect(stack.isEmpty()).toBe(true);
+    });
+
+    it('should pass on that focus should return to each closed menu\'s activator', () => {
+      stack.close(child, { focusParentTrigger: true });
+
+      expect(events.every(({ focusParentTrigger }) => focusParentTrigger)).toBe(true);
+    });
+
+    it('should not ask for focus when a submenu is only being replaced', () => {
+      stack.closeSubMenuOf(child);
+
+      expect(events.every(({ focusParentTrigger }) => !focusParentTrigger)).toBe(true);
+    });
+  });
+
+  describe('focus', () => {
+    let reported: boolean[];
+
+    // Subscribed inside each test so the debounce runs on the fake timers.
+    const watchFocus = () => {
+      reported = [];
+      stack.hasFocus.subscribe((hasFocus) => reported.push(hasFocus));
+    };
+
+    it('should start out unfocused', fakeAsync(() => {
+      watchFocus();
+      tick();
+
+      expect(reported).toEqual([false]);
+    }));
+
+    it('should collapse focus moving from one menu to another into staying focused', fakeAsync(() => {
+      watchFocus();
+      stack.setHasFocus(true);
+      tick();
+      // Leaving one open menu for another reports a leave and an enter back to back.
+      stack.setHasFocus(false);
+      stack.setHasFocus(true);
+      tick();
+
+      expect(reported).toEqual([true]);
+    }));
+
+    it('should report focus leaving the open menus', fakeAsync(() => {
+      watchFocus();
+      stack.setHasFocus(true);
+      tick();
+      stack.setHasFocus(false);
+      tick();
+
+      expect(reported).toEqual([true, false]);
+    }));
+  });
+});

--- a/libs/design/menu/src/services/menu-stack.ts
+++ b/libs/design/menu/src/services/menu-stack.ts
@@ -1,0 +1,170 @@
+import {
+  Inject,
+  InjectionToken,
+  Optional,
+  Provider,
+  SkipSelf,
+} from '@angular/core';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  Observable,
+  startWith,
+  Subject,
+} from 'rxjs';
+
+/**
+ * @docs-private
+ *
+ * A menu that can be put on a {@link DaffMenuStack}.
+ */
+export interface DaffMenuStackItem {
+  /**
+   * The stack this menu belongs to.
+   */
+  menuStack?: DaffMenuStack;
+}
+
+/**
+ * @docs-private
+ *
+ * Options for the {@link DaffMenuStack} close method.
+ */
+export interface DaffMenuStackCloseOptions {
+  /**
+   * Whether to move focus to the activator of each menu that closes.
+   */
+  focusParentTrigger?: boolean;
+}
+
+/**
+ * @docs-private
+ *
+ * Emitted for each menu taken off a {@link DaffMenuStack}.
+ */
+export interface DaffMenuStackCloseEvent extends DaffMenuStackCloseOptions {
+  /**
+   * The menu being closed.
+   */
+  item: DaffMenuStackItem;
+}
+
+/**
+ * @docs-private
+ *
+ * The menus that are currently open, innermost last.
+ */
+export class DaffMenuStack {
+  private _elements: DaffMenuStackItem[] = [];
+  private _close = new Subject<DaffMenuStackCloseEvent>();
+  private _hasFocus = new Subject<boolean>();
+
+  /**
+   * Emits once for each menu taken off the stack, innermost first.
+   */
+  readonly closed: Observable<DaffMenuStackCloseEvent> = this._close;
+
+  /**
+   * Whether any of the open menus currently holds focus.
+   */
+  readonly hasFocus: Observable<boolean> = this._hasFocus.pipe(
+    startWith(false),
+    debounceTime(0),
+    distinctUntilChanged(),
+  );
+
+  /**
+   * Puts a menu on the stack.
+   */
+  push(menu: DaffMenuStackItem) {
+    this._elements.push(menu);
+  }
+
+  /**
+   * Closes the given menu and everything opened from it.
+   */
+  close(lastItem: DaffMenuStackItem, options?: DaffMenuStackCloseOptions) {
+    if (this._elements.indexOf(lastItem) >= 0) {
+      let popped: DaffMenuStackItem | undefined;
+
+      do {
+        popped = this._elements.pop();
+        this._close.next({ item: popped, focusParentTrigger: options?.focusParentTrigger });
+      } while (popped !== lastItem);
+    }
+  }
+
+  /**
+   * Closes everything opened from the given menu, leaving the menu itself open. Returns whether
+   * anything closed.
+   */
+  closeSubMenuOf(lastItem: DaffMenuStackItem): boolean {
+    let removed = false;
+
+    if (this._elements.indexOf(lastItem) >= 0) {
+      removed = this.peek() !== lastItem;
+
+      while (this.peek() !== lastItem) {
+        this._close.next({ item: this._elements.pop() });
+      }
+    }
+
+    return removed;
+  }
+
+  /**
+   * Closes every open menu.
+   */
+  closeAll(options?: DaffMenuStackCloseOptions) {
+    while (!this.isEmpty()) {
+      this._close.next({ item: this._elements.pop(), focusParentTrigger: options?.focusParentTrigger });
+    }
+  }
+
+  /**
+   * Whether no menu is open.
+   */
+  isEmpty(): boolean {
+    return !this._elements.length;
+  }
+
+  /**
+   * How many menus are open.
+   */
+  length(): number {
+    return this._elements.length;
+  }
+
+  /**
+   * The innermost open menu.
+   */
+  peek(): DaffMenuStackItem | undefined {
+    return this._elements[this._elements.length - 1];
+  }
+
+  /**
+   * Reports whether any of the open menus holds focus.
+   */
+  setHasFocus(hasFocus: boolean) {
+    this._hasFocus.next(hasFocus);
+  }
+}
+
+/**
+ * @docs-private
+ *
+ * An injection token for the {@link DaffMenuStack} shared by a menu and its submenus.
+ */
+export const DAFF_MENU_STACK = new InjectionToken<DaffMenuStack>('DAFF_MENU_STACK');
+
+/**
+ * @docs-private
+ *
+ * Provides the stack of the menu that contains this activator, or a new stack when the activator
+ * isn't inside a menu. Every menu opened from a root activator therefore shares one stack.
+ */
+export const DAFF_PARENT_OR_NEW_MENU_STACK_PROVIDER: Provider = {
+  provide: DAFF_MENU_STACK,
+  deps: [[new Optional(), new SkipSelf(), new Inject(DAFF_MENU_STACK)]],
+  useFactory: (parentStack: DaffMenuStack | null) => parentStack || new DaffMenuStack(),
+};

--- a/libs/design/menu/src/services/menu.service.ts
+++ b/libs/design/menu/src/services/menu.service.ts
@@ -1,3 +1,4 @@
+import { FocusOrigin } from '@angular/cdk/a11y';
 import {
   Overlay,
   OverlayRef,
@@ -7,8 +8,12 @@ import {
   TemplatePortal,
 } from '@angular/cdk/portal';
 import {
+  Inject,
   Injectable,
   Injector,
+  OnDestroy,
+  Optional,
+  SkipSelf,
   TemplateRef,
   Type,
   ViewContainerRef,
@@ -17,22 +22,41 @@ import {
   BehaviorSubject,
   map,
   Observable,
+  Subscription,
 } from 'rxjs';
 
 import { DaffLazyComponent } from '@daffodil/design';
 
 import {
+  DAFF_MENU_STACK,
+  DaffMenuStack,
+  DaffMenuStackItem,
+} from './menu-stack';
+import {
   DAFF_MENU_CONFIG,
   DaffMenuConfig,
 } from '../config/menu-config';
 import { daffMenuCreateOverlay } from '../helpers/create-overlay';
+import { DaffMenuPanel } from '../menu/menu-panel';
 
 export type DaffMenuSlot = TemplateRef<unknown> | DaffLazyComponent | Type<unknown>;
 
 @Injectable()
-export class DaffMenuService {
+export class DaffMenuService implements DaffMenuStackItem, OnDestroy {
   protected _overlay: OverlayRef | null;
   private _activator: ViewContainerRef;
+  private _nested = false;
+  private _panel: DaffMenuPanel | null = null;
+  private _pendingFocusOrigin: FocusOrigin | null = null;
+  private _closedSubscription: Subscription;
+
+  /**
+   * @docs-private
+   *
+   * The stack of open menus this menu belongs to, shared with the menu
+   * it opened from and any submenus it opens.
+   */
+  readonly menuStack: DaffMenuStack;
 
   private $_open: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public open$: Observable<boolean> = this.$_open.asObservable();
@@ -40,14 +64,80 @@ export class DaffMenuService {
   constructor(
     protected overlay: Overlay,
     private injector: Injector,
-  ) {}
+
+    /**
+     * @docs-private
+     *
+     * The service of the menu that contains this menu's activator, if this menu is nested.
+     */
+    @Optional() @SkipSelf() private _parent: DaffMenuService | null,
+
+    @Optional() @Inject(DAFF_MENU_STACK) menuStack: DaffMenuStack | null,
+  ) {
+    this.menuStack = menuStack || new DaffMenuStack();
+
+    this._closedSubscription = this.menuStack.closed.subscribe(({ item, focusParentTrigger }) => {
+      if (item === this) {
+        this._destroyOverlay();
+        this.$_open.next(false);
+
+        if (focusParentTrigger) {
+          this._activator?.element.nativeElement.focus();
+        }
+      }
+    });
+  }
 
   /**
    * @docs-private
    */
-  protected async _createOverlay(activatorElement: ViewContainerRef, component: DaffMenuSlot, config?: DaffMenuConfig) {
+  ngOnDestroy() {
+    this._closedSubscription.unsubscribe();
+  }
+
+  /**
+   * Whether this menu is a nested submenu.
+   */
+  get isNested(): boolean {
+    return this._nested;
+  }
+
+  /**
+   * @docs-private
+   *
+   * Registers the panel this menu opened. Called by the panel itself, since it's created inside the
+   * overlay rather than by the service.
+   */
+  registerPanel(panel: DaffMenuPanel) {
+    this._panel = panel;
+
+    if (this._pendingFocusOrigin) {
+      panel.focusFirstItem(this._pendingFocusOrigin);
+      this._pendingFocusOrigin = null;
+    }
+  }
+
+  /**
+   * @docs-private
+   *
+   * Moves focus to the first item of this menu. A lazily imported menu isn't rendered by the time
+   * `open` returns, so the request is held until the panel registers itself.
+   */
+  focusFirstItem(origin: FocusOrigin = 'program') {
+    if (this._panel) {
+      this._panel.focusFirstItem(origin);
+    } else {
+      this._pendingFocusOrigin = origin;
+    }
+  }
+
+  /**
+   * @docs-private
+   */
+  protected async _createOverlay(activatorElement: ViewContainerRef, component: DaffMenuSlot, config: DaffMenuConfig | undefined, nested: boolean) {
     if (!this._overlay) {
-      this._overlay = daffMenuCreateOverlay(this.overlay, activatorElement.element, config?.xPosition, config?.yPosition);
+      this._overlay = daffMenuCreateOverlay(this.overlay, activatorElement.element, config?.xPosition, config?.yPosition, nested);
+
       if(typeof component === 'object' && (<DaffLazyComponent>component)?.import) {
         component = await (<DaffLazyComponent>component).import();
       }
@@ -63,8 +153,9 @@ export class DaffMenuService {
         this._overlay.attach(new TemplatePortal(component, activatorElement, null, injector));
       }
 
+      // Only the root overlay has a backdrop; clicking it closes every open menu.
       this._overlay.backdropClick().pipe(
-        map(() => this.close()),
+        map(() => this.closeAll()),
       ).subscribe();
     }
   }
@@ -77,21 +168,57 @@ export class DaffMenuService {
       this._overlay.detach();
       this._overlay.dispose();
       this._overlay = null;
+      this._panel = null;
+      this._pendingFocusOrigin = null;
     }
   }
 
-  close() {
-    this._destroyOverlay();
-    this.$_open.next(false);
-    this._activator.element.nativeElement.focus();
+  /**
+   * Closes this menu, along with any submenus opened from it, and returns focus to this menu's
+   * activator.
+   */
+  close(focusActivator = true) {
+    this.menuStack.close(this, { focusParentTrigger: focusActivator });
+  }
+
+  /**
+   * Closes every open menu, returning focus to the activator of the outermost one.
+   */
+  closeAll() {
+    this.menuStack.closeAll({ focusParentTrigger: true });
   }
 
   open(activator: ViewContainerRef, component: DaffMenuSlot, config?: DaffMenuConfig) {
+    // A menu is nested when the menu that contains its activator is currently open.
+    const nested = !!(this._parent && this._parent._overlay);
+
+    // Opening replaces whatever is already open at this level: the sibling submenu of the same
+    // menu, or every open menu when this menu is the outermost one.
+    if (nested && this._parent) {
+      this.menuStack.closeSubMenuOf(this._parent);
+    } else {
+      this.menuStack.closeAll();
+    }
+
     if (this._overlay) {
       this._destroyOverlay();
     }
-    this._createOverlay(activator, component, config);
+
+    this._nested = nested;
     this._activator = activator;
+    this._createOverlay(activator, component, config, nested);
+    this.menuStack.push(this);
     this.$_open.next(true);
+  }
+
+  /**
+   * Opens the menu if it's closed, or closes it if it's already open.
+   */
+  toggle(activator: ViewContainerRef, component: DaffMenuSlot, config?: DaffMenuConfig) {
+    if (this._overlay) {
+      this.close();
+    } else {
+      this.open(activator, component, config);
+    }
   }
 }

--- a/libs/design/menu/src/testing/dummy-service.ts
+++ b/libs/design/menu/src/testing/dummy-service.ts
@@ -1,18 +1,31 @@
 import { Provider } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
+import { DaffMenuStack } from '../services/menu-stack';
 import { DaffMenuService } from '../services/menu.service';
 
 type PublicPart<T> = {[K in keyof T]: T[K]};
 
 export class DummyMenuService implements PublicPart<DaffMenuService>{
   open$ = new BehaviorSubject(true);
+  isNested = false;
+  menuStack = new DaffMenuStack();
+
   open() {
+    this.open$.next(true);
+  }
+  toggle() {
     this.open$.next(true);
   }
   close() {
     this.open$.next(false);
   }
+  closeAll() {
+    this.open$.next(false);
+  }
+  registerPanel() {}
+  focusFirstItem() {}
+  ngOnDestroy() {}
 }
 
 export function provideTestMenuService(): Provider {


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Fixes: #4559

## New behavior
- Add `daffMenuActivator` to a `<daff-menu-item>` to open a submenu from that item. Submenus open on hover by default. `trigger="click"` opens them on click instead.
- New `trigger` property to set opening submenus either on `click` or `hover`.
- Add keyboard interactions for submenu:
  - Right arrow opens submenu and moves focus into it
  - Left arrow returns to the parent item
  - Escape closes one level at a time
- A parent item shows a chevron and `aria-haspopup="menu"`
- Only one submenu of a menu is open at a time, and all open menus close when focus leaves them, on Tab, or on backdrop click

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->