### PR TITLE
feat(design, design-examples, daffio, demo): deprecate `@daffodil/design/image` in favor of `@daffodil/design/image-lite`

### DIFF
--- a/apps/daffio/src/app/content/home/components/home-callout-platforms/home-callout-platforms.component.html
+++ b/apps/daffio/src/app/content/home/components/home-callout-platforms/home-callout-platforms.component.html
@@ -7,8 +7,8 @@
       Transition between Magento, Shopify or any other platforms without the hassle of reinventing your front-end.
     </p>
     <div daffCalloutBody class="daffio-home-callout-platforms__logos">
-      <daff-image src="/assets/magento-monotone-logo.svg" alt="Magento Logo" width="300" height="83"></daff-image>
-      <daff-image src="/assets/shopify-monotone-logo.svg" alt="Shopify Logo" width="300" height="86"></daff-image>
+      <img daff-image ngSrc="/assets/magento-monotone-logo.svg" alt="Magento Logo" width="300" height="83" />
+      <img daff-image ngSrc="/assets/shopify-monotone-logo.svg" alt="Shopify Logo" width="300" height="86" />
     </div>
   </daff-container>
 </daff-callout>

--- a/apps/daffio/src/app/content/home/components/home-callout-platforms/home-callout-platforms.component.ts
+++ b/apps/daffio/src/app/content/home/components/home-callout-platforms/home-callout-platforms.component.ts
@@ -6,7 +6,7 @@ import {
 
 import { DAFF_CALLOUT_COMPONENTS } from '@daffodil/design/callout';
 import { DAFF_CONTAINER_COMPONENTS } from '@daffodil/design/container';
-import { DAFF_IMAGE_COMPONENTS } from '@daffodil/design/image';
+import { DAFF_IMAGE_LITE_COMPONENTS } from '@daffodil/design/image-lite';
 
 @Component({
   selector: 'daffio-home-callout-platforms',
@@ -15,7 +15,7 @@ import { DAFF_IMAGE_COMPONENTS } from '@daffodil/design/image';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_CALLOUT_COMPONENTS,
-    DAFF_IMAGE_COMPONENTS,
+    DAFF_IMAGE_LITE_COMPONENTS,
     DAFF_CONTAINER_COMPONENTS,
   ],
 })

--- a/apps/daffio/src/app/content/home/components/home-callout-sponsors/home-callout-sponsors.component.html
+++ b/apps/daffio/src/app/content/home/components/home-callout-sponsors/home-callout-sponsors.component.html
@@ -12,7 +12,7 @@
     <div daffCalloutBody>
       <div class="daffio-home-callout-sponsors__logo-wrapper">
         <a class="daffio-home-callout-sponsors__logo" href="https://www.develodesign.co.uk/" target="_blank">
-          <daff-image class="daffio-home-callout-sponsors__logo-image" src="/assets/sponsors/develo.svg" width="151" height="37" alt="Develo"></daff-image>
+          <img daff-image class="daffio-home-callout-sponsors__logo-image" ngSrc="/assets/sponsors/develo.svg" width="151" height="37" alt="Develo" />
         </a>
         <a href="https://github.com/sponsors/graycoreio" class="daffio-home-callout-sponsors__link" target="_blank" color="theme-contrast">
           Become a sponsor

--- a/apps/demo/src/app/core/image-gallery/components/image-gallery.component.html
+++ b/apps/demo/src/app/core/image-gallery/components/image-gallery.component.html
@@ -1,12 +1,11 @@
 <daff-media-gallery>
   @for(image of images; track image) {
     <ng-template daffThumbnail [thumbnailSrc]="image.url" [label]="image.label">
-      <daff-image 
+      <img daff-image
         alt="{{ image.label }}"
-        src="{{ image.url }}"
+        ngSrc="{{ image.url }}"
         width="594"
-        height="737">
-      </daff-image>
+        height="737" />
     </ng-template>
   }
 </daff-media-gallery>

--- a/apps/demo/src/app/core/image-gallery/components/image-gallery.component.ts
+++ b/apps/demo/src/app/core/image-gallery/components/image-gallery.component.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/core';
 import { Store } from '@ngrx/store';
 
-import { DaffImageComponent } from '@daffodil/design/image';
+import { DAFF_IMAGE_LITE_COMPONENTS } from '@daffodil/design/image-lite';
 import { DAFF_MEDIA_GALLERY_COMPONENTS } from '@daffodil/design/media-gallery';
 
 import { SetSelectedImageState } from '../actions/image-gallery.actions';
@@ -17,7 +17,7 @@ import * as fromDemoImageGallery from '../reducers/index';
   templateUrl: './image-gallery.component.html',
   encapsulation: ViewEncapsulation.None,
   imports: [
-    DaffImageComponent,
+    DAFF_IMAGE_LITE_COMPONENTS,
     DAFF_MEDIA_GALLERY_COMPONENTS,
   ],
 })

--- a/libs/design-examples/card/src/basic-cards/basic-cards.component.html
+++ b/libs/design-examples/card/src/basic-cards/basic-cards.component.html
@@ -1,12 +1,11 @@
 <daff-card>
-  <daff-image
+  <img daff-image
     daffCardImage
-    src="https://images.unsplash.com/photo-1593519749347-80f101e93113?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=3774&q=80"
+    ngSrc="https://images.unsplash.com/photo-1593519749347-80f101e93113?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=3774&q=80"
     alt="Bottom up view of Basel exhibition centre"
     width="1261"
     height="946"
-  >
-  </daff-image>
+  />
   <fa-icon daffCardIcon [icon]="faMapMarked"></fa-icon>
   <div daffCardTagline>Basel, Switzerland</div>
   <h4 daffCardTitle>Basel Exhibition Centre</h4>
@@ -21,14 +20,13 @@
 </daff-card>
 
 <daff-stroked-card>
-  <daff-image
+  <img daff-image
     daffCardImage
-    src="https://images.unsplash.com/photo-1593519749347-80f101e93113?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=3774&q=80"
+    ngSrc="https://images.unsplash.com/photo-1593519749347-80f101e93113?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=3774&q=80"
     alt="Bottom up view of Basel exhibition centre"
     width="1261"
     height="946"
-  >
-  </daff-image>
+  />
   <fa-icon daffCardIcon [icon]="faMapMarked"></fa-icon>
   <div daffCardTagline>Basel, Switzerland</div>
   <h4 daffCardTitle>Basel Exhibition Centre</h4>

--- a/libs/design-examples/card/src/basic-cards/basic-cards.component.ts
+++ b/libs/design-examples/card/src/basic-cards/basic-cards.component.ts
@@ -7,7 +7,7 @@ import { faMapMarked } from '@fortawesome/free-solid-svg-icons';
 
 import { DaffButtonComponent } from '@daffodil/design/button';
 import { DAFF_ALL_CARD_COMPONENTS } from '@daffodil/design/card';
-import { DAFF_IMAGE_COMPONENTS } from '@daffodil/design/image';
+import { DAFF_IMAGE_LITE_COMPONENTS } from '@daffodil/design/image-lite';
 
 @Component({
   selector: 'basic-cards-example',
@@ -16,9 +16,9 @@ import { DAFF_IMAGE_COMPONENTS } from '@daffodil/design/image';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_ALL_CARD_COMPONENTS,
-    DAFF_IMAGE_COMPONENTS,
     FaIconComponent,
     DaffButtonComponent,
+    DAFF_IMAGE_LITE_COMPONENTS,
   ],
 })
 export class BasicCardsExampleComponent {

--- a/libs/design-examples/card/src/card-orientation/card-orientation.component.html
+++ b/libs/design-examples/card/src/card-orientation/card-orientation.component.html
@@ -8,14 +8,12 @@
 </daff-form-field>
 
 <daff-card [orientation]="orientationControl.value?.value">
-  <daff-image
+  <img daff-image
     daffCardImage
-    src="https://images.unsplash.com/photo-1460353581641-37baddab0fa2?auto=format&fit=crop&w=3774&q=80"
+    ngSrc="https://images.unsplash.com/photo-1460353581641-37baddab0fa2?auto=format&fit=crop&w=3774&q=80"
     alt="Assortment of running shoes lined up"
     width="1261"
-    height="946"
-  >
-  </daff-image>
+    height="946" />
   <div daffCardTagline>Featured Category</div>
   <h4 daffCardTitle>Running Shoes</h4>
   <div daffCardContent>

--- a/libs/design-examples/media-gallery/src/basic-media-gallery/basic-media-gallery.component.html
+++ b/libs/design-examples/media-gallery/src/basic-media-gallery/basic-media-gallery.component.html
@@ -4,47 +4,43 @@
     thumbnailSrc="https://assets.daff.io/elegant_gold_soap.png"
     label="Elegant Golf Soap T-Shirt"
   >
-    <daff-image
-      src="https://assets.daff.io/elegant_gold_soap.png"
+    <img daff-image
+      ngSrc="https://assets.daff.io/elegant_gold_soap.png"
       alt="Elegant Golf Soap T-Shirt"
-      [width]="934"
-      [height]="934"
-    ></daff-image>
+      width="934"
+      height="934" />
   </ng-template>
   <ng-template
     daffThumbnail
     thumbnailSrc="https://assets.daff.io/ergonomic_bronze_pants.png"
     label="Ergonomic Bronze Pants T-Shirt"
   >
-    <daff-image
-      src="https://assets.daff.io/ergonomic_bronze_pants.png"
+    <img daff-image
+      ngSrc="https://assets.daff.io/ergonomic_bronze_pants.png"
       alt="Ergonomic Bronze Pants T-Shirt"
-      [width]="934"
-      [height]="934"
-    ></daff-image>
+      width="934"
+      height="934" />
   </ng-template>
   <ng-template
     daffThumbnail
     thumbnailSrc="https://assets.daff.io/frozen_metal_soap_bubbles.png"
     label="Frozen Metal Soap T-Shirt"
   >
-    <daff-image
-      src="https://assets.daff.io/frozen_metal_soap_bubbles.png"
+    <img daff-image
+      ngSrc="https://assets.daff.io/frozen_metal_soap_bubbles.png"
       alt="Frozen Metal Soap T-Shirt"
-      [width]="934"
-      [height]="934"
-    ></daff-image>
+      width="934"
+      height="934" />
   </ng-template>
   <ng-template
     daffThumbnail
     thumbnailSrc="https://assets.daff.io/handcrafted_bamboo_cheese.png"
     label="Handcrafted Bamboo Cheese T-Shirt"
   >
-    <daff-image
-      src="https://assets.daff.io/handcrafted_bamboo_cheese.png"
+    <img daff-image
+      ngSrc="https://assets.daff.io/handcrafted_bamboo_cheese.png"
       alt="Handcrafted Bamboo Cheese T-Shirt"
-      [width]="934"
-      [height]="934"
-    ></daff-image>
+      width="934"
+      height="934" />
   </ng-template>
 </daff-media-gallery>

--- a/libs/design-examples/media-gallery/src/basic-media-gallery/basic-media-gallery.component.ts
+++ b/libs/design-examples/media-gallery/src/basic-media-gallery/basic-media-gallery.component.ts
@@ -3,7 +3,7 @@ import {
   Component,
 } from '@angular/core';
 
-import { DAFF_IMAGE_COMPONENTS } from '@daffodil/design/image';
+import { DAFF_IMAGE_LITE_COMPONENTS } from '@daffodil/design/image-lite';
 import { DAFF_MEDIA_GALLERY_COMPONENTS } from '@daffodil/design/media-gallery';
 
 @Component({
@@ -12,7 +12,7 @@ import { DAFF_MEDIA_GALLERY_COMPONENTS } from '@daffodil/design/media-gallery';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_MEDIA_GALLERY_COMPONENTS,
-    DAFF_IMAGE_COMPONENTS,
+    DAFF_IMAGE_LITE_COMPONENTS,
   ],
 })
 export class BasicMediaGalleryExampleComponent {}

--- a/libs/design-examples/media-gallery/src/iterated-media-gallery/iterated-media-gallery.component.html
+++ b/libs/design-examples/media-gallery/src/iterated-media-gallery/iterated-media-gallery.component.html
@@ -6,12 +6,11 @@
     [label]="element.alt"
   >
     @switch (element.type) { @case ('image') {
-    <daff-image
-      [src]="element.src"
+    <img daff-image
+      [ngSrc]="element.src"
       [alt]="element.alt"
       [width]="element.width"
-      [height]="element.height"
-    ></daff-image>
+      [height]="element.height" />
     } }
   </ng-template>
   }

--- a/libs/design-examples/media-gallery/src/iterated-media-gallery/iterated-media-gallery.component.ts
+++ b/libs/design-examples/media-gallery/src/iterated-media-gallery/iterated-media-gallery.component.ts
@@ -3,7 +3,7 @@ import {
   Component,
 } from '@angular/core';
 
-import { DAFF_IMAGE_COMPONENTS } from '@daffodil/design/image';
+import { DAFF_IMAGE_LITE_COMPONENTS } from '@daffodil/design/image-lite';
 import { DAFF_MEDIA_GALLERY_COMPONENTS } from '@daffodil/design/media-gallery';
 
 @Component({
@@ -12,7 +12,7 @@ import { DAFF_MEDIA_GALLERY_COMPONENTS } from '@daffodil/design/media-gallery';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_MEDIA_GALLERY_COMPONENTS,
-    DAFF_IMAGE_COMPONENTS,
+    DAFF_IMAGE_LITE_COMPONENTS,
   ],
 })
 export class IteratedMediaGalleryExampleComponent {

--- a/libs/design-examples/media-gallery/src/media-gallery-with-video/media-gallery-with-video.component.html
+++ b/libs/design-examples/media-gallery/src/media-gallery-with-video/media-gallery-with-video.component.html
@@ -4,36 +4,33 @@
     thumbnailSrc="https://assets.daff.io/elegant_gold_soap.png"
     label="Elegant Golf Soap T-Shirt"
   >
-    <daff-image
-      src="https://assets.daff.io/elegant_gold_soap.png"
+    <img daff-image
+      ngSrc="https://assets.daff.io/elegant_gold_soap.png"
       alt="Elegant Golf Soap T-Shirt"
-      [width]="934"
-      [height]="934"
-    ></daff-image>
+      width="934"
+      height="934" />
   </ng-template>
   <ng-template
     daffThumbnail
     thumbnailSrc="https://assets.daff.io/elegant_plastic_gloves.png"
     label="Elegant Plastic Gloves T-Shirt"
   >
-    <daff-image
-      src="https://assets.daff.io/elegant_plastic_gloves.png"
+    <img daff-image
+      ngSrc="https://assets.daff.io/elegant_plastic_gloves.png"
       alt="Elegant Plastic Gloves T-Shirt"
-      [width]="622"
-      [height]="934"
-    ></daff-image>
+      width="622"
+      height="934" />
   </ng-template>
   <ng-template
     daffThumbnail
     thumbnailSrc="https://assets.daff.io/ergonomic_bronze_pants.png"
     label="Ergonomic Bronze Pants T-Shirt"
   >
-    <daff-image
-      src="https://assets.daff.io/ergonomic_bronze_pants.png"
+    <img daff-image
+      ngSrc="https://assets.daff.io/ergonomic_bronze_pants.png"
       alt="Ergonomic Bronze Pants T-Shirt"
-      [width]="934"
-      [height]="934"
-    ></daff-image>
+      width="934"
+      height="934" />
   </ng-template>
   <ng-template
     daffThumbnail
@@ -42,10 +39,7 @@
     [isVideo]="true"
   >
     <daff-youtube-player
-      [src]="
-        'https://www.youtube.com/embed/bBQA7yy7EBU?si=gQcCoChmofSeO-vE_-'
-          | daffYoutubeSafe
-      "
+      [src]="'https://www.youtube.com/embed/bBQA7yy7EBU?si=gQcCoChmofSeO-vE_-' | daffYoutubeSafe"
       width="560"
       height="315"
       title="Jazzy Lofi"

--- a/libs/design-examples/media-gallery/src/media-gallery-with-video/media-gallery-with-video.component.ts
+++ b/libs/design-examples/media-gallery/src/media-gallery-with-video/media-gallery-with-video.component.ts
@@ -3,7 +3,7 @@ import {
   Component,
 } from '@angular/core';
 
-import { DAFF_IMAGE_COMPONENTS } from '@daffodil/design/image';
+import { DAFF_IMAGE_LITE_COMPONENTS } from '@daffodil/design/image-lite';
 import { DAFF_MEDIA_GALLERY_COMPONENTS } from '@daffodil/design/media-gallery';
 import { DAFF_YOUTUBE_PLAYER_COMPONENTS } from '@daffodil/design/youtube-player';
 
@@ -14,7 +14,7 @@ import { DAFF_YOUTUBE_PLAYER_COMPONENTS } from '@daffodil/design/youtube-player'
   imports: [
     DAFF_MEDIA_GALLERY_COMPONENTS,
     DAFF_YOUTUBE_PLAYER_COMPONENTS,
-    DAFF_IMAGE_COMPONENTS,
+    DAFF_IMAGE_LITE_COMPONENTS,
   ],
 })
 export class MediaGalleryWithVideoExampleComponent {}

--- a/libs/design-examples/media-gallery/src/mismatched-sizes-media-gallery/mismatched-sizes-media-gallery.component.html
+++ b/libs/design-examples/media-gallery/src/mismatched-sizes-media-gallery/mismatched-sizes-media-gallery.component.html
@@ -4,47 +4,43 @@
     thumbnailSrc="https://assets.daff.io/elegant_gold_soap.png"
     label="Elegant Golf Soap T-Shirt"
   >
-    <daff-image
-      src="https://assets.daff.io/elegant_gold_soap.png"
+    <img img daff-image
+      ngSrc="https://assets.daff.io/elegant_gold_soap.png"
       alt="Elegant Golf Soap T-Shirt"
-      [width]="934"
-      [height]="934"
-    ></daff-image>
+      width="934"
+      height="934" />
   </ng-template>
   <ng-template
     daffThumbnail
     thumbnailSrc="https://assets.daff.io/elegant_plastic_gloves.png"
     label="Elegant Plastic Gloves T-Shirt"
   >
-    <daff-image
-      src="https://assets.daff.io/elegant_plastic_gloves.png"
+    <img daff-image
+      ngSrc="https://assets.daff.io/elegant_plastic_gloves.png"
       alt="Elegant Plastic Gloves T-Shirt"
-      [width]="622"
-      [height]="934"
-    ></daff-image>
+      width="622"
+      height="934" />
   </ng-template>
   <ng-template
     daffThumbnail
     thumbnailSrc="https://assets.daff.io/ergonomic_bronze_pants.png"
     label="Ergonomic Bronze Pants T-Shirt"
   >
-    <daff-image
-      src="https://assets.daff.io/ergonomic_bronze_pants.png"
+    <img daff-image
+      ngSrc="https://assets.daff.io/ergonomic_bronze_pants.png"
       alt="Ergonomic Bronze Pants T-Shirt"
-      [width]="934"
-      [height]="934"
-    ></daff-image>
+      width="934"
+      height="934" />
   </ng-template>
   <ng-template
     daffThumbnail
     thumbnailSrc="https://assets.daff.io/fantastic_aluminum_keyboard.png"
     label="Fantastic Aluminum Keyboard"
   >
-    <daff-image
-      src="https://assets.daff.io/fantastic_aluminum_keyboard.png"
+    <img daff-image
+      ngSrc="https://assets.daff.io/fantastic_aluminum_keyboard.png"
       alt="Fantastic Aluminum Keyboard"
-      [width]="320"
-      [height]="320"
-    ></daff-image>
+      width="400"
+      height="400" />
   </ng-template>
 </daff-media-gallery>

--- a/libs/design-examples/media-gallery/src/mismatched-sizes-media-gallery/mismatched-sizes-media-gallery.component.ts
+++ b/libs/design-examples/media-gallery/src/mismatched-sizes-media-gallery/mismatched-sizes-media-gallery.component.ts
@@ -3,7 +3,7 @@ import {
   Component,
 } from '@angular/core';
 
-import { DAFF_IMAGE_COMPONENTS } from '@daffodil/design/image';
+import { DAFF_IMAGE_LITE_COMPONENTS } from '@daffodil/design/image-lite';
 import { DAFF_MEDIA_GALLERY_COMPONENTS } from '@daffodil/design/media-gallery';
 
 @Component({
@@ -12,7 +12,7 @@ import { DAFF_MEDIA_GALLERY_COMPONENTS } from '@daffodil/design/media-gallery';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DAFF_MEDIA_GALLERY_COMPONENTS,
-    DAFF_IMAGE_COMPONENTS,
+    DAFF_IMAGE_LITE_COMPONENTS,
   ],
 })
 export class MismatchedSizesMediaGalleryExampleComponent {}

--- a/libs/design/card/src/card-base.scss
+++ b/libs/design/card/src/card-base.scss
@@ -10,7 +10,6 @@ $card-border-radius: 0.5rem;
 
 	.daff-card__image {
 		display: inline-block;
-		overflow: hidden;
 		height: 100%;
 		width: 100%;
 	}

--- a/libs/design/image/README.md
+++ b/libs/design/image/README.md
@@ -1,6 +1,10 @@
 # Image
 Image has built-in performance and accessibility optimizations that allow users to easily display responsive images.
 
+> **Deprecation notice:**
+>
+> Image is deprecated in version 0.95.0 and will be removed in version 0.98.0. Use [Image Lite](/libs/design/image-lite/README.md) instead.
+
 ## Overview
 Image builds on Angular's [`NgOptimizedImage`](https://angular.dev/guide/image-optimization) to provide responsive images with stable layouts out of the box. It helps to avoid common image-related performance and accessibility issues by:
 

--- a/libs/design/image/src/image.module.ts
+++ b/libs/design/image/src/image.module.ts
@@ -4,7 +4,7 @@ import { NgModule } from '@angular/core';
 import { DaffImageComponent } from './image/image.component';
 
 /**
- * @deprecated in favor of {@link DAFF_IMAGE_COMPONENTS}. Deprecated in version 0.78.0. Will be removed in version 1.0.0.
+ * @deprecated in favor of {@link DAFF_IMAGE_COMPONENTS}. Deprecated in version 0.78.0. Will be removed in version 0.98.0.
  * */
 @NgModule({
   imports: [

--- a/libs/design/image/src/image.ts
+++ b/libs/design/image/src/image.ts
@@ -2,6 +2,8 @@ import { DaffImageComponent } from './image/image.component';
 
 /**
  * @docs-private
+ *
+ * @deprecated in favor of {@link DAFF_IMAGE_LITE_COMPONENTS}. Deprecated in version 0.95.0. Will be removed in version 0.98.0.
  */
 export const DAFF_IMAGE_COMPONENTS = <const> [
   DaffImageComponent,

--- a/libs/design/image/src/image/image.component.ts
+++ b/libs/design/image/src/image/image.component.ts
@@ -21,6 +21,9 @@ const validateInput = (prop: string) => <T>(value: T): T => {
   return value;
 };
 
+/**
+ * @deprecated in favor of {@link DaffImageLiteComponent}. Deprecated in version 0.95.0. Will be removed in version 0.98.0.
+ */
 @Component({
   selector: 'daff-image',
   templateUrl: './image.component.html',

--- a/libs/design/media-gallery/README.md
+++ b/libs/design/media-gallery/README.md
@@ -43,7 +43,7 @@ A media gallery is composed of a container and one or more thumbnails:
 ```html
 <daff-media-gallery>
   <ng-template daffThumbnail thumbnailSrc="/thumbnail-path.jpg" label="Your description">
-    <daff-image src="/image-path.jpg" alt="Your description" width="500" height="500"></daff-image>
+    <img daff-image ngSrc="/image-path.jpg" alt="Your description" width="500" height="500" />
   </ng-template>
 </daff-media-gallery>
 ```

--- a/libs/design/media-gallery/src/media-gallery/media-gallery.component.scss
+++ b/libs/design/media-gallery/src/media-gallery/media-gallery.component.scss
@@ -99,16 +99,11 @@
 	}
 
 	&__selected-thumbnail {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		flex-grow: 1;
-		width: 100%;
 		order: 1;
+		width: 100%;
 
 		@include layout.breakpoint(big-tablet) {
 			order: 2;
-			margin: 0;
 		}
 	}
 

--- a/libs/design/media-gallery/src/media-gallery/media-gallery.component.ts
+++ b/libs/design/media-gallery/src/media-gallery/media-gallery.component.ts
@@ -31,7 +31,7 @@ let uniqueGalleryId = 0;
  * ```html
  * <daff-media-gallery>
  *  <ng-template daffThumbnail thumbnailSrc="/thumbnail-path.jpg" label="Your description">
- *    <daff-image src="/image-path.jpg" alt="Your description" width="100" height="100"></daff-image>
+ *    <img daff-image ngSrc="/image-path.jpg" alt="Your description" width="100" height="100" />
  *  </ng-template>
  * </daff-media-gallery>
  * ```

--- a/libs/design/media-gallery/src/media-gallery/specs/with-loop.spec.ts
+++ b/libs/design/media-gallery/src/media-gallery/specs/with-loop.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { DAFF_IMAGE_COMPONENTS } from '@daffodil/design/image';
+import { DAFF_IMAGE_LITE_COMPONENTS } from '@daffodil/design/image-lite';
 import {
   DAFF_MEDIA_GALLERY_COMPONENTS,
   DaffMediaGalleryComponent,
@@ -20,12 +20,11 @@ import {
 		<daff-media-gallery>
 			@for(image of images; track image) {
 				<ng-template daffThumbnail [thumbnailSrc]="image.url" [label]="image.label">
-					<daff-image 
+					<img daff-image
 						alt="{{ image.label }}"
-						src="{{ image.url }}"
+						ngSrc="{{ image.url }}"
 						width="594"
-						height="737">
-					</daff-image>
+						height="737" />
 				</ng-template>
 			}
 		</daff-media-gallery>
@@ -33,7 +32,7 @@ import {
 	`,
   imports: [
     DAFF_MEDIA_GALLERY_COMPONENTS,
-    DAFF_IMAGE_COMPONENTS,
+    DAFF_IMAGE_LITE_COMPONENTS,
   ],
 })
 class WrapperComponent {


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4674

## New behavior
`DaffImageComponent` and `DAFF_IMAGE_COMPONENTS` have been deprecated in version 0.95.0 and will be removed in version 0.101.0, along with the already deprecated `DaffImageModule`.

Migrated every usage to `img[daff-image]` from `@daffodil/design/image-lite`.

Because image-lite applies directly to the `img` element rather than wrapping it in a host element, the styles that compensated for that wrapper are no longer needed: `overflow: hidden` on `.daff-card__image`, and the flex centering on the media gallery's selected thumbnail.

Blocked by #4681

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->