### PR TITLE
feat(design, storefront)!: share dropdown styling across form field controls

### DIFF
--- a/libs/design/form-field/src/form-field-control.ts
+++ b/libs/design/form-field/src/form-field-control.ts
@@ -5,6 +5,7 @@ import {
 } from 'rxjs';
 
 import { DaffFormFieldState } from './form-field-state';
+import { DaffFormFieldControlTypesEnum } from './helpers/control-types';
 
 /**
  * Form controls must extend this class to be used inside `DaffFormFieldComponent`.
@@ -16,10 +17,9 @@ import { DaffFormFieldState } from './form-field-state';
  */
 export abstract class DaffFormFieldControl<T> {
   /**
-   * The type of the control (e.g., 'input', 'select', 'textarea').
-   * Used to apply control-specific styling or behavior.
+   * The type of the control. Used to apply control-specific styling or behavior.
    */
-  abstract readonly controlType?: any;
+  abstract readonly controlType?: DaffFormFieldControlTypesEnum;
 
   /**
    * Whether the control supports automatic label behavior.
@@ -55,6 +55,16 @@ export abstract class DaffFormFieldControl<T> {
    */
   get raised() {
     return this.focused;
+  };
+
+  /**
+   * Whether the control is currently open. Only relevant for controls
+   * that expand, like dropdowns.
+   *
+   * Defaults to `false`.
+   */
+  get opened(): boolean {
+    return false;
   };
 
   /**

--- a/libs/design/form-field/src/form-field-theme.scss
+++ b/libs/design/form-field/src/form-field-theme.scss
@@ -14,7 +14,7 @@
 	.daff-form-field {
 		@include daff-light-mode($mode) {
 			.daff-form-field__control {
-				border: 1px solid daff-color($neutral);
+				border: 0.0625rem solid daff-color($neutral);
 				color: daff-color($neutral);
 
 				* {
@@ -32,7 +32,7 @@
 
 		@include daff-dark-mode($mode) {
 			.daff-form-field__control {
-				border: 1px solid daff-color($neutral, 40);
+				border: 0.0625rem solid daff-color($neutral, 40);
 				color: daff-color($neutral, 40);
 
 				* {
@@ -50,7 +50,7 @@
 
 		&.daff-focused {
 			.daff-form-field__control {
-				border: 1px solid daff-color($primary);
+				border: 0.0625rem solid daff-color($primary);
 			}
 
 			&.fluid {
@@ -64,7 +64,11 @@
 
 		&.daff-error {
 			.daff-form-field__control {
-				border: 1px solid daff-color($critical);
+				border: 0.0625rem solid daff-color($critical);
+
+				&::after {
+					border-color: daff-color($critical);
+				}
 			}
 
 			&.fluid {

--- a/libs/design/form-field/src/form-field/form-field.component.html
+++ b/libs/design/form-field/src/form-field/form-field.component.html
@@ -3,7 +3,7 @@
 @if (isFixed()) {
   <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
 }
-<div class="daff-form-field__wrapper">
+<div class="daff-form-field__wrapper" #wrapper>
 	<div class="daff-form-field__control">
 		@if (_prefix()) {
 			<ng-content select="[daffPrefix]"></ng-content>

--- a/libs/design/form-field/src/form-field/form-field.component.scss
+++ b/libs/design/form-field/src/form-field/form-field.component.scss
@@ -4,9 +4,10 @@
 // stylelint-disable selector-class-pattern
 .daff-form-field {
 	$root: &;
-	display: flex;
+	display: inline-flex;
 	flex-direction: column;
 	gap: 0.25rem;
+	min-width: 0;
 	position: relative;
 
 	&.has-prefix {
@@ -26,6 +27,8 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.25rem;
+		width: 0;
+		min-width: 100%;
 	}
 
 	&__wrapper {
@@ -38,7 +41,7 @@
 		align-items: center;
 		border-radius: 0.25rem;
 		font-size: t.$font-size-base;
-		line-height: 1rem;
+		line-height: 1.25rem;
 		padding: 0 1rem;
 		position: relative;
 		width: 100%;
@@ -51,7 +54,7 @@
 		}
 	}
 
-	&.is-native-select {
+	&.is-dropdown {
 		#{$root}__control {
 			&::after {
 				content: '';
@@ -64,6 +67,22 @@
 				width: 0.5rem;
 				height: 0.5rem;
 				transform: translateY(-50%) rotate(45deg);
+				transition: transform 150ms;
+			}
+		}
+
+		label,
+		.daff-form-label,
+		.daff-form-field__label {
+			padding-right: 1rem;
+		}
+
+		&.daff-open {
+			#{$root}__control {
+				&::after {
+					top: 56%;
+					transform: translateY(-50%) rotate(225deg);
+				}
 			}
 		}
 	}
@@ -74,7 +93,7 @@
 		select {
 			font-size: 1rem;
 			line-height: 1.5rem;
-			padding: calc(0.75rem - 1px) 0;
+			padding: calc(0.75rem - 0.0625rem) 0;
 
 			* {
 				::-webkit-input-placeholder {
@@ -120,18 +139,19 @@
 		.daff-form-field__label {
 			position: absolute;
 			left: 0;
-			top: 1.25rem;
+			top: 1.125rem;
+			max-width: 100%;
 			pointer-events: none;
 			transform-origin: left top;
 			transition: transform 150ms;
-			white-space: nowrap;
+			@include t.text-truncate();
 
 			+,
 			~ * {
 				input,
 				textarea,
 				select {
-					padding: calc(1.5rem - 1px) 0 calc(0.5rem - 1px);
+					padding: calc(1.5rem - 0.0625rem) 0 calc(0.5rem - 0.0625rem);
 				}
 			}
 		}
@@ -140,7 +160,8 @@
 			label,
 			.daff-form-label,
 			#{$root}__label {
-				transform: translateY(-75%) scale(0.75);
+				max-width: calc(100% * 4 / 3);
+				transform: translateY(-50%) scale(0.75);
 			}
 
 			* {
@@ -163,9 +184,15 @@
 	}
 
 	&__inner {
-		flex-grow: 1;
+		flex: auto;
+		min-width: 0;
+		width: 12rem;
 		position: relative;
 		overflow: hidden;
+
+		&:has(textarea[cols]) {
+			width: auto;
+		}
 	}
 
 	.daff-prefix,
@@ -176,8 +203,8 @@
 		appearance: none;
 		background: none;
 		border: none;
-		height: calc(3rem - 2px);
-		min-width: calc(3rem - 2px);
+		height: calc(3rem - 0.125rem);
+		min-width: calc(3rem - 0.125rem);
 	}
 
 	&.daff-skeleton {

--- a/libs/design/form-field/src/form-field/form-field.component.ts
+++ b/libs/design/form-field/src/form-field/form-field.component.ts
@@ -11,6 +11,7 @@ import {
   ElementRef,
   input,
   contentChild,
+  viewChild,
   signal,
   computed,
 } from '@angular/core';
@@ -29,15 +30,13 @@ import {
 
 import { DaffFormFieldActionDirective } from '../action/action.directive';
 import { DaffFormFieldControl } from '../form-field-control';
+import {
+  DaffFormFieldAppearance,
+  DaffFormFieldAppearanceEnum,
+} from '../helpers/appearance';
+import { DaffFormFieldControlTypesEnum } from '../helpers/control-types';
 
 let daffFormFieldId = 0;
-
-export type DaffFormFieldAppearance = 'fluid' | 'fixed';
-
-enum DaffFormFieldAppearanceEnum {
-  Fluid = 'fluid',
-  Fixed = 'fixed',
-}
 
 export const DaffFormFieldMissingControlMessage = 'A DaffFormFieldComponent must contain a DaffFormFieldControl';
 
@@ -55,7 +54,7 @@ export const DaffFormFieldMissingControlMessage = 'A DaffFormFieldComponent must
   ],
   host: {
     class: 'daff-form-field',
-    '[class.is-native-select]': 'isNativeSelect()',
+    '[class.is-dropdown]': 'isDropdown()',
     '[class.has-prefix]': '_prefix()',
     '[class.has-suffix]': '_suffix()',
     '[class.has-action]': '_action()',
@@ -64,6 +63,7 @@ export const DaffFormFieldMissingControlMessage = 'A DaffFormFieldComponent must
     '[class.daff-valid]': 'isValid()',
     '[class.daff-focused]': 'isFocused',
     '[class.daff-raised]': 'isRaised',
+    '[class.daff-open]': 'isOpen',
     '[class.fluid]': 'appearance() === "fluid"',
     '[class.fixed]': 'appearance() === "fixed"',
   },
@@ -76,12 +76,21 @@ export const DaffFormFieldMissingControlMessage = 'A DaffFormFieldComponent must
 })
 export class DaffFormFieldComponent implements AfterContentInit, AfterContentChecked, AfterViewInit {
   /** @docs-private */
-  isNativeSelect = computed(() => this._control()?.controlType === 'native-select');
+  isDropdown = computed(() => this._control()?.controlType === DaffFormFieldControlTypesEnum.Dropdown);
 
   constructor(
     private cd: ChangeDetectorRef,
     public elementRef: ElementRef,
   ) {}
+
+  /**
+   * @docs-private
+   *
+   * The element that wraps the form field's control. Useful as an anchor for
+   * controls that need to position content relative to the control itself,
+   * rather than the entire form field.
+   */
+  _wrapper = viewChild<ElementRef<HTMLElement>>('wrapper');
 
   /** @docs-private */
   _prefix = contentChild(DaffPrefixDirective);
@@ -169,6 +178,15 @@ export class DaffFormFieldComponent implements AfterContentInit, AfterContentChe
    */
   get isRaised() {
     return this._control()?.raised || this.isFilled();
+  }
+
+  /**
+   * @docs-private
+   *
+   * Determines whether or not the form field should display its open state.
+   */
+  get isOpen() {
+    return this._control()?.opened;
   }
 
   /**

--- a/libs/design/form-field/src/helpers/appearance.ts
+++ b/libs/design/form-field/src/helpers/appearance.ts
@@ -1,0 +1,6 @@
+export type DaffFormFieldAppearance = 'fluid' | 'fixed';
+
+export enum DaffFormFieldAppearanceEnum {
+  Fluid = 'fluid',
+  Fixed = 'fixed',
+}

--- a/libs/design/form-field/src/helpers/control-types.ts
+++ b/libs/design/form-field/src/helpers/control-types.ts
@@ -1,0 +1,9 @@
+/**
+ * The types of controls that can be used inside a form field.
+ * - 'input': A control that the user types into, like an input or a textarea.
+ * - 'dropdown': A control that opens a list of options, like a select.
+ */
+export enum DaffFormFieldControlTypesEnum {
+  Input = 'input',
+  Dropdown = 'dropdown',
+}

--- a/libs/design/form-field/src/public_api.ts
+++ b/libs/design/form-field/src/public_api.ts
@@ -1,5 +1,6 @@
 export { DaffFormFieldModule } from './form-field.module';
 export { DaffFormFieldComponent } from './form-field/form-field.component';
 export { DaffFormFieldControl } from './form-field-control';
+export { DaffFormFieldControlTypesEnum } from './helpers/control-types';
 export { DAFF_FORM_FIELD_COMPONENTS } from './form-field';
 export { DaffFormFieldActionDirective } from './action/action.directive';

--- a/libs/design/form-field/src/specs/usage.spec.ts
+++ b/libs/design/form-field/src/specs/usage.spec.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   DebugElement,
+  Input,
   signal,
 } from '@angular/core';
 import {
@@ -19,9 +20,9 @@ import {
   DAFF_FORM_FIELD_COMPONENTS,
   DaffFormFieldComponent,
   DaffFormFieldControl,
+  DaffFormFieldControlTypesEnum,
 } from '@daffodil/design/form-field';
 import { DaffInputComponent } from '@daffodil/design/input';
-import { DaffNativeSelectComponent } from '@daffodil/design/native-select';
 import { patchElementFocus } from '@daffodil/design/testing';
 
 import { DaffFormFieldAppearance } from '../helpers/appearance';
@@ -44,7 +45,7 @@ class WrapperComponent {
   appearance = signal<DaffFormFieldAppearance>('fixed');
 }
 
-describe('@daffodil/design | DaffFormFieldComponent | Usage', () => {
+describe('@daffodil/design/form-field | DaffFormFieldComponent | Usage', () => {
   let wrapper: WrapperComponent;
   let component: DaffFormFieldComponent;
   let fixture: ComponentFixture<WrapperComponent>;
@@ -193,6 +194,21 @@ describe('@daffodil/design | DaffFormFieldComponent | Usage', () => {
     });
   });
 
+  describe('open state', () => {
+    it('should set the `daff-open` class on the host element when the child control is open', () => {
+      spyOnProperty(control, 'opened').and.returnValue(true);
+      control.emitState();
+      fixture.detectChanges();
+
+      expect(de.nativeElement.classList.contains('daff-open')).toEqual(true);
+    });
+
+    it('should not set the `daff-open` class on the host element when the child control is not open', () => {
+      expect(control.opened).toBeFalse();
+      expect(de.nativeElement.classList.contains('daff-open')).toEqual(false);
+    });
+  });
+
   it('should not add the `has-prefix` class to the host element if prefix is not used', () => {
     expect(de.nativeElement.classList.contains('has-prefix')).toEqual(false);
   });
@@ -218,7 +234,7 @@ imports: [
 class WithPrefixSuffixComponent {
 }
 
-describe('@daffodil/design | DaffFormFieldComponent | Usage - Prefix, Suffix, & Action', () => {
+describe('@daffodil/design/form-field | DaffFormFieldComponent | Usage - Prefix, Suffix, & Action', () => {
   let wrapper: WithPrefixSuffixComponent;
   let component: DaffFormFieldComponent;
   let fixture: ComponentFixture<WithPrefixSuffixComponent>;
@@ -260,45 +276,79 @@ describe('@daffodil/design | DaffFormFieldComponent | Usage - Prefix, Suffix, & 
 });
 
 @Component({
+  selector: 'daff-control-stub',
+  template: '',
+  providers: [
+    { provide: DaffFormFieldControl, useExisting: ControlStubComponent },
+  ],
+})
+class ControlStubComponent extends DaffFormFieldControl<string> {
+  @Input() controlType: DaffFormFieldControlTypesEnum;
+
+  focused = false;
+  required = false;
+  disabled = false;
+  value = '';
+
+  constructor() {
+    super(null);
+  }
+
+  focus() {}
+}
+
+@Component({
   template: `
     <daff-form-field>
-      <select daff-native-select></select>
+      <daff-control-stub [controlType]="controlType"></daff-control-stub>
     </daff-form-field>`,
   imports: [
     DAFF_FORM_FIELD_COMPONENTS,
-    DaffNativeSelectComponent,
-    ReactiveFormsModule,
+    ControlStubComponent,
   ],
 })
 
-class NativeSelectWrapper {}
+class ControlWrapper {
+  controlType: DaffFormFieldControlTypesEnum;
+}
 
-describe('@daffodil/design | DaffFormFieldComponent | Usage - Native Select Control', () => {
-  let wrapper: NativeSelectWrapper;
-  let fixture: ComponentFixture<NativeSelectWrapper>;
+describe('@daffodil/design/form-field | DaffFormFieldComponent | Usage - Control Types', () => {
+  let wrapper: ControlWrapper;
+  let fixture: ComponentFixture<ControlWrapper>;
   let de: DebugElement;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        NativeSelectWrapper,
+        ControlWrapper,
       ],
     })
       .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(NativeSelectWrapper);
+    fixture = TestBed.createComponent(ControlWrapper);
     wrapper = fixture.componentInstance;
     de = fixture.debugElement.query(By.css('daff-form-field'));
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
+
     expect(wrapper).toBeTruthy();
   });
 
-  it('should add a class of "is-native-select" to a native select control', () => {
-    expect(de.nativeElement.classList.contains('is-native-select')).toEqual(true);
+  it('should add a class of "is-dropdown" when the control is a dropdown', () => {
+    wrapper.controlType = DaffFormFieldControlTypesEnum.Dropdown;
+    fixture.detectChanges();
+
+    expect(de.nativeElement.classList.contains('is-dropdown')).toEqual(true);
+  });
+
+  it('should not add a class of "is-dropdown" when the control is not a dropdown', () => {
+    wrapper.controlType = DaffFormFieldControlTypesEnum.Input;
+    fixture.detectChanges();
+
+    expect(de.nativeElement.classList.contains('is-dropdown')).toEqual(false);
   });
 });

--- a/libs/design/form-field/src/specs/usage.spec.ts
+++ b/libs/design/form-field/src/specs/usage.spec.ts
@@ -24,7 +24,7 @@ import { DaffInputComponent } from '@daffodil/design/input';
 import { DaffNativeSelectComponent } from '@daffodil/design/native-select';
 import { patchElementFocus } from '@daffodil/design/testing';
 
-import { DaffFormFieldAppearance } from '../form-field/form-field.component';
+import { DaffFormFieldAppearance } from '../helpers/appearance';
 
 @Component({ template: `
   <daff-form-field [id]="id()" [appearance]="appearance()">

--- a/libs/design/input/src/input.component.ts
+++ b/libs/design/input/src/input.component.ts
@@ -23,6 +23,7 @@ import {
 import {
   DaffFormFieldComponent,
   DaffFormFieldControl,
+  DaffFormFieldControlTypesEnum,
 } from '@daffodil/design/form-field';
 
 /**
@@ -49,8 +50,12 @@ import {
   },
 })
 export class DaffInputComponent extends DaffFormFieldControl<string> implements DaffFormFieldControl<string>, OnInit {
-  /** @docs-private */
-  controlType = 'native-input';
+  /**
+   * @docs-private
+   *
+   * Implemented as part of DaffFormFieldControl.
+   */
+  controlType = DaffFormFieldControlTypesEnum.Input;
 
   /**
    * @docs-private

--- a/libs/design/input/src/specs/with-form-field.spec.ts
+++ b/libs/design/input/src/specs/with-form-field.spec.ts
@@ -61,8 +61,8 @@ describe('@daffodil/design | DaffInputComponent | With Form Field', () => {
     expect(wrapper).toBeTruthy();
   });
 
-  it('should set the control type to native-input', () => {
-    expect(formField._control().controlType).toEqual('native-input');
+  it('should set the control type to input', () => {
+    expect(formField._control().controlType).toEqual('input');
   });
 
   it('should set the input id to the form field id', () => {

--- a/libs/design/native-select/src/native-select/native-select.component.ts
+++ b/libs/design/native-select/src/native-select/native-select.component.ts
@@ -22,6 +22,7 @@ import {
 import {
   DaffFormFieldComponent,
   DaffFormFieldControl,
+  DaffFormFieldControlTypesEnum,
 } from '@daffodil/design/form-field';
 
 /**
@@ -54,7 +55,7 @@ export class DaffNativeSelectComponent extends DaffFormFieldControl<string> impl
    *
    * Implemented as part of DaffFormFieldControl.
    */
-  controlType = 'native-select';
+  controlType = DaffFormFieldControlTypesEnum.Dropdown;
 
   /**
    * @docs-private

--- a/libs/design/native-select/src/native-select/specs/with-form-field.spec.ts
+++ b/libs/design/native-select/src/native-select/specs/with-form-field.spec.ts
@@ -65,8 +65,8 @@ describe('@daffodil/design | DaffNativeSelectComponent | With Form Field', () =>
     expect(wrapper).toBeTruthy();
   });
 
-  it('should set the control type to `native-select', () => {
-    expect(component.controlType).toEqual('native-select');
+  it('should set the control type to `dropdown', () => {
+    expect(component.controlType).toEqual('dropdown');
   });
 
   it('should set the native select id to the form field id', () => {

--- a/libs/design/quantity-field/src/quantity-field.component.ts
+++ b/libs/design/quantity-field/src/quantity-field.component.ts
@@ -13,7 +13,10 @@ import {
   NgControl,
 } from '@angular/forms';
 
-import { DaffFormFieldControl } from '@daffodil/design/form-field';
+import {
+  DaffFormFieldControl,
+  DaffFormFieldControlTypesEnum,
+} from '@daffodil/design/form-field';
 
 import { DaffQuantityInputComponent } from './quantity-input/quantity-input.component';
 import { DaffQuantitySelectComponent } from './quantity-select/quantity-select.component';
@@ -102,8 +105,7 @@ export class DaffQuantityFieldComponent extends DaffFormFieldControl<number> imp
   get controlType() {
     // TODO: use enum
     return this.showInputField
-      ? 'native-input'
-      : 'native-select';
+      ? DaffFormFieldControlTypesEnum.Input : DaffFormFieldControlTypesEnum.Dropdown;
   }
 
   get showInputField(): boolean {

--- a/libs/design/select/src/select/select.component.scss
+++ b/libs/design/select/src/select/select.component.scss
@@ -29,20 +29,6 @@
 		&[disabled] {
 			cursor: not-allowed;
 		}
-
-		&::after {
-			content: '';
-			position: absolute;
-			top: 48%;
-			right: 0.125rem;
-			display: inline-block;
-			border-right: 0.125rem solid currentColor;
-			border-bottom: 0.125rem solid currentColor;
-			width: 0.5rem;
-			height: 0.5rem;
-			transform: translateY(-50%) rotate(45deg);
-			transition: transform 150ms;
-		}
 	}
 
 	&.daff-open {

--- a/libs/design/select/src/select/select.component.ts
+++ b/libs/design/select/src/select/select.component.ts
@@ -42,6 +42,7 @@ import {
 
 import { DaffOpenableDirective } from '@daffodil/design';
 import {
+  DaffFormFieldControlTypesEnum ,
   DaffFormFieldComponent,
   DaffFormFieldControl,
 } from '@daffodil/design/form-field';
@@ -81,8 +82,12 @@ let daffSelectOtionsId = 0;
   ],
 })
 export class DaffSelectComponent<T = unknown> extends DaffFormFieldControl<string> implements DaffFormFieldControl<string>, OnInit, OnDestroy, ControlValueAccessor {
-  /** @docs-private */
-  controlType = 'custom-select';
+  /**
+   * @docs-private
+   *
+   * Implemented as part of DaffFormFieldControl.
+   */
+  controlType = DaffFormFieldControlTypesEnum.Dropdown;
 
   /**
    * @docs-private
@@ -106,6 +111,13 @@ export class DaffSelectComponent<T = unknown> extends DaffFormFieldControl<strin
    */
   get raised() {
     return this.focused && this.isOpen;
+  }
+
+  /**
+   * @docs-private
+   */
+  get opened() {
+    return this.isOpen;
   }
 
   /** @docs-private */
@@ -307,18 +319,18 @@ export class DaffSelectComponent<T = unknown> extends DaffFormFieldControl<strin
         this._highlighted = this.options.findIndex((v) => v === this._value);
       }
 
-      const formFieldEl = this.formField.elementRef.nativeElement;
-      const formFieldWidth = formFieldEl.getBoundingClientRect().width;
+      const wrapperEl = this.formField._wrapper().nativeElement;
+      const wrapperWidth = wrapperEl.getBoundingClientRect().width;
 
       this._overlay = this.overlay.create({
         hasBackdrop: true,
         backdropClass: 'cdk-overlay-transparent-backdrop',
         scrollStrategy: this.overlay.scrollStrategies.block(),
         disposeOnNavigation: true,
-        width: `${formFieldWidth}px`,
+        width: `${wrapperWidth}px`,
         positionStrategy: this.overlay
           .position()
-          .flexibleConnectedTo(formFieldEl)
+          .flexibleConnectedTo(wrapperEl)
           .withPositions([
             {
               originX: 'start',

--- a/libs/design/select/src/specs/with-form-field.spec.ts
+++ b/libs/design/select/src/specs/with-form-field.spec.ts
@@ -60,8 +60,8 @@ describe('@daffodil/design/select | DaffSelectComponent | With Form Field', () =
     expect(wrapper).toBeTruthy();
   });
 
-  it('should set the control type to custom-select', () => {
-    expect(formField._control().controlType).toEqual('custom-select');
+  it('should set the control type to dropdown', () => {
+    expect(formField._control().controlType).toEqual('dropdown');
   });
 
   it('should set required to false', () => {

--- a/libs/design/textarea/src/specs/with-form-field.spec.ts
+++ b/libs/design/textarea/src/specs/with-form-field.spec.ts
@@ -62,8 +62,8 @@ describe('@daffodil/design/textarea | DaffTextareaComponent | With Form Field', 
     expect(wrapper).toBeTruthy();
   });
 
-  it('should set the control type to native-textarea', () => {
-    expect(formField._control().controlType).toEqual('native-textarea');
+  it('should set the control type to input', () => {
+    expect(formField._control().controlType).toEqual('input');
   });
 
   it('should set the textarea id to the form field id', () => {

--- a/libs/design/textarea/src/textarea.component.ts
+++ b/libs/design/textarea/src/textarea.component.ts
@@ -22,6 +22,7 @@ import {
 import {
   DaffFormFieldComponent,
   DaffFormFieldControl,
+  DaffFormFieldControlTypesEnum,
 } from '@daffodil/design/form-field';
 
 /**
@@ -49,7 +50,7 @@ import {
 })
 export class DaffTextareaComponent extends DaffFormFieldControl<string> implements DaffFormFieldControl<string>, OnInit {
   /** @docs-private */
-  controlType = 'native-textarea';
+  controlType = DaffFormFieldControlTypesEnum.Input;
 
   /**
    * @docs-private

--- a/libs/storefront/quantity-field/src/quantity-field.component.ts
+++ b/libs/storefront/quantity-field/src/quantity-field.component.ts
@@ -30,6 +30,7 @@ import { takeUntil } from 'rxjs/operators';
 import {
   DaffFormFieldComponent,
   DaffFormFieldControl,
+  DaffFormFieldControlTypesEnum,
 } from '@daffodil/design/form-field';
 
 import { DaffSfQuantityInputComponent } from './quantity-input/quantity-input.component';
@@ -78,7 +79,7 @@ export class DaffSfQuantityFieldComponent extends DaffFormFieldControl<number> i
 
   /** @docs-private */
   get controlType() {
-    return this._showInputField() ? 'native-input' : 'native-select';
+    return this._showInputField() ? DaffFormFieldControlTypesEnum.Input : DaffFormFieldControlTypesEnum.Dropdown;
   }
 
   /**


### PR DESCRIPTION
## PR Checklist

- [x] Commit message follows our [contributing guidelines](https://github.com/graycoreio/daffodil/blob/develop/CONTRIBUTING.md#commit)
- [x] Tests added/updated (for bug fixes/features)
- [x] Documentation added/updated (for bug fixes/features)

## PR Type
<!-- Select the relevant type(s) -->

- [ ] Bug fix
- [x] Feature
- [ ] Style update
- [ ] Refactor
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Docs
- [ ] Performance
- [ ] Other (please describe)

## Current behavior
<!-- Describe the current behavior and link to relevant issue -->

Part of: #4535 

## New behavior
- Moved the dropdown arrow from `@daffodil/design/select` into `@daffodil/design/form-field` so native and custom selects render the same indicator.
- Added `DaffFormFieldControlTypesEnum` to type `DaffFormFieldControl.controlType`
- Added `DaffFormFieldControl.opened`
- Anchored the select overlay to the new form field wrapper element so the overlay opens at the correct location
- Truncated long floating labels instead of letting them overflow.

## Breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `DaffFormFieldControl.controlType` is now typed as `DaffFormFieldControlTypesEnum` instead of `any`. Controls that set it to an arbitrary string such as `'native-input'` or `'native-select'` must use `DaffFormFieldControlTypesEnum.Input` or `DaffFormFieldControlTypesEnum.Dropdown` instead. The `is-native-select` class on `DaffFormFieldComponent` has been renamed to `is-dropdown`.

## Additional context
<!-- Any other relevant information -->