### PR TITLE
fix(design): render list item prefix above the nav list hover overlay

### DIFF
--- a/libs/design/list/src/list-base.scss
+++ b/libs/design/list/src/list-base.scss
@@ -35,6 +35,7 @@
 			align-items: center;
 			height: 1.5rem;
 			width: auto;
+			z-index: 2;
 		}
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [ ] Tests added/updated (for bug fixes/features)
- [ ] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [x] Bug fix
- [ ] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
The nav list item hover state is set with an ::after pseudo-element that has a specific `z-index: 1;` set. This ends up stacking the pseudo-element above the `.daff-prefix` icon, which clashes with icon styles on hover. 

## New behavior
Set a higher z-index on the prefix so it stays above the pseuo-element.

## Breaking change?

- [ ] Yes
- [x] No

<!-- If yes, describe impact and migration path -->

## Additional context
<!-- Any other relevant information -->