### PR TITLE
fix(all): lazy loaded environments do not load extra reducers

### DIFF
--- a/libs/auth/state/src/auth-state.module.ts
+++ b/libs/auth/state/src/auth-state.module.ts
@@ -4,10 +4,14 @@ import {
   inject,
 } from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
-import { StoreModule } from '@ngrx/store';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
 import { of } from 'rxjs';
 
 import { DaffAuthStorageService } from '@daffodil/auth';
+import { daffComposeReducers } from '@daffodil/core/state';
 
 import {
   DaffAuthStateConfig,
@@ -22,8 +26,13 @@ import {
   DAFF_AUTH_UNAUTHENTICATED_HOOKS,
   DaffAuthUnauthenticatedHook,
 } from './injection-tokens/public_api';
+import { daffAuthReducers } from './reducers/auth-reducers';
 import { DAFF_AUTH_STORE_FEATURE_KEY } from './reducers/public_api';
-import { DAFF_AUTH_REDUCERS } from './reducers/token/reducers.token';
+import { DAFF_AUTH_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_AUTH_REDUCERS,
+  provideDaffAuthReducersFactory,
+} from './reducers/token/reducers.token';
 
 
 @NgModule({
@@ -53,6 +62,10 @@ import { DAFF_AUTH_REDUCERS } from './reducers/token/reducers.token';
       },
       multi: true,
     },
+    provideDaffAuthReducersFactory(() => daffComposeReducers([
+      combineReducers(daffAuthReducers),
+      ...inject(DAFF_AUTH_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffAuthStateModule {

--- a/libs/auth/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/auth/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,123 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import {
+  DAFF_AUTH_STORE_FEATURE_KEY,
+  DaffAuthCheck,
+  DaffAuthFeatureState,
+  daffAuthProvideExtraReducers,
+  daffAuthReducers,
+} from '@daffodil/auth/state';
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
+
+import { DAFF_AUTH_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_AUTH_REDUCERS,
+  provideDaffAuthReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the auth feature's reducers
+ * (registered the same way `DaffAuthStateModule` registers them) plus a
+ * consumer's extra reducers are provided on a lazy-loaded route, rather than
+ * eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_AUTH_REDUCERS` was defined
+ * as a tree-shakable ("provided in root") `InjectionToken`. A token defined
+ * that way always resolves its factory using the root environment injector,
+ * even when it's actually requested from within a lazy-loaded route's own
+ * child injector. As a result, `inject(DAFF_AUTH_EXTRA_REDUCERS)` inside
+ * that factory could never see extra reducers that were only provided on
+ * the lazy route - they would be silently dropped. Without the fix, the
+ * assertion below fails because the error added by `lazyExtraReducer` never
+ * makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const extraError: DaffStateError = {
+  code: 'code',
+  message: 'added-by-lazily-loaded-extra-reducer',
+};
+
+const lazyExtraReducer = (state: DaffAuthFeatureState) => ({
+  ...state,
+  auth: {
+    ...state.auth,
+    daffErrors: [
+      ...state.auth.daffErrors,
+      extraError,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_AUTH_STORE_FEATURE_KEY, DAFF_AUTH_REDUCERS)),
+          provideDaffAuthReducersFactory(() => daffComposeReducers([
+            combineReducers(daffAuthReducers),
+            ...inject(DAFF_AUTH_EXTRA_REDUCERS),
+          ])),
+          ...daffAuthProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/auth/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<{ [DAFF_AUTH_STORE_FEATURE_KEY]: DaffAuthFeatureState }>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffAuthCheck());
+
+    let state: DaffAuthFeatureState;
+    store.select(DAFF_AUTH_STORE_FEATURE_KEY).subscribe((s: DaffAuthFeatureState) => state = s);
+
+    expect(state.auth.daffErrors).toContain(extraError);
+  });
+});

--- a/libs/auth/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/auth/state/src/reducers/token/reducers.token.spec.ts
@@ -1,15 +1,29 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionReducer } from '@ngrx/store';
+import {
+  ActionReducer,
+  combineReducers,
+} from '@ngrx/store';
 
 import {
   DaffAuthFeatureState,
   daffAuthInitialState,
   DaffAuthCheck,
 } from '@daffodil/auth/state';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
 
-import { daffAuthProvideExtraReducers } from './extra.token';
-import { DAFF_AUTH_REDUCERS } from './reducers.token';
+import {
+  DAFF_AUTH_EXTRA_REDUCERS,
+  daffAuthProvideExtraReducers,
+} from './extra.token';
+import {
+  DAFF_AUTH_REDUCERS,
+  provideDaffAuthReducersFactory,
+} from './reducers.token';
+import { daffAuthReducers } from '../auth-reducers';
 
 describe('@daffodil/auth/state | daffAuthProvideExtraReducers', () => {
   let extraReducer: ActionReducer<DaffAuthFeatureState>;
@@ -47,6 +61,10 @@ describe('@daffodil/auth/state | daffAuthProvideExtraReducers', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffAuthProvideExtraReducers(extraReducer),
+        provideDaffAuthReducersFactory(() => daffComposeReducers([
+          combineReducers(daffAuthReducers),
+          ...inject(DAFF_AUTH_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/auth/state/src/reducers/token/reducers.token.ts
+++ b/libs/auth/state/src/reducers/token/reducers.token.ts
@@ -1,15 +1,8 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_AUTH_EXTRA_REDUCERS } from './extra.token';
 import { DaffAuthFeatureState } from '../auth-feature-state.interface';
-import { daffAuthReducers } from '../auth-reducers';
 
 export const {
   /**
@@ -23,12 +16,10 @@ export const {
    * Provider function for {@link DAFF_AUTH_REDUCERS}.
    */
   provider: provideDaffAuthReducers,
+  /**
+   * Factory provider function for {@link DAFF_AUTH_REDUCERS}.
+   */
+  factoryProvider: provideDaffAuthReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffAuthFeatureState>>(
   'DAFF_AUTH_REDUCERS',
-  {
-    factory: () => daffComposeReducers([
-      combineReducers(daffAuthReducers),
-      ...inject(DAFF_AUTH_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/authorizenet/state/src/authorize-net-state.module.ts
+++ b/libs/authorizenet/state/src/authorize-net-state.module.ts
@@ -1,9 +1,15 @@
 import {
+  inject,
   ModuleWithProviders,
   NgModule,
 } from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
-import { StoreModule } from '@ngrx/store';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
+
+import { daffComposeReducers } from '@daffodil/core/state';
 
 import {
   DaffAuthorizeNetStateConfig,
@@ -11,8 +17,13 @@ import {
   provideDaffAuthorizeNetStateConfig,
 } from './config/public_api';
 import { DaffAuthorizeNetEffects } from './effects/authorize-net.effects';
+import { daffAuthorizeNetReducer } from './reducers/authorize-net/authorize-net.reducer';
 import { DAFF_AUTHORIZENET_STORE_FEATURE_KEY } from './reducers/authorizenet-store-feature-key';
-import { DAFF_AUTHORIZE_NET_REDUCERS } from './reducers/token/reducers.token';
+import { DAFF_AUTHORIZE_NET_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_AUTHORIZE_NET_REDUCERS,
+  provideDaffAuthorizeNetReducersFactory,
+} from './reducers/token/reducers.token';
 
 @NgModule({
   imports: [
@@ -21,6 +32,12 @@ import { DAFF_AUTHORIZE_NET_REDUCERS } from './reducers/token/reducers.token';
   ],
   providers: [
     provideDaffAuthorizeNetStateConfig(daffAuthorizeNetStateDefaultConfig),
+    provideDaffAuthorizeNetReducersFactory(() => daffComposeReducers([
+      combineReducers({
+        authorizeNet: daffAuthorizeNetReducer,
+      }),
+      ...inject(DAFF_AUTHORIZE_NET_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffAuthorizeNetStateModule {

--- a/libs/authorizenet/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/authorizenet/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,124 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  inject,
+  importProvidersFrom,
+  Component,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import {
+  DAFF_AUTHORIZENET_STORE_FEATURE_KEY,
+  DaffAuthorizeNetReducersState,
+  DaffAuthorizeNetStateRootSlice,
+  DaffLoadAcceptJsFailure,
+  daffAuthorizeNetProvideExtraReducers,
+  daffAuthorizeNetReducers,
+} from '@daffodil/authorizenet/state';
+import {
+  daffComposeReducers ,
+  DaffStateError,
+} from '@daffodil/core/state';
+
+import { DAFF_AUTHORIZE_NET_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_AUTHORIZE_NET_REDUCERS,
+  provideDaffAuthorizeNetReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the authorizenet feature's
+ * reducers (registered the same way `DaffAuthorizeNetStateModule` registers
+ * them) plus a consumer's extra reducers are provided on a lazy-loaded
+ * route, rather than eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_AUTHORIZE_NET_REDUCERS` was
+ * defined as a tree-shakable ("provided in root") `InjectionToken`. A token
+ * defined that way always resolves its factory using the root environment
+ * injector, even when it's actually requested from within a lazy-loaded
+ * route's own child injector. As a result,
+ * `inject(DAFF_AUTHORIZE_NET_EXTRA_REDUCERS)` inside that factory could
+ * never see extra reducers that were only provided on the lazy route - they
+ * would be silently dropped. Without the fix, the assertion below fails
+ * because the error added by `lazyExtraReducer` never makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const extraError: DaffStateError = {
+  code: 'code',
+  message: 'added-by-lazily-loaded-extra-reducer',
+};
+
+const lazyExtraReducer = (state: DaffAuthorizeNetReducersState) => ({
+  ...state,
+  authorizeNet: {
+    ...state.authorizeNet,
+    acceptJsLoadError: extraError,
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_AUTHORIZENET_STORE_FEATURE_KEY, DAFF_AUTHORIZE_NET_REDUCERS)),
+          provideDaffAuthorizeNetReducersFactory(() => daffComposeReducers([
+            combineReducers(daffAuthorizeNetReducers),
+            ...inject(DAFF_AUTHORIZE_NET_EXTRA_REDUCERS),
+          ])),
+          ...daffAuthorizeNetProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/authorizenet/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<DaffAuthorizeNetStateRootSlice>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffLoadAcceptJsFailure({
+      code: 'code',
+      message: 'already in state',
+    }));
+
+    let state: DaffAuthorizeNetReducersState;
+    store.select(DAFF_AUTHORIZENET_STORE_FEATURE_KEY).subscribe((s: DaffAuthorizeNetReducersState) => state = s);
+
+    expect(state.authorizeNet.acceptJsLoadError).toEqual(extraError);
+  });
+});

--- a/libs/authorizenet/state/src/reducers/token/reducers.token.ts
+++ b/libs/authorizenet/state/src/reducers/token/reducers.token.ts
@@ -1,14 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_AUTHORIZE_NET_EXTRA_REDUCERS } from './extra.token';
-import { daffAuthorizeNetReducer } from '../authorize-net/authorize-net.reducer';
 import { DaffAuthorizeNetReducersState } from '../authorize-net-reducers.interface';
 
 export const {
@@ -23,15 +16,10 @@ export const {
    * Provider function for {@link DAFF_AUTHORIZE_NET_REDUCERS}.
    */
   provider: provideDaffAuthorizeNetReducers,
+  /**
+   * Factory provider function for {@link DAFF_AUTHORIZE_NET_REDUCERS}.
+   */
+  factoryProvider: provideDaffAuthorizeNetReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffAuthorizeNetReducersState>>(
   'DAFF_AUTHORIZE_NET_REDUCERS',
-  {
-    providedIn: 'any',
-    factory: () => daffComposeReducers([
-      combineReducers({
-        authorizeNet: daffAuthorizeNetReducer,
-      }),
-      ...inject(DAFF_AUTHORIZE_NET_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/cart-store-credit/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/cart-store-credit/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,129 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import {
+  DAFF_CART_STORE_CREDIT_STORE_FEATURE_KEY,
+  DaffCartStoreCreditApplyFailure,
+  DaffCartStoreCreditReducersState,
+  daffCartStoreCreditProvideExtraReducers,
+  daffCartStoreCreditReducer,
+} from '@daffodil/cart-store-credit/state';
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
+
+import { DAFF_CART_STORE_CREDIT_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CART_STORE_CREDIT_REDUCERS,
+  provideDaffCartStoreCreditReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the cart store credit
+ * feature's reducers (registered the same way
+ * `DaffCartStoreCreditStateModule` registers them) plus a consumer's extra
+ * reducers are provided on a lazy-loaded route, rather than eagerly at the
+ * application root.
+ *
+ * It is a regression test for a bug where `DAFF_CART_STORE_CREDIT_REDUCERS`
+ * was defined as a tree-shakable ("provided in root") `InjectionToken`. A
+ * token defined that way always resolves its factory using the root
+ * environment injector, even when it's actually requested from within a
+ * lazy-loaded route's own child injector. As a result,
+ * `inject(DAFF_CART_STORE_CREDIT_EXTRA_REDUCERS)` inside that factory could
+ * never see extra reducers that were only provided on the lazy route - they
+ * would be silently dropped. Without the fix, the assertion below fails
+ * because the error added by `lazyExtraReducer` never makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const extraError: DaffStateError = {
+  code: 'code',
+  message: 'added-by-lazily-loaded-extra-reducer',
+};
+
+const lazyExtraReducer = (state: DaffCartStoreCreditReducersState) => ({
+  ...state,
+  storeCredit: {
+    ...state.storeCredit,
+    daffErrors: [
+      ...state.storeCredit.daffErrors,
+      extraError,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_CART_STORE_CREDIT_STORE_FEATURE_KEY, DAFF_CART_STORE_CREDIT_REDUCERS)),
+          provideDaffCartStoreCreditReducersFactory(() => daffComposeReducers([
+            combineReducers({
+              storeCredit: daffCartStoreCreditReducer,
+            }),
+            ...inject(DAFF_CART_STORE_CREDIT_EXTRA_REDUCERS),
+          ])),
+          ...daffCartStoreCreditProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/cart-store-credit/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<{ [DAFF_CART_STORE_CREDIT_STORE_FEATURE_KEY]: DaffCartStoreCreditReducersState }>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffCartStoreCreditApplyFailure([{
+      code: 'code',
+      message: 'already in state',
+    }]));
+
+    let state: DaffCartStoreCreditReducersState;
+    store.select(DAFF_CART_STORE_CREDIT_STORE_FEATURE_KEY).subscribe((s: DaffCartStoreCreditReducersState) => state = s);
+
+    expect(state.storeCredit.daffErrors).toContain(extraError);
+  });
+});

--- a/libs/cart-store-credit/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/cart-store-credit/state/src/reducers/token/reducers.token.spec.ts
@@ -1,5 +1,9 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionReducer } from '@ngrx/store';
+import {
+  ActionReducer,
+  combineReducers,
+} from '@ngrx/store';
 
 import {
   daffCartStoreCreditProvideExtraReducers,
@@ -7,9 +11,17 @@ import {
   daffCartStoreCreditInitialState,
   DaffCartStoreCreditApplyFailure,
 } from '@daffodil/cart-store-credit/state';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
 
-import { DAFF_CART_STORE_CREDIT_REDUCERS } from './reducers.token';
+import { DAFF_CART_STORE_CREDIT_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CART_STORE_CREDIT_REDUCERS,
+  provideDaffCartStoreCreditReducersFactory,
+} from './reducers.token';
+import { daffCartStoreCreditReducer } from '../store-credit/public_api';
 
 describe('@daffodil/cart-store-credit/state | daffCartStoreCreditProvideExtraReducers', () => {
   let extraError: DaffStateError;
@@ -46,6 +58,12 @@ describe('@daffodil/cart-store-credit/state | daffCartStoreCreditProvideExtraRed
     TestBed.configureTestingModule({
       providers: [
         ...daffCartStoreCreditProvideExtraReducers(extraReducer),
+        provideDaffCartStoreCreditReducersFactory(() => daffComposeReducers([
+          combineReducers({
+            storeCredit: daffCartStoreCreditReducer,
+          }),
+          ...inject(DAFF_CART_STORE_CREDIT_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/cart-store-credit/state/src/reducers/token/reducers.token.ts
+++ b/libs/cart-store-credit/state/src/reducers/token/reducers.token.ts
@@ -1,15 +1,8 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_CART_STORE_CREDIT_EXTRA_REDUCERS } from './extra.token';
 import { DaffCartStoreCreditReducersState } from '../reducers.interface';
-import { daffCartStoreCreditReducer } from '../store-credit/public_api';
 
 export const {
   /**
@@ -23,15 +16,10 @@ export const {
    * Provider function for {@link DAFF_CART_STORE_CREDIT_REDUCERS}.
    */
   provider: provideDaffCartStoreCreditReducers,
+  /**
+   * Factory provider function for {@link DAFF_CART_STORE_CREDIT_REDUCERS}.
+   */
+  factoryProvider: provideDaffCartStoreCreditReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffCartStoreCreditReducersState>>(
   'DAFF_CART_STORE_CREDIT_REDUCERS',
-  {
-    providedIn: 'any',
-    factory: () => daffComposeReducers([
-      combineReducers({
-        storeCredit: daffCartStoreCreditReducer,
-      }),
-      ...inject(DAFF_CART_STORE_CREDIT_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/cart-store-credit/state/src/state.module.ts
+++ b/libs/cart-store-credit/state/src/state.module.ts
@@ -1,4 +1,7 @@
-import { NgModule } from '@angular/core';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
 import {
   combineReducers,
@@ -6,13 +9,19 @@ import {
 } from '@ngrx/store';
 
 import { daffCartProvideExtraReducers } from '@daffodil/cart/state';
+import { daffComposeReducers } from '@daffodil/core/state';
 
 import { DaffCartStoreCreditEffects } from './effects/store-credit.effects';
 import {
   daffCartStoreCreditCartReducers,
   DAFF_CART_STORE_CREDIT_STORE_FEATURE_KEY,
 } from './reducers/public_api';
-import { DAFF_CART_STORE_CREDIT_REDUCERS } from './reducers/token/reducers.token';
+import { daffCartStoreCreditReducer } from './reducers/store-credit/public_api';
+import { DAFF_CART_STORE_CREDIT_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_CART_STORE_CREDIT_REDUCERS,
+  provideDaffCartStoreCreditReducersFactory,
+} from './reducers/token/reducers.token';
 
 /**
  * Creates the cart store credit feature store.
@@ -28,6 +37,12 @@ import { DAFF_CART_STORE_CREDIT_REDUCERS } from './reducers/token/reducers.token
     ...daffCartProvideExtraReducers(
       combineReducers(daffCartStoreCreditCartReducers),
     ),
+    provideDaffCartStoreCreditReducersFactory(() => daffComposeReducers([
+      combineReducers({
+        storeCredit: daffCartStoreCreditReducer,
+      }),
+      ...inject(DAFF_CART_STORE_CREDIT_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffCartStoreCreditStateModule {}

--- a/libs/cart/state/src/cart-state.module.ts
+++ b/libs/cart/state/src/cart-state.module.ts
@@ -1,14 +1,24 @@
-import { NgModule } from '@angular/core';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
 import {
   combineReducers,
   StoreModule,
 } from '@ngrx/store';
 
+import {
+  daffComposeReducers,
+  daffIdentityReducer,
+} from '@daffodil/core/state';
 import { daffPaymentProvideExtraReducers } from '@daffodil/payment/state';
 
 import { daffCartRetrivalActions } from './actions/cart-retrieval';
-import { daffCartProvideRetrievalActions } from './cart-retrieval/public_api';
+import {
+  DAFF_CART_RETRIEVAL_ACTIONS,
+  daffCartProvideRetrievalActions,
+} from './cart-retrieval/public_api';
 import { DaffCartAddressEffects } from './effects/cart-address.effects';
 import { DaffCartBillingAddressEffects } from './effects/cart-billing-address.effects';
 import { DaffCartCouponEffects } from './effects/cart-coupon.effects';
@@ -23,10 +33,17 @@ import { DaffCartShippingInformationEffects } from './effects/cart-shipping-info
 import { DaffCartShippingMethodsEffects } from './effects/cart-shipping-methods.effects';
 import { DaffCartEffects } from './effects/cart.effects';
 import { provideDaffCartItemStateDebounceTime } from './injection-tokens/cart-item-state-debounce-time';
+import { daffCartRetrievalActionsReducerFactory } from './reducers/cart/retrieval-actions.reducer';
+import { daffCartItemEntitiesRetrievalActionsReducerFactory } from './reducers/cart-item-entities/retrieval-actions.reducer';
 import { daffCartPaymentReducer } from './reducers/cart-payment/payment.reducer';
+import { daffCartReducers } from './reducers/cart-reducers';
 import { DAFF_CART_STORE_FEATURE_KEY } from './reducers/public_api';
 import { DAFF_CART_STORE_CONFIG } from './reducers/token/config.token';
-import { DAFF_CART_REDUCERS } from './reducers/token/reducers.token';
+import { DAFF_CART_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_CART_REDUCERS,
+  provideDaffCartReducersFactory,
+} from './reducers/token/reducers.token';
 
 @NgModule({
   imports: [
@@ -53,6 +70,22 @@ import { DAFF_CART_REDUCERS } from './reducers/token/reducers.token';
       payment: daffCartPaymentReducer,
     })),
     daffCartProvideRetrievalActions(...daffCartRetrivalActions),
+    provideDaffCartReducersFactory(() => {
+      const retrievalActions = inject(DAFF_CART_RETRIEVAL_ACTIONS);
+
+      return daffComposeReducers([
+        // daffodil reducers should run first, don't change this
+        // TODO: enforce this somehow (meta-reducers?)
+        combineReducers(daffCartReducers),
+        //
+        combineReducers({
+          cart: daffCartRetrievalActionsReducerFactory(retrievalActions),
+          cartItems: daffCartItemEntitiesRetrievalActionsReducerFactory(retrievalActions),
+          order: daffIdentityReducer,
+        }),
+        ...inject(DAFF_CART_EXTRA_REDUCERS),
+      ]);
+    }),
   ],
 })
 export class DaffCartStateModule {}

--- a/libs/cart/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/cart/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,141 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import { DaffCartPaymentMethod } from '@daffodil/cart';
+import {
+  DAFF_CART_RETRIEVAL_ACTIONS,
+  DAFF_CART_STORE_FEATURE_KEY,
+  DaffCartPaymentLoadSuccess,
+  DaffCartReducersState,
+  daffCartItemEntitiesRetrievalActionsReducerFactory,
+  daffCartProvideExtraReducers,
+  daffCartReducers,
+  daffCartRetrievalActionsReducerFactory,
+} from '@daffodil/cart/state';
+import { DaffCartPaymentFactory } from '@daffodil/cart/testing';
+import {
+  daffComposeReducers,
+  daffIdentityReducer,
+} from '@daffodil/core/state';
+
+import { DAFF_CART_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CART_REDUCERS,
+  provideDaffCartReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the cart feature's reducers
+ * (registered the same way `DaffCartStateModule` registers them) plus a
+ * consumer's extra reducers are provided on a lazy-loaded route, rather than
+ * eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_CART_REDUCERS` was defined
+ * as a tree-shakable ("provided in root") `InjectionToken`. A token defined
+ * that way always resolves its factory using the root environment injector,
+ * even when it's actually requested from within a lazy-loaded route's own
+ * child injector. As a result, `inject(DAFF_CART_EXTRA_REDUCERS)` inside
+ * that factory could never see extra reducers that were only provided on
+ * the lazy route - they would be silently dropped. Without the fix, the
+ * assertion below fails because the extra reducer's contribution never
+ * makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const EXTRA_REDUCER_PAYMENT_METHOD = 'added-by-lazily-loaded-extra-reducer';
+
+const lazyExtraReducer = (state: DaffCartReducersState) => ({
+  ...state,
+  cart: {
+    ...state.cart,
+    cart: {
+      ...state.cart.cart,
+      payment: {
+        ...state.cart.cart.payment,
+        method: EXTRA_REDUCER_PAYMENT_METHOD,
+      },
+    },
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_CART_STORE_FEATURE_KEY, DAFF_CART_REDUCERS)),
+          provideDaffCartReducersFactory(() => {
+            const retrievalActions = inject(DAFF_CART_RETRIEVAL_ACTIONS);
+
+            return daffComposeReducers([
+              combineReducers(daffCartReducers),
+              combineReducers({
+                cart: daffCartRetrievalActionsReducerFactory(retrievalActions),
+                cartItems: daffCartItemEntitiesRetrievalActionsReducerFactory(retrievalActions),
+                order: daffIdentityReducer,
+              }),
+              ...inject(DAFF_CART_EXTRA_REDUCERS),
+            ]);
+          }),
+          ...daffCartProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/cart/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<{ [DAFF_CART_STORE_FEATURE_KEY]: DaffCartReducersState }>;
+  let paymentFactory: DaffCartPaymentFactory;
+  let payment: DaffCartPaymentMethod;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+    paymentFactory = TestBed.inject(DaffCartPaymentFactory);
+    payment = paymentFactory.create();
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffCartPaymentLoadSuccess(payment));
+
+    let state: DaffCartReducersState;
+    store.select(DAFF_CART_STORE_FEATURE_KEY).subscribe((s: DaffCartReducersState) => state = s);
+
+    expect(state.cart.cart.payment.method).toEqual(EXTRA_REDUCER_PAYMENT_METHOD);
+  });
+});

--- a/libs/cart/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/cart/state/src/reducers/token/reducers.token.spec.ts
@@ -1,5 +1,9 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionReducer } from '@ngrx/store';
+import {
+  ActionReducer,
+  combineReducers,
+} from '@ngrx/store';
 
 import { DaffCartPaymentMethod } from '@daffodil/cart';
 import {
@@ -9,8 +13,20 @@ import {
   DaffCartPaymentLoadSuccess,
 } from '@daffodil/cart/state';
 import { DaffCartPaymentFactory } from '@daffodil/cart/testing';
+import {
+  daffComposeReducers,
+  daffIdentityReducer,
+} from '@daffodil/core/state';
 
-import { DAFF_CART_REDUCERS } from './reducers.token';
+import { DAFF_CART_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CART_REDUCERS,
+  provideDaffCartReducersFactory,
+} from './reducers.token';
+import { DAFF_CART_RETRIEVAL_ACTIONS } from '../../cart-retrieval/public_api';
+import { daffCartRetrievalActionsReducerFactory } from '../cart/retrieval-actions.reducer';
+import { daffCartItemEntitiesRetrievalActionsReducerFactory } from '../cart-item-entities/retrieval-actions.reducer';
+import { daffCartReducers } from '../cart-reducers';
 
 describe('@daffodil/cart/state | daffCartProvideExtraReducers', () => {
   let paymentFactory: DaffCartPaymentFactory;
@@ -43,6 +59,19 @@ describe('@daffodil/cart/state | daffCartProvideExtraReducers', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffCartProvideExtraReducers(extraReducer),
+        provideDaffCartReducersFactory(() => {
+          const retrievalActions = inject(DAFF_CART_RETRIEVAL_ACTIONS);
+
+          return daffComposeReducers([
+            combineReducers(daffCartReducers),
+            combineReducers({
+              cart: daffCartRetrievalActionsReducerFactory(retrievalActions),
+              cartItems: daffCartItemEntitiesRetrievalActionsReducerFactory(retrievalActions),
+              order: daffIdentityReducer,
+            }),
+            ...inject(DAFF_CART_EXTRA_REDUCERS),
+          ]);
+        }),
       ],
     });
 

--- a/libs/cart/state/src/reducers/token/reducers.token.ts
+++ b/libs/cart/state/src/reducers/token/reducers.token.ts
@@ -1,20 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import {
-  daffComposeReducers,
-  daffIdentityReducer,
-} from '@daffodil/core/state';
 
-import { DAFF_CART_EXTRA_REDUCERS } from './extra.token';
-import { DAFF_CART_RETRIEVAL_ACTIONS } from '../../cart-retrieval/public_api';
-import { daffCartRetrievalActionsReducerFactory } from '../cart/retrieval-actions.reducer';
-import { daffCartItemEntitiesRetrievalActionsReducerFactory } from '../cart-item-entities/retrieval-actions.reducer';
-import { daffCartReducers } from '../cart-reducers';
 import { DaffCartReducersState } from '../cart-reducers-state.interface';
 
 export const {
@@ -29,24 +16,10 @@ export const {
    * Provider function for {@link DAFF_CART_REDUCERS}.
    */
   provider: provideDaffCartReducers,
+  /**
+   * Factory provider function for {@link DAFF_CART_REDUCERS}.
+   */
+  factoryProvider: provideDaffCartReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffCartReducersState>>(
   'DAFF_CART_REDUCERS',
-  {
-    factory: () => {
-      const retrievalActions = inject(DAFF_CART_RETRIEVAL_ACTIONS);
-
-      return daffComposeReducers([
-        // daffodil reducers should run first, don't change this
-        // TODO: enforce this somehow (meta-reducers?)
-        combineReducers(daffCartReducers),
-        //
-        combineReducers({
-          cart: daffCartRetrievalActionsReducerFactory(retrievalActions),
-          cartItems: daffCartItemEntitiesRetrievalActionsReducerFactory(retrievalActions),
-          order: daffIdentityReducer,
-        }),
-        ...inject(DAFF_CART_EXTRA_REDUCERS),
-      ]);
-    },
-  },
 );

--- a/libs/category/state/src/category-state.module.ts
+++ b/libs/category/state/src/category-state.module.ts
@@ -1,14 +1,26 @@
-import { NgModule } from '@angular/core';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
-import { StoreModule } from '@ngrx/store';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
 
+import { daffComposeReducers } from '@daffodil/core/state';
 import { DaffProductStateModule } from '@daffodil/product/state';
 
 import { DaffCategoryPageMetadataEffects } from './effects/category-page-metadata.effects';
 import { DaffCategoryPageEffects } from './effects/category-page.effects';
 import { DaffCategoryEffects } from './effects/category.effects';
+import { daffCategoryReducers } from './reducers/category-reducers';
 import { DAFF_CATEGORY_STORE_FEATURE_KEY } from './reducers/public_api';
-import { DAFF_CATEGORY_REDUCERS } from './reducers/token/reducers.token';
+import { DAFF_CATEGORY_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_CATEGORY_REDUCERS,
+  provideDaffCategoryReducersFactory,
+} from './reducers/token/reducers.token';
 
 /**
  * A module that provides default reducers and effects for the category redux state.
@@ -18,6 +30,12 @@ import { DAFF_CATEGORY_REDUCERS } from './reducers/token/reducers.token';
     StoreModule.forFeature(DAFF_CATEGORY_STORE_FEATURE_KEY, DAFF_CATEGORY_REDUCERS),
     EffectsModule.forFeature([DaffCategoryEffects, DaffCategoryPageEffects, DaffCategoryPageMetadataEffects]),
     DaffProductStateModule,
+  ],
+  providers: [
+    provideDaffCategoryReducersFactory(() => daffComposeReducers([
+      combineReducers(daffCategoryReducers),
+      ...inject(DAFF_CATEGORY_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffCategoryStateModule {}

--- a/libs/category/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/category/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,126 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import {
+  DAFF_CATEGORY_STORE_FEATURE_KEY,
+  DaffCategoryLoadFailure,
+  DaffCategoryReducersState,
+  daffCategoryProvideExtraReducers,
+  daffCategoryReducers,
+} from '@daffodil/category/state';
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
+
+import { DAFF_CATEGORY_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CATEGORY_REDUCERS,
+  provideDaffCategoryReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the category feature's
+ * reducers (registered the same way `DaffCategoryStateModule` registers
+ * them) plus a consumer's extra reducers are provided on a lazy-loaded
+ * route, rather than eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_CATEGORY_REDUCERS` was
+ * defined as a tree-shakable ("provided in root") `InjectionToken`. A token
+ * defined that way always resolves its factory using the root environment
+ * injector, even when it's actually requested from within a lazy-loaded
+ * route's own child injector. As a result,
+ * `inject(DAFF_CATEGORY_EXTRA_REDUCERS)` inside that factory could never see
+ * extra reducers that were only provided on the lazy route - they would be
+ * silently dropped. Without the fix, the assertion below fails because the
+ * error added by `lazyExtraReducer` never makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const extraError: DaffStateError = {
+  code: 'code',
+  message: 'added-by-lazily-loaded-extra-reducer',
+};
+
+const lazyExtraReducer = (state: DaffCategoryReducersState) => ({
+  ...state,
+  category: {
+    ...state.category,
+    daffErrors: [
+      ...state.category.daffErrors,
+      extraError,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_CATEGORY_STORE_FEATURE_KEY, DAFF_CATEGORY_REDUCERS)),
+          provideDaffCategoryReducersFactory(() => daffComposeReducers([
+            combineReducers(daffCategoryReducers),
+            ...inject(DAFF_CATEGORY_EXTRA_REDUCERS),
+          ])),
+          ...daffCategoryProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/category/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<{ [DAFF_CATEGORY_STORE_FEATURE_KEY]: DaffCategoryReducersState }>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffCategoryLoadFailure({
+      code: 'code',
+      message: 'already in state',
+    }));
+
+    let state: DaffCategoryReducersState;
+    store.select(DAFF_CATEGORY_STORE_FEATURE_KEY).subscribe((s: DaffCategoryReducersState) => state = s);
+
+    expect(state.category.daffErrors).toContain(extraError);
+  });
+});

--- a/libs/category/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/category/state/src/reducers/token/reducers.token.spec.ts
@@ -1,16 +1,28 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionReducer } from '@ngrx/store';
+import {
+  ActionReducer,
+  combineReducers,
+} from '@ngrx/store';
 
 import {
   daffCategoryProvideExtraReducers,
   DaffCategoryReducersState,
   DaffCategoryLoadFailure,
 } from '@daffodil/category/state';
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
 
-import { DAFF_CATEGORY_REDUCERS } from './reducers.token';
+import { DAFF_CATEGORY_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CATEGORY_REDUCERS,
+  provideDaffCategoryReducersFactory,
+} from './reducers.token';
 import { daffCategoryInitialState } from '../category/category.reducer';
 import { daffCategoryEntitiesAdapter } from '../category-entities/category-entities-adapter';
+import { daffCategoryReducers } from '../category-reducers';
 import { daffCategoryPageMetadataInitialState } from '../page-metadata/reducer';
 
 describe('@daffodil/category/state | daffCategoryProvideExtraReducers', () => {
@@ -50,6 +62,10 @@ describe('@daffodil/category/state | daffCategoryProvideExtraReducers', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffCategoryProvideExtraReducers(extraReducer),
+        provideDaffCategoryReducersFactory(() => daffComposeReducers([
+          combineReducers(daffCategoryReducers),
+          ...inject(DAFF_CATEGORY_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/category/state/src/reducers/token/reducers.token.ts
+++ b/libs/category/state/src/reducers/token/reducers.token.ts
@@ -1,14 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_CATEGORY_EXTRA_REDUCERS } from './extra.token';
-import { daffCategoryReducers } from '../category-reducers';
 import { DaffCategoryReducersState } from '../category-reducers.interface';
 
 export const {
@@ -23,13 +16,10 @@ export const {
    * Provider function for {@link DAFF_CATEGORY_REDUCERS}.
    */
   provider: provideDaffCategoryReducers,
+  /**
+   * Factory provider function for {@link DAFF_CATEGORY_REDUCERS}.
+   */
+  factoryProvider: provideDaffCategoryReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffCategoryReducersState>>(
   'DAFF_CATEGORY_REDUCERS',
-  {
-    providedIn: 'any',
-    factory: () => daffComposeReducers([
-      combineReducers(daffCategoryReducers),
-      ...inject(DAFF_CATEGORY_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/customer-payment/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/customer-payment/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,131 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
+import {
+  DAFF_CUSTOMER_PAYMENT_STORE_FEATURE_KEY,
+  DaffCustomerPaymentListFailure,
+  DaffCustomerPaymentReducersState,
+  daffCustomerPaymentEntitiesReducer,
+  daffCustomerPaymentProvideExtraReducers,
+  daffCustomerPaymentReducer,
+} from '@daffodil/customer-payment/state';
+
+import { DAFF_CUSTOMER_PAYMENT_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CUSTOMER_PAYMENT_REDUCERS,
+  provideDaffCustomerPaymentReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the customer payment
+ * feature's reducers (registered the same way
+ * `DaffCustomerPaymentStateModule` registers them) plus a consumer's extra
+ * reducers are provided on a lazy-loaded route, rather than eagerly at the
+ * application root.
+ *
+ * It is a regression test for a bug where `DAFF_CUSTOMER_PAYMENT_REDUCERS`
+ * was defined as a tree-shakable ("provided in root") `InjectionToken`. A
+ * token defined that way always resolves its factory using the root
+ * environment injector, even when it's actually requested from within a
+ * lazy-loaded route's own child injector. As a result,
+ * `inject(DAFF_CUSTOMER_PAYMENT_EXTRA_REDUCERS)` inside that factory could
+ * never see extra reducers that were only provided on the lazy route - they
+ * would be silently dropped. Without the fix, the assertion below fails
+ * because the error added by `lazyExtraReducer` never makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const extraError: DaffStateError = {
+  code: 'code',
+  message: 'added-by-lazily-loaded-extra-reducer',
+};
+
+const lazyExtraReducer = (state: DaffCustomerPaymentReducersState) => ({
+  ...state,
+  payment: {
+    ...state.payment,
+    daffErrors: [
+      ...state.payment.daffErrors,
+      extraError,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_CUSTOMER_PAYMENT_STORE_FEATURE_KEY, DAFF_CUSTOMER_PAYMENT_REDUCERS)),
+          provideDaffCustomerPaymentReducersFactory(() => daffComposeReducers([
+            combineReducers({
+              payment: daffCustomerPaymentReducer,
+              paymentEntities: daffCustomerPaymentEntitiesReducer,
+            }),
+            ...inject(DAFF_CUSTOMER_PAYMENT_EXTRA_REDUCERS),
+          ])),
+          ...daffCustomerPaymentProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/customer-payment/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<{ [DAFF_CUSTOMER_PAYMENT_STORE_FEATURE_KEY]: DaffCustomerPaymentReducersState }>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffCustomerPaymentListFailure({
+      code: 'code',
+      message: 'already in state',
+    }));
+
+    let state: DaffCustomerPaymentReducersState;
+    store.select(DAFF_CUSTOMER_PAYMENT_STORE_FEATURE_KEY).subscribe((s: DaffCustomerPaymentReducersState) => state = s);
+
+    expect(state.payment.daffErrors).toContain(extraError);
+  });
+});

--- a/libs/customer-payment/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/customer-payment/state/src/reducers/token/reducers.token.spec.ts
@@ -1,7 +1,14 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionReducer } from '@ngrx/store';
+import {
+  ActionReducer,
+  combineReducers,
+} from '@ngrx/store';
 
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
 import {
   daffCustomerPaymentProvideExtraReducers,
   DaffCustomerPaymentReducersState,
@@ -10,7 +17,13 @@ import {
   daffCustomerPaymentEntitiesAdapter,
 } from '@daffodil/customer-payment/state';
 
-import { DAFF_CUSTOMER_PAYMENT_REDUCERS } from './reducers.token';
+import { DAFF_CUSTOMER_PAYMENT_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CUSTOMER_PAYMENT_REDUCERS,
+  provideDaffCustomerPaymentReducersFactory,
+} from './reducers.token';
+import { daffCustomerPaymentReducer } from '../payment/public_api';
+import { daffCustomerPaymentEntitiesReducer } from '../payment-entities/public_api';
 
 describe('@daffodil/customer-payment/state | daffCustomerPaymentProvideExtraReducers', () => {
   let extraError: DaffStateError;
@@ -48,6 +61,13 @@ describe('@daffodil/customer-payment/state | daffCustomerPaymentProvideExtraRedu
     TestBed.configureTestingModule({
       providers: [
         ...daffCustomerPaymentProvideExtraReducers(extraReducer),
+        provideDaffCustomerPaymentReducersFactory(() => daffComposeReducers([
+          combineReducers({
+            payment: daffCustomerPaymentReducer,
+            paymentEntities: daffCustomerPaymentEntitiesReducer,
+          }),
+          ...inject(DAFF_CUSTOMER_PAYMENT_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/customer-payment/state/src/reducers/token/reducers.token.ts
+++ b/libs/customer-payment/state/src/reducers/token/reducers.token.ts
@@ -1,15 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_CUSTOMER_PAYMENT_EXTRA_REDUCERS } from './extra.token';
-import { daffCustomerPaymentReducer } from '../payment/public_api';
-import { daffCustomerPaymentEntitiesReducer } from '../payment-entities/public_api';
 import { DaffCustomerPaymentReducersState } from '../reducers.interface';
 
 export const {
@@ -24,16 +16,10 @@ export const {
    * Provider function for {@link DAFF_CUSTOMER_PAYMENT_REDUCERS}.
    */
   provider: provideDaffCustomerPaymentReducers,
+  /**
+   * Factory provider function for {@link DAFF_CUSTOMER_PAYMENT_REDUCERS}.
+   */
+  factoryProvider: provideDaffCustomerPaymentReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffCustomerPaymentReducersState>>(
   'DAFF_CUSTOMER_PAYMENT_REDUCERS',
-  {
-    providedIn: 'any',
-    factory: () => daffComposeReducers([
-      combineReducers({
-        payment: daffCustomerPaymentReducer,
-        paymentEntities: daffCustomerPaymentEntitiesReducer,
-      }),
-      ...inject(DAFF_CUSTOMER_PAYMENT_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/customer-payment/state/src/state.module.ts
+++ b/libs/customer-payment/state/src/state.module.ts
@@ -1,10 +1,24 @@
-import { NgModule } from '@angular/core';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
-import { StoreModule } from '@ngrx/store';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
+
+import { daffComposeReducers } from '@daffodil/core/state';
 
 import { DaffCustomerPaymentEffects } from './effects/payment.effects';
+import { daffCustomerPaymentReducer } from './reducers/payment/public_api';
+import { daffCustomerPaymentEntitiesReducer } from './reducers/payment-entities/public_api';
 import { DAFF_CUSTOMER_PAYMENT_STORE_FEATURE_KEY } from './reducers/public_api';
-import { DAFF_CUSTOMER_PAYMENT_REDUCERS } from './reducers/token/reducers.token';
+import { DAFF_CUSTOMER_PAYMENT_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_CUSTOMER_PAYMENT_REDUCERS,
+  provideDaffCustomerPaymentReducersFactory,
+} from './reducers/token/reducers.token';
 
 /**
  * Creates the customer feature store.
@@ -15,6 +29,15 @@ import { DAFF_CUSTOMER_PAYMENT_REDUCERS } from './reducers/token/reducers.token'
     EffectsModule.forFeature([
       DaffCustomerPaymentEffects,
     ]),
+  ],
+  providers: [
+    provideDaffCustomerPaymentReducersFactory(() => daffComposeReducers([
+      combineReducers({
+        payment: daffCustomerPaymentReducer,
+        paymentEntities: daffCustomerPaymentEntitiesReducer,
+      }),
+      ...inject(DAFF_CUSTOMER_PAYMENT_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffCustomerPaymentStateModule {}

--- a/libs/customer-store-credit/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/customer-store-credit/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,130 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
+import {
+  DAFF_CUSTOMER_STORE_CREDIT_STORE_FEATURE_KEY,
+  DaffCustomerStoreCreditLoadFailure,
+  DaffCustomerStoreCreditReducersState,
+  daffCustomerStoreCreditProvideExtraReducers,
+  daffCustomerStoreCreditReducer,
+} from '@daffodil/customer-store-credit/state';
+
+import { DAFF_CUSTOMER_STORE_CREDIT_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CUSTOMER_STORE_CREDIT_REDUCERS,
+  provideDaffCustomerStoreCreditReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the customer store credit
+ * feature's reducers (registered the same way
+ * `DaffCustomerStoreCreditStateModule` registers them) plus a consumer's
+ * extra reducers are provided on a lazy-loaded route, rather than eagerly at
+ * the application root.
+ *
+ * It is a regression test for a bug where
+ * `DAFF_CUSTOMER_STORE_CREDIT_REDUCERS` was defined as a tree-shakable
+ * ("provided in root") `InjectionToken`. A token defined that way always
+ * resolves its factory using the root environment injector, even when it's
+ * actually requested from within a lazy-loaded route's own child injector.
+ * As a result, `inject(DAFF_CUSTOMER_STORE_CREDIT_EXTRA_REDUCERS)` inside
+ * that factory could never see extra reducers that were only provided on
+ * the lazy route - they would be silently dropped. Without the fix, the
+ * assertion below fails because the error added by `lazyExtraReducer` never
+ * makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const extraError: DaffStateError = {
+  code: 'code',
+  message: 'added-by-lazily-loaded-extra-reducer',
+};
+
+const lazyExtraReducer = (state: DaffCustomerStoreCreditReducersState) => ({
+  ...state,
+  storeCredit: {
+    ...state.storeCredit,
+    daffErrors: [
+      ...state.storeCredit.daffErrors,
+      extraError,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_CUSTOMER_STORE_CREDIT_STORE_FEATURE_KEY, DAFF_CUSTOMER_STORE_CREDIT_REDUCERS)),
+          provideDaffCustomerStoreCreditReducersFactory(() => daffComposeReducers([
+            combineReducers({
+              storeCredit: daffCustomerStoreCreditReducer,
+            }),
+            ...inject(DAFF_CUSTOMER_STORE_CREDIT_EXTRA_REDUCERS),
+          ])),
+          ...daffCustomerStoreCreditProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/customer-store-credit/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<{ [DAFF_CUSTOMER_STORE_CREDIT_STORE_FEATURE_KEY]: DaffCustomerStoreCreditReducersState }>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffCustomerStoreCreditLoadFailure({
+      code: 'code',
+      message: 'already in state',
+    }));
+
+    let state: DaffCustomerStoreCreditReducersState;
+    store.select(DAFF_CUSTOMER_STORE_CREDIT_STORE_FEATURE_KEY).subscribe((s: DaffCustomerStoreCreditReducersState) => state = s);
+
+    expect(state.storeCredit.daffErrors).toContain(extraError);
+  });
+});

--- a/libs/customer-store-credit/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/customer-store-credit/state/src/reducers/token/reducers.token.spec.ts
@@ -1,7 +1,14 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionReducer } from '@ngrx/store';
+import {
+  ActionReducer,
+  combineReducers,
+} from '@ngrx/store';
 
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
 import {
   daffCustomerStoreCreditProvideExtraReducers,
   DaffCustomerStoreCreditReducersState,
@@ -9,7 +16,12 @@ import {
   DaffCustomerStoreCreditLoadFailure,
 } from '@daffodil/customer-store-credit/state';
 
-import { DAFF_CUSTOMER_STORE_CREDIT_REDUCERS } from './reducers.token';
+import { DAFF_CUSTOMER_STORE_CREDIT_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CUSTOMER_STORE_CREDIT_REDUCERS,
+  provideDaffCustomerStoreCreditReducersFactory,
+} from './reducers.token';
+import { daffCustomerStoreCreditReducer } from '../store-credit/public_api';
 
 describe('@daffodil/customer-store-credit/state | daffCustomerStoreCreditProvideExtraReducers', () => {
   let extraError: DaffStateError;
@@ -46,6 +58,12 @@ describe('@daffodil/customer-store-credit/state | daffCustomerStoreCreditProvide
     TestBed.configureTestingModule({
       providers: [
         ...daffCustomerStoreCreditProvideExtraReducers(extraReducer),
+        provideDaffCustomerStoreCreditReducersFactory(() => daffComposeReducers([
+          combineReducers({
+            storeCredit: daffCustomerStoreCreditReducer,
+          }),
+          ...inject(DAFF_CUSTOMER_STORE_CREDIT_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/customer-store-credit/state/src/reducers/token/reducers.token.ts
+++ b/libs/customer-store-credit/state/src/reducers/token/reducers.token.ts
@@ -1,15 +1,8 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_CUSTOMER_STORE_CREDIT_EXTRA_REDUCERS } from './extra.token';
 import { DaffCustomerStoreCreditReducersState } from '../reducers.interface';
-import { daffCustomerStoreCreditReducer } from '../store-credit/public_api';
 
 export const {
   /**
@@ -23,15 +16,10 @@ export const {
    * Provider function for {@link DAFF_CUSTOMER_STORE_CREDIT_REDUCERS}.
    */
   provider: provideDaffCustomerStoreCreditReducers,
+  /**
+   * Factory provider function for {@link DAFF_CUSTOMER_STORE_CREDIT_REDUCERS}.
+   */
+  factoryProvider: provideDaffCustomerStoreCreditReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffCustomerStoreCreditReducersState>>(
   'DAFF_CUSTOMER_STORE_CREDIT_REDUCERS',
-  {
-    providedIn: 'any',
-    factory: () => daffComposeReducers([
-      combineReducers({
-        storeCredit: daffCustomerStoreCreditReducer,
-      }),
-      ...inject(DAFF_CUSTOMER_STORE_CREDIT_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/customer-store-credit/state/src/state.module.ts
+++ b/libs/customer-store-credit/state/src/state.module.ts
@@ -1,10 +1,23 @@
-import { NgModule } from '@angular/core';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
-import { StoreModule } from '@ngrx/store';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
+
+import { daffComposeReducers } from '@daffodil/core/state';
 
 import { DaffCustomerStoreCreditEffects } from './effects/store-credit.effects';
 import { DAFF_CUSTOMER_STORE_CREDIT_STORE_FEATURE_KEY } from './reducers/public_api';
-import { DAFF_CUSTOMER_STORE_CREDIT_REDUCERS } from './reducers/token/reducers.token';
+import { daffCustomerStoreCreditReducer } from './reducers/store-credit/public_api';
+import { DAFF_CUSTOMER_STORE_CREDIT_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_CUSTOMER_STORE_CREDIT_REDUCERS,
+  provideDaffCustomerStoreCreditReducersFactory,
+} from './reducers/token/reducers.token';
 
 /**
  * Creates the customer store credit feature store.
@@ -15,6 +28,14 @@ import { DAFF_CUSTOMER_STORE_CREDIT_REDUCERS } from './reducers/token/reducers.t
     EffectsModule.forFeature([
       DaffCustomerStoreCreditEffects,
     ]),
+  ],
+  providers: [
+    provideDaffCustomerStoreCreditReducersFactory(() => daffComposeReducers([
+      combineReducers({
+        storeCredit: daffCustomerStoreCreditReducer,
+      }),
+      ...inject(DAFF_CUSTOMER_STORE_CREDIT_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffCustomerStoreCreditStateModule {}

--- a/libs/customer/state/src/customer.module.ts
+++ b/libs/customer/state/src/customer.module.ts
@@ -1,11 +1,26 @@
-import { NgModule } from '@angular/core';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
-import { StoreModule } from '@ngrx/store';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
+
+import { daffComposeReducers } from '@daffodil/core/state';
 
 import { DaffCustomerAddressEffects } from './effects/address.effects';
 import { DaffCustomerEffects } from './effects/customer.effects';
+import { daffCustomerAddressReducer } from './reducers/address/public_api';
+import { daffCustomerAddressEntitiesReducer } from './reducers/address-entities/public_api';
+import { daffCustomerReducer } from './reducers/customer/reducer';
 import { DAFF_CUSTOMER_STORE_FEATURE_KEY } from './reducers/public_api';
-import { DAFF_CUSTOMER_REDUCERS } from './reducers/token/reducers.token';
+import { DAFF_CUSTOMER_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_CUSTOMER_REDUCERS,
+  provideDaffCustomerReducersFactory,
+} from './reducers/token/reducers.token';
 
 /**
  * Creates the customer feature store.
@@ -17,6 +32,16 @@ import { DAFF_CUSTOMER_REDUCERS } from './reducers/token/reducers.token';
       DaffCustomerEffects,
       DaffCustomerAddressEffects,
     ]),
+  ],
+  providers: [
+    provideDaffCustomerReducersFactory(() => daffComposeReducers([
+      combineReducers({
+        customer: daffCustomerReducer,
+        address: daffCustomerAddressReducer,
+        addressEntities: daffCustomerAddressEntitiesReducer,
+      }),
+      ...inject(DAFF_CUSTOMER_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffCustomerStateModule {}

--- a/libs/customer/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/customer/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,132 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
+import {
+  DAFF_CUSTOMER_STORE_FEATURE_KEY,
+  DaffCustomerLoadFailure,
+  DaffCustomerReducersState,
+  daffCustomerAddressEntitiesReducer,
+  daffCustomerAddressReducer,
+  daffCustomerProvideExtraReducers,
+  daffCustomerReducer,
+} from '@daffodil/customer/state';
+
+import { DAFF_CUSTOMER_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CUSTOMER_REDUCERS,
+  provideDaffCustomerReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the customer feature's
+ * reducers (registered the same way `DaffCustomerStateModule` registers
+ * them) plus a consumer's extra reducers are provided on a lazy-loaded
+ * route, rather than eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_CUSTOMER_REDUCERS` was
+ * defined as a tree-shakable ("provided in root") `InjectionToken`. A token
+ * defined that way always resolves its factory using the root environment
+ * injector, even when it's actually requested from within a lazy-loaded
+ * route's own child injector. As a result,
+ * `inject(DAFF_CUSTOMER_EXTRA_REDUCERS)` inside that factory could never see
+ * extra reducers that were only provided on the lazy route - they would be
+ * silently dropped. Without the fix, the assertion below fails because the
+ * error added by `lazyExtraReducer` never makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const extraError: DaffStateError = {
+  code: 'code',
+  message: 'added-by-lazily-loaded-extra-reducer',
+};
+
+const lazyExtraReducer = (state: DaffCustomerReducersState) => ({
+  ...state,
+  customer: {
+    ...state.customer,
+    daffErrors: [
+      ...state.customer.daffErrors,
+      extraError,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_CUSTOMER_STORE_FEATURE_KEY, DAFF_CUSTOMER_REDUCERS)),
+          provideDaffCustomerReducersFactory(() => daffComposeReducers([
+            combineReducers({
+              customer: daffCustomerReducer,
+              address: daffCustomerAddressReducer,
+              addressEntities: daffCustomerAddressEntitiesReducer,
+            }),
+            ...inject(DAFF_CUSTOMER_EXTRA_REDUCERS),
+          ])),
+          ...daffCustomerProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/customer/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<{ [DAFF_CUSTOMER_STORE_FEATURE_KEY]: DaffCustomerReducersState }>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffCustomerLoadFailure({
+      code: 'code',
+      message: 'already in state',
+    }));
+
+    let state: DaffCustomerReducersState;
+    store.select(DAFF_CUSTOMER_STORE_FEATURE_KEY).subscribe((s: DaffCustomerReducersState) => state = s);
+
+    expect(state.customer.daffErrors).toContain(extraError);
+  });
+});

--- a/libs/customer/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/customer/state/src/reducers/token/reducers.token.spec.ts
@@ -1,7 +1,14 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionReducer } from '@ngrx/store';
+import {
+  ActionReducer,
+  combineReducers,
+} from '@ngrx/store';
 
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
 import {
   daffCustomerProvideExtraReducers,
   DaffCustomerReducersState,
@@ -11,7 +18,14 @@ import {
   daffCustomerAddressEntitiesAdapter,
 } from '@daffodil/customer/state';
 
-import { DAFF_CUSTOMER_REDUCERS } from './reducers.token';
+import { DAFF_CUSTOMER_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_CUSTOMER_REDUCERS,
+  provideDaffCustomerReducersFactory,
+} from './reducers.token';
+import { daffCustomerAddressReducer } from '../address/public_api';
+import { daffCustomerAddressEntitiesReducer } from '../address-entities/public_api';
+import { daffCustomerReducer } from '../customer/reducer';
 
 describe('@daffodil/customer/state | daffCustomerProvideExtraReducers', () => {
   let extraError: DaffStateError;
@@ -50,6 +64,14 @@ describe('@daffodil/customer/state | daffCustomerProvideExtraReducers', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffCustomerProvideExtraReducers(extraReducer),
+        provideDaffCustomerReducersFactory(() => daffComposeReducers([
+          combineReducers({
+            customer: daffCustomerReducer,
+            address: daffCustomerAddressReducer,
+            addressEntities: daffCustomerAddressEntitiesReducer,
+          }),
+          ...inject(DAFF_CUSTOMER_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/customer/state/src/reducers/token/reducers.token.ts
+++ b/libs/customer/state/src/reducers/token/reducers.token.ts
@@ -1,16 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_CUSTOMER_EXTRA_REDUCERS } from './extra.token';
-import { daffCustomerAddressReducer } from '../address/public_api';
-import { daffCustomerAddressEntitiesReducer } from '../address-entities/public_api';
-import { daffCustomerReducer } from '../customer/reducer';
 import { DaffCustomerReducersState } from '../reducers.interface';
 
 export const {
@@ -25,17 +16,10 @@ export const {
    * Provider function for {@link DAFF_CUSTOMER_REDUCERS}.
    */
   provider: provideDaffCustomerReducers,
+  /**
+   * Factory provider function for {@link DAFF_CUSTOMER_REDUCERS}.
+   */
+  factoryProvider: provideDaffCustomerReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffCustomerReducersState>>(
   'DAFF_CUSTOMER_REDUCERS',
-  {
-    providedIn: 'any',
-    factory: () => daffComposeReducers([
-      combineReducers({
-        customer: daffCustomerReducer,
-        address: daffCustomerAddressReducer,
-        addressEntities: daffCustomerAddressEntitiesReducer,
-      }),
-      ...inject(DAFF_CUSTOMER_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/order/state/src/order-state.module.ts
+++ b/libs/order/state/src/order-state.module.ts
@@ -1,13 +1,29 @@
-import { NgModule } from '@angular/core';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
-import { StoreModule } from '@ngrx/store';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
 
 import { DaffCartStateModule } from '@daffodil/cart/state';
+import { daffComposeReducers } from '@daffodil/core/state';
 
 import { DaffOrderCollectionEffects } from './effects/order-collection.effects';
 import { DaffOrderEffects } from './effects/order.effects';
-import { DAFF_ORDER_STORE_FEATURE_KEY } from './reducers/public_api';
-import { DAFF_ORDER_REDUCERS } from './reducers/token/reducers.token';
+import { daffOrderReducer } from './reducers/order/order.reducer';
+import { daffOrderEntitiesReducer } from './reducers/order-entities/public_api';
+import {
+  daffOrdersCollectionReducer,
+  DAFF_ORDER_STORE_FEATURE_KEY,
+} from './reducers/public_api';
+import { DAFF_ORDER_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_ORDER_REDUCERS,
+  provideDaffOrderReducersFactory,
+} from './reducers/token/reducers.token';
 
 @NgModule({
   imports: [
@@ -17,6 +33,16 @@ import { DAFF_ORDER_REDUCERS } from './reducers/token/reducers.token';
       DaffOrderCollectionEffects,
     ]),
     StoreModule.forFeature(DAFF_ORDER_STORE_FEATURE_KEY, DAFF_ORDER_REDUCERS),
+  ],
+  providers: [
+    provideDaffOrderReducersFactory(() => daffComposeReducers([
+      combineReducers({
+        order: daffOrderReducer,
+        orders: daffOrderEntitiesReducer,
+        collection: daffOrdersCollectionReducer,
+      }),
+      ...inject(DAFF_ORDER_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffOrderStateModule {}

--- a/libs/order/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/order/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,126 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
+import {
+  DAFF_ORDER_STORE_FEATURE_KEY,
+  DaffOrderLoadFailure,
+  DaffOrderReducersState,
+  daffOrderProvideExtraReducers,
+  daffOrderReducers,
+} from '@daffodil/order/state';
+
+import { DAFF_ORDER_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_ORDER_REDUCERS,
+  provideDaffOrderReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the order feature's reducers
+ * (registered the same way `DaffOrderStateModule` registers them) plus a
+ * consumer's extra reducers are provided on a lazy-loaded route, rather than
+ * eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_ORDER_REDUCERS` was defined
+ * as a tree-shakable ("provided in root") `InjectionToken`. A token defined
+ * that way always resolves its factory using the root environment injector,
+ * even when it's actually requested from within a lazy-loaded route's own
+ * child injector. As a result, `inject(DAFF_ORDER_EXTRA_REDUCERS)` inside
+ * that factory could never see extra reducers that were only provided on
+ * the lazy route - they would be silently dropped. Without the fix, the
+ * assertion below fails because the error added by `lazyExtraReducer` never
+ * makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const extraError: DaffStateError = {
+  code: 'code',
+  message: 'added-by-lazily-loaded-extra-reducer',
+};
+
+const lazyExtraReducer = (state: DaffOrderReducersState) => ({
+  ...state,
+  order: {
+    ...state.order,
+    daffErrors: [
+      ...state.order.daffErrors,
+      extraError,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_ORDER_STORE_FEATURE_KEY, DAFF_ORDER_REDUCERS)),
+          provideDaffOrderReducersFactory(() => daffComposeReducers([
+            combineReducers(daffOrderReducers),
+            ...inject(DAFF_ORDER_EXTRA_REDUCERS),
+          ])),
+          ...daffOrderProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/order/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<{ [DAFF_ORDER_STORE_FEATURE_KEY]: DaffOrderReducersState }>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffOrderLoadFailure({
+      code: 'code',
+      message: 'already in state',
+    }));
+
+    let state: DaffOrderReducersState;
+    store.select(DAFF_ORDER_STORE_FEATURE_KEY).subscribe((s: DaffOrderReducersState) => state = s);
+
+    expect(state.order.daffErrors).toContain(extraError);
+  });
+});

--- a/libs/order/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/order/state/src/reducers/token/reducers.token.spec.ts
@@ -1,9 +1,14 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionReducer } from '@ngrx/store';
+import {
+  ActionReducer,
+  combineReducers,
+} from '@ngrx/store';
 
 import {
   DaffStateError,
   daffCollectionReducerInitialState,
+  daffComposeReducers,
 } from '@daffodil/core/state';
 import {
   daffOrderProvideExtraReducers,
@@ -13,7 +18,14 @@ import {
   daffGetOrderAdapter,
 } from '@daffodil/order/state';
 
-import { DAFF_ORDER_REDUCERS } from './reducers.token';
+import { daffOrderReducer } from '../order/order.reducer';
+import { daffOrderEntitiesReducer } from '../order-entities/public_api';
+import { daffOrdersCollectionReducer } from '../public_api';
+import { DAFF_ORDER_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_ORDER_REDUCERS,
+  provideDaffOrderReducersFactory,
+} from './reducers.token';
 
 describe('@daffodil/order/state | daffOrderProvideExtraReducers', () => {
   let extraError: DaffStateError;
@@ -52,6 +64,14 @@ describe('@daffodil/order/state | daffOrderProvideExtraReducers', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffOrderProvideExtraReducers(extraReducer),
+        provideDaffOrderReducersFactory(() => daffComposeReducers([
+          combineReducers({
+            order: daffOrderReducer,
+            orders: daffOrderEntitiesReducer,
+            collection: daffOrdersCollectionReducer,
+          }),
+          ...inject(DAFF_ORDER_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/order/state/src/reducers/token/reducers.token.ts
+++ b/libs/order/state/src/reducers/token/reducers.token.ts
@@ -1,17 +1,8 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_ORDER_EXTRA_REDUCERS } from './extra.token';
-import { daffOrderReducer } from '../order/order.reducer';
-import { daffOrderEntitiesReducer } from '../order-entities/public_api';
 import { DaffOrderReducersState } from '../order-reducers.interface';
-import { daffOrdersCollectionReducer } from '../public_api';
 
 export const {
   /**
@@ -25,17 +16,10 @@ export const {
    * Provider function for {@link DAFF_ORDER_REDUCERS}.
    */
   provider: provideDaffOrderReducers,
+  /**
+   * Factory provider function for {@link DAFF_ORDER_REDUCERS}.
+   */
+  factoryProvider: provideDaffOrderReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffOrderReducersState>>(
   ' DAFF_ORDER_REDUCERS',
-  {
-    providedIn: 'any',
-    factory: () => daffComposeReducers([
-      combineReducers({
-        order: daffOrderReducer,
-        orders: daffOrderEntitiesReducer,
-        collection: daffOrdersCollectionReducer,
-      }),
-      ...inject(DAFF_ORDER_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/payment/state/src/payment.module.ts
+++ b/libs/payment/state/src/payment.module.ts
@@ -1,8 +1,22 @@
-import { NgModule } from '@angular/core';
-import { StoreModule } from '@ngrx/store';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
 
+import { daffComposeReducers } from '@daffodil/core/state';
+
+import { DAFF_PAYMENT_AVAILABLE_PROCESSORS } from './injection-tokens/public_api';
+import { daffPaymentReducerFactory } from './reducers/payment/reducer';
 import { DAFF_PAYMENT_STORE_FEATURE_KEY } from './reducers/public_api';
-import { DAFF_PAYMENT_REDUCERS } from './reducers/token/reducers.token';
+import { DAFF_PAYMENT_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_PAYMENT_REDUCERS,
+  provideDaffPaymentReducersFactory,
+} from './reducers/token/reducers.token';
 
 /**
  * Creates the payment feature store.
@@ -10,6 +24,14 @@ import { DAFF_PAYMENT_REDUCERS } from './reducers/token/reducers.token';
 @NgModule({
   imports: [
     StoreModule.forFeature(DAFF_PAYMENT_STORE_FEATURE_KEY, DAFF_PAYMENT_REDUCERS),
+  ],
+  providers: [
+    provideDaffPaymentReducersFactory(() => daffComposeReducers([
+      combineReducers({
+        payment: daffPaymentReducerFactory(inject(DAFF_PAYMENT_AVAILABLE_PROCESSORS).map(({ action }) => action)),
+      }),
+      ...inject(DAFF_PAYMENT_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffPaymentStateModule {}

--- a/libs/payment/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/payment/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,111 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import { DaffStateError } from '@daffodil/core/state';
+import {
+  DAFF_PAYMENT_STORE_FEATURE_KEY,
+  DaffPaymentGenerateTokenFailure,
+  DaffPaymentReducersState,
+  DaffPaymentStateModule,
+  DaffPaymentStateRootSlice,
+  daffPaymentProvideExtraReducers,
+} from '@daffodil/payment/state';
+
+/**
+ * This test simulates a real application where the entire payment feature
+ * (`DaffPaymentStateModule` plus a consumer's extra reducers) is registered
+ * on a lazy-loaded route, rather than eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_PAYMENT_REDUCERS` was
+ * defined as a tree-shakable ("provided in root") `InjectionToken`. A token
+ * defined that way always resolves its factory using the root environment
+ * injector, even when it's actually requested from within a lazy-loaded
+ * route's own child injector. As a result,
+ * `inject(DAFF_PAYMENT_EXTRA_REDUCERS)` inside that factory could never see
+ * extra reducers that were only provided on the lazy route - they would be
+ * silently dropped. Without the fix, the assertion below fails because the
+ * error added by `lazyExtraReducer` never makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const extraError: DaffStateError = {
+  code: 'code',
+  message: 'added-by-lazily-loaded-extra-reducer',
+};
+
+const lazyExtraReducer = (state: DaffPaymentReducersState) => ({
+  ...state,
+  payment: {
+    ...state.payment,
+    errors: [
+      ...state.payment.errors,
+      extraError,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(DaffPaymentStateModule),
+          ...daffPaymentProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/payment/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<DaffPaymentStateRootSlice>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the state module on the lazy route', () => {
+    store.dispatch(new DaffPaymentGenerateTokenFailure({
+      code: 'code',
+      message: 'already in state',
+    }));
+
+    let state: DaffPaymentReducersState;
+    store.select(DAFF_PAYMENT_STORE_FEATURE_KEY).subscribe((s: DaffPaymentReducersState) => state = s);
+
+    expect(state.payment.errors).toContain(extraError);
+  });
+});

--- a/libs/payment/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/payment/state/src/reducers/token/reducers.token.spec.ts
@@ -1,7 +1,14 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionReducer } from '@ngrx/store';
+import {
+  ActionReducer,
+  combineReducers,
+} from '@ngrx/store';
 
-import { DaffStateError } from '@daffodil/core/state';
+import {
+  daffComposeReducers,
+  DaffStateError,
+} from '@daffodil/core/state';
 import {
   daffPaymentProvideExtraReducers,
   DaffPaymentReducersState,
@@ -9,7 +16,13 @@ import {
   DaffPaymentGenerateTokenFailure,
 } from '@daffodil/payment/state';
 
-import { DAFF_PAYMENT_REDUCERS } from './reducers.token';
+import { DAFF_PAYMENT_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_PAYMENT_REDUCERS,
+  provideDaffPaymentReducersFactory,
+} from './reducers.token';
+import { DAFF_PAYMENT_AVAILABLE_PROCESSORS } from '../../injection-tokens/public_api';
+import { daffPaymentReducerFactory } from '../payment/reducer';
 
 describe('daffPaymentProvideExtraReducers', () => {
   let extraError: DaffStateError;
@@ -46,6 +59,12 @@ describe('daffPaymentProvideExtraReducers', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffPaymentProvideExtraReducers(extraReducer),
+        provideDaffPaymentReducersFactory(() => daffComposeReducers([
+          combineReducers({
+            payment: daffPaymentReducerFactory(inject(DAFF_PAYMENT_AVAILABLE_PROCESSORS).map(({ action }) => action)),
+          }),
+          ...inject(DAFF_PAYMENT_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/payment/state/src/reducers/token/reducers.token.ts
+++ b/libs/payment/state/src/reducers/token/reducers.token.ts
@@ -1,15 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_PAYMENT_EXTRA_REDUCERS } from './extra.token';
-import { DAFF_PAYMENT_AVAILABLE_PROCESSORS } from '../../injection-tokens/public_api';
-import { daffPaymentReducerFactory } from '../payment/reducer';
 import { DaffPaymentReducersState } from '../reducers.interface';
 
 export const {
@@ -24,15 +16,10 @@ export const {
    * Provider function for {@link DAFF_PAYMENT_REDUCERS}.
    */
   provider: provideDaffPaymentReducers,
+  /**
+   * Factory provider function for {@link DAFF_PAYMENT_REDUCERS}.
+   */
+  factoryProvider: provideDaffPaymentReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffPaymentReducersState>>(
   'DAFF_PAYMENT_REDUCERS',
-  {
-    providedIn: 'any',
-    factory: () => daffComposeReducers([
-      combineReducers({
-        payment: daffPaymentReducerFactory(inject(DAFF_PAYMENT_AVAILABLE_PROCESSORS).map(({ action }) => action)),
-      }),
-      ...inject(DAFF_PAYMENT_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/product-composite/state/src/composite-product-state.module.ts
+++ b/libs/product-composite/state/src/composite-product-state.module.ts
@@ -1,10 +1,22 @@
-import { NgModule } from '@angular/core';
-import { StoreModule } from '@ngrx/store';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
 
+import { daffComposeReducers } from '@daffodil/core/state';
 import { daffProductProvideMetaReducers } from '@daffodil/product/state';
 
+import { daffCompositeProductReducers } from './reducers/composite-product-reducers';
 import { daffProductCompositeEnsureItemsMetaReducer } from './reducers/ensure-items.meta-reducer';
-import { DAFF_PRODUCT_COMPOSITE_REDUCERS } from './reducers/injection-tokens/reducers.token';
+import { DAFF_PRODUCT_COMPOSITE_EXTRA_REDUCERS } from './reducers/injection-tokens/extra.token';
+import {
+  DAFF_PRODUCT_COMPOSITE_REDUCERS,
+  provideDaffProductCompositeReducersFactory,
+} from './reducers/injection-tokens/reducers.token';
 import { DAFF_COMPOSITE_PRODUCT_STORE_FEATURE_KEY } from './reducers/public_api';
 
 /**
@@ -16,6 +28,10 @@ import { DAFF_COMPOSITE_PRODUCT_STORE_FEATURE_KEY } from './reducers/public_api'
   ],
   providers: [
     ...daffProductProvideMetaReducers(daffProductCompositeEnsureItemsMetaReducer),
+    provideDaffProductCompositeReducersFactory(() => daffComposeReducers([
+      combineReducers(daffCompositeProductReducers),
+      ...inject(DAFF_PRODUCT_COMPOSITE_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffCompositeProductStateModule { }

--- a/libs/product-composite/state/src/reducers/injection-tokens/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/product-composite/state/src/reducers/injection-tokens/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,114 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  Store ,
+  StoreModule,
+} from '@ngrx/store';
+
+import { DaffProductPageLoadSuccess } from '@daffodil/product/state';
+import { DaffCompositeProduct } from '@daffodil/product-composite';
+import {
+  DaffCompositeProductReducersState,
+  DaffCompositeProductStateModule,
+  DaffCompositeProductStateRootSlice,
+  DAFF_COMPOSITE_PRODUCT_STORE_FEATURE_KEY,
+  daffProductCompositeProvideExtraReducers,
+} from '@daffodil/product-composite/state';
+import { DaffCompositeProductFactory } from '@daffodil/product-composite/testing';
+
+/**
+ * This test simulates a real application where the entire composite product
+ * feature (`DaffCompositeProductStateModule` plus a consumer's extra reducers)
+ * is registered on a lazy-loaded route, rather than eagerly at the application
+ * root.
+ *
+ * It is a regression test for a bug where `DAFF_PRODUCT_COMPOSITE_REDUCERS`
+ * was defined as a tree-shakable ("provided in root") `InjectionToken`. A
+ * token defined that way always resolves its factory using the root
+ * environment injector, even when it's actually requested from within a
+ * lazy-loaded route's own child injector. As a result,
+ * `inject(DAFF_PRODUCT_COMPOSITE_EXTRA_REDUCERS)` inside that factory could
+ * never see extra reducers that were only provided on the lazy route - they
+ * would be silently dropped. Without the fix, the assertion below fails
+ * because the id added by `lazyExtraReducer` never makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const EXTRA_REDUCER_ATTRIBUTE_ID = 'added-by-lazily-loaded-extra-reducer';
+
+const lazyExtraReducer = (state: DaffCompositeProductReducersState) => ({
+  ...state,
+  compositeProductOptions: {
+    ...state.compositeProductOptions,
+    ids: [
+      ...(<string[]>state.compositeProductOptions.ids),
+      EXTRA_REDUCER_ATTRIBUTE_ID,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(DaffCompositeProductStateModule),
+          ...daffProductCompositeProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/product-composite/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<DaffCompositeProductStateRootSlice>;
+  let productFactory: DaffCompositeProductFactory;
+  let mockProduct: DaffCompositeProduct;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+    productFactory = TestBed.inject(DaffCompositeProductFactory);
+    mockProduct = productFactory.create();
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the state module on the lazy route', () => {
+    store.dispatch(new DaffProductPageLoadSuccess({
+      id: mockProduct.id,
+      products: [mockProduct],
+    }));
+
+    let state: DaffCompositeProductReducersState;
+    store.select(DAFF_COMPOSITE_PRODUCT_STORE_FEATURE_KEY).subscribe((s: DaffCompositeProductReducersState) => state = s);
+
+    expect(state.compositeProductOptions.ids).toContain(EXTRA_REDUCER_ATTRIBUTE_ID);
+  });
+});

--- a/libs/product-composite/state/src/reducers/injection-tokens/reducers.token.spec.ts
+++ b/libs/product-composite/state/src/reducers/injection-tokens/reducers.token.spec.ts
@@ -1,9 +1,11 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   ActionReducer,
   combineReducers,
 } from '@ngrx/store';
 
+import { daffComposeReducers } from '@daffodil/core/state';
 import { DaffProductPageLoadSuccess } from '@daffodil/product/state';
 import { DaffCompositeProduct } from '@daffodil/product-composite';
 import {
@@ -12,8 +14,13 @@ import {
 } from '@daffodil/product-composite/state';
 import { DaffCompositeProductFactory } from '@daffodil/product-composite/testing';
 
-import { DAFF_PRODUCT_COMPOSITE_REDUCERS } from './reducers.token';
+import { DAFF_PRODUCT_COMPOSITE_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_PRODUCT_COMPOSITE_REDUCERS,
+  provideDaffProductCompositeReducersFactory,
+} from './reducers.token';
 import { daffCompositeProductAppliedOptionsEntitiesAdapter } from '../composite-product-entities/composite-product-entities-reducer-adapter';
+import { daffCompositeProductReducers } from '../composite-product-reducers';
 
 describe('daffProductCompositeProvideExtraReducers', () => {
   let productFactory: DaffCompositeProductFactory;
@@ -42,6 +49,10 @@ describe('daffProductCompositeProvideExtraReducers', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffProductCompositeProvideExtraReducers(extraReducer),
+        provideDaffProductCompositeReducersFactory(() => daffComposeReducers([
+          combineReducers(daffCompositeProductReducers),
+          ...inject(DAFF_PRODUCT_COMPOSITE_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/product-composite/state/src/reducers/injection-tokens/reducers.token.ts
+++ b/libs/product-composite/state/src/reducers/injection-tokens/reducers.token.ts
@@ -1,14 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_PRODUCT_COMPOSITE_EXTRA_REDUCERS } from './extra.token';
-import { daffCompositeProductReducers } from '../composite-product-reducers';
 import { DaffCompositeProductReducersState } from '../composite-product-reducers-state.interface';
 
 export const {
@@ -23,12 +16,10 @@ export const {
    * Provider function for {@link DAFF_PRODUCT_COMPOSITE_REDUCERS}.
    */
   provider: provideDaffProductCompositeReducers,
+  /**
+   * Factory provider function for {@link DAFF_PRODUCT_COMPOSITE_REDUCERS}.
+   */
+  factoryProvider: provideDaffProductCompositeReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffCompositeProductReducersState>>(
   'DAFF_PRODUCT_COMPOSITE_REDUCERS',
-  {
-    factory: () => daffComposeReducers([
-      combineReducers(daffCompositeProductReducers),
-      ...inject(DAFF_PRODUCT_COMPOSITE_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/product-configurable/state/src/configurable-product-state.module.ts
+++ b/libs/product-configurable/state/src/configurable-product-state.module.ts
@@ -1,11 +1,25 @@
-import { NgModule } from '@angular/core';
-import { StoreModule } from '@ngrx/store';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
 
+import { daffComposeReducers } from '@daffodil/core/state';
 import { daffProductProvideMetaReducers } from '@daffodil/product/state';
 
 import { DAFF_CONFIGURABLE_PRODUCT_STORE_FEATURE_KEY } from './reducers/configurable-product-store-feature-key';
 import { daffProductConfigurableEnsureChildrenMetaReducer } from './reducers/ensure-children.meta-reducer';
-import { DAFF_PRODUCT_CONFIGURABLE_REDUCERS } from './reducers/injection-tokens/reducers.token';
+import {
+  DAFF_PRODUCT_CONFIGURABLE_REDUCERS,
+  provideDaffProductConfigurableReducersFactory,
+} from './reducers/injection-tokens/reducers.token';
+import {
+  DAFF_PRODUCT_CONFIGURABLE_EXTRA_REDUCERS,
+  daffConfigurableProductReducers,
+} from './reducers/public_api';
 
 /**
  * A module that provides the default reducers and effects for the configurable product redux state.
@@ -16,6 +30,10 @@ import { DAFF_PRODUCT_CONFIGURABLE_REDUCERS } from './reducers/injection-tokens/
   ],
   providers: [
     daffProductProvideMetaReducers(daffProductConfigurableEnsureChildrenMetaReducer),
+    provideDaffProductConfigurableReducersFactory(() => daffComposeReducers([
+      combineReducers(daffConfigurableProductReducers),
+      ...inject(DAFF_PRODUCT_CONFIGURABLE_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffConfigurableProductStateModule { }

--- a/libs/product-configurable/state/src/reducers/injection-tokens/reducers.token.spec.ts
+++ b/libs/product-configurable/state/src/reducers/injection-tokens/reducers.token.spec.ts
@@ -1,9 +1,11 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   ActionReducer,
   combineReducers,
 } from '@ngrx/store';
 
+import { daffComposeReducers } from '@daffodil/core/state';
 import { DaffProductPageLoadSuccess } from '@daffodil/product/state';
 import { DaffConfigurableProduct } from '@daffodil/product-configurable';
 import {
@@ -12,8 +14,13 @@ import {
 } from '@daffodil/product-configurable/state';
 import { DaffConfigurableProductFactory } from '@daffodil/product-configurable/testing';
 
-import { DAFF_PRODUCT_CONFIGURABLE_REDUCERS } from './reducers.token';
+import { DAFF_PRODUCT_CONFIGURABLE_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_PRODUCT_CONFIGURABLE_REDUCERS,
+  provideDaffProductConfigurableReducersFactory,
+} from './reducers.token';
 import { daffConfigurableProductAppliedAttributesEntitiesAdapter } from '../configurable-product-entities/configurable-product-entities-reducer-adapter';
+import { daffConfigurableProductReducers } from '../configurable-product-reducers';
 
 describe('daffProductConfigurableProvideExtraReducers', () => {
   let productFactory: DaffConfigurableProductFactory;
@@ -42,6 +49,10 @@ describe('daffProductConfigurableProvideExtraReducers', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffProductConfigurableProvideExtraReducers(extraReducer),
+        provideDaffProductConfigurableReducersFactory(() => daffComposeReducers([
+          combineReducers(daffConfigurableProductReducers),
+          ...inject(DAFF_PRODUCT_CONFIGURABLE_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/product-configurable/state/src/reducers/injection-tokens/reducers.token.ts
+++ b/libs/product-configurable/state/src/reducers/injection-tokens/reducers.token.ts
@@ -1,14 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_PRODUCT_CONFIGURABLE_EXTRA_REDUCERS } from './extra.token';
-import { daffConfigurableProductReducers } from '../configurable-product-reducers';
 import { DaffConfigurableProductReducersState } from '../configurable-product-reducers-state.interface';
 
 export const {
@@ -23,12 +16,10 @@ export const {
    * Provider function for {@link DAFF_PRODUCT_CONFIGURABLE_REDUCERS}.
    */
   provider: provideDaffProductConfigurableReducers,
+  /**
+   * Factory provider function for {@link DAFF_PRODUCT_CONFIGURABLE_REDUCERS}.
+   */
+  factoryProvider: provideDaffProductConfigurableReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffConfigurableProductReducersState>>(
   'DAFF_PRODUCT_CONFIGURABLE_REDUCERS',
-  {
-    factory: () => daffComposeReducers([
-      combineReducers(daffConfigurableProductReducers),
-      ...inject(DAFF_PRODUCT_CONFIGURABLE_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/product-configurable/state/src/reducers/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/product-configurable/state/src/reducers/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,113 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  ActionReducer,
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import { DaffProductPageLoadSuccess } from '@daffodil/product/state';
+import { DaffConfigurableProduct } from '@daffodil/product-configurable';
+import {
+  DAFF_CONFIGURABLE_PRODUCT_STORE_FEATURE_KEY,
+  DaffConfigurableProductReducersState,
+  DaffConfigurableProductStateModule,
+  DaffConfigurableProductStateRootSlice,
+  daffProductConfigurableProvideExtraReducers,
+} from '@daffodil/product-configurable/state';
+import { DaffConfigurableProductFactory } from '@daffodil/product-configurable/testing';
+
+/**
+ * This test simulates a real application where the entire configurable product
+ * feature (`DaffConfigurableProductStateModule` plus a consumer's extra reducers)
+ * is registered on a lazy-loaded route, rather than eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_PRODUCT_CONFIGURABLE_REDUCERS` was
+ * defined as a tree-shakable ("provided in root") `InjectionToken`. A token defined
+ * that way always resolves its factory using the root environment injector, even when
+ * it's actually requested from within a lazy-loaded route's own child injector. As a
+ * result, `inject(DAFF_PRODUCT_CONFIGURABLE_EXTRA_REDUCERS)` inside that factory could
+ * never see extra reducers that were only provided on the lazy route - they would be
+ * silently dropped. Without the fix, the assertion below fails because the id added by
+ * `lazyExtraReducer` never makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const EXTRA_REDUCER_ATTRIBUTE_ID = 'added-by-lazily-loaded-extra-reducer';
+
+const lazyExtraReducer: ActionReducer<DaffConfigurableProductReducersState> = combineReducers<DaffConfigurableProductReducersState>({
+  configurableProductAttributes: (state, action) => ({
+    ...state,
+    ids: [
+      ...(<string[]>state.ids),
+      EXTRA_REDUCER_ATTRIBUTE_ID,
+    ],
+  }),
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(DaffConfigurableProductStateModule),
+          ...daffProductConfigurableProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/product-configurable/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<DaffConfigurableProductStateRootSlice>;
+  let productFactory: DaffConfigurableProductFactory;
+  let mockProduct: DaffConfigurableProduct;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+    productFactory = TestBed.inject(DaffConfigurableProductFactory);
+    mockProduct = productFactory.create();
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the state module on the lazy route', () => {
+    store.dispatch(new DaffProductPageLoadSuccess({
+      id: mockProduct.id,
+      products: [mockProduct],
+    }));
+
+    let state: DaffConfigurableProductReducersState;
+    store.select(DAFF_CONFIGURABLE_PRODUCT_STORE_FEATURE_KEY).subscribe((s: DaffConfigurableProductReducersState) => state = s);
+
+    expect(state.configurableProductAttributes.ids).toContain(EXTRA_REDUCER_ATTRIBUTE_ID);
+  });
+});

--- a/libs/product/state/src/product-state.module.ts
+++ b/libs/product/state/src/product-state.module.ts
@@ -1,12 +1,25 @@
-import { NgModule } from '@angular/core';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
-import { StoreModule } from '@ngrx/store';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
+
+import { daffComposeReducers } from '@daffodil/core/state';
 
 import { DaffProductGridEffects } from './effects/product-grid.effects';
 import { DaffProductPageEffects } from './effects/product-page.effects';
 import { DaffProductEffects } from './effects/product.effects';
 import { DAFF_PRODUCT_STORE_CONFIG } from './reducers/injection-tokens/config.token';
-import { DAFF_PRODUCT_REDUCERS } from './reducers/injection-tokens/reducers.token';
+import { DAFF_PRODUCT_EXTRA_REDUCERS } from './reducers/injection-tokens/extra.token';
+import {
+  DAFF_PRODUCT_REDUCERS,
+  provideDaffProductReducersFactory,
+} from './reducers/injection-tokens/reducers.token';
+import { daffProductReducers } from './reducers/product-reducers';
 import { DAFF_PRODUCT_STORE_FEATURE_KEY } from './reducers/public_api';
 
 /**
@@ -20,6 +33,12 @@ import { DAFF_PRODUCT_STORE_FEATURE_KEY } from './reducers/public_api';
       DaffProductEffects,
       DaffProductPageEffects,
     ]),
+  ],
+  providers: [
+    provideDaffProductReducersFactory(() => daffComposeReducers([
+      combineReducers(daffProductReducers),
+      ...inject(DAFF_PRODUCT_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffProductStateModule { }

--- a/libs/product/state/src/reducers/injection-tokens/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/product/state/src/reducers/injection-tokens/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,123 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import { daffComposeReducers } from '@daffodil/core/state';
+import { DaffProduct } from '@daffodil/product';
+import {
+  DAFF_PRODUCT_STORE_FEATURE_KEY,
+  DaffProductPageLoadSuccess,
+  DaffProductReducersState,
+  daffProductProvideExtraReducers,
+  daffProductReducers,
+} from '@daffodil/product/state';
+import { DaffProductFactory } from '@daffodil/product/testing';
+
+import { DAFF_PRODUCT_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_PRODUCT_REDUCERS,
+  provideDaffProductReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the product feature's
+ * reducers (registered the same way `DaffProductStateModule` registers
+ * them) plus a consumer's extra reducers are provided on a lazy-loaded
+ * route, rather than eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_PRODUCT_REDUCERS` was
+ * defined as a tree-shakable ("provided in root") `InjectionToken`. A token
+ * defined that way always resolves its factory using the root environment
+ * injector, even when it's actually requested from within a lazy-loaded
+ * route's own child injector. As a result,
+ * `inject(DAFF_PRODUCT_EXTRA_REDUCERS)` inside that factory could never see
+ * extra reducers that were only provided on the lazy route - they would be
+ * silently dropped. Without the fix, the assertion below fails because the
+ * id added by `lazyExtraReducer` never makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const EXTRA_REDUCER_PRODUCT_ID = 'added-by-lazily-loaded-extra-reducer';
+
+const lazyExtraReducer = (state: DaffProductReducersState) => ({
+  ...state,
+  product: {
+    ...state.product,
+    currentProductId: EXTRA_REDUCER_PRODUCT_ID,
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_PRODUCT_STORE_FEATURE_KEY, DAFF_PRODUCT_REDUCERS)),
+          provideDaffProductReducersFactory(() => daffComposeReducers([
+            combineReducers(daffProductReducers),
+            ...inject(DAFF_PRODUCT_EXTRA_REDUCERS),
+          ])),
+          ...daffProductProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/product/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<{ [DAFF_PRODUCT_STORE_FEATURE_KEY]: DaffProductReducersState }>;
+  let productFactory: DaffProductFactory;
+  let mockProduct: DaffProduct;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+    productFactory = TestBed.inject(DaffProductFactory);
+    mockProduct = productFactory.create();
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffProductPageLoadSuccess({
+      id: mockProduct.id,
+      products: [mockProduct],
+    }));
+
+    let state: DaffProductReducersState;
+    store.select(DAFF_PRODUCT_STORE_FEATURE_KEY).subscribe((s: DaffProductReducersState) => state = s);
+
+    expect(state.product.currentProductId).toEqual(EXTRA_REDUCER_PRODUCT_ID);
+  });
+});

--- a/libs/product/state/src/reducers/injection-tokens/reducers.token.spec.ts
+++ b/libs/product/state/src/reducers/injection-tokens/reducers.token.spec.ts
@@ -1,10 +1,14 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   ActionReducer,
   combineReducers,
 } from '@ngrx/store';
 
-import { daffIdentityReducer } from '@daffodil/core/state';
+import {
+  daffComposeReducers,
+  daffIdentityReducer,
+} from '@daffodil/core/state';
 import { DaffProduct } from '@daffodil/product';
 import {
   daffProductEntitiesAdapter,
@@ -14,8 +18,13 @@ import {
 } from '@daffodil/product/state';
 import { DaffProductFactory } from '@daffodil/product/testing';
 
-import { DAFF_PRODUCT_REDUCERS } from './reducers.token';
+import { DAFF_PRODUCT_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_PRODUCT_REDUCERS,
+  provideDaffProductReducersFactory,
+} from './reducers.token';
 import { daffProductReducerInitialState } from '../product/product.reducer';
+import { daffProductReducers } from '../product-reducers';
 
 describe('@daffodil/product/state | daffProductProvideExtraReducers', () => {
   let productFactory: DaffProductFactory;
@@ -43,6 +52,10 @@ describe('@daffodil/product/state | daffProductProvideExtraReducers', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffProductProvideExtraReducers(extraReducer),
+        provideDaffProductReducersFactory(() => daffComposeReducers([
+          combineReducers(daffProductReducers),
+          ...inject(DAFF_PRODUCT_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/product/state/src/reducers/injection-tokens/reducers.token.ts
+++ b/libs/product/state/src/reducers/injection-tokens/reducers.token.ts
@@ -1,14 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_PRODUCT_EXTRA_REDUCERS } from './extra.token';
-import { daffProductReducers } from '../product-reducers';
 import { DaffProductReducersState } from '../product-reducers-state.interface';
 
 export const {
@@ -23,12 +16,10 @@ export const {
    * Provider function for {@link DAFF_PRODUCT_REDUCERS}.
    */
   provider: provideDaffProductReducers,
+  /**
+   * Factory provider function for {@link DAFF_PRODUCT_REDUCERS}.
+   */
+  factoryProvider: provideDaffProductReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffProductReducersState>>(
   'DAFF_PRODUCT_REDUCERS',
-  {
-    factory: () => daffComposeReducers([
-      combineReducers(daffProductReducers),
-      ...inject(DAFF_PRODUCT_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/reviews/state/src/reducers/injection-tokens/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/reviews/state/src/reducers/injection-tokens/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,123 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  combineReducers,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import { daffComposeReducers } from '@daffodil/core/state';
+import { DaffProductReviews } from '@daffodil/reviews';
+import {
+  DAFF_REVIEWS_STORE_FEATURE_KEY,
+  DaffReviewsProductListSuccess,
+  DaffReviewsReducersState,
+  daffReviewsProvideExtraReducers,
+  daffReviewsReducers,
+} from '@daffodil/reviews/state';
+import { DaffProductReviewsFactory } from '@daffodil/reviews/testing';
+
+import { DAFF_REVIEWS_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_REVIEWS_REDUCERS,
+  provideDaffReviewsReducersFactory,
+} from './reducers.token';
+
+/**
+ * This test simulates a real application where the reviews feature's
+ * reducers (registered the same way `DaffReviewsStateModule` registers
+ * them) plus a consumer's extra reducers are provided on a lazy-loaded
+ * route, rather than eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_REVIEWS_REDUCERS` was
+ * defined as a tree-shakable ("provided in root") `InjectionToken`. A token
+ * defined that way always resolves its factory using the root environment
+ * injector, even when it's actually requested from within a lazy-loaded
+ * route's own child injector. As a result,
+ * `inject(DAFF_REVIEWS_EXTRA_REDUCERS)` inside that factory could never see
+ * extra reducers that were only provided on the lazy route - they would be
+ * silently dropped. Without the fix, the assertion below fails because the
+ * id added by `lazyExtraReducer` never makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const EXTRA_REDUCER_ID = 'added-by-lazily-loaded-extra-reducer';
+
+const lazyExtraReducer = (state: DaffReviewsReducersState) => ({
+  ...state,
+  productReviewsCollection: {
+    ...state.productReviewsCollection,
+    ids: [
+      ...state.productReviewsCollection.ids,
+      EXTRA_REDUCER_ID,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(StoreModule.forFeature(DAFF_REVIEWS_STORE_FEATURE_KEY, DAFF_REVIEWS_REDUCERS)),
+          provideDaffReviewsReducersFactory(() => daffComposeReducers([
+            combineReducers(daffReviewsReducers),
+            ...inject(DAFF_REVIEWS_EXTRA_REDUCERS),
+          ])),
+          ...daffReviewsProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/reviews/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<{ [DAFF_REVIEWS_STORE_FEATURE_KEY]: DaffReviewsReducersState }>;
+  let productReviewsFactory: DaffProductReviewsFactory;
+  let mockProductReviews: DaffProductReviews;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+    productReviewsFactory = TestBed.inject(DaffProductReviewsFactory);
+    mockProductReviews = productReviewsFactory.create();
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the reducers on the lazy route', () => {
+    store.dispatch(new DaffReviewsProductListSuccess(mockProductReviews));
+
+    let state: DaffReviewsReducersState;
+    store.select(DAFF_REVIEWS_STORE_FEATURE_KEY).subscribe((s: DaffReviewsReducersState) => state = s);
+
+    expect(state.productReviewsCollection.ids).toContain(EXTRA_REDUCER_ID);
+  });
+});

--- a/libs/reviews/state/src/reducers/injection-tokens/reducers.token.spec.ts
+++ b/libs/reviews/state/src/reducers/injection-tokens/reducers.token.spec.ts
@@ -1,3 +1,4 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   ActionReducer,
@@ -6,6 +7,7 @@ import {
 
 import {
   daffCollectionReducerInitialState,
+  daffComposeReducers,
   daffIdentityReducer,
 } from '@daffodil/core/state';
 import { DaffProductReviews } from '@daffodil/reviews';
@@ -18,7 +20,12 @@ import {
 } from '@daffodil/reviews/state';
 import { DaffProductReviewsFactory } from '@daffodil/reviews/testing';
 
-import { DAFF_REVIEWS_REDUCERS } from './reducers.token';
+import { DAFF_REVIEWS_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_REVIEWS_REDUCERS,
+  provideDaffReviewsReducersFactory,
+} from './reducers.token';
+import { daffReviewsReducers } from '../reducers';
 
 describe('@daffodil/reviews/state | DAFF_REVIEWS_REDUCERS', () => {
   let productReviewsFactory: DaffProductReviewsFactory;
@@ -51,6 +58,10 @@ describe('@daffodil/reviews/state | DAFF_REVIEWS_REDUCERS', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffReviewsProvideExtraReducers(extraReducer),
+        provideDaffReviewsReducersFactory(() => daffComposeReducers([
+          combineReducers(daffReviewsReducers),
+          ...inject(DAFF_REVIEWS_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/reviews/state/src/reducers/injection-tokens/reducers.token.ts
+++ b/libs/reviews/state/src/reducers/injection-tokens/reducers.token.ts
@@ -1,14 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_REVIEWS_EXTRA_REDUCERS } from './extra.token';
-import { daffReviewsReducers } from '../reducers';
 import { DaffReviewsReducersState } from '../reducers-state.interface';
 
 export const {
@@ -23,12 +16,10 @@ export const {
    * Provider function for {@link DAFF_REVIEWS_REDUCERS}.
    */
   provider: provideDaffReviewsReducers,
+  /**
+   * Factory provider function for {@link DAFF_REVIEWS_REDUCERS}.
+   */
+  factoryProvider: provideDaffReviewsReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffReviewsReducersState>>(
   'DAFF_REVIEWS_REDUCERS',
-  {
-    factory: () => daffComposeReducers([
-      combineReducers(daffReviewsReducers),
-      ...inject(DAFF_REVIEWS_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/reviews/state/src/state.module.ts
+++ b/libs/reviews/state/src/state.module.ts
@@ -1,14 +1,26 @@
-import { NgModule } from '@angular/core';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
-import { StoreModule } from '@ngrx/store';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
 
+import { daffComposeReducers } from '@daffodil/core/state';
 import { DaffProductStateModule } from '@daffodil/product/state';
 
 import { DaffProductReviewCollectionEffects } from './effects/product-page-review-collection.effects';
 import { DaffProductPageReviewsEffects } from './effects/product-page-reviews.effects';
 import { DAFF_REVIEWS_STORE_CONFIG } from './reducers/injection-tokens/config.token';
-import { DAFF_REVIEWS_REDUCERS } from './reducers/injection-tokens/reducers.token';
+import { DAFF_REVIEWS_EXTRA_REDUCERS } from './reducers/injection-tokens/extra.token';
+import {
+  DAFF_REVIEWS_REDUCERS,
+  provideDaffReviewsReducersFactory,
+} from './reducers/injection-tokens/reducers.token';
 import { DAFF_REVIEWS_STORE_FEATURE_KEY } from './reducers/public_api';
+import { daffReviewsReducers } from './reducers/reducers';
 
 /**
  * A module that provides the default reducers and effects for the reviews redux state.
@@ -21,6 +33,12 @@ import { DAFF_REVIEWS_STORE_FEATURE_KEY } from './reducers/public_api';
       DaffProductPageReviewsEffects,
       DaffProductReviewCollectionEffects,
     ]),
+  ],
+  providers: [
+    provideDaffReviewsReducersFactory(() => daffComposeReducers([
+      combineReducers(daffReviewsReducers),
+      ...inject(DAFF_REVIEWS_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffReviewsStateModule { }

--- a/libs/search/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
+++ b/libs/search/state/src/reducers/token/lazy-route-extra-reducers.integration.spec.ts
@@ -1,0 +1,105 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  Component,
+  importProvidersFrom,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  provideRouter,
+  Routes,
+} from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import {
+  ActionReducer,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+
+import {
+  DAFF_SEARCH_STORE_FEATURE_KEY,
+  DaffSearchLoad,
+  DaffSearchReducersState,
+  DaffSearchStateModule,
+  DaffSearchStateRootSlice,
+  daffSearchProvideExtraReducers,
+} from '@daffodil/search/state';
+
+/**
+ * This test simulates a real application where the entire search feature
+ * (`DaffSearchStateModule` plus a consumer's extra reducers) is registered
+ * on a lazy-loaded route, rather than eagerly at the application root.
+ *
+ * It is a regression test for a bug where `DAFF_SEARCH_REDUCERS` was defined
+ * as a tree-shakable ("provided in root") `InjectionToken`. A token defined
+ * that way always resolves its factory using the root environment injector,
+ * even when it's actually requested from within a lazy-loaded route's own
+ * child injector. As a result, `inject(DAFF_SEARCH_EXTRA_REDUCERS)` inside
+ * that factory could never see extra reducers that were only provided on the
+ * lazy route - they would be silently dropped. Without the fix, the
+ * assertion below fails because the query added by `lazyExtraReducer` never
+ * makes it into state.
+ */
+
+@Component({
+  selector: 'daff-lazy-route-test',
+  template: '',
+  standalone: true,
+})
+class DaffLazyRouteTestComponent {}
+
+const EXTRA_REDUCER_QUERY = 'added-by-lazily-loaded-extra-reducer';
+
+const lazyExtraReducer: ActionReducer<DaffSearchReducersState> = (state, action) => ({
+  ...state,
+  search: {
+    ...state.search,
+    recent: [
+      ...state.search.recent,
+      EXTRA_REDUCER_QUERY,
+    ],
+  },
+});
+
+const routes: Routes = [
+  {
+    path: 'lazy',
+    loadChildren: () => Promise.resolve([
+      {
+        path: '',
+        component: DaffLazyRouteTestComponent,
+        providers: [
+          importProvidersFrom(DaffSearchStateModule),
+          ...daffSearchProvideExtraReducers(lazyExtraReducer),
+        ],
+      },
+    ]),
+  },
+];
+
+describe('@daffodil/search/state | Integration | extra reducers provided on a lazy-loaded route', () => {
+  let store: Store<DaffSearchStateRootSlice>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        provideLocationMocks(),
+        importProvidersFrom(StoreModule.forRoot({})),
+      ],
+    });
+
+    store = TestBed.inject(Store);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/lazy', DaffLazyRouteTestComponent);
+  });
+
+  it('runs the extra reducer registered alongside the state module on the lazy route', () => {
+    store.dispatch(new DaffSearchLoad('any'));
+
+    let state: DaffSearchReducersState;
+    store.select(DAFF_SEARCH_STORE_FEATURE_KEY).subscribe((s: DaffSearchReducersState) => state = s);
+
+    expect(state.search.recent).toContain(EXTRA_REDUCER_QUERY);
+  });
+});

--- a/libs/search/state/src/reducers/token/reducers.token.spec.ts
+++ b/libs/search/state/src/reducers/token/reducers.token.spec.ts
@@ -1,6 +1,11 @@
+import { inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionReducer } from '@ngrx/store';
+import {
+  ActionReducer,
+  combineReducers,
+} from '@ngrx/store';
 
+import { daffComposeReducers } from '@daffodil/core/state';
 import {
   daffSearchProvideExtraReducers,
   DaffSearchReducersState,
@@ -8,7 +13,12 @@ import {
   DaffSearchLoad,
 } from '@daffodil/search/state';
 
-import { DAFF_SEARCH_REDUCERS } from './reducers.token';
+import { daffSearchReducers } from '../reducers';
+import { DAFF_SEARCH_EXTRA_REDUCERS } from './extra.token';
+import {
+  DAFF_SEARCH_REDUCERS,
+  provideDaffSearchReducersFactory,
+} from './reducers.token';
 
 describe('daffSearchProvideExtraReducers', () => {
   let extraQuery: string;
@@ -36,6 +46,10 @@ describe('daffSearchProvideExtraReducers', () => {
     TestBed.configureTestingModule({
       providers: [
         ...daffSearchProvideExtraReducers(extraReducer),
+        provideDaffSearchReducersFactory(() => daffComposeReducers([
+          combineReducers(daffSearchReducers),
+          ...inject(DAFF_SEARCH_EXTRA_REDUCERS),
+        ])),
       ],
     });
 

--- a/libs/search/state/src/reducers/token/reducers.token.ts
+++ b/libs/search/state/src/reducers/token/reducers.token.ts
@@ -1,14 +1,7 @@
-import { inject } from '@angular/core';
-import {
-  ActionReducer,
-  combineReducers,
-} from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
 
 import { createSingleInjectionToken } from '@daffodil/core';
-import { daffComposeReducers } from '@daffodil/core/state';
 
-import { DAFF_SEARCH_EXTRA_REDUCERS } from './extra.token';
-import { daffSearchReducers } from '../reducers';
 import { DaffSearchReducersState } from '../reducers.interface';
 
 export const {
@@ -23,13 +16,10 @@ export const {
    * Provider function for {@link DAFF_SEARCH_REDUCERS}.
    */
   provider: provideDaffSearchReducers,
+  /**
+   * Factory provider function for {@link DAFF_SEARCH_REDUCERS}.
+   */
+  factoryProvider: provideDaffSearchReducersFactory,
 } = createSingleInjectionToken<ActionReducer<DaffSearchReducersState>>(
   'DAFF_SEARCH_REDUCERS',
-  {
-    providedIn: 'any',
-    factory: () => daffComposeReducers([
-      combineReducers(daffSearchReducers),
-      ...inject(DAFF_SEARCH_EXTRA_REDUCERS),
-    ]),
-  },
 );

--- a/libs/search/state/src/search.module.ts
+++ b/libs/search/state/src/search.module.ts
@@ -1,8 +1,21 @@
-import { NgModule } from '@angular/core';
-import { StoreModule } from '@ngrx/store';
+import {
+  inject,
+  NgModule,
+} from '@angular/core';
+import {
+  combineReducers,
+  StoreModule,
+} from '@ngrx/store';
+
+import { daffComposeReducers } from '@daffodil/core/state';
 
 import { DAFF_SEARCH_STORE_FEATURE_KEY } from './reducers/public_api';
-import { DAFF_SEARCH_REDUCERS } from './reducers/token/reducers.token';
+import { daffSearchReducers } from './reducers/reducers';
+import { DAFF_SEARCH_EXTRA_REDUCERS } from './reducers/token/extra.token';
+import {
+  DAFF_SEARCH_REDUCERS,
+  provideDaffSearchReducersFactory,
+} from './reducers/token/reducers.token';
 
 /**
  * Creates the search feature store.
@@ -10,6 +23,12 @@ import { DAFF_SEARCH_REDUCERS } from './reducers/token/reducers.token';
 @NgModule({
   imports: [
     StoreModule.forFeature(DAFF_SEARCH_STORE_FEATURE_KEY, DAFF_SEARCH_REDUCERS),
+  ],
+  providers: [
+    provideDaffSearchReducersFactory(() => daffComposeReducers([
+      combineReducers(daffSearchReducers),
+      ...inject(DAFF_SEARCH_EXTRA_REDUCERS),
+    ])),
   ],
 })
 export class DaffSearchStateModule {}


### PR DESCRIPTION
## PR Checklist

- [ ] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->
Loading one of the affected state module in a lazy loaded environment (such as a route) would result in the extra reducers not being loaded.

## New behavior
<!-- Describe the changes -->
The extra reducers are correctly loaded in lazy envs. This is accomplished by moving the factory that combines the extra reducers with the package's own reducers out of the token declaration and into the state module.
## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->
the change in each package is identical which is why they're all grouped together into a single PR