### PR TITLE
fix(design): remove nav list item hover flicker on non-white backgrounds

### DIFF
--- a/libs/design/list/src/list-theme.scss
+++ b/libs/design/list/src/list-theme.scss
@@ -6,6 +6,7 @@
 	$base: daff-get-base-color($theme, base);
 	$base-contrast: daff-get-base-color($theme, base-contrast);
 	$mode: daff-get-theme-mode($theme);
+	$bg-color: daff-color($neutral, 20);
 
 	.daff-list,
 	.daff-nav-list {
@@ -15,20 +16,20 @@
 	.daff-nav-list {
 		.daff-list-item {
 			&::after {
-				background-color: $base;
+				background-color: rgba($bg-color, 0.5);
 			}
 
 			@include daff-light-mode($mode) {
 				&.active {
 					&::after {
-						background-color: rgba(daff-color($neutral, 20), 0.5);
+						background-color: rgba($bg-color, 0.5);
 					}
 				}
 
 				@media (hover: hover) {
 					&:hover {
 						&::after {
-							background-color: rgba(daff-color($neutral, 20), 0.5);
+							background-color: rgba($bg-color, 0.5);
 						}
 					}
 				}
@@ -37,14 +38,14 @@
 			@include daff-dark-mode($mode) {
 				&.active {
 					&::after {
-						background-color: rgba(daff-color($neutral, 20), 0.08);
+						background-color: rgba($bg-color, 0.08);
 					}
 				}
 
 				@media (hover: hover) {
 					&:hover {
 						&::after {
-							background-color: rgba(daff-color($neutral, 20), 0.08);
+							background-color: rgba($bg-color, 0.08);
 						}
 					}
 				}


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
The `::after` overlay on `.daff-list-item` defaults to the base color, so on hover-off it briefly flickers to that color while the opacity is still fading out, It's visible as a flicker when the background isn't white.

## New behavior
Use the same overlay color for the default, hover, and active states.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->